### PR TITLE
Immutable bus

### DIFF
--- a/libs/agent/rescript.json
+++ b/libs/agent/rescript.json
@@ -1,6 +1,9 @@
 {
 	"name": "@ask-the-llm/agent",
 	"namespace": true,
+	"exposed-modules": [
+		"Agent"
+	],
 	"sources": [
 		{
 			"dir": "src",

--- a/libs/agent/src/Agent.res
+++ b/libs/agent/src/Agent.res
@@ -17,7 +17,6 @@ module Part = Agent__Task__Message__Part
 module Artifact = Agent__Artifact
 module Id = Agent__Id
 module TaskId = Agent__Task__Id
-module EventBus = Agent__EventBus
 module Effect = Agent__Effect
 module Command = Agent__Command
 module CommandQueue = Agent__CommandQueue
@@ -25,7 +24,7 @@ module Reactor = Agent__Reactor
 
 type t = {
   projectRoot: string,
-  eventBus: EventBus.t,
+  eventBus: ref<Agent__EventBus.t>,
   tasks: Agent__Tasks.t,
   llm: Adapters.Vercel.t,
   config: Agent__Config.t,
@@ -36,7 +35,7 @@ type config = Agent__Config.t
 
 let make = (config: config) => {
   Console.log(`Initializing agent for project: ${config.projectRoot}`)
-  let eventBus = EventBus.make()
+  let eventBus = Agent__EventBus.make()
 
   // Use provided toolRegistry for testing, or create default registry with all tools
   let toolRegistry = config.toolRegistry->Option.getOr(Agent__ToolsRegistry.make())
@@ -49,13 +48,28 @@ let make = (config: config) => {
 
   {
     projectRoot: config.projectRoot,
-    eventBus,
+    eventBus: ref(eventBus),
     tasks: Agent__Tasks.make(),
     llm,
     config,
     toolRegistry,
     commandQueue: Agent__CommandQueue.make(),
   }
+}
+
+// Subscribe to events and return unsubscribe function
+let subscribe = (agent: t, handler: Agent__EventBus.subscriber): (unit => unit) => {
+  agent.eventBus := agent.eventBus.contents->Agent__EventBus.on(handler)
+
+  // Return unsubscribe function
+  () => {
+    agent.eventBus := agent.eventBus.contents->Agent__EventBus.off(handler)
+  }
+}
+
+// Emit event to all subscribers
+let emit = (agent: t, event: Agent__EventBus.events): unit => {
+  agent.eventBus.contents->Agent__EventBus.emit(event)
 }
 
 // Main execution loop - drains command queue
@@ -70,7 +84,7 @@ let run = async (agent: t) => {
           | Some(updatedTask) => {
               Agent__Tasks.update(agent.tasks, updatedTask)
               events->List.forEach(event => {
-                agent.eventBus->EventBus.emit(TaskEvent(updatedTask, event))
+                agent->emit(Agent__EventBus.TaskEvent(updatedTask, event))
               })
             }
           | None => Console.error("Internal error: evolve returned None after decide succeeded")
@@ -100,7 +114,7 @@ let run = async (agent: t) => {
 }
 
 let initialize = (agent: t): (unit => unit) => {
-  let unsubscribe = agent.eventBus->EventBus.on(event => {
+  let unsubscribe = agent->subscribe(event => {
     let commands = Agent__Reactor.react(event)
 
     // Enqueue all commands and trigger run

--- a/libs/agent/src/Agent__EventBus.res
+++ b/libs/agent/src/Agent__EventBus.res
@@ -3,21 +3,20 @@
 type events = TaskEvent(Agent__Task.t, Agent__Task.evt)
 // Future: ProjectEvent, UserEvent, etc.
 type subscriber = events => unit
-type t = {subs: ref<array<subscriber>>}
+type t = {subs: array<subscriber>}
 
 let make = (): t => {
-  subs: ref([]),
+  subs: [],
 }
 
 let emit = (bus: t, event: events): unit => {
-  bus.subs.contents->Array.forEach(sub => sub(event))
+  bus.subs->Array.forEach(sub => sub(event))
 }
 
-let on = (bus: t, handler: subscriber) => {
-  bus.subs := Array.concat(bus.subs.contents, [handler])
+let on = (bus: t, handler: subscriber): t => {
+  {subs: Array.concat(bus.subs, [handler])}
+}
 
-  // Return unsubscribe function
-  () => {
-    bus.subs := bus.subs.contents->Array.filter(h => h !== handler)
-  }
+let off = (bus: t, handler: subscriber): t => {
+  {subs: bus.subs->Array.filter(h => h !== handler)}
 }

--- a/libs/agent/test/Agent.test.res
+++ b/libs/agent/test/Agent.test.res
@@ -12,7 +12,7 @@ module TestHelpers = {
   // Test context that tracks events and task IDs
   type testContext = {
     agent: Agent.t,
-    events: ref<array<Agent.EventBus.events>>,
+    events: ref<array<Agent__EventBus.events>>,
     taskId: ref<option<Agent__Task__Id.t>>,
     unsubscribe: unit => unit,
   }
@@ -22,10 +22,10 @@ module TestHelpers = {
     let events = ref([])
     let taskId = ref(None)
 
-    let unsubscribe = agent.eventBus->Agent.EventBus.on(event => {
+    let unsubscribe = agent->Agent.subscribe(event => {
       events := Array.concat(events.contents, [event])
       switch event {
-      | Agent.EventBus.TaskEvent(_, Created({id})) => taskId := Some(id)
+      | Agent__EventBus.TaskEvent(_, Created({id})) => taskId := Some(id)
       | _ => ()
       }
     })
@@ -41,14 +41,14 @@ module TestHelpers = {
         let unsubscribe = ref(None)
         let handler = event => {
           switch event {
-          | Agent.EventBus.TaskEvent(task, Completed(_)) if task.id == id => {
+          | Agent__EventBus.TaskEvent(task, Completed(_)) if task.id == id => {
               unsubscribe.contents->Option.forEach(unsub => unsub())
               resolve()
             }
           | _ => ()
           }
         }
-        unsubscribe := Some(context.agent.eventBus->Agent.EventBus.on(handler))
+        unsubscribe := Some(context.agent->Agent.subscribe(handler))
       })
     | None => ()
     }
@@ -155,9 +155,9 @@ module TestHelpers = {
   let assertHasEvent = (t, context, eventType) => {
     let hasEvent = context.events.contents->Array.some(event =>
       switch (event, eventType) {
-      | (Agent.EventBus.TaskEvent(_, Created(_)), #Created)
-      | (Agent.EventBus.TaskEvent(_, Completed(_)), #Completed)
-      | (Agent.EventBus.TaskEvent(_, MessageAdded({message: Message.Tool(_)})), #ToolResult) => true
+      | (Agent__EventBus.TaskEvent(_, Created(_)), #Created)
+      | (Agent__EventBus.TaskEvent(_, Completed(_)), #Completed)
+      | (Agent__EventBus.TaskEvent(_, MessageAdded({message: Message.Tool(_)})), #ToolResult) => true
       | _ => false
       }
     )
@@ -167,8 +167,8 @@ module TestHelpers = {
   let assertEventOrder = (t, context, first, second) => {
     let types = context.events.contents->Array.map(e =>
       switch e {
-      | Agent.EventBus.TaskEvent(_, Created(_)) => #Created
-      | Agent.EventBus.TaskEvent(_, Completed(_)) => #Completed
+      | Agent__EventBus.TaskEvent(_, Created(_)) => #Created
+      | Agent__EventBus.TaskEvent(_, Completed(_)) => #Completed
       | _ => #Other
       }
     )

--- a/libs/agent/test/Agent__EventBus.test.res
+++ b/libs/agent/test/Agent__EventBus.test.res
@@ -8,10 +8,10 @@ open Vitest
 describe("EventBus emission", () => {
   testAsync("TaskCreated event is emitted when Create command succeeds", async t => {
     let agent = Agent.make({projectRoot: ".", apiKey: "test-api-key"})
-    let receivedEvents: ref<array<Agent.EventBus.events>> = ref([])
+    let receivedEvents: ref<array<Agent__EventBus.events>> = ref([])
 
     // Subscribe to events (subscribers now return unit)
-    let _unsubscribe = agent.eventBus->Agent.EventBus.on(
+    let _unsubscribe = agent->Agent.subscribe(
       event => {
         receivedEvents := Array.concat(receivedEvents.contents, [event])
       },
@@ -44,10 +44,10 @@ describe("EventBus emission", () => {
 
   testAsync("Events are emitted through complete message flow", async t => {
     let agent = Agent.make({projectRoot: ".", apiKey: "test-api-key"})
-    let receivedEvents: ref<array<Agent.EventBus.events>> = ref([])
+    let receivedEvents: ref<array<Agent__EventBus.events>> = ref([])
 
     // Subscribe to events
-    let _unsubscribe = agent.eventBus->Agent.EventBus.on(
+    let _unsubscribe = agent->Agent.subscribe(
       event => {
         receivedEvents := Array.concat(receivedEvents.contents, [event])
       },

--- a/libs/nextjs/src/Nextjs__ApiRoute.res
+++ b/libs/nextjs/src/Nextjs__ApiRoute.res
@@ -129,7 +129,7 @@ let createStreamHandler = (): apiHandler => {
       res->ApiResponse.write(`data: ${data}\n\n`)
     }
 
-    let unsubsribe = agent.eventBus->Agent.EventBus.on(event => {
+    let unsubsribe = agent->Agent.subscribe(event => {
       switch event {
       | TaskEvent(_task, MessageAdded({message})) =>
         Console.log2("taskMessageAdded", message)


### PR DESCRIPTION
  Summary

  Refactored Agent__EventBus from mutable to purely
  functional/immutable

  Why?

  Before: EventBus used ref for mutation, was publicly
  accessible, and hard to test in isolation.

  After: EventBus is pure/immutable, completely hidden, and
  easily testable. Agent manages the mutation.

  Architecture

  External Code → Agent.subscribe/emit (manages mutation) →
  EventBus (pure functions)
