### PR TITLE
refactor(tools): extract execution_target routing decision

### DIFF
--- a/apps/frontman_server/lib/frontman_server/agents/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/tool_executor.ex
@@ -62,11 +62,11 @@ defmodule FrontmanServer.Agents.ToolExecutor do
 
   # Returns true if this is an MCP tool (registered for response), false for backend tools
   defp register_if_mcp_tool(tool_call) do
-    case Tools.find_tool(tool_call.name) do
-      {:ok, _module} ->
+    case Tools.execution_target(tool_call.name) do
+      :backend ->
         false
 
-      :not_found ->
+      :mcp ->
         Registry.register(FrontmanServer.AgentRegistry, {:tool_call, tool_call.id}, %{
           caller_pid: self()
         })

--- a/apps/frontman_server/lib/frontman_server/tools.ex
+++ b/apps/frontman_server/lib/frontman_server/tools.ex
@@ -35,6 +35,20 @@ defmodule FrontmanServer.Tools do
     end
   end
 
+  @doc """
+  Returns the execution target for a tool.
+
+  Backend tools are executed server-side by ToolExecutor.
+  MCP tools are routed to the browser client for execution.
+  """
+  @spec execution_target(String.t()) :: :backend | :mcp
+  def execution_target(tool_name) do
+    case find_tool(tool_name) do
+      {:ok, _module} -> :backend
+      :not_found -> :mcp
+    end
+  end
+
   @spec todo_mutation?(String.t()) :: boolean()
   def todo_mutation?(tool_name), do: tool_name in @todo_mutations
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -374,16 +374,15 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     push(socket, "acp:message", args_notification)
 
-    # Check if it's a backend tool or MCP tool
-    case Tools.find_tool(tool_call.tool_name) do
-      {:ok, _tool_module} ->
+    case Tools.execution_target(tool_call.tool_name) do
+      :backend ->
         # Backend tools are executed by ToolExecutor in the agent loop.
         # The channel just notifies the UI (already done above).
         # When the tool completes, we'll receive a ToolResult notification.
         {:noreply, socket}
 
-      :not_found ->
-        # Not a backend tool, route to MCP client for execution
+      :mcp ->
+        # Route to MCP client for execution
         route_to_mcp(tool_call, socket)
     end
   end

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -41,6 +41,24 @@ defmodule FrontmanServer.ToolsTest do
     end
   end
 
+  describe "execution_target/1" do
+    test "returns :backend for all registered backend tools" do
+      Tools.backend_tools()
+      |> Enum.each(fn tool ->
+        assert Tools.execution_target(tool.name) == :backend,
+               "Expected #{tool.name} to target :backend"
+      end)
+    end
+
+    test "returns :mcp for non-backend tools" do
+      # These aren't in @backend_tools, so they route to MCP
+      assert Tools.execution_target("read_file") == :mcp
+      assert Tools.execution_target("screenshot") == :mcp
+      assert Tools.execution_target("unknown_tool") == :mcp
+      assert Tools.execution_target("") == :mcp
+    end
+  end
+
   describe "todo_mutation?/1" do
     test "returns true for todo mutation tools" do
       assert Tools.todo_mutation?("todo_add")


### PR DESCRIPTION
## Summary

- Add explicit `Tools.execution_target/1` function that returns `:backend` or `:mcp`
- Replace implicit routing logic that interpreted `find_tool/1` results
- Make tool routing a domain concern rather than transport layer knowledge

## Changes

| File | Change |
|------|--------|
| `tools.ex` | Added `execution_target/1` function with spec and docs |
| `task_channel.ex` | Updated routing to use `execution_target/1` |
| `tool_executor.ex` | Updated `register_if_mcp_tool/1` to use `execution_target/1` |
| `tools_test.exs` | Added dynamic tests for all backend tools + non-backend tools |

## Test plan

- [x] Unit tests for `execution_target/1` pass
- [x] All 229 existing tests pass (no regressions)
- [x] Verified `execution_target/1` returns `:backend` for all registered backend tools
- [x] Verified `execution_target/1` returns `:mcp` for unknown tool names

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)