### PR TITLE
refactor: extract conditional sections from root agent base prompt

### DIFF
--- a/apps/frontman_server/lib/frontman_server/agents.ex
+++ b/apps/frontman_server/lib/frontman_server/agents.ex
@@ -148,12 +148,15 @@ defmodule FrontmanServer.Agents do
           oauth_mode: resolved_key.oauth_mode
         ]
 
+        has_typescript_react = framework in ["nextjs"]
+
         # Create RootAgent with context
         # API key is passed via llm_opts - no scope/env_api_key needed
         RootAgent.new(
           tools: tools,
           has_figma_context: has_figma,
           has_selected_component: has_selected_component,
+          has_typescript_react: has_typescript_react,
           figma_node_id: figma_node_id,
           framework: framework,
           model: resolved_key.model,

--- a/apps/frontman_server/lib/frontman_server/agents/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/prompts.ex
@@ -484,41 +484,11 @@ defmodule FrontmanServer.Agents.Prompts do
   ## Rules
 
   - Use paths as provided. If given an absolute path, use it as-is.
-  - List → Read → Modify. Never edit unseen files. **Exception**: When Figma workflow is active (see below), follow the tool-based workflow instead.
+  - List → Read → Modify. Never edit unseen files.
   - Keep diffs small and reversible. Match repo style.
   - After 2 failed tool calls, ask one clarifying question about the error (not about requirements/design).
-  - IMPORTANT: If you have a figma design and node selected, use the `breakdown_figma_design` tool to analyze the design into components, then use `implement_component` for each one.
 
   #{@base_tool_selection_guidance}
-
-  ## Figma Tools
-
-  ### CRITICAL: get_figma_node Tool Usage
-
-  **NEVER call `get_figma_node` with a node that has a volume (`v`) parameter larger than 6!**
-
-  When using `get_figma_node`:
-  - **Node ID format** - Use the node ID WITHOUT the `#` prefix
-  - **Use the nodeDSL** that comes along with the Figma image to figure out which nodes can be selected
-  - **Select nodes that don't exceed the volume limit** - choose smaller, more specific nodes if needed
-  - **Use `withChildren` parameter** - Select parent nodes with `withChildren: true` to get the complete picture of a component hierarchy without exceeding volume limits
-  - **Plan your selections carefully** - Analyze the nodeDSL structure first to identify which nodes you need before making any `get_figma_node` calls
-
-  ## ReScript handling (explicit)
-
-  - Treat generated files (*.res.mjs) as read-only.
-  - Always edit the source *.res.
-  - Procedure when you see X.res.mjs:
-    1. Locate X.res by name/path. If not found, search siblings or module index.
-    2. read_file both X.res and X.res.mjs to understand mapping and exports.
-    3. Apply changes to X.res only. Preserve types and module boundaries.
-  - If no matching *.res exists or mapping is unclear, stop and ask for the exact source path.
-  - Never write to generated artifacts. Note this in the output if a change seems required there.
-
-  ## TypeScript / React
-
-  - Avoid any. Prefer discriminated unions.
-  - Pure components and stable hooks.
 
   ## Output
 
@@ -623,11 +593,16 @@ defmodule FrontmanServer.Agents.Prompts do
     has_selected_component = Keyword.get(opts, :has_selected_component, false)
     figma_node_id = Keyword.get(opts, :figma_node_id)
     framework = Keyword.get(opts, :framework)
+    has_typescript_react = Keyword.get(opts, :has_typescript_react, false)
 
     prompt
     |> append_figma_guidance(has_figma, has_selected_component, figma_node_id)
+    |> maybe_append(has_typescript_react, &typescript_react_guidance/0)
     |> append_framework_guidance(framework)
   end
+
+  defp maybe_append(prompt, true, guidance_fn), do: prompt <> "\n" <> guidance_fn.()
+  defp maybe_append(prompt, false, _guidance_fn), do: prompt
 
   defp append_figma_guidance(prompt, true, true, figma_node_id) do
     prompt <> "\n" <> figma_with_selected_component_guidance(figma_node_id)
@@ -671,6 +646,36 @@ defmodule FrontmanServer.Agents.Prompts do
   defp format_rule(%{path: path, content: content}),
     do: "Instructions from: #{path}\n#{content}"
 
+  defp figma_tool_guidance do
+    """
+    **Exception**: When Figma workflow is active (see below), follow the tool-based workflow instead of List → Read → Modify.
+
+    IMPORTANT: If you have a figma design and node selected, use the `breakdown_figma_design` tool to analyze the design into components, then use `implement_component` for each one.
+
+    ## Figma Tools
+
+    ### CRITICAL: get_figma_node Tool Usage
+
+    **NEVER call `get_figma_node` with a node that has a volume (`v`) parameter larger than 6!**
+
+    When using `get_figma_node`:
+    - **Node ID format** - Use the node ID WITHOUT the `#` prefix
+    - **Use the nodeDSL** that comes along with the Figma image to figure out which nodes can be selected
+    - **Select nodes that don't exceed the volume limit** - choose smaller, more specific nodes if needed
+    - **Use `withChildren` parameter** - Select parent nodes with `withChildren: true` to get the complete picture of a component hierarchy without exceeding volume limits
+    - **Plan your selections carefully** - Analyze the nodeDSL structure first to identify which nodes you need before making any `get_figma_node` calls
+    """
+  end
+
+  defp typescript_react_guidance do
+    """
+    ## TypeScript / React
+
+    - Avoid any. Prefer discriminated unions.
+    - Pure components and stable hooks.
+    """
+  end
+
   defp figma_context_guidance(figma_node_id) do
     node_id_section =
       if figma_node_id do
@@ -690,8 +695,9 @@ defmodule FrontmanServer.Agents.Prompts do
         ""
       end
 
-    """
-    ## IMPORTANT: Figma Design Context Detected
+    figma_tool_guidance() <>
+      """
+      ## IMPORTANT: Figma Design Context Detected
 
     You have received Figma design context (a design image and/or node DSL structure).
     #{node_id_section}
@@ -777,8 +783,9 @@ defmodule FrontmanServer.Agents.Prompts do
         ""
       end
 
-    """
-    ## CRITICAL: Figma Design + Selected Component Detected
+    figma_tool_guidance() <>
+      """
+      ## CRITICAL: Figma Design + Selected Component Detected
 
     **YOU HAVE BOTH:**
     1. **Figma design context** - A design image and/or node DSL structure is attached to this conversation

--- a/apps/frontman_server/lib/frontman_server/agents/root_agent.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/root_agent.ex
@@ -23,6 +23,7 @@ defmodule FrontmanServer.Agents.RootAgent do
     field(:tools, [Swarm.Tool.t()], default: [])
     field(:has_figma_context, boolean(), default: false)
     field(:has_selected_component, boolean(), default: false)
+    field(:has_typescript_react, boolean(), default: false)
     field(:figma_node_id, String.t() | nil, default: nil)
     field(:framework, String.t() | nil, default: nil)
     # llm_opts must include :api_key (resolved at domain layer)
@@ -54,6 +55,7 @@ defmodule FrontmanServer.Agents.RootAgent do
       tools: Keyword.get(opts, :tools, []),
       has_figma_context: Keyword.get(opts, :has_figma_context, false),
       has_selected_component: Keyword.get(opts, :has_selected_component, false),
+      has_typescript_react: Keyword.get(opts, :has_typescript_react, false),
       figma_node_id: Keyword.get(opts, :figma_node_id),
       framework: Keyword.get(opts, :framework),
       llm_opts: Keyword.get(opts, :llm_opts, []),
@@ -72,6 +74,7 @@ defimpl Swarm.Agent, for: FrontmanServer.Agents.RootAgent do
     Prompts.build(
       has_figma_context: agent.has_figma_context,
       has_selected_component: agent.has_selected_component,
+      has_typescript_react: agent.has_typescript_react,
       figma_node_id: agent.figma_node_id,
       framework: agent.framework,
       project_rules: agent.project_rules

--- a/apps/frontman_server/test/frontman_server/agents/prompts_test.exs
+++ b/apps/frontman_server/test/frontman_server/agents/prompts_test.exs
@@ -125,6 +125,44 @@ defmodule FrontmanServer.Agents.PromptsTest do
     end
   end
 
+  describe "build/1 conditional sections" do
+    test "base prompt (no flags) excludes Figma, ReScript, and TypeScript content" do
+      prompt = Prompts.build([])
+
+      refute prompt =~ "get_figma_node"
+      refute prompt =~ "ReScript"
+      refute prompt =~ "## TypeScript / React"
+    end
+
+    test "base prompt always includes Rules, Tool Selection Guidelines, and Output" do
+      prompt = Prompts.build([])
+
+      assert prompt =~ "## Rules"
+      assert prompt =~ "## Tool Selection Guidelines"
+      assert prompt =~ "## Output"
+    end
+
+    test "has_figma_context includes get_figma_node and volume guidance" do
+      prompt = Prompts.build(has_figma_context: true)
+
+      assert prompt =~ "get_figma_node"
+      assert prompt =~ "volume"
+    end
+
+    test "has_typescript_react includes TypeScript / React section" do
+      prompt = Prompts.build(has_typescript_react: true)
+
+      assert prompt =~ "## TypeScript / React"
+      assert prompt =~ "discriminated unions"
+    end
+
+    test "has_typescript_react false excludes TypeScript / React section" do
+      prompt = Prompts.build(has_typescript_react: false)
+
+      refute prompt =~ "## TypeScript / React"
+    end
+  end
+
   describe "build/1 project_rules option" do
     test "project rules are appended to prompt" do
       rules = [


### PR DESCRIPTION
## Summary

- Moved Figma tool rules (exception clause, `get_figma_node` usage) from compile-time `@base_system_prompt` into `figma_tool_guidance/0`, prepended into existing Figma guidance functions
- Moved TypeScript/React guidance into `typescript_react_guidance/0`, gated by new `has_typescript_react` flag derived from `framework == "nextjs"`
- Deleted the ReScript handling section entirely (no longer needed in root agent prompt)
- Added `maybe_append/3` helper for conditional guidance appending
- ~300 tokens saved per agent call when neither Figma nor TS/React context applies

## Test plan

- [x] All 5 new tests in `prompts_test.exs` pass (base excludes Figma/ReScript/TS; figma flag includes tool guidance; TS flag includes/excludes correctly)
- [x] All 20 existing prompt tests pass unchanged
- [x] Full suite: 482 tests, 0 failures
- [ ] Manual IEx verification: `Prompts.build([])` has no Figma/ReScript/TS content
- [ ] Manual IEx verification: `Prompts.build(has_figma_context: true, has_typescript_react: true)` includes all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/217">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
