### PR TITLE
fix: prevent consecutive assistant messages from overwriting each other

### DIFF
--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -140,24 +140,15 @@ let make = () => {
 
     switch update {
     | AgentMessageChunk({content}) =>
-      // Text delta from assistant
       content
       ->Option.flatMap(c => c.text)
       ->Option.forEach(text => {
-        // Use a consistent ID for the current message stream
-        let id = `msg_${taskId}`
-        // The reducer will handle creating a new streaming message if needed
-        // (e.g., if last message is not an assistant message)
-        Client__State.Actions.textDeltaReceived(~taskId, ~id, ~text)
+        Client__State.Actions.textDeltaReceived(~taskId, ~text)
       })
 
-    | AgentMessageStart =>
-      let id = `msg_${taskId}`
-      Client__State.Actions.streamingStarted(~taskId, ~id)
+    | AgentMessageStart => Client__State.Actions.streamingStarted(~taskId)
 
-    | AgentMessageEnd =>
-      let id = `msg_${taskId}`
-      Client__State.Actions.messageCompleted(~taskId, ~id)
+    | AgentMessageEnd => Client__State.Actions.messageCompleted(~taskId)
 
     | ToolCall({toolCallId, title, parentAgentId, spawningToolName}) =>
       // Tool call started - create tool call entry

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -29,14 +29,14 @@ module Actions = {
       }),
     )
 
-  let messageCompleted = (~taskId, ~id) =>
-    Client__State__Store.dispatch(MessageCompleted({taskId, id}))
+  let messageCompleted = (~taskId) =>
+    Client__State__Store.dispatch(MessageCompleted({taskId: taskId}))
 
-  let textDeltaReceived = (~taskId, ~id, ~text) =>
-    Client__State__Store.dispatch(TextDeltaReceived({taskId, id, text}))
+  let textDeltaReceived = (~taskId, ~text) =>
+    Client__State__Store.dispatch(TextDeltaReceived({taskId, text}))
 
-  let streamingStarted = (~taskId, ~id) =>
-    Client__State__Store.dispatch(StreamingStarted({taskId, id}))
+  let streamingStarted = (~taskId) =>
+    Client__State__Store.dispatch(StreamingStarted({taskId: taskId}))
 
   // TOOLS
   let toolCallReceived = (~taskId, ~toolCall) =>

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -61,14 +61,30 @@ module Lens = {
   let getTaskById = (state: state, taskId: string): option<Task.t> => {
     state.tasks->Dict.get(taskId)
   }
+
+  // Get the streaming message in a task (at most one per task).
+  let getStreamingMessage = (task: Task.t): option<Message.assistantMessage> => {
+    let streaming =
+      task.messages
+      ->Dict.valuesToArray
+      ->Array.filterMap(msg => {
+        switch msg {
+        | Message.Assistant(Streaming(_) as streaming) => Some(streaming)
+        | _ => None
+        }
+      })
+
+    assert(Array.length(streaming) <= 1)
+    streaming->Array.get(0)
+  }
 }
 
 type action =
   // User actions
   | AddUserMessage({id: string, content: array<UserContentPart.t>})
-  // Streaming actions (from SSE events)
-  | StreamingStarted({taskId: string, id: string})
-  | TextDeltaReceived({taskId: string, id: string, text: string})
+  // Streaming actions (from ACP session updates)
+  | StreamingStarted({taskId: string})
+  | TextDeltaReceived({taskId: string, text: string})
   | ToolCallReceived({taskId: string, toolCall: Message.toolCall})
   | ToolInputStartReceived({taskId: string, id: string, toolName: string, parentAgentId: option<string>, spawningToolName: option<string>})
   | ToolInputDeltaReceived({taskId: string, id: string, delta: string})
@@ -77,7 +93,7 @@ type action =
   | ToolResultReceived({taskId: string, id: string, result: JSON.t})
   | ToolErrorReceived({taskId: string, id: string, error: string})
   // Completion action
-  | MessageCompleted({taskId: string, id: string})
+  | MessageCompleted({taskId: string})
   // Preview frame actions
   | SetPreviewUrl({url: string})
   | SetPreviewFrame({
@@ -149,8 +165,8 @@ let defaultState: state = {
 let actionToString = action => {
   switch action {
   | AddUserMessage({id}) => `AddUserMessage(${id})`
-  | StreamingStarted({taskId, id}) => `StreamingStarted(${taskId}, ${id})`
-  | TextDeltaReceived({taskId, id, text}) => `TextDeltaReceived(${taskId}, ${id}, "${text}")`
+  | StreamingStarted({taskId}) => `StreamingStarted(${taskId})`
+  | TextDeltaReceived({taskId, text}) => `TextDeltaReceived(${taskId}, "${text}")`
   | ToolCallReceived({taskId, toolCall}) => `ToolCallReceived(${taskId}, ${toolCall.toolName})`
   | ToolInputStartReceived({taskId, id, toolName, parentAgentId: _}) =>
     `ToolInputStartReceived(${taskId}, ${id}, ${toolName})`
@@ -159,7 +175,7 @@ let actionToString = action => {
   | ToolInputReceived({taskId, id, _}) => `ToolInputReceived(${taskId}, ${id})`
   | ToolResultReceived({taskId, id}) => `ToolResultReceived(${taskId}, ${id})`
   | ToolErrorReceived({taskId, id}) => `ToolErrorReceived(${taskId}, ${id})`
-  | MessageCompleted({taskId, id}) => `MessageCompleted(${taskId}, ${id})`
+  | MessageCompleted({taskId}) => `MessageCompleted(${taskId})`
   | SetPreviewUrl({url}) => `SetPreviewUrl(${url})`
   | SetPreviewFrame(_) => `SetPreviewFrame(contentDocument, contentWindow)`
   | ToggleWebPreviewSelection => `ToggleWebPreviewSelection`
@@ -334,7 +350,7 @@ let handleEffect = (effect, state: state, dispatch) => {
 
       let streamingMessages = Selectors.streamingMessages(state)
       switch streamingMessages[Array.length(streamingMessages) - 1] {
-      | Some(Message.Streaming({id, _})) => dispatch(MessageCompleted({taskId, id}))
+      | Some(Message.Streaming(_)) => dispatch(MessageCompleted({taskId: taskId}))
       | Some(Message.Completed(_)) | None => ()
       }
 
@@ -504,13 +520,15 @@ let next = (state, action) => {
       )
     }
 
-  | StreamingStarted({taskId, id}) =>
+  | StreamingStarted({taskId}) =>
     state
     ->Lens.updateTask(taskId, task => {
-      switch task.messages->Dict.get(id) {
-      | Some(Message.Assistant(Streaming(_))) =>
+      switch Lens.getStreamingMessage(task) {
+      | Some(_) =>
+        // Already have a streaming message, don't create another
         task
-      | _ =>
+      | None =>
+        let id = `msg_${taskId}_${Date.now()->Float.toString}`
         let newMessage = Message.Assistant(
           Streaming({
             id,
@@ -518,40 +536,29 @@ let next = (state, action) => {
             createdAt: Date.now(),
           }),
         )
-        let updatedMessages = task.messages->Dict.copy
-        updatedMessages->Dict.set(id, newMessage)
-        {...task, messages: updatedMessages}
+        Lens.insertTaskMessage(task, newMessage)
       }
     })
     ->FrontmanReactStatestore.StateReducer.update
 
-  | TextDeltaReceived({taskId, id, text}) =>
+  | TextDeltaReceived({taskId, text}) =>
     state
     ->Lens.updateTask(taskId, task => {
-      switch task.messages->Dict.get(id) {
-      | Some(Message.Assistant(Streaming({id: msgId, textBuffer, createdAt}))) =>
-        let newBuffer = textBuffer ++ text
+      switch Lens.getStreamingMessage(task) {
+      | Some(Message.Streaming({id, textBuffer, createdAt})) =>
         let updatedMsg = Message.Assistant(
-          Streaming({
-            id: msgId,
-            textBuffer: newBuffer,
-            createdAt,
-          }),
+          Streaming({id, textBuffer: textBuffer ++ text, createdAt}),
         )
         let updatedMessages = task.messages->Dict.copy
-        updatedMessages->Dict.set(msgId, updatedMsg)
+        updatedMessages->Dict.set(id, updatedMsg)
         {...task, messages: updatedMessages}
-      | _ =>
-        let newMessage = Message.Assistant(
-          Streaming({
-            id,
-            textBuffer: text,
-            createdAt: Date.now(),
-          }),
+      | Some(Message.Completed(_)) => task
+      | None =>
+        let id = `msg_${taskId}_${Date.now()->Float.toString}`
+        Lens.insertTaskMessage(
+          task,
+          Message.Assistant(Streaming({id, textBuffer: text, createdAt: Date.now()})),
         )
-        let updatedMessages = task.messages->Dict.copy
-        updatedMessages->Dict.set(id, newMessage)
-        {...task, messages: updatedMessages}
       }
     })
     ->FrontmanReactStatestore.StateReducer.update
@@ -703,22 +710,22 @@ let next = (state, action) => {
     )
     ->FrontmanReactStatestore.StateReducer.update
 
-  | MessageCompleted({taskId, id}) =>
+  | MessageCompleted({taskId}) =>
     state
     ->Lens.updateTask(taskId, task => {
-      Lens.updateTaskMessage(task, id, msg =>
-        switch msg {
-        | Message.Assistant(Streaming({id: msgId, textBuffer, createdAt})) => {
-            let content = if String.length(textBuffer) > 0 {
-              [AssistantContentPart.Text({text: textBuffer})]
-            } else {
-              []
-            }
-            Message.Assistant(Completed({id: msgId, content, createdAt}))
-          }
-        | other => other
+      switch Lens.getStreamingMessage(task) {
+      | Some(Message.Streaming({id, textBuffer, createdAt})) =>
+        let content = if String.length(textBuffer) > 0 {
+          [AssistantContentPart.Text({text: textBuffer})]
+        } else {
+          []
         }
-      )
+        let completedMsg = Message.Assistant(Completed({id, content, createdAt}))
+        let updatedMessages = task.messages->Dict.copy
+        updatedMessages->Dict.set(id, completedMsg)
+        {...task, messages: updatedMessages}
+      | Some(Message.Completed(_)) | None => task
+      }
     })
     ->FrontmanReactStatestore.StateReducer.update
 

--- a/libs/client/test/Client__State__ConcurrentTasks.test.res
+++ b/libs/client/test/Client__State__ConcurrentTasks.test.res
@@ -24,7 +24,7 @@ describe("Concurrent Tasks Event Routing", () => {
     // Act: Receive StreamingStarted event for Task A (not current task)
     let (finalState, _) = StateReducer.next(
       stateWithBothTasks,
-      StreamingStarted({taskId: taskAId, id: "msg-1"}),
+      StreamingStarted({taskId: taskAId}),
     )
 
     // Assert: Message should be in Task A, not Task B
@@ -47,7 +47,7 @@ describe("Concurrent Tasks Event Routing", () => {
     // Add streaming message to Task A
     let (stateWithMessage, _) = StateReducer.next(
       stateWithBothTasks,
-      StreamingStarted({taskId: taskAId, id: "msg-1"}),
+      StreamingStarted({taskId: taskAId}),
     )
 
     // Current task is still B
@@ -56,16 +56,16 @@ describe("Concurrent Tasks Event Routing", () => {
     // Act: Receive text delta for Task A
     let (finalState, _) = StateReducer.next(
       stateWithMessage,
-      TextDeltaReceived({taskId: taskAId, id: "msg-1", text: "Hello from Task A"}),
+      TextDeltaReceived({taskId: taskAId, text: "Hello from Task A"}),
     )
 
     // Assert: Text should be in Task A's message, not Task B
     let taskA = finalState.tasks->Dict.get(taskAId)->Option.getOrThrow
     let taskB = finalState.tasks->Dict.get(taskBId)->Option.getOrThrow
 
-    let taskAMessage = taskA.messages->Dict.get("msg-1")->Option.getOrThrow
-    switch taskAMessage {
-    | Assistant(Streaming({textBuffer})) => t->expect(textBuffer)->Expect.toBe("Hello from Task A")
+    switch StateReducer.Lens.getStreamingMessage(taskA) {
+    | Some(StateReducer.Message.Streaming({textBuffer})) =>
+      t->expect(textBuffer)->Expect.toBe("Hello from Task A")
     | _ => t->expect(false)->Expect.toBe(true)
     }
 
@@ -114,26 +114,14 @@ describe("Concurrent Tasks Event Routing", () => {
     let taskCId = stateWithAllTasks.currentTaskId->Option.getOrThrow
 
     // Act: Start streaming in all three tasks
-    let (state1, _) = StateReducer.next(
-      stateWithAllTasks,
-      StreamingStarted({taskId: taskAId, id: "msg-a"}),
-    )
-    let (state2, _) = StateReducer.next(state1, StreamingStarted({taskId: taskBId, id: "msg-b"}))
-    let (state3, _) = StateReducer.next(state2, StreamingStarted({taskId: taskCId, id: "msg-c"}))
+    let (state1, _) = StateReducer.next(stateWithAllTasks, StreamingStarted({taskId: taskAId}))
+    let (state2, _) = StateReducer.next(state1, StreamingStarted({taskId: taskBId}))
+    let (state3, _) = StateReducer.next(state2, StreamingStarted({taskId: taskCId}))
 
     // Send text deltas to each task
-    let (state4, _) = StateReducer.next(
-      state3,
-      TextDeltaReceived({taskId: taskAId, id: "msg-a", text: "A"}),
-    )
-    let (state5, _) = StateReducer.next(
-      state4,
-      TextDeltaReceived({taskId: taskBId, id: "msg-b", text: "B"}),
-    )
-    let (finalState, _) = StateReducer.next(
-      state5,
-      TextDeltaReceived({taskId: taskCId, id: "msg-c", text: "C"}),
-    )
+    let (state4, _) = StateReducer.next(state3, TextDeltaReceived({taskId: taskAId, text: "A"}))
+    let (state5, _) = StateReducer.next(state4, TextDeltaReceived({taskId: taskBId, text: "B"}))
+    let (finalState, _) = StateReducer.next(state5, TextDeltaReceived({taskId: taskCId, text: "C"}))
 
     // Assert: Each task has its own message with correct content
     let taskA = finalState.tasks->Dict.get(taskAId)->Option.getOrThrow
@@ -144,16 +132,16 @@ describe("Concurrent Tasks Event Routing", () => {
     t->expect(taskB.messages->Dict.size)->Expect.toBe(1)
     t->expect(taskC.messages->Dict.size)->Expect.toBe(1)
 
-    let getStreamingText = (task: StateReducer.Task.t, msgId) => {
-      switch task.messages->Dict.get(msgId) {
-      | Some(Assistant(Streaming({textBuffer}))) => textBuffer
+    let getStreamingText = (task: StateReducer.Task.t) => {
+      switch StateReducer.Lens.getStreamingMessage(task) {
+      | Some(StateReducer.Message.Streaming({textBuffer})) => textBuffer
       | _ => ""
       }
     }
 
-    t->expect(getStreamingText(taskA, "msg-a"))->Expect.toBe("A")
-    t->expect(getStreamingText(taskB, "msg-b"))->Expect.toBe("B")
-    t->expect(getStreamingText(taskC, "msg-c"))->Expect.toBe("C")
+    t->expect(getStreamingText(taskA))->Expect.toBe("A")
+    t->expect(getStreamingText(taskB))->Expect.toBe("B")
+    t->expect(getStreamingText(taskC))->Expect.toBe("C")
   })
 
   test("MessageCompleted event routes to correct task", t => {
@@ -168,26 +156,34 @@ describe("Concurrent Tasks Event Routing", () => {
     // Start streaming in Task A
     let (stateWithStream, _) = StateReducer.next(
       stateWithBothTasks,
-      StreamingStarted({taskId: taskAId, id: "msg-1"}),
+      StreamingStarted({taskId: taskAId}),
     )
     let (stateWithText, _) = StateReducer.next(
       stateWithStream,
-      TextDeltaReceived({taskId: taskAId, id: "msg-1", text: "Complete message"}),
+      TextDeltaReceived({taskId: taskAId, text: "Complete message"}),
     )
 
     // Act: Complete the message in Task A
-    let (finalState, _) = StateReducer.next(
-      stateWithText,
-      MessageCompleted({taskId: taskAId, id: "msg-1"}),
-    )
+    let (finalState, _) = StateReducer.next(stateWithText, MessageCompleted({taskId: taskAId}))
 
     // Assert: Message in Task A should be completed
     let taskA = finalState.tasks->Dict.get(taskAId)->Option.getOrThrow
     let taskB = finalState.tasks->Dict.get(taskBId)->Option.getOrThrow
 
-    let message = taskA.messages->Dict.get("msg-1")->Option.getOrThrow
-    switch message {
-    | Assistant(Completed({content})) => {
+    // Find the completed message (there should be exactly one)
+    let completedMessages =
+      taskA.messages
+      ->Dict.valuesToArray
+      ->Array.filter(msg =>
+        switch msg {
+        | Assistant(Completed(_)) => true
+        | _ => false
+        }
+      )
+
+    t->expect(Array.length(completedMessages))->Expect.toBe(1)
+    switch completedMessages[0] {
+    | Some(Assistant(Completed({content}))) => {
         t->expect(Array.length(content))->Expect.toBe(1)
         switch content[0] {
         | Some(Text({text})) => t->expect(text)->Expect.toBe("Complete message")
@@ -248,13 +244,10 @@ describe("Concurrent Tasks Event Routing", () => {
     let taskAId = stateWithTaskA.currentTaskId->Option.getOrThrow
 
     // Start streaming in Task A
-    let (stateWithStream, _) = StateReducer.next(
-      stateWithTaskA,
-      StreamingStarted({taskId: taskAId, id: "msg-1"}),
-    )
+    let (stateWithStream, _) = StateReducer.next(stateWithTaskA, StreamingStarted({taskId: taskAId}))
     let (stateWithText1, _) = StateReducer.next(
       stateWithStream,
-      TextDeltaReceived({taskId: taskAId, id: "msg-1", text: "Part 1. "}),
+      TextDeltaReceived({taskId: taskAId, text: "Part 1. "}),
     )
 
     // Switch to Task B mid-stream
@@ -264,16 +257,16 @@ describe("Concurrent Tasks Event Routing", () => {
     // Continue receiving text for Task A
     let (finalState, _) = StateReducer.next(
       stateWithTaskB,
-      TextDeltaReceived({taskId: taskAId, id: "msg-1", text: "Part 2."}),
+      TextDeltaReceived({taskId: taskAId, text: "Part 2."}),
     )
 
     // Assert: All text should be in Task A, Task B should be empty
     let taskA = finalState.tasks->Dict.get(taskAId)->Option.getOrThrow
     let taskB = finalState.tasks->Dict.get(taskBId)->Option.getOrThrow
 
-    let message = taskA.messages->Dict.get("msg-1")->Option.getOrThrow
-    switch message {
-    | Assistant(Streaming({textBuffer})) => t->expect(textBuffer)->Expect.toBe("Part 1. Part 2.")
+    switch StateReducer.Lens.getStreamingMessage(taskA) {
+    | Some(StateReducer.Message.Streaming({textBuffer})) =>
+      t->expect(textBuffer)->Expect.toBe("Part 1. Part 2.")
     | _ => t->expect(false)->Expect.toBe(true)
     }
 

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -87,7 +87,7 @@ describe("Client State Reducer", () => {
     )
 
     let taskId = state.currentTaskId->Option.getOrThrow
-    let action = Reducer.TextDeltaReceived({taskId, id: "assistant-1", text: " world"})
+    let action = Reducer.TextDeltaReceived({taskId, text: " world"})
     let (nextState, _effects) = Reducer.next(state, action)
 
     let message = TestHelpers.getMessage(nextState, 0)->Option.getOrThrow
@@ -107,7 +107,7 @@ describe("Client State Reducer", () => {
     )
 
     let taskId = state.currentTaskId->Option.getOrThrow
-    let action = Reducer.MessageCompleted({taskId, id: "assistant-1"})
+    let action = Reducer.MessageCompleted({taskId: taskId})
     let (nextState, _effects) = Reducer.next(state, action)
 
     let message = TestHelpers.getMessage(nextState, 0)->Option.getOrThrow
@@ -142,16 +142,13 @@ describe("Client State Reducer", () => {
     let taskId = state.currentTaskId->Option.getOrThrow
 
     // Start assistant streaming
-    let (state, _) = Reducer.next(state, StreamingStarted({taskId, id: "assistant-1"}))
+    let (state, _) = Reducer.next(state, StreamingStarted({taskId: taskId}))
 
     // Add text delta
-    let (state, _) = Reducer.next(
-      state,
-      TextDeltaReceived({taskId, id: "assistant-1", text: "Hello"}),
-    )
+    let (state, _) = Reducer.next(state, TextDeltaReceived({taskId, text: "Hello"}))
 
     // Complete message
-    let (state, _) = Reducer.next(state, MessageCompleted({taskId, id: "assistant-1"}))
+    let (state, _) = Reducer.next(state, MessageCompleted({taskId: taskId}))
 
     let messages = TestHelpers.getMessages(state)
     t->expect(messages->Array.length)->Expect.toBe(2)
@@ -269,7 +266,7 @@ describe("Client State Reducer - MessageCompleted Content Conversion", () => {
     )
 
     let taskId = state.currentTaskId->Option.getOrThrow
-    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId, id: "msg-2"}))
+    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId: taskId}))
 
     let message = TestHelpers.getMessage(nextState, 0)->Option.getOrThrow
 
@@ -296,7 +293,7 @@ describe("Client State Reducer - MessageCompleted Content Conversion", () => {
     )
 
     let taskId = state.currentTaskId->Option.getOrThrow
-    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId, id: "msg-3"}))
+    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId: taskId}))
 
     let messages = TestHelpers.getMessages(nextState)
     switch messages->Array.get(0) {
@@ -327,11 +324,12 @@ describe("Client State Reducer - MessageCompleted Content Conversion", () => {
     )
 
     let taskId = state.currentTaskId->Option.getOrThrow
-    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId, id: "stable-id-123"}))
+    let (nextState, _) = Reducer.next(state, MessageCompleted({taskId: taskId}))
 
     let message = TestHelpers.getMessage(nextState, 0)->Option.getOrThrow
 
     switch message {
+    // The message ID should be preserved from the streaming message
     | Assistant(Completed({id, _})) => t->expect(id)->Expect.toBe("stable-id-123")
     | _ => JsExn.throw("Expected Assistant Completed message")
     }
@@ -354,24 +352,28 @@ describe("Client State Reducer - Streaming Flow", () => {
     // Get taskId after task creation
     let taskId = state.currentTaskId->Option.getOrThrow
 
-    // 1. Start streaming
-    let (state, _) = Reducer.next(state, StreamingStarted({taskId, id: "text-abc"}))
+    // 1. Start streaming (ID is now generated internally)
+    let (state, _) = Reducer.next(state, StreamingStarted({taskId: taskId}))
+
+    // Get the generated message ID
+    let task = state.tasks->Dict.get(taskId)->Option.getOrThrow
+    let generatedId = switch Reducer.Lens.getStreamingMessage(task) {
+    | Some(Reducer.Message.Streaming({id})) => id
+    | _ => JsExn.throw("Expected streaming message")
+    }
 
     // 2. Receive text deltas
-    let (state, _) = Reducer.next(state, TextDeltaReceived({taskId, id: "text-abc", text: "Hello"}))
-    let (state, _) = Reducer.next(
-      state,
-      TextDeltaReceived({taskId, id: "text-abc", text: " world"}),
-    )
+    let (state, _) = Reducer.next(state, TextDeltaReceived({taskId, text: "Hello"}))
+    let (state, _) = Reducer.next(state, TextDeltaReceived({taskId, text: " world"}))
 
     // 3. Complete message
-    let (state, _) = Reducer.next(state, MessageCompleted({taskId, id: "text-abc"}))
+    let (state, _) = Reducer.next(state, MessageCompleted({taskId: taskId}))
 
     // Verify: Message ID stayed stable throughout (check second message, first is user)
     let messages = TestHelpers.getMessages(state)
     switch messages->Array.get(1) {
     | Some(Assistant(Completed({id, content, _}))) => {
-        t->expect(id)->Expect.toBe("text-abc")
+        t->expect(id)->Expect.toBe(generatedId)
         switch content->Array.get(0) {
         | Some(AssistantContentPart.Text({text})) => t->expect(text)->Expect.toBe("Hello world")
         | _ => t->expect("Got text content")->Expect.toBe("Expected text content")


### PR DESCRIPTION
## Summary

- Remove vestigial `id` parameter from `StreamingStarted`, `TextDeltaReceived`, and `MessageCompleted` actions
- Add `Lens.getStreamingMessage` helper to find the streaming message in a task (with assertion for at-most-one)
- Reducer now generates unique IDs internally (`msg_${taskId}_${timestamp}`)

**Root cause**: The `id` parameter was from the old SSE architecture where the server sent message IDs. After migrating to ACP (which doesn't send message IDs for agent messages), the client generated static IDs (`msg_${taskId}`), causing consecutive messages to overwrite each other in the Dict.

## Test plan

- [x] All existing tests pass (56 tests)
- [x] Verified concurrent task tests still work
- [ ] Manual test: send multiple consecutive messages and verify both appear

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)