### PR TITLE
fix: replace native select with Radix Select for Linux compatibility

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -24,34 +24,36 @@ echo "==> Found workspace at: $WORKSPACE_DIR (worktree: $WORKTREE_NAME)"
 cd "$WORKSPACE_DIR"
 
 # Generate worktree hash for URL scheme
+# URL format: {hash}.{service}.frontman.local (required for WorkOS OAuth)
 WT_HASH=$(echo -n "$WORKTREE_NAME" | md5sum | cut -c1-4)
-WT_ID="wt-$WT_HASH"
-echo "==> Worktree ID: $WT_ID"
+echo "==> Worktree ID: $WT_HASH"
 
 # Create environment file with worktree-specific URLs
 cat > "$WORKSPACE_DIR/.env.devpod" << EOF
 # Auto-generated DevPod environment for worktree: $WORKTREE_NAME
-# Worktree ID: $WT_ID
-# Access via SSH tunnel: ./scripts/tunnel.sh
+# Worktree Hash: $WT_HASH
+# URL Format: {hash}.{service}.frontman.local (required for WorkOS OAuth)
+# Access via SSH tunnel: make tunnel
 
 # Worktree identification
 WORKTREE_NAME=$WORKTREE_NAME
-WORKTREE_ID=$WT_ID
+WORKTREE_ID=$WT_HASH
 
 # External URLs (via Caddy reverse proxy)
-FRONTMAN_HOST=$WT_ID-api.local:8443
-VITE_DEV_URL=https://$WT_ID-vite.local:8443
-VITE_HMR_HOST=$WT_ID-vite.local
+# Format: {hash}.{service}.frontman.local:8443
+FRONTMAN_HOST=$WT_HASH.api.frontman.local:8443
+VITE_DEV_URL=https://$WT_HASH.vite.frontman.local:8443
+VITE_HMR_HOST=$WT_HASH.vite.frontman.local
 VITE_HMR_PORT=8443
 VITE_HMR_PROTOCOL=wss
-NEXTJS_URL=https://$WT_ID-nextjs.local:8443
+NEXTJS_URL=https://$WT_HASH.nextjs.frontman.local:8443
 
 # Phoenix configuration
-PHX_HOST=$WT_ID-api.local
+PHX_HOST=$WT_HASH.api.frontman.local
 PHX_PORT=4000
 
 # Client URL for Next.js middleware
-FRONTMAN_CLIENT_URL=https://$WT_ID-vite.local:8443/src/Main.res.mjs
+FRONTMAN_CLIENT_URL=https://$WT_HASH.vite.frontman.local:8443/src/Main.res.mjs
 EOF
 
 echo "==> Created .env.devpod with worktree-specific URLs"
@@ -73,25 +75,63 @@ which elixir && elixir --version
 echo "==> Installing project dependencies..."
 yarn install
 
+echo "==> Building ReScript..."
+yarn rescript build
+
+echo "==> Setting up Phoenix database..."
+# Get Docker bridge gateway IP for PostgreSQL connection
+DOCKER_GATEWAY=$(ip route | grep default | awk '{print $3}' 2>/dev/null || echo "172.17.0.1")
+
+# Update Phoenix dev.env with database host
+cat >> "$WORKSPACE_DIR/apps/frontman_server/envs/.dev.env" << EOF
+
+# DevPod: Database connection to host PostgreSQL
+DB_HOST=$DOCKER_GATEWAY
+EOF
+
+# Update dev.exs to use the gateway IP (compile-time config)
+sed -i "s/hostname: \"localhost\"/hostname: \"$DOCKER_GATEWAY\"/" "$WORKSPACE_DIR/apps/frontman_server/config/dev.exs"
+
+# Install Elixir dependencies and run migrations
+cd "$WORKSPACE_DIR/apps/frontman_server"
+mix local.hex --force
+mix local.rebar --force
+mix deps.get
+mix ecto.create || true  # May already exist
+mix ecto.migrate
+cd "$WORKSPACE_DIR"
+
+echo "==> Setting up Next.js test site..."
+cd "$WORKSPACE_DIR/test/sites/blog-starter"
+# Disable Sentry instrumentation (causes issues in DevPod)
+if [ -f "instrumentation.ts" ]; then
+    mv instrumentation.ts instrumentation.ts.bak
+fi
+rm -rf .next
+cd "$WORKSPACE_DIR"
+
 echo ""
 echo "=========================================="
 echo "==> Setup complete!"
 echo "=========================================="
 echo ""
-echo "Worktree: $WORKTREE_NAME ($WT_ID)"
+echo "Worktree: $WORKTREE_NAME ($WT_HASH)"
 echo ""
 echo "URLs (via tunnel):"
-echo "  Next.js:   https://$WT_ID-nextjs.local:8443"
-echo "  Vite:      https://$WT_ID-vite.local:8443"
-echo "  Phoenix:   https://$WT_ID-api.local:8443"
-echo "  Storybook: https://$WT_ID-storybook.local:8443"
+echo "  Next.js:   https://$WT_HASH.nextjs.frontman.local:8443/__frontman"
+echo "  Vite:      https://$WT_HASH.vite.frontman.local:8443"
+echo "  Phoenix:   https://$WT_HASH.api.frontman.local:8443"
+echo "  Storybook: https://$WT_HASH.storybook.frontman.local:8443"
 echo ""
 echo "Add to /etc/hosts on your Mac:"
-echo "127.0.0.1 $WT_ID-nextjs.local $WT_ID-vite.local $WT_ID-api.local $WT_ID-storybook.local $WT_ID-dogfood.local"
+echo "127.0.0.1 $WT_HASH.nextjs.frontman.local $WT_HASH.vite.frontman.local $WT_HASH.api.frontman.local $WT_HASH.storybook.frontman.local $WT_HASH.dogfood.frontman.local"
 echo ""
 echo "Commands:"
 echo "  make dev-server  - Start Phoenix server"
 echo "  make dev-client  - Start Vite client"
 echo "  make dev-nextjs  - Start Next.js test site"
 echo ""
-echo "Database: postgres://postgres:postgres@host.docker.internal:5432/frontman_server_dev"
+echo "Database: postgres://postgres:postgres@$DOCKER_GATEWAY:5432/frontman_server_dev"
+echo ""
+echo "Note: Caddy config must be added on the server for this worktree."
+echo "Run: make worktree-register BRANCH=$WORKTREE_NAME CONTAINER=<container-name>"

--- a/Makefile
+++ b/Makefile
@@ -192,18 +192,17 @@ worktree-urls: ## Show URLs for a worktree (usage: make worktree-urls BRANCH=fea
 		exit 1; \
 	fi
 	@HASH=$$(printf '%s' "$(BRANCH)" | md5 | cut -c1-4); \
-	WT_ID="wt-$$HASH"; \
 	echo ""; \
-	echo "Worktree: $(BRANCH) ($$WT_ID)"; \
+	echo "Worktree: $(BRANCH) ($$HASH)"; \
 	echo ""; \
 	echo "URLs (via tunnel):"; \
-	echo "  Next.js:   https://$$WT_ID-nextjs.local:8443"; \
-	echo "  Vite:      https://$$WT_ID-vite.local:8443"; \
-	echo "  Phoenix:   https://$$WT_ID-api.local:8443"; \
-	echo "  Storybook: https://$$WT_ID-storybook.local:8443"; \
+	echo "  Next.js:   https://$$HASH.nextjs.frontman.local:8443/__frontman"; \
+	echo "  Vite:      https://$$HASH.vite.frontman.local:8443"; \
+	echo "  Phoenix:   https://$$HASH.api.frontman.local:8443"; \
+	echo "  Storybook: https://$$HASH.storybook.frontman.local:8443"; \
 	echo ""; \
 	echo "Add to /etc/hosts:"; \
-	echo "127.0.0.1 $$WT_ID-nextjs.local $$WT_ID-vite.local $$WT_ID-api.local $$WT_ID-storybook.local $$WT_ID-dogfood.local"
+	echo "127.0.0.1 $$HASH.nextjs.frontman.local $$HASH.vite.frontman.local $$HASH.api.frontman.local $$HASH.storybook.frontman.local $$HASH.dogfood.frontman.local"
 
 worktree-hosts: ## Generate /etc/hosts entries for all worktrees
 	@echo "# Frontman DevPod worktrees"
@@ -212,7 +211,7 @@ worktree-hosts: ## Generate /etc/hosts entries for all worktrees
 			if [ -d "$$wt" ]; then \
 				name=$$(basename "$$wt"); \
 				hash=$$(printf '%s' "$$name" | md5 | cut -c1-4); \
-				echo "127.0.0.1 wt-$$hash-nextjs.local wt-$$hash-vite.local wt-$$hash-api.local wt-$$hash-storybook.local wt-$$hash-dogfood.local # $$name"; \
+				echo "127.0.0.1 $$hash.nextjs.frontman.local $$hash.vite.frontman.local $$hash.api.frontman.local $$hash.storybook.frontman.local $$hash.dogfood.frontman.local # $$name"; \
 			fi \
 		done; \
 	else \

--- a/apps/frontman_server/config/dev.exs
+++ b/apps/frontman_server/config/dev.exs
@@ -6,11 +6,12 @@ config :frontman_server, env: :dev
 config :req_llm, receive_timeout: 600_000
 
 # Configure your database
-# DB_HOST can be set to "host.docker.internal" for DevPod/container development
+# For DevPod: post-create.sh updates hostname to the Docker gateway IP
+# For local dev: uses localhost
 config :frontman_server, FrontmanServer.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: System.get_env("DB_HOST") || "localhost",
+  hostname: "localhost",
   database: "frontman_server_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -88,6 +88,16 @@ config :sentry,
   root_source_code_paths: [File.cwd!()],
   tags: %{service: "frontman-server"}
 
+# Dev/Test: Allow DB_HOST override for container development (e.g., DevPod)
+# The docker bridge gateway IP (172.17.0.1) is used to connect from container to host PostgreSQL
+if config_env() in [:dev, :test] do
+  db_host = env!("DB_HOST", :string, "localhost")
+
+  if db_host != "localhost" do
+    config :frontman_server, FrontmanServer.Repo, hostname: db_host
+  end
+end
+
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||

--- a/docs/remote-development.md
+++ b/docs/remote-development.md
@@ -29,26 +29,32 @@ This guide explains how to use DevPod to run Frontman development environments o
           ↓
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Your Local Machine                                                     │
-│  - /etc/hosts: wt-ea0c-nextjs.local → 127.0.0.1                         │
-│  - Browser: https://wt-ea0c-nextjs.local:8443                           │
+│  - /etc/hosts: ea0c.nextjs.frontman.local → 127.0.0.1                   │
+│  - Browser: https://ea0c.nextjs.frontman.local:8443/__frontman          │
 │  - All services accessible via subdomains                               │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## URL Scheme
 
-Each worktree gets a unique 4-character hash ID based on its name:
+Each worktree gets a unique 4-character hash ID based on its name. URLs follow this format for WorkOS OAuth compatibility:
+
+```
+https://{hash}.{service}.frontman.local:8443
+```
 
 | Worktree | Hash | Next.js URL | Vite URL | Phoenix URL |
 |----------|------|-------------|----------|-------------|
-| issue-164 | wt-ea0c | https://wt-ea0c-nextjs.local:8443 | https://wt-ea0c-vite.local:8443 | https://wt-ea0c-api.local:8443 |
-| issue-189 | wt-b09b | https://wt-b09b-nextjs.local:8443 | https://wt-b09b-vite.local:8443 | https://wt-b09b-api.local:8443 |
+| issue-164 | ea0c | https://ea0c.nextjs.frontman.local:8443 | https://ea0c.vite.frontman.local:8443 | https://ea0c.api.frontman.local:8443 |
+| issue-189 | b09b | https://b09b.nextjs.frontman.local:8443 | https://b09b.vite.frontman.local:8443 | https://b09b.api.frontman.local:8443 |
 
 Services per worktree:
-- `wt-{hash}-nextjs.local` - Next.js dev server (port 3000)
-- `wt-{hash}-vite.local` - Vite client dev server (port 5173)
-- `wt-{hash}-api.local` - Phoenix server (port 4000)
-- `wt-{hash}-storybook.local` - Storybook (port 6006)
+- `{hash}.nextjs.frontman.local` - Next.js dev server (port 3000) - access at `/__frontman`
+- `{hash}.vite.frontman.local` - Vite client dev server (port 5173)
+- `{hash}.api.frontman.local` - Phoenix server (port 4000)
+- `{hash}.storybook.frontman.local` - Storybook (port 6006)
+
+**Important:** The URL format `{hash}.{service}.frontman.local` is required for WorkOS OAuth redirects to work correctly. WorkOS needs consistent redirect URIs, and this subdomain pattern allows multiple development environments while maintaining OAuth compatibility.
 
 ## Prerequisites
 
@@ -161,10 +167,10 @@ make tunnel
 
 Then access services via their subdomains (get URLs with `make worktree-urls BRANCH=your-branch`):
 
-- `https://wt-xxxx-nextjs.local:8443` - Next.js
-- `https://wt-xxxx-vite.local:8443` - Vite client
-- `https://wt-xxxx-api.local:8443` - Phoenix server
-- `https://wt-xxxx-storybook.local:8443` - Storybook
+- `https://xxxx.nextjs.frontman.local:8443/__frontman` - Next.js (Frontman UI)
+- `https://xxxx.vite.frontman.local:8443` - Vite client
+- `https://xxxx.api.frontman.local:8443` - Phoenix server
+- `https://xxxx.storybook.frontman.local:8443` - Storybook
 
 The services are routed through Caddy reverse proxy on the server, which handles SSL termination with locally-trusted certificates.
 
@@ -298,12 +304,12 @@ The post-create script generates `.env.devpod` with worktree-specific URLs:
 ```bash
 # Example for worktree "issue-164" (hash: ea0c)
 WORKTREE_NAME=issue-164
-WORKTREE_ID=wt-ea0c
-FRONTMAN_HOST=wt-ea0c-api.local:8443
-VITE_HMR_HOST=wt-ea0c-vite.local
+WORKTREE_ID=ea0c
+FRONTMAN_HOST=ea0c.api.frontman.local:8443
+VITE_HMR_HOST=ea0c.vite.frontman.local
 VITE_HMR_PORT=8443
 VITE_HMR_PROTOCOL=wss
-PHX_HOST=wt-ea0c-api.local
+PHX_HOST=ea0c.api.frontman.local
 DB_HOST=host.docker.internal
 ```
 

--- a/libs/client/src/bindings/Bindings__RadixUI__Select.res
+++ b/libs/client/src/bindings/Bindings__RadixUI__Select.res
@@ -1,0 +1,189 @@
+// Radix UI Select bindings
+// Usage:
+// <RadixUI__Select.Root value={selected} onValueChange={v => setSelected(_ => v)}>
+//   <RadixUI__Select.Trigger className="trigger-class">
+//     <RadixUI__Select.Value placeholder="Select..." />
+//     <RadixUI__Select.Icon><ChevronDownIcon /></RadixUI__Select.Icon>
+//   </RadixUI__Select.Trigger>
+//   <RadixUI__Select.Portal>
+//     <RadixUI__Select.Content className="content-class">
+//       <RadixUI__Select.Viewport>
+//         <RadixUI__Select.Group>
+//           <RadixUI__Select.Label>{React.string("Group Label")}</RadixUI__Select.Label>
+//           <RadixUI__Select.Item value="item1">
+//             <RadixUI__Select.ItemText>{React.string("Item 1")}</RadixUI__Select.ItemText>
+//           </RadixUI__Select.Item>
+//         </RadixUI__Select.Group>
+//       </RadixUI__Select.Viewport>
+//     </RadixUI__Select.Content>
+//   </RadixUI__Select.Portal>
+// </RadixUI__Select.Root>
+
+type dir = [#ltr | #rtl]
+type position = [#"item-aligned" | #popper]
+type side = [#top | #right | #bottom | #left]
+type align = [#start | #center | #end_]
+type sticky = [#partial | #always]
+
+module Root = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~defaultValue: string=?,
+    ~value: string=?,
+    ~onValueChange: string => unit=?,
+    ~defaultOpen: bool=?,
+    ~open_: bool=?,
+    ~onOpenChange: bool => unit=?,
+    ~dir: dir=?,
+    ~name: string=?,
+    ~disabled: bool=?,
+    ~required: bool=?,
+    ~children: React.element=?,
+  ) => React.element = "Root"
+}
+
+module Trigger = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Trigger"
+}
+
+module Value = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~placeholder: React.element=?,
+    ~className: string=?,
+    ~style: {..}=?,
+  ) => React.element = "Value"
+}
+
+module Icon = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Icon"
+}
+
+module Portal = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~container: Dom.element=?,
+    ~children: React.element=?,
+  ) => React.element = "Portal"
+}
+
+module Content = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~position: position=?,
+    ~side: side=?,
+    ~sideOffset: int=?,
+    ~align: align=?,
+    ~alignOffset: int=?,
+    ~avoidCollisions: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Content"
+}
+
+module Viewport = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Viewport"
+}
+
+module Group = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Group"
+}
+
+module Label = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Label"
+}
+
+module Item = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~value: string,
+    ~disabled: bool=?,
+    ~textValue: string=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "Item"
+}
+
+module ItemText = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "ItemText"
+}
+
+module ItemIndicator = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "ItemIndicator"
+}
+
+module ScrollUpButton = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "ScrollUpButton"
+}
+
+module ScrollDownButton = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+    ~children: React.element=?,
+  ) => React.element = "ScrollDownButton"
+}
+
+module Separator = {
+  @module("@radix-ui/react-select") @react.component
+  external make: (
+    ~asChild: bool=?,
+    ~className: string=?,
+    ~style: {..}=?,
+  ) => React.element = "Separator"
+}

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -66,51 +66,110 @@ module AttachmentChip = {
 }
 
 // Model selector dropdown - supports grouped providers
+// Uses Radix UI Select for consistent dark theme styling across all platforms (including Linux)
 module ModelSelector = {
+  module Select = Bindings__RadixUI__Select
+
+  // Get the display name for the currently selected model
+  let getSelectedModelDisplay = (
+    providers: array<StateTypes.providerConfig>,
+    selectedValue: string,
+  ): option<string> => {
+    // selectedValue is "provider:modelValue"
+    switch selectedValue->String.split(":")->Array.get(0) {
+    | Some(providerId) =>
+      let modelValue =
+        selectedValue->String.slice(~start=String.length(providerId) + 1, ~end=String.length(selectedValue))
+      providers
+      ->Array.findMap(provider => {
+        if provider.id == providerId {
+          provider.models->Array.findMap(model => {
+            if model.value == modelValue {
+              Some(model.displayName)
+            } else {
+              None
+            }
+          })
+        } else {
+          None
+        }
+      })
+    | None => None
+    }
+  }
+
   @react.component
   let make = (
     ~providers: array<StateTypes.providerConfig>,
     ~selectedValue: string,
     ~onModelChange: (~provider: string, ~value: string) => unit,
   ) => {
-    <div className="relative">
-      <select
-        value={selectedValue}
-        onChange={e => {
-          let target = ReactEvent.Form.target(e)
-          let value: string = target["value"]
-          // Parse the combined value "provider:model_value"
-          switch value->String.split(":")->Array.get(0) {
-          | Some(provider) =>
-            // Value is everything after "provider:"
-            let modelValue = value->String.slice(~start=String.length(provider) + 1, ~end=String.length(value))
-            onModelChange(~provider, ~value=modelValue)
-          | None => ()
-          }
-        }}
-        className="appearance-none h-7 pl-2 pr-6 text-xs
+    let selectedDisplay = getSelectedModelDisplay(providers, selectedValue)
+
+    <Select.Root
+      value={selectedValue}
+      onValueChange={value => {
+        // Parse the combined value "provider:model_value"
+        switch value->String.split(":")->Array.get(0) {
+        | Some(provider) =>
+          // Value is everything after "provider:"
+          let modelValue =
+            value->String.slice(~start=String.length(provider) + 1, ~end=String.length(value))
+          onModelChange(~provider, ~value=modelValue)
+        | None => ()
+        }
+      }}>
+      <Select.Trigger
+        className="inline-flex items-center justify-between gap-1 h-7 pl-2 pr-1 text-xs
                    bg-transparent text-zinc-400 
                    border-none rounded cursor-pointer
                    hover:text-zinc-200 hover:bg-zinc-700/30
-                   focus:outline-none focus:ring-0"
-      >
-        {providers->Array.map(provider => {
-          <optgroup key={provider.id} label={provider.name}>
-            {provider.models->Array.map(model => {
-              // Combine provider:value for unique identification
-              let combinedValue = `${provider.id}:${model.value}`
-              <option key={combinedValue} value={combinedValue}>
-                {React.string(model.displayName)}
-              </option>
-            })->React.array}
-          </optgroup>
-        })->React.array}
-      </select>
-      <Icons.ChevronDownIcon 
-        size=12 
-        className="absolute right-1 top-1/2 -translate-y-1/2 pointer-events-none text-zinc-400"
-      />
-    </div>
+                   focus:outline-none focus:ring-0
+                   data-[placeholder]:text-zinc-500">
+        <span className="truncate max-w-[140px]">
+          {React.string(selectedDisplay->Option.getOr("Select model..."))}
+        </span>
+        <Select.Icon className="text-zinc-400">
+          <Icons.ChevronDownIcon size=12 />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          position=#popper
+          sideOffset=4
+          className="z-50 min-w-[180px] max-h-[300px] overflow-hidden
+                     bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl
+                     animate-in fade-in-0 zoom-in-95">
+          <Select.Viewport className="p-1">
+            {providers
+            ->Array.map(provider => {
+              <Select.Group key={provider.id}>
+                <Select.Label
+                  className="px-2 py-1.5 text-xs font-medium text-zinc-400">
+                  {React.string(provider.name)}
+                </Select.Label>
+                {provider.models
+                ->Array.map(model => {
+                  // Combine provider:value for unique identification
+                  let combinedValue = `${provider.id}:${model.value}`
+                  <Select.Item
+                    key={combinedValue}
+                    value={combinedValue}
+                    className="relative flex items-center px-2 py-1.5 text-xs text-zinc-200 rounded
+                               cursor-pointer select-none outline-none
+                               data-[highlighted]:bg-zinc-700 data-[highlighted]:text-white
+                               data-[disabled]:opacity-50 data-[disabled]:pointer-events-none">
+                    <Select.ItemText> {React.string(model.displayName)} </Select.ItemText>
+                  </Select.Item>
+                })
+                ->React.array}
+              </Select.Group>
+            })
+            ->React.array}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes the model selector dropdown showing a light gray/white background on Linux instead of the dark theme.

## Problem
On Linux, browsers delegate native `<select>`/`<option>` dropdown rendering to the GTK system theme, which ignores CSS styling entirely.

## Solution
Replace the native `<select>` with **Radix UI Select**, which renders the dropdown as regular DOM elements via React Portal, giving full CSS control across all platforms.

## Changes
- Add `Bindings__RadixUI__Select.res` - ReScript bindings for `@radix-ui/react-select`
- Update `Client__PromptInput.res` - Replace native select in ModelSelector with Radix Select

## DevPod Improvements
- Update URL scheme to `{hash}.{service}.frontman.local` format (WorkOS OAuth compatibility)
- Automate Phoenix DB setup in `post-create.sh`
- Automate Next.js setup (disable Sentry instrumentation that causes issues)

## Testing
Tested on DevPod at https://b09b.nextjs.frontman.local/__frontman - dropdown now displays with correct dark theme styling.

Closes #189
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/203">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
