### PR TITLE
chore: add process-compose shortcuts for F-key-less keyboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dev-extension: ## Start development server for Chrome extension
 	cd apps/chrome-extension && $(MAKE) dev
 
 dev-all: ## Start all core services (client + server + nextjs)
-	mise exec -- process-compose up
+	mise exec -- process-compose up --shortcuts shortcuts.yaml
 
 pull-webapi: ## Pull latest changes from experimental-rescript-webapi subtree
 	git subtree pull --prefix libs/experimental-rescript-webapi git@github.com:itayadler/experimental-rescript-webapi.git main --squash

--- a/shortcuts.yaml
+++ b/shortcuts.yaml
@@ -1,0 +1,42 @@
+# process-compose TUI shortcuts
+# Remapped from F-keys to Ctrl combos that don't conflict with Zellij normal mode
+shortcuts:
+  log_follow:
+    shortcut: Ctrl-F
+    toggle_description:
+      false: Follow Off
+      true: Follow On
+
+  log_screen:
+    shortcut: Ctrl-L
+    toggle_description:
+      false: Half Screen
+      true: Full Screen
+
+  log_wrap:
+    shortcut: Ctrl-W
+    toggle_description:
+      false: Wrap Off
+      true: Wrap On
+
+  process_start:
+    shortcut: Ctrl-S
+    description: Start
+
+  process_screen:
+    shortcut: Ctrl-E
+    toggle_description:
+      false: Half Screen
+      true: Full Screen
+
+  process_stop:
+    shortcut: Ctrl-X
+    description: Stop
+
+  process_restart:
+    shortcut: Ctrl-R
+    description: Restart
+
+  quit:
+    shortcut: q
+    description: Quit


### PR DESCRIPTION
## Summary
- Add `shortcuts.yaml` remapping process-compose F-key bindings to Ctrl combos compatible with Zellij normal mode
- Update `Makefile` to pass `--shortcuts shortcuts.yaml` to process-compose

| Action | Key |
|---|---|
| Log follow | `Ctrl-F` |
| Log fullscreen | `Ctrl-L` |
| Log wrap | `Ctrl-W` |
| Start process | `Ctrl-S` |
| Process fullscreen | `Ctrl-E` |
| Stop process | `Ctrl-X` |
| Restart process | `Ctrl-R` |
| Quit | `q` |

## Test plan
- [ ] Run `make dev-all` and verify the TUI footer shows the new keybindings
- [ ] Verify each shortcut works as expected
- [ ] Confirm no conflicts with Zellij in normal mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/216">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
