### PR TITLE
refactor: co-locate apiBaseUrl inside connectionState

### DIFF
--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -152,7 +152,6 @@ let snapshotToState = (snapshot: Snapshot.t): StateTypes.state => {
     connectionState: Disconnected, // Cannot restore connection from snapshot
     sessionInitialized: snapshot.sessionInitialized,
     usageInfo: None,
-    apiBaseUrl: None,
     openrouterKeySettings: {
       source: Client__State__Types.None,
       saveStatus: Client__State__Types.Idle,

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -274,7 +274,6 @@ let defaultState: state = {
   connectionState: Disconnected,
   sessionInitialized: false,
   usageInfo: None,
-  apiBaseUrl: None,
   openrouterKeySettings: {
     source: Client__State__Types.None,
     saveStatus: Client__State__Types.Idle,
@@ -1365,10 +1364,10 @@ let next = (state, action) => {
   | Connect({sendPrompt, loadTask, deleteSession, apiBaseUrl}) =>
     // Just set up connection functions - task creation happens in AddUserMessage
     // when user sends their first message (lazy session creation)
+    // apiBaseUrl is now co-located in Connected to make illegal state unrepresentable
     {
       ...state,
-      connectionState: Connected({sendPrompt, loadTask, deleteSession}),
-      apiBaseUrl: Some(apiBaseUrl),
+      connectionState: Connected({sendPrompt, loadTask, deleteSession, apiBaseUrl}),
       sessionInitialized: true,
     }->FrontmanReactStatestore.StateReducer.update(
       ~sideEffects=[
@@ -1389,9 +1388,9 @@ let next = (state, action) => {
 
   | TurnCompleted({taskId}) =>
     // Mark agent turn as complete and fetch updated usage
-    let sideEffects = switch state.apiBaseUrl {
-    | Some(apiBaseUrl) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
-    | None => []
+    let sideEffects = switch state.connectionState {
+    | Connected({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
+    | Disconnected => []
     }
     state
     ->Lens.updateTaskLoadedData(taskId, data => {...data, isAgentRunning: false})
@@ -1409,12 +1408,12 @@ let next = (state, action) => {
 
   // API key settings actions
   | FetchApiKeySettings =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchApiKeySettingsEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | ApiKeySettingsReceived({source}) =>
@@ -1427,12 +1426,12 @@ let next = (state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | SaveOpenRouterKey({key}) =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[SaveOpenRouterKeyEffect({apiBaseUrl, key})],
       )
-    | None =>
+    | Disconnected =>
       {
         ...state,
         openrouterKeySettings: {
@@ -1453,9 +1452,9 @@ let next = (state, action) => {
 
   | OpenRouterKeySaved =>
     // After saving the API key, refresh usage info so the chatbox reflects the new state
-    let effects = switch state.apiBaseUrl {
-    | Some(apiBaseUrl) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
-    | None => []
+    let effects = switch state.connectionState {
+    | Connected({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
+    | Disconnected => []
     }
     {
       ...state,
@@ -1485,12 +1484,12 @@ let next = (state, action) => {
 
   // Model selection actions
   | FetchModelsConfig =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchModelsConfigEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | ModelsConfigReceived({config}) =>
@@ -1517,15 +1516,15 @@ let next = (state, action) => {
 
   // Anthropic OAuth actions
   | FetchAnthropicOAuthStatus =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       {
         ...state,
         anthropicOAuthStatus: Client__State__Types.FetchingStatus,
       }->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchAnthropicOAuthStatusEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthStatusReceived({connected, expiresAt}) =>
@@ -1543,12 +1542,12 @@ let next = (state, action) => {
     {...state, anthropicOAuthStatus: status}->FrontmanReactStatestore.StateReducer.update
 
   | InitiateAnthropicOAuth =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[GetAnthropicOAuthUrlEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthUrlReceived({authorizeUrl, verifier}) =>
@@ -1558,15 +1557,15 @@ let next = (state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | ExchangeAnthropicOAuthCode({code, verifier}) =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       {
         ...state,
         anthropicOAuthStatus: Client__State__Types.Exchanging,
       }->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[ExchangeAnthropicOAuthCodeEffect({apiBaseUrl, code, verifier})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthConnected({expiresAt}) =>
@@ -1583,12 +1582,12 @@ let next = (state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | DisconnectAnthropicOAuth =>
-    switch state.apiBaseUrl {
-    | Some(apiBaseUrl) =>
+    switch state.connectionState {
+    | Connected({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[DisconnectAnthropicOAuthEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | None => state->FrontmanReactStatestore.StateReducer.update
+    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthDisconnected =>

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -512,9 +512,15 @@ type deleteSessionFn = (string, ~onComplete: result<unit, string> => unit) => un
 // Connection state for the Frontman ACP session
 // Note: sessionId is NOT stored here - it's managed by ConnectionReducer (ACP layer)
 // Tasks store their own ID which equals the ACP session ID
+// apiBaseUrl is co-located with Connected to make illegal state (Connected + no apiBaseUrl) unrepresentable
 type connectionState =
   | Disconnected
-  | Connected({sendPrompt: sendPromptFn, loadTask: loadTaskFn, deleteSession: deleteSessionFn})
+  | Connected({
+      sendPrompt: sendPromptFn,
+      loadTask: loadTaskFn,
+      deleteSession: deleteSessionFn,
+      apiBaseUrl: string,
+    })
 
 // Usage info from API
 @schema
@@ -599,7 +605,6 @@ type state = {
   connectionState: connectionState,
   sessionInitialized: bool,
   usageInfo: option<usageInfo>,
-  apiBaseUrl: option<string>,
   openrouterKeySettings: apiKeySettings,
   anthropicOAuthStatus: anthropicOAuthStatus,
   modelsConfig: option<modelsConfig>,

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -41,7 +41,6 @@ module TestHelpers = {
         connectionState: Disconnected,
         sessionInitialized: false,
         usageInfo: None,
-        apiBaseUrl: None,
         openrouterKeySettings: {
           source: Client__State__Types.None,
           saveStatus: Client__State__Types.Idle,
@@ -771,7 +770,6 @@ describe("Client State Reducer - Task Management Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,
@@ -826,7 +824,6 @@ describe("Client State Reducer - Task Management Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,
@@ -859,7 +856,6 @@ describe("Client State Reducer - Task Management Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,
@@ -888,7 +884,6 @@ describe("Client State Reducer - Task Management Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,
@@ -1009,7 +1004,6 @@ describe("Client State Reducer - Session Loading Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,
@@ -1092,7 +1086,6 @@ describe("Client State Reducer - Session Loading Actions", () => {
       connectionState: Disconnected,
       sessionInitialized: false,
       usageInfo: None,
-      apiBaseUrl: None,
       openrouterKeySettings: {
         source: Client__State__Types.None,
         saveStatus: Client__State__Types.Idle,


### PR DESCRIPTION
## Summary

- Moves `apiBaseUrl` from a separate `option<string>` field in root state into the `Connected` variant of `connectionState`
- Makes illegal state (Connected + no apiBaseUrl) unrepresentable at the type level
- Updates all handlers to pattern match on `connectionState` instead of checking `state.apiBaseUrl` separately

## Changes

**Type changes:**
```rescript
// Before
type connectionState =
  | Disconnected
  | Connected({sendPrompt, loadTask, deleteSession})

type state = {
  connectionState: connectionState,
  apiBaseUrl: option<string>,  // Implicit invariant: should be Some when Connected
  ...
}

// After
type connectionState =
  | Disconnected
  | Connected({sendPrompt, loadTask, deleteSession, apiBaseUrl: string})

type state = {
  connectionState: connectionState,
  // apiBaseUrl removed - now co-located in Connected
  ...
}
```

**Handler pattern:**
```rescript
// Before
switch state.apiBaseUrl {
| Some(apiBaseUrl) => [FetchUsageInfo({apiBaseUrl})]
| None => []
}

// After - clearer intent
switch state.connectionState {
| Connected({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl})]
| Disconnected => []
}
```

## Test plan

- [x] All 66 tests pass
- [x] Build compiles without errors
- [ ] Manual testing of connection flow

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
