### PR TITLE
refactor(client): rename connectionState to acpSession in StateReducer

### DIFF
--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -126,14 +126,14 @@ let make = (~apiBaseUrl: string) => {
   // Use Frontman context for ACP connection
   let {connectionState, sendPrompt, loadTask, deleteSession, _} = Client__FrontmanProvider.useFrontman()
 
-  // Set up connection functions when ACP+Relay are ready
+  // Set up ACP session callbacks when ACP+Relay are ready
   // Session creation is deferred until user sends first message (lazy session creation)
   React.useEffect(() => {
     switch connectionState {
     | Connected | SessionActive(_) =>
       Client__Debug.init()
-      Client__State.Actions.connect(~sendPrompt, ~loadTask, ~deleteSession, ~apiBaseUrl)
-    | Disconnected | Error(_) => Client__State.Actions.disconnect()
+      Client__State.Actions.setAcpSession(~sendPrompt, ~loadTask, ~deleteSession, ~apiBaseUrl)
+    | Disconnected | Error(_) => Client__State.Actions.clearAcpSession()
     | _ => ()
     }
     None

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -106,7 +106,7 @@ let make = () => {
   let messages = Client__State.useSelector(Client__State.Selectors.messages)
   let isStreaming = Client__State.useSelector(Client__State.Selectors.isStreaming)
   let isAgentRunning = Client__State.useSelector(Client__State.Selectors.isAgentRunning)
-  let isConnected = Client__State.useSelector(Client__State.Selectors.isConnected)
+  let hasActiveACPSession = Client__State.useSelector(Client__State.Selectors.hasActiveACPSession)
   let sessionInitialized = Client__State.useSelector(Client__State.Selectors.sessionInitialized)
   let planEntries = Client__State.useSelector(Client__State.Selectors.currentPlanEntries)
   let usageInfo = Client__State.useSelector(Client__State.Selectors.usageInfo)
@@ -126,7 +126,7 @@ let make = () => {
   let (thinkingState, thinkingMessageId) = UseThinkingState.useWithMessageId(
     ~messages,
     ~isStreaming,
-    ~isConnected,
+    ~hasActiveACPSession,
     ~sessionInitialized,
   )
 
@@ -340,7 +340,7 @@ let make = () => {
       onModelChange={(~provider, ~value) =>
         Client__State.Actions.setSelectedModel(~provider, ~value)}
       isAgentRunning
-      isConnected
+      hasActiveACPSession
       disabled={isUsageExhausted}
       disabledPlaceholder="Free requests exhausted. Add your API key in Settings to continue."
     />

--- a/libs/client/src/Client__TaskTabs.story.res
+++ b/libs/client/src/Client__TaskTabs.story.res
@@ -58,7 +58,7 @@ module Fixtures = {
   let emptyState: StateTypes.state = {
     tasks: Dict.make(),
     currentTask: StateTypes.Task.New(StateTypes.Task.makeNew(~previewUrl="http://localhost:3000")),
-    connectionState: Disconnected,
+    acpSession: NoAcpSession,
     sessionInitialized: false,
     usageInfo: None,
     openrouterKeySettings: {

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -204,7 +204,7 @@ let make = (
   ~selectedModel: option<StateTypes.selectedModel>,
   ~onModelChange: (~provider: string, ~value: string) => unit,
   ~isAgentRunning: bool,
-  ~isConnected: bool,
+  ~hasActiveACPSession: bool,
   ~placeholder: string="What would you like to change?",
   ~disabled: bool=false,
   ~disabledPlaceholder: option<string>=?,
@@ -274,25 +274,25 @@ let make = (
     
     if key == "Enter" && !shiftKey {
       ReactEvent.Keyboard.preventDefault(e)
-      // Don't submit while agent is running or disconnected
-      if !isAgentRunning && isConnected && (value != "" || Array.length(attachments) > 0) {
+      // Don't submit while agent is running or no active session
+      if !isAgentRunning && hasActiveACPSession && (value != "" || Array.length(attachments) > 0) {
         onSubmit()
         setAttachments(_ => [])
       }
     }
   }
-  
+
   // Handle form submit
   let handleSubmit = () => {
-    // Don't submit while agent is running or disconnected
-    if !isAgentRunning && isConnected && (value != "" || Array.length(attachments) > 0) {
+    // Don't submit while agent is running or no active session
+    if !isAgentRunning && hasActiveACPSession && (value != "" || Array.length(attachments) > 0) {
       onSubmit()
       setAttachments(_ => [])
     }
   }
-  
+
   let hasContent = value != "" || Array.length(attachments) > 0
-  let isInputDisabled = !isConnected || isAgentRunning || disabled
+  let isInputDisabled = !hasActiveACPSession || isAgentRunning || disabled
   let isSubmitDisabled = isInputDisabled || !hasContent
   
   // Determine placeholder text based on state

--- a/libs/client/src/hooks/Client__UseThinkingState.res
+++ b/libs/client/src/hooks/Client__UseThinkingState.res
@@ -68,16 +68,16 @@ let isAwaitingResponse = (lastMessage: option<Message.t>): bool => {
 let use = (
   ~messages: array<Message.t>,
   ~isStreaming: bool,
-  ~isConnected: bool,
+  ~hasActiveACPSession: bool,
   ~sessionInitialized: bool,
 ): thinkingState => {
   // Get the last message
   let lastMessage = messages->Array.get(Array.length(messages) - 1)
-  
+
   // Calculate thinking state
-  let showThinking = 
-    // Must be connected and initialized
-    isConnected &&
+  let showThinking =
+    // Must have active ACP session and be initialized
+    hasActiveACPSession &&
     sessionInitialized &&
     // Not currently streaming (AI is responding)
     !isStreaming &&
@@ -103,10 +103,10 @@ let use = (
 let useWithMessageId = (
   ~messages: array<Message.t>,
   ~isStreaming: bool,
-  ~isConnected: bool,
+  ~hasActiveACPSession: bool,
   ~sessionInitialized: bool,
 ): (thinkingState, string) => {
-  let state = use(~messages, ~isStreaming, ~isConnected, ~sessionInitialized)
+  let state = use(~messages, ~isStreaming, ~hasActiveACPSession, ~sessionInitialized)
   
   // Generate a stable ID based on last message
   let messageId = switch messages->Array.get(Array.length(messages) - 1) {

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -87,13 +87,13 @@ module Actions = {
 
   let clearFigmaNodeWaiting = () => Client__State__Store.dispatch(ClearFigmaNodeWaiting)
 
-  // Connection action creators
-  let connect = (~sendPrompt, ~loadTask, ~deleteSession, ~apiBaseUrl) =>
+  // ACP session action creators
+  let setAcpSession = (~sendPrompt, ~loadTask, ~deleteSession, ~apiBaseUrl) =>
     Client__State__Store.dispatch(
-      Connect({sendPrompt, loadTask, deleteSession, apiBaseUrl}),
+      SetAcpSession({sendPrompt, loadTask, deleteSession, apiBaseUrl}),
     )
 
-  let disconnect = () => Client__State__Store.dispatch(Disconnect)
+  let clearAcpSession = () => Client__State__Store.dispatch(ClearAcpSession)
 
   // Task loading action creators
   let taskLoadStarted = (~taskId) =>

--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -151,7 +151,7 @@ let snapshotToState = (snapshot: Snapshot.t): StateTypes.state => {
   {
     tasks: tasksDict,
     currentTask,
-    connectionState: Disconnected, // Cannot restore connection from snapshot
+    acpSession: NoAcpSession, // Cannot restore ACP session from snapshot
     sessionInitialized: snapshot.sessionInitialized,
     usageInfo: None,
     openrouterKeySettings: {

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -54,14 +54,14 @@ type action =
   | ClearFigmaNode
   | SetFigmaNodeWaiting
   | ClearFigmaNodeWaiting
-  // Connection actions
-  | Connect({
+  // ACP session actions
+  | SetAcpSession({
       sendPrompt: Client__State__Types.sendPromptFn,
       loadTask: Client__State__Types.loadTaskFn,
       deleteSession: Client__State__Types.deleteSessionFn,
       apiBaseUrl: string,
     })
-  | Disconnect
+  | ClearAcpSession
   // Task loading actions (for persisted sessions)
   | TaskLoadStarted({taskId: string})
   | TaskLoadComplete({taskId: string})
@@ -227,7 +227,7 @@ let saveSelectedModelToStorage = (model: Client__State__Types.selectedModel): un
 let defaultState: state = {
   tasks: Dict.make(),
   currentTask: Task.New(Task.makeNew(~previewUrl=getInitialUrl())),
-  connectionState: Disconnected,
+  acpSession: NoAcpSession,
   sessionInitialized: false,
   usageInfo: None,
   openrouterKeySettings: {
@@ -266,8 +266,8 @@ let actionToString = action => {
   | ClearFigmaNode => `ClearFigmaNode`
   | SetFigmaNodeWaiting => `SetFigmaNodeWaiting`
   | ClearFigmaNodeWaiting => `ClearFigmaNodeWaiting`
-  | Connect(_) => `Connect`
-  | Disconnect => `Disconnect`
+  | SetAcpSession(_) => `SetAcpSession`
+  | ClearAcpSession => `ClearAcpSession`
   | TaskLoadStarted({taskId}) => `TaskLoadStarted(${taskId})`
   | TaskLoadComplete({taskId}) => `TaskLoadComplete(${taskId})`
   | TaskLoadError({taskId, error}) => `TaskLoadError(${taskId}, ${error})`
@@ -421,14 +421,14 @@ module Selectors = {
   }
 
   // Global state selectors
-  let connectionState = (state: state): Client__State__Types.connectionState => {
-    state.connectionState
+  let acpSession = (state: state): Client__State__Types.acpSession => {
+    state.acpSession
   }
 
-  let isConnected = (state: state): bool => {
-    switch state.connectionState {
-    | Connected(_) => true
-    | Disconnected => false
+  let hasActiveACPSession = (state: state): bool => {
+    switch state.acpSession {
+    | AcpSessionActive(_) => true
+    | NoAcpSession => false
     }
   }
 
@@ -477,8 +477,8 @@ module Selectors = {
 let handleEffect = (effect, state: state, dispatch) => {
   switch effect {
   | SendMessageToAPI({message, taskId}) =>
-    switch state.connectionState {
-    | Connected({sendPrompt}) =>
+    switch state.acpSession {
+    | AcpSessionActive({sendPrompt}) =>
       let additionalBlocks =
         state.tasks
         ->Dict.get(taskId)
@@ -524,7 +524,7 @@ let handleEffect = (effect, state: state, dispatch) => {
         },
         ~metadata,
       )
-    | Disconnected => Console.error("[Effect] Cannot send message: not connected")
+    | NoAcpSession => Console.error("[Effect] Cannot send message: no active ACP session")
     }
   | FetchUsageInfo({apiBaseUrl}) =>
     let fetch = async () => {
@@ -856,8 +856,8 @@ let handleEffect = (effect, state: state, dispatch) => {
     disconnect()->ignore
 
   | LoadTaskEffect({taskId}) =>
-    switch state.connectionState {
-    | Connected({loadTask}) =>
+    switch state.acpSession {
+    | AcpSessionActive({loadTask}) =>
       let taskIdToLoad = taskId
       // Check if task needs history loading or just channel activation
       let needsHistory = switch state.tasks->Dict.get(taskId) {
@@ -876,7 +876,7 @@ let handleEffect = (effect, state: state, dispatch) => {
         | Error(err) => dispatch(TaskLoadError({taskId: taskIdToLoad, error: err}))
         }
       })
-    | Disconnected => dispatch(TaskLoadError({taskId, error: "Not connected"}))
+    | NoAcpSession => dispatch(TaskLoadError({taskId, error: "No active ACP session"}))
     }
   }
 }
@@ -1017,9 +1017,9 @@ let next = (state: state, action) => {
       }
 
       // Persist deletion to server (fire and forget - optimistic UI)
-      switch state.connectionState {
-      | Connected({deleteSession}) => deleteSession(taskId, ~onComplete=_ => ())
-      | Disconnected => ()
+      switch state.acpSession {
+      | AcpSessionActive({deleteSession}) => deleteSession(taskId, ~onComplete=_ => ())
+      | NoAcpSession => ()
       }
 
       {
@@ -1049,13 +1049,13 @@ let next = (state: state, action) => {
   | ClearFigmaNodeWaiting =>
     state->Lens.delegateToTask(state.currentTask, ClearFigmaNodeWaiting)
 
-  | Connect({sendPrompt, loadTask, deleteSession, apiBaseUrl}) =>
-    // Just set up connection functions - task creation happens in AddUserMessage
+  | SetAcpSession({sendPrompt, loadTask, deleteSession, apiBaseUrl}) =>
+    // Just set up session callbacks - task creation happens in AddUserMessage
     // when user sends their first message (lazy session creation)
-    // apiBaseUrl is now co-located in Connected to make illegal state unrepresentable
+    // apiBaseUrl is co-located in AcpSessionActive to make illegal state unrepresentable
     {
       ...state,
-      connectionState: Connected({sendPrompt, loadTask, deleteSession, apiBaseUrl}),
+      acpSession: AcpSessionActive({sendPrompt, loadTask, deleteSession, apiBaseUrl}),
       sessionInitialized: true,
     }->FrontmanReactStatestore.StateReducer.update(
       ~sideEffects=[
@@ -1064,8 +1064,8 @@ let next = (state: state, action) => {
       ],
     )
 
-  | Disconnect =>
-    {...state, connectionState: Disconnected}->FrontmanReactStatestore.StateReducer.update
+  | ClearAcpSession =>
+    {...state, acpSession: NoAcpSession}->FrontmanReactStatestore.StateReducer.update
 
   | ReceivedDiscoveredProjectRule({taskId: _}) =>
     // Mark initialization complete
@@ -1075,9 +1075,9 @@ let next = (state: state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | TurnCompleted({taskId}) =>
-    let sideEffects = switch state.connectionState {
-    | Connected({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
-    | Disconnected => []
+    let sideEffects = switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
+    | NoAcpSession => []
     }
     state->Lens.delegateToTask(Task.Selected(taskId), TurnCompleted, ~sideEffects)
 
@@ -1090,12 +1090,12 @@ let next = (state: state, action) => {
 
   // API key settings actions
   | FetchApiKeySettings =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchApiKeySettingsEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | ApiKeySettingsReceived({source}) =>
@@ -1108,17 +1108,17 @@ let next = (state: state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | SaveOpenRouterKey({key}) =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[SaveOpenRouterKeyEffect({apiBaseUrl, key})],
       )
-    | Disconnected =>
+    | NoAcpSession =>
       {
         ...state,
         openrouterKeySettings: {
           ...state.openrouterKeySettings,
-          saveStatus: SaveError("Not connected to server"),
+          saveStatus: SaveError("No active ACP session"),
         },
       }->FrontmanReactStatestore.StateReducer.update
     }
@@ -1134,9 +1134,9 @@ let next = (state: state, action) => {
 
   | OpenRouterKeySaved =>
     // After saving the API key, refresh usage info so the chatbox reflects the new state
-    let effects = switch state.connectionState {
-    | Connected({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
-    | Disconnected => []
+    let effects = switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) => [FetchUsageInfo({apiBaseUrl: apiBaseUrl})]
+    | NoAcpSession => []
     }
     {
       ...state,
@@ -1166,12 +1166,12 @@ let next = (state: state, action) => {
 
   // Model selection actions
   | FetchModelsConfig =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchModelsConfigEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | ModelsConfigReceived({config}) =>
@@ -1202,15 +1202,15 @@ let next = (state: state, action) => {
 
   // Anthropic OAuth actions
   | FetchAnthropicOAuthStatus =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       {
         ...state,
         anthropicOAuthStatus: Client__State__Types.FetchingStatus,
       }->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[FetchAnthropicOAuthStatusEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthStatusReceived({connected, expiresAt}) =>
@@ -1228,12 +1228,12 @@ let next = (state: state, action) => {
     {...state, anthropicOAuthStatus: status}->FrontmanReactStatestore.StateReducer.update
 
   | InitiateAnthropicOAuth =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[GetAnthropicOAuthUrlEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthUrlReceived({authorizeUrl, verifier}) =>
@@ -1243,15 +1243,15 @@ let next = (state: state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | ExchangeAnthropicOAuthCode({code, verifier}) =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       {
         ...state,
         anthropicOAuthStatus: Client__State__Types.Exchanging,
       }->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[ExchangeAnthropicOAuthCodeEffect({apiBaseUrl, code, verifier})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthConnected({expiresAt}) =>
@@ -1268,12 +1268,12 @@ let next = (state: state, action) => {
     }->FrontmanReactStatestore.StateReducer.update
 
   | DisconnectAnthropicOAuth =>
-    switch state.connectionState {
-    | Connected({apiBaseUrl}) =>
+    switch state.acpSession {
+    | AcpSessionActive({apiBaseUrl}) =>
       state->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[DisconnectAnthropicOAuthEffect({apiBaseUrl: apiBaseUrl})],
       )
-    | Disconnected => state->FrontmanReactStatestore.StateReducer.update
+    | NoAcpSession => state->FrontmanReactStatestore.StateReducer.update
     }
 
   | AnthropicOAuthDisconnected =>

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -40,13 +40,13 @@ type loadTaskFn = (string, ~needsHistory: bool, ~onComplete: result<unit, string
 // onComplete: called when deletion finishes (success or error)
 type deleteSessionFn = (string, ~onComplete: result<unit, string> => unit) => unit
 
-// Connection state for the Frontman ACP session
+// ACP session state - stores callbacks for API operations when session is active
 // Note: sessionId is NOT stored here - it's managed by ConnectionReducer (ACP layer)
 // Tasks store their own ID which equals the ACP session ID
-// apiBaseUrl is co-located with Connected to make illegal state (Connected + no apiBaseUrl) unrepresentable
-type connectionState =
-  | Disconnected
-  | Connected({
+// apiBaseUrl is co-located with AcpSessionActive to make illegal state (active + no apiBaseUrl) unrepresentable
+type acpSession =
+  | NoAcpSession
+  | AcpSessionActive({
       sendPrompt: sendPromptFn,
       loadTask: loadTaskFn,
       deleteSession: deleteSessionFn,
@@ -133,7 +133,7 @@ type sessionsLoadState =
 type state = {
   tasks: Dict.t<Task.t>,
   currentTask: Task.currentTask,
-  connectionState: connectionState,
+  acpSession: acpSession,
   sessionInitialized: bool,
   usageInfo: option<usageInfo>,
   openrouterKeySettings: apiKeySettings,

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -27,7 +27,7 @@ module TestHelpers = {
       {
         tasks,
         currentTask: Task.Selected(taskId),
-        connectionState: Disconnected,
+        acpSession: NoAcpSession,
         sessionInitialized: false,
         usageInfo: None,
         openrouterKeySettings: {
@@ -748,7 +748,7 @@ describe("Client State Reducer - Task Management Actions", () => {
     let state: Reducer.state = {
       tasks,
       currentTask: Task.Selected("task-1"),
-      connectionState: Disconnected,
+      acpSession: NoAcpSession,
       sessionInitialized: false,
       usageInfo: None,
       openrouterKeySettings: {
@@ -794,7 +794,7 @@ describe("Client State Reducer - Task Management Actions", () => {
     let state: Reducer.state = {
       tasks,
       currentTask: Task.Selected("task-1"),
-      connectionState: Disconnected,
+      acpSession: NoAcpSession,
       sessionInitialized: false,
       usageInfo: None,
       openrouterKeySettings: {
@@ -830,7 +830,7 @@ describe("Client State Reducer - Task Management Actions", () => {
     let state: Reducer.state = {
       tasks,
       currentTask: Task.Selected("task-1"),
-      connectionState: Disconnected,
+      acpSession: NoAcpSession,
       sessionInitialized: false,
       usageInfo: None,
       openrouterKeySettings: {
@@ -942,7 +942,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
     let state: Reducer.state = {
       tasks,
       currentTask: Task.Selected("session-1"),
-      connectionState: Disconnected,
+      acpSession: NoAcpSession,
       sessionInitialized: false,
       usageInfo: None,
       openrouterKeySettings: {
@@ -1028,7 +1028,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
     let state: Reducer.state = {
       tasks,
       currentTask: Task.Selected("task-123"),
-      connectionState: Disconnected,
+      acpSession: NoAcpSession,
       sessionInitialized: false,
       usageInfo: None,
       openrouterKeySettings: {


### PR DESCRIPTION
## Summary

- Renames `connectionState` → `acpSession` in StateReducer to disambiguate from ConnectionReducer's `connectionStatus`
- Updates type variants: `Disconnected` → `NoAcpSession`, `Connected` → `AcpSessionActive`
- Updates actions: `Connect` → `SetAcpSession`, `Disconnect` → `ClearAcpSession`
- Updates selector: `isConnected` → `hasActiveACPSession`

Now clear that:
- **FrontmanProvider.connectionState** = user-facing connection lifecycle (from ConnectionReducer)
- **StateReducer.acpSession** = ACP session callbacks for API operations

## Test plan

- [x] `make build` compiles successfully
- [x] `make test` - all 83 tests pass
- [ ] Manual test: connect to ACP, send a message, verify streaming works

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/211">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
