### PR TITLE
refactor: extract generic parseSchema helper to reduce boilerplate

### DIFF
--- a/libs/frontman-client/src/FrontmanClient__ACP__Client.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Client.res
@@ -4,6 +4,7 @@
 module Types = FrontmanClient__ACP__Types
 module JsonRpc = FrontmanClient__JsonRpc
 module Channel = FrontmanClient__Phoenix__Channel
+module Decoders = FrontmanClient__Decoders
 
 type connectionState =
   | Disconnected
@@ -97,42 +98,17 @@ let buildInitializeParams = (config: config): JSON.t => {
 }
 
 // Parse initialize result
-let parseInitializeResult = (json: JSON.t): result<Types.initializeResult, string> => {
-  try {
-    Ok(json->S.parseOrThrow(Types.initializeResultSchema))
-  } catch {
-  | S.Error(e) => Error(e.message)
-  }
-}
+let parseInitializeResult = json => json->Decoders.parseSchema(Types.initializeResultSchema)
 
 // Parse session/new result
-let parseSessionNewResult = (json: JSON.t): result<Types.sessionNewResult, string> => {
-  try {
-    Ok(json->S.parseOrThrow(Types.sessionNewResultSchema))
-  } catch {
-  | S.Error(e) => Error(e.message)
-  }
-}
+let parseSessionNewResult = json => json->Decoders.parseSchema(Types.sessionNewResultSchema)
 
 // Parse session/prompt result
-let parsePromptResult = (json: JSON.t): result<Types.promptResult, string> => {
-  try {
-    Ok(json->S.parseOrThrow(Types.promptResultSchema))
-  } catch {
-  | S.Error(e) => Error(e.message)
-  }
-}
+let parsePromptResult = json => json->Decoders.parseSchema(Types.promptResultSchema)
 
 // Parse session/update notification
-let parseSessionUpdateNotification = (
-  json: JSON.t,
-): result<Types.sessionUpdateNotification, string> => {
-  try {
-    Ok(json->S.parseOrThrow(Types.sessionUpdateNotificationSchema))
-  } catch {
-  | S.Error(e) => Error(e.message)
-  }
-}
+let parseSessionUpdateNotification = json =>
+  json->Decoders.parseSchema(Types.sessionUpdateNotificationSchema)
 
 // Check if initialized
 let isInitialized = (state: state): bool => {

--- a/libs/frontman-client/src/FrontmanClient__Decoders.res
+++ b/libs/frontman-client/src/FrontmanClient__Decoders.res
@@ -1,5 +1,14 @@
 // Simple JSON decoders
 
+// Generic schema parser - wraps S.parseOrThrow with Result error handling
+let parseSchema = (json: JSON.t, schema: S.t<'a>): result<'a, string> => {
+  try {
+    Ok(json->S.parseOrThrow(schema))
+  } catch {
+  | S.Error(e) => Error(e.message)
+  }
+}
+
 let getString = (dict, key) =>
   dict->Dict.get(key)->Option.flatMap(JSON.Decode.string)
 

--- a/libs/frontman-client/src/FrontmanClient__MCP.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP.res
@@ -5,6 +5,7 @@
 module Types = FrontmanClient__MCP__Types
 module Channel = FrontmanClient__Phoenix__Channel
 module JsonRpc = FrontmanClient__JsonRpc
+module Decoders = FrontmanClient__Decoders
 
 type messageDirection = Send | Receive
 
@@ -49,11 +50,7 @@ let hasIdField = (json: JSON.t): bool => {
 // Discriminates by presence of 'id' field
 let parse = (json: JSON.t): result<mcpMessage, string> => {
   let schema = if hasIdField(json) { requestSchema } else { notificationSchema }
-  try {
-    Ok(json->S.parseOrThrow(schema))
-  } catch {
-  | S.Error(e) => Error(e.message)
-  }
+  json->Decoders.parseSchema(schema)
 }
 
 // Send a JSON-RPC response

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -3,6 +3,7 @@
 module Types = FrontmanClient__Relay__Types
 module MCPTypes = FrontmanClient__MCP__Types
 module SSE = FrontmanClient__SSE
+module Decoders = FrontmanClient__Decoders
 
 type connectionState =
   | Disconnected
@@ -39,13 +40,12 @@ let connect = async (relay: t): result<unit, string> => {
     Error(msg)
   } else {
     let json = await response->WebAPI.Response.json
-    try {
-      let data = json->S.parseOrThrow(Types.toolsResponseSchema)
+    switch json->Decoders.parseSchema(Types.toolsResponseSchema) {
+    | Ok(data) =>
       relay.state = Connected({tools: data.tools, serverInfo: data.serverInfo})
       Ok()
-    } catch {
-    | S.Error(e) =>
-      let msg = `Invalid tools response: ${e.message}`
+    | Error(parseError) =>
+      let msg = `Invalid tools response: ${parseError}`
       relay.state = Error(msg)
       Error(msg)
     }
@@ -116,12 +116,9 @@ let executeTool = async (
       // Read SSE stream and return result
       switch await SSE.readStream(response, ~onProgress?) {
       | Ok(json) =>
-        try {
-          let result = json->S.parseOrThrow(MCPTypes.callToolResultSchema)
-          Ok(result)
-        } catch {
-        | S.Error(e) => Error(`Invalid result: ${e.message}`)
-        }
+        json
+        ->Decoders.parseSchema(MCPTypes.callToolResultSchema)
+        ->Result.mapError(msg => `Invalid result: ${msg}`)
       | Error(msg) => Error(msg)
       }
     }


### PR DESCRIPTION
## Summary

- Adds a generic `parseSchema` helper to `FrontmanClient__Decoders` that wraps `S.parseOrThrow` with Result error handling
- Refactors 4 files to use the new helper, eliminating ~28 lines of duplicated try-catch blocks
- All existing tests pass (42/42)

## Changes

| File | Before | After |
|------|--------|-------|
| `FrontmanClient__ACP__Client.res` | 4 separate parse functions (28 lines) | 4 one-liners (8 lines) |
| `FrontmanClient__MCP.res` | 6 lines | 2 lines |
| `FrontmanClient__Relay.res` | 12 lines (2 usages) | 8 lines |

## Test plan

- [x] ReScript build passes
- [x] All 42 existing tests pass
- [ ] Manual verification of schema parsing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)