### PR TITLE
fix: correct MCP tools architecture issues

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tools.ex
+++ b/apps/frontman_server/lib/frontman_server/tools.ex
@@ -54,9 +54,8 @@ defmodule FrontmanServer.Tools do
   @doc """
   Prepares all available tools for a task.
 
-  Aggregates backend tools and MCP tools, stores MCP tools on the task
-  for later retrieval by backend tools (e.g., Figma tools), and returns
-  all tools in LLM format.
+  Aggregates backend tools and MCP tools into LLM format.
+  MCP tools are passed through the agent execution chain via Backend.Context.
 
   ## Example
       mcp_tools |> Tools.prepare_for_task(task_id)

--- a/apps/frontman_server/lib/frontman_server/tools/replace_component.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/replace_component.ex
@@ -18,7 +18,6 @@ defmodule FrontmanServer.Tools.ReplaceComponent do
 
   alias FrontmanServer.Agents.SpecializedAgent
   alias FrontmanServer.Tools.Backend.Context
-  alias FrontmanServer.Tools.MCP
   alias Swarm.Message
 
   @impl true
@@ -67,12 +66,10 @@ defmodule FrontmanServer.Tools.ReplaceComponent do
   end
 
   @impl true
-  def execute(args, %Context{task: task, tool_executor: tool_executor, llm_opts: llm_opts}) do
+  def execute(args, %Context{mcp_tools: mcp_tools, tool_executor: tool_executor, llm_opts: llm_opts}) do
     component_name = Map.get(args, "componentName")
     source_file_path = Map.get(args, "sourceFilePath")
     target_file_path = Map.get(args, "targetFilePath")
-
-    mcp_tools = MCP.to_swarm_tools(task.mcp_tools)
 
     Logger.info("ReplaceComponent: Replacing #{target_file_path} with #{source_file_path}")
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -28,7 +28,7 @@ defmodule FrontmanServerWeb.TaskChannel do
         # 1. MCPInitializer performs a stateful handshake with the browser-side MCP client
         # 2. Each websocket connection needs its own MCP session
         # 3. Project rules loading depends on client-specific context
-        # Tools are persisted to task.mcp_tools for agent access, not for reuse on reconnect.
+        # Tools are stored in socket assigns and passed through Backend.Context for agent access.
         {:ok, initializer_pid} = MCPInitializer.start_link(self(), task_id, scope)
 
         socket =

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -573,11 +573,11 @@ defmodule FrontmanServerWeb.TaskChannelTest do
   end
 
   describe "MCP tools race condition" do
-    @tag :skip
-    test "task gets MCP tools even when prompt arrives before MCP init completes", %{scope: scope} do
-      # Verifies the fix: MCP tools are stored on task when MCP init completes,
-      # independent of prompt timing. ToolExecutor fetches fresh task, so backend
-      # tools will have access to tools.
+    test "queued prompt is processed with MCP tools after initialization completes", %{scope: scope} do
+      # Verifies the prompt queuing mechanism:
+      # 1. Prompt sent before MCP init is queued in socket assigns
+      # 2. MCP init completes, storing tools in socket assigns
+      # 3. Queued prompt is processed with the loaded MCP tools
 
       task_id = Ecto.UUID.generate()
       {:ok, ^task_id} = Tasks.create_task(scope, task_id, "test-framework")
@@ -609,10 +609,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       push(socket, "acp:message", prompt_request)
       :sys.get_state(socket.channel_pid)
-
-      # At this point, task has no MCP tools (prompt arrived before init)
-      {:ok, task_before} = Tasks.get_task(scope, task_id)
-      assert task_before.mcp_tools == []
 
       # NOW complete MCP init with tools
       init_result = %{
@@ -653,13 +649,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       assert_push "acp:message", %{"method" => "project_rules_initialized"}
 
-      # Force synchronization
-      :sys.get_state(socket.channel_pid)
+      # Verify MCP tools are now stored in socket assigns
+      channel_socket = :sys.get_state(socket.channel_pid)
+      assert length(channel_socket.assigns.mcp_tools) == 1
+      assert hd(channel_socket.assigns.mcp_tools).name == "get_figma_node"
 
-      # THE FIX: Task now has MCP tools even though prompt arrived first
-      {:ok, task_after} = Tasks.get_task(scope, task_id)
-      assert length(task_after.mcp_tools) == 1
-      assert hd(task_after.mcp_tools).name == "get_figma_node"
+      # After MCP init completes, the queued prompt is processed (task_channel.ex:471-479)
+      # This creates a UserMessage interaction broadcast via PubSub
+      assert_receive {:interaction, %Tasks.Interaction.UserMessage{}}
     end
   end
 


### PR DESCRIPTION
## Summary

- Fix `replace_component.ex` to extract `mcp_tools` from `Backend.Context` instead of accessing non-existent `task.mcp_tools` field
- Update misleading comment in `task_channel.ex` about tool storage location
- Fix stale docstring in `tools.ex` that incorrectly described MCP tool storage
- Fix and unskip test that had wrong assertions about `task.mcp_tools`

## Problem

The MCP tools system had several issues:

1. **Broken backend tool** - `replace_component.ex` tried to access `task.mcp_tools` which doesn't exist on the Task struct
2. **Misleading documentation** - Comments and docstrings incorrectly stated tools were "persisted to task.mcp_tools"
3. **Skipped test with wrong assertions** - Test expected `task.mcp_tools` field that doesn't exist

## Solution

MCP tools are **session-specific** (ephemeral, stored in socket assigns) and passed through the agent execution chain via `Backend.Context`. This PR:

1. Fixes `replace_component.ex` to correctly extract `mcp_tools` from context (matching the pattern used by other backend tools)
2. Updates documentation to accurately describe the actual architecture
3. Fixes the test to verify MCP tools are stored in socket assigns and that queued prompts are processed after MCP init

## Test plan

- [x] Run specific test: `mix test test/frontman_server_web/channels/task_channel_test.exs:576`
- [x] Run all channel tests: `mix test test/frontman_server_web/channels/`
- [x] Run all tests: `mix test` (374 tests pass)
- [x] Run dialyzer: `mix dialyzer` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)