### PR TITLE
feat(client): add overflow menu for task tabs

### DIFF
--- a/libs/client/src/Client__TaskTabs.res
+++ b/libs/client/src/Client__TaskTabs.res
@@ -3,6 +3,21 @@ module Button = Bindings__UI__Button
 module Icons = Bindings__RadixUI__Icons
 module AlertDialog = Bindings__UI__AlertDialog
 module Input = Bindings__UI__Input
+module Tooltip = Bindings__UI__Tooltip
+module DropdownMenu = Bindings__UI__DropdownMenu
+
+// DOM bindings for overflow measurement
+@get external clientWidth: Dom.element => int = "clientWidth"
+
+type resizeObserver
+@new external makeResizeObserver: (unit => unit) => resizeObserver = "ResizeObserver"
+@send external observeEl: (resizeObserver, Dom.element) => unit = "observe"
+@send external disconnectObs: resizeObserver => unit = "disconnect"
+
+// Width constants for overflow calculation
+let tabWidth = 150
+let newButtonWidth = 80
+let overflowButtonWidth = 50
 
 @react.component
 let make = () => {
@@ -11,12 +26,78 @@ let make = () => {
   let (deleteDialogOpen, setDeleteDialogOpen) = React.useState(() => false)
   let (taskToDelete, setTaskToDelete) = React.useState(() => None)
 
+  // Overflow state
+  let containerRef = React.useRef(Nullable.null)
+  let (visibleCount, setVisibleCount) = React.useState(() => 1000)
+
   // Get clearSession from FrontmanProvider context
   let {clearSession} = Client__FrontmanProvider.useFrontman()
 
   // Global state selectors
   let tasks = Client__State.useSelector(Client__State.Selectors.tasks)
   let currentTaskId = Client__State.useSelector(Client__State.Selectors.currentTaskId)
+  let tasksLen = Array.length(tasks)
+
+  // ResizeObserver effect — recalculate how many tabs fit
+  React.useEffect2(() => {
+    switch containerRef.current->Nullable.toOption {
+    | Some(el) => {
+        let recalc = () => {
+          let containerW = clientWidth(el)
+          let available = containerW - newButtonWidth
+          let allFit = available >= tasksLen * tabWidth
+          if allFit {
+            setVisibleCount(_ => tasksLen)
+          } else {
+            let withOverflow = available - overflowButtonWidth
+            let fits = Math.Int.max(1, withOverflow / tabWidth)
+            setVisibleCount(_ => fits)
+          }
+        }
+        recalc()
+        let observer = makeResizeObserver(() => recalc())
+        observer->observeEl(el)
+        Some(() => disconnectObs(observer))
+      }
+    | None => None
+    }
+  }, (tasksLen, currentTaskId))
+
+  // Compute visible / overflow split with active-task guarantee
+  let (visibleTasks, overflowTasks) = React.useMemo3(() => {
+    if visibleCount >= tasksLen {
+      (tasks, [])
+    } else {
+      let visible = tasks->Array.slice(~start=0, ~end=visibleCount)
+      let overflow = tasks->Array.slice(~start=visibleCount, ~end=tasksLen)
+
+      // If the active task ended up in overflow, swap it into the last visible slot
+      let activeInOverflow =
+        currentTaskId->Option.flatMap(activeId =>
+          overflow->Array.findIndex(t =>
+            Client__Task__Types.Task.getId(t) == Some(activeId)
+          )->Some
+        )->Option.flatMap(idx => idx >= 0 ? Some(idx) : None)
+
+      switch activeInOverflow {
+      | Some(overflowIdx) => {
+          let activeTask = overflow->Array.getUnsafe(overflowIdx)
+          let lastVisibleIdx = Array.length(visible) - 1
+          let displacedTask = visible->Array.getUnsafe(lastVisibleIdx)
+
+          let newVisible = visible->Array.mapWithIndex((t, i) =>
+            i == lastVisibleIdx ? activeTask : t
+          )
+          let newOverflow =
+            overflow
+            ->Array.filterWithIndex((_, i) => i != overflowIdx)
+            ->Array.concat([displacedTask])
+          (newVisible, newOverflow)
+        }
+      | None => (visible, overflow)
+      }
+    }
+  }, (tasks, visibleCount, currentTaskId))
 
   // Event handlers
   let handleTabChange = (taskId: string) => {
@@ -24,8 +105,6 @@ let make = () => {
   }
 
   let handleNewTask = (_e: ReactEvent.Mouse.t) => {
-    // Clear both the ACP session and the current task selection
-    // The new task will be created when user sends their first message (lazy session creation)
     clearSession()
     Client__State.Actions.clearCurrentTask()
   }
@@ -55,7 +134,6 @@ let make = () => {
   // Tab rendering function - memoized to avoid recreating on every render
   let renderTab = React.useCallback2(
     (task: Client__State__StateReducer.Task.t, isEditing: bool) => {
-      // Tasks in the dict always have IDs (not New tasks)
       let taskId =
         Client__Task__Types.Task.getId(task)->Option.getOrThrow(
           ~message="[TaskTabs] Task in dict has no ID",
@@ -66,74 +144,122 @@ let make = () => {
         setEditingTaskId(_ => Some(taskId))
       }
 
-      <UI.TabsTrigger
-        key={taskId}
-        value={taskId}
-        className="min-w-[80px] max-w-[120px] px-2 flex items-center gap-2 relative group cursor-pointer bg-transparent data-[state=active]:bg-transparent"
-      >
-        {isEditing
-          ? <Input.Input
-              autoFocus={true}
-              defaultValue={taskTitle}
-              className="max-w-[90px] text-xs"
-              onKeyDown={e => {
-                let key = e->ReactEvent.Keyboard.key
-                if key == "Enter" {
-                  let target = ReactEvent.Keyboard.target(e)
-                  let newTitle = target["value"]->String.trim
-                  if String.length(newTitle) > 0 {
-                    Client__State.Actions.updateTaskTitle(~taskId, ~title=newTitle)
-                  }
-                  setEditingTaskId(_ => None)
-                  ReactEvent.Keyboard.preventDefault(e)
-                } else if key == "Escape" {
-                  setEditingTaskId(_ => None)
-                  ReactEvent.Keyboard.preventDefault(e)
-                }
-              }}
-              onBlur={e => {
-                let target = ReactEvent.Focus.target(e)
-                let newTitle = target["value"]->String.trim
-                if String.length(newTitle) > 0 {
-                  Client__State.Actions.updateTaskTitle(~taskId, ~title=newTitle)
-                }
-                setEditingTaskId(_ => None)
-              }}
-            />
-          : <>
-              <span
-                className="truncate max-w-[90px] text-xs cursor-pointer"
-                onDoubleClick={handleDoubleClick}
-              >
-                {React.string(taskTitle)}
-              </span>
-              <span
-                className="ml-auto p-0.5 rounded-sm opacity-0 group-hover:opacity-100 data-[state=active]:opacity-100 hover:bg-accent transition-opacity duration-150 cursor-pointer"
-                onClick={e => handleDeleteClick(e, taskId)}
-              >
-                <Icons.Cross2Icon style={{"width": "14px", "height": "14px"}} />
-              </span>
-            </>}
-      </UI.TabsTrigger>
+      <Tooltip.Tooltip key={taskId}>
+        <Tooltip.TooltipTrigger asChild=true>
+          <UI.TabsTrigger
+            value={taskId}
+            className="w-[150px] shrink-0 px-2 flex items-center gap-2 relative group cursor-pointer bg-transparent data-[state=active]:bg-transparent"
+          >
+            {isEditing
+              ? <Input.Input
+                  autoFocus={true}
+                  defaultValue={taskTitle}
+                  className="w-full text-xs"
+                  onKeyDown={e => {
+                    let key = e->ReactEvent.Keyboard.key
+                    if key == "Enter" {
+                      let target = ReactEvent.Keyboard.target(e)
+                      let newTitle = target["value"]->String.trim
+                      if String.length(newTitle) > 0 {
+                        Client__State.Actions.updateTaskTitle(~taskId, ~title=newTitle)
+                      }
+                      setEditingTaskId(_ => None)
+                      ReactEvent.Keyboard.preventDefault(e)
+                    } else if key == "Escape" {
+                      setEditingTaskId(_ => None)
+                      ReactEvent.Keyboard.preventDefault(e)
+                    }
+                  }}
+                  onBlur={e => {
+                    let target = ReactEvent.Focus.target(e)
+                    let newTitle = target["value"]->String.trim
+                    if String.length(newTitle) > 0 {
+                      Client__State.Actions.updateTaskTitle(~taskId, ~title=newTitle)
+                    }
+                    setEditingTaskId(_ => None)
+                  }}
+                />
+              : <>
+                  <span
+                    className="truncate text-xs cursor-pointer"
+                    onDoubleClick={handleDoubleClick}
+                  >
+                    {React.string(taskTitle)}
+                  </span>
+                  <span
+                    className="ml-auto p-0.5 rounded-sm opacity-0 group-hover:opacity-100 data-[state=active]:opacity-100 hover:bg-accent transition-opacity duration-150 cursor-pointer"
+                    onClick={e => handleDeleteClick(e, taskId)}
+                  >
+                    <Icons.Cross2Icon style={{"width": "14px", "height": "14px"}} />
+                  </span>
+                </>}
+          </UI.TabsTrigger>
+        </Tooltip.TooltipTrigger>
+        <Tooltip.TooltipContent sideOffset=4>
+          {React.string(taskTitle)}
+        </Tooltip.TooltipContent>
+      </Tooltip.Tooltip>
     },
     (setEditingTaskId, handleDeleteClick),
   )
 
+  let overflowCount = Array.length(overflowTasks)
+
   // Main render
-  <div className="h-12 border-b">
+  <div className="h-12 border-b" ref={ReactDOM.Ref.domRef(containerRef)}>
     <UI.Tabs
       value={currentTaskId->Option.getOr("")} onValueChange={handleTabChange} className="h-full"
     >
       <UI.TabsList
-        className="h-full w-full rounded-none justify-start overflow-x-auto bg-transparent p-0"
+        className="h-full w-full rounded-none justify-start overflow-hidden bg-transparent p-0"
       >
-        {tasks
+        {visibleTasks
         ->Array.map(task =>
           renderTab(task, editingTaskId == Client__Task__Types.Task.getId(task))
         )
         ->React.array}
+        {overflowCount > 0
+          ? <DropdownMenu.DropdownMenu>
+              <DropdownMenu.DropdownMenuTrigger asChild=true>
+                <Button.Button
+                  variant=#ghost
+                  size=#sm
+                  className="cursor-pointer gap-1 shrink-0 px-2"
+                >
+                  <span className="text-xs font-medium">
+                    {React.string(`+${Int.toString(overflowCount)}`)}
+                  </span>
+                  <Icons.ChevronDownIcon style={{"width": "12px", "height": "12px"}} />
+                </Button.Button>
+              </DropdownMenu.DropdownMenuTrigger>
+              <DropdownMenu.DropdownMenuContent align="start" sideOffset=4>
+                <DropdownMenu.DropdownMenuLabel>
+                  {React.string("More tasks")}
+                </DropdownMenu.DropdownMenuLabel>
+                <DropdownMenu.DropdownMenuSeparator />
+                {overflowTasks
+                ->Array.map(task => {
+                  let taskId =
+                    Client__Task__Types.Task.getId(task)->Option.getOrThrow(
+                      ~message="[TaskTabs] Overflow task has no ID",
+                    )
+                  let taskTitle =
+                    Client__Task__Types.Task.getTitle(task)->Option.getOr("Untitled")
+                  let isActive = currentTaskId == Some(taskId)
+                  <DropdownMenu.DropdownMenuItem
+                    key={taskId}
+                    className={isActive ? "font-semibold" : ""}
+                    onSelect={_ => handleTabChange(taskId)}
+                  >
+                    {React.string(taskTitle)}
+                  </DropdownMenu.DropdownMenuItem>
+                })
+                ->React.array}
+              </DropdownMenu.DropdownMenuContent>
+            </DropdownMenu.DropdownMenu>
+          : React.null}
         <Button.Button
-          variant=#ghost size=#sm onClick={handleNewTask} className="cursor-pointer gap-1"
+          variant=#ghost size=#sm onClick={handleNewTask} className="cursor-pointer gap-1 shrink-0"
         >
           <Icons.PlusIcon style={{"width": "14px", "height": "14px"}} />
           <span className="text-xs"> {React.string("New")} </span>

--- a/libs/client/src/Client__TaskTabs.story.res
+++ b/libs/client/src/Client__TaskTabs.story.res
@@ -275,3 +275,73 @@ let mixedTasks: Story.t<args> = {
     </ContextWrapper>
   },
 }
+
+/**
+ * Many tasks in a 600px container — exercises the overflow dropdown.
+ * Active task (task-8) is in the middle, so it must be swapped into
+ * visible slots to guarantee visibility.
+ */
+let manyTasksOverflow: Story.t<args> = {
+  name: "Many Tasks (Overflow)",
+  render: _ => {
+    let now = Date.now()
+    let tasks = Array.fromInitializer(~length=15, i => {
+      let idx = Int.toString(i + 1)
+      Fixtures.makeTask(
+        ~id=`task-${idx}`,
+        ~title=`Task ${idx}: ${switch mod(i, 4) {
+          | 0 => "Fix login page styling"
+          | 1 => "Add dark mode support"
+          | 2 => "Refactor API client"
+          | _ => "Update dependencies"
+          }}`,
+        ~createdAt=now -. Int.toFloat((15 - i) * 3600000),
+        ~updatedAt=now -. Int.toFloat(i * 600000),
+        ~withMessages=true,
+      )
+    })
+
+    React.useEffect0(() => {
+      _forceState(Fixtures.stateWithTasks(~tasks, ~currentTaskId="task-8"))
+      Some(() => Client__StateSnapshot__Storybook.resetState())
+    })
+
+    <ContextWrapper>
+      <div style={{width: "600px", backgroundColor: "#18181b"}}>
+        <Client__TaskTabs />
+      </div>
+    </ContextWrapper>
+  },
+}
+
+/**
+ * 8 tasks in a very narrow 300px container — extreme overflow.
+ * Almost all tasks should collapse into the dropdown.
+ */
+let narrowContainer: Story.t<args> = {
+  name: "Narrow Container",
+  render: _ => {
+    let now = Date.now()
+    let tasks = Array.fromInitializer(~length=8, i => {
+      let idx = Int.toString(i + 1)
+      Fixtures.makeTask(
+        ~id=`task-${idx}`,
+        ~title=`Task ${idx}: Some descriptive title`,
+        ~createdAt=now -. Int.toFloat((8 - i) * 3600000),
+        ~updatedAt=now -. Int.toFloat(i * 300000),
+        ~withMessages=mod(i, 2) == 0,
+      )
+    })
+
+    React.useEffect0(() => {
+      _forceState(Fixtures.stateWithTasks(~tasks, ~currentTaskId="task-5"))
+      Some(() => Client__StateSnapshot__Storybook.resetState())
+    })
+
+    <ContextWrapper>
+      <div style={{width: "300px", backgroundColor: "#18181b"}}>
+        <Client__TaskTabs />
+      </div>
+    </ContextWrapper>
+  },
+}

--- a/libs/client/src/bindings/Bindings__UI__DropdownMenu.res
+++ b/libs/client/src/bindings/Bindings__UI__DropdownMenu.res
@@ -1,0 +1,65 @@
+// UI DropdownMenu component bindings (wraps @radix-ui/react-dropdown-menu)
+// Usage:
+// <DropdownMenu.DropdownMenu>
+//   <DropdownMenu.DropdownMenuTrigger asChild=true>
+//     <button>{React.string("+3")}</button>
+//   </DropdownMenu.DropdownMenuTrigger>
+//   <DropdownMenu.DropdownMenuContent align="end" sideOffset=4>
+//     <DropdownMenu.DropdownMenuLabel>{React.string("More tasks")}</DropdownMenu.DropdownMenuLabel>
+//     <DropdownMenu.DropdownMenuSeparator />
+//     <DropdownMenu.DropdownMenuItem onSelect={_ => handleSelect()}>
+//       {React.string("Task title")}
+//     </DropdownMenu.DropdownMenuItem>
+//   </DropdownMenu.DropdownMenuContent>
+// </DropdownMenu.DropdownMenu>
+
+module DropdownMenu = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (
+    @as("open") ~open_: bool=?,
+    ~defaultOpen: bool=?,
+    ~onOpenChange: bool => unit=?,
+    ~children: React.element=?,
+  ) => React.element = "DropdownMenu"
+}
+
+module DropdownMenuTrigger = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (
+    ~className: string=?,
+    ~asChild: bool=?,
+    ~children: React.element=?,
+  ) => React.element = "DropdownMenuTrigger"
+}
+
+module DropdownMenuContent = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (
+    ~className: string=?,
+    ~align: string=?,
+    ~sideOffset: int=?,
+    ~children: React.element=?,
+  ) => React.element = "DropdownMenuContent"
+}
+
+module DropdownMenuItem = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (
+    ~className: string=?,
+    ~onSelect: ReactEvent.Mouse.t => unit=?,
+    ~children: React.element=?,
+  ) => React.element = "DropdownMenuItem"
+}
+
+module DropdownMenuSeparator = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (~className: string=?) => React.element = "DropdownMenuSeparator"
+}
+
+module DropdownMenuLabel = {
+  @module("@/components/ui/dropdown-menu") @react.component
+  external make: (
+    ~className: string=?,
+    ~children: React.element=?,
+  ) => React.element = "DropdownMenuLabel"
+}


### PR DESCRIPTION
## Summary
- Show N tabs that fit at readable width (150px each), collapse the rest behind a `+N` dropdown menu with full titles
- Active task is always guaranteed a visible slot — if it's in overflow, it swaps into the last visible position
- Each visible tab gets a tooltip showing the full title on hover
- ResizeObserver dynamically recalculates visible count on container resize
- New `Bindings__UI__DropdownMenu.res` binding for the existing shadcn dropdown-menu component

## Test plan
- [ ] `cd libs/client && make storybook` — check "Many Tasks (Overflow)" and "Narrow Container" stories
- [ ] Resize browser in overflow stories → tabs collapse/expand into overflow menu
- [ ] Click an overflow task → it appears in visible tabs (active guarantee)
- [ ] Hover a visible tab → tooltip shows full title
- [ ] Edge cases: 0 tasks, 1 task, all fit, none fit
- [ ] Existing stories (No Tasks, Single Empty Task, Multiple Tasks, Mixed Tasks) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
