### PR TITLE
fix: harden component selection against cross-origin failures

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -81,7 +81,7 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
       id: data["id"],
       timestamp: parse_datetime(data["timestamp"]),
       messages: data["messages"] || [],
-      selected_component: data["selected_component"],
+      selected_component: parse_selected_component(data["selected_component"]),
       selected_component_screenshot: data["selected_component_screenshot"],
       selected_figma_node: parse_figma_node(data["selected_figma_node"])
     }
@@ -154,6 +154,19 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
       {:ok, dt, _} -> dt
       _ -> nil
     end
+  end
+
+  @spec parse_selected_component(map() | nil) :: map() | nil
+  defp parse_selected_component(nil), do: nil
+
+  defp parse_selected_component(data) when is_map(data) do
+    %{
+      file: data["file"],
+      line: data["line"],
+      column: data["column"],
+      source_snippet: data["source_snippet"],
+      source_type: data["source_type"]
+    }
   end
 
   @spec parse_figma_node(map() | nil) :: Interaction.FigmaNode.t() | nil

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -326,6 +326,83 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
+  describe "selected_component round-trip through JSONB" do
+    test "selected_component location survives DB round-trip and appears in LLM messages", %{
+      scope: scope
+    } do
+      task_id = Ecto.UUID.generate()
+      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "test-framework")
+
+      # Content blocks matching the ACP format sent by the client:
+      # 1. Text message
+      # 2. Resource with selected_component _meta annotation
+      # 3. Resource with selected_component_screenshot blob
+      content_blocks = [
+        %{"type" => "text", "text" => "Fix the button"},
+        %{
+          "type" => "resource",
+          "resource" => %{
+            "_meta" => %{
+              "selected_component" => true,
+              "file" => "src/components/Button.tsx",
+              "line" => 42,
+              "column" => 5
+            },
+            "resource" => %{
+              "uri" => "file://src/components/Button.tsx:42:5",
+              "mimeType" => "text/plain",
+              "text" => "Selected component: button at src/components/Button.tsx:42:5"
+            }
+          }
+        },
+        %{
+          "type" => "resource",
+          "resource" => %{
+            "_meta" => %{"selected_component_screenshot" => true},
+            "resource" => %{
+              "uri" => "component://screenshot",
+              "mimeType" => "image/png",
+              "blob" => "iVBORw0KGgoAAAANSUhEUg=="
+            }
+          }
+        }
+      ]
+
+      {:ok, _interaction} = Tasks.add_user_message(scope, task_id, content_blocks, [])
+
+      # Retrieve via LLM conversion (exercises the full JSONB round-trip)
+      {:ok, messages} = Tasks.get_llm_messages(scope, task_id)
+
+      assert length(messages) == 1
+      [msg] = messages
+      assert msg.role == :user
+
+      # Extract text from content parts
+      content_text = extract_content_text(msg.content)
+
+      # The component location should have been appended by append_component_location/2
+      assert content_text =~ "[Selected Component Location]"
+      assert content_text =~ "src/components/Button.tsx"
+      assert content_text =~ "42"
+      assert content_text =~ "5"
+
+      # Screenshot should be present as an image content part
+      image_parts =
+        case msg.content do
+          parts when is_list(parts) ->
+            Enum.filter(parts, fn
+              %{type: :image} -> true
+              _ -> false
+            end)
+
+          _ ->
+            []
+        end
+
+      assert length(image_parts) >= 1
+    end
+  end
+
   defp extract_content_text(content) when is_binary(content), do: content
 
   defp extract_content_text(content) when is_list(content) do

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -469,9 +469,9 @@ let handleEffect = (effect, state: state, dispatch) => {
   | SendMessageToAPI({message, taskId}) =>
     switch state.acpSession {
     | AcpSessionActive({sendPrompt}) =>
+      let task = state.tasks->Dict.get(taskId)
       let additionalBlocks =
-        state.tasks
-        ->Dict.get(taskId)
+        task
         ->Option.mapOr([], Client__State__Types.taskToContentBlocks)
 
       // Include runtime config metadata (e.g., openrouterKeyValue) with each prompt
@@ -547,6 +547,9 @@ let handleEffect = (effect, state: state, dispatch) => {
           },
         )
         Promise.resolve(Some(selector))
+      })->Promise.catch(error => {
+        Console.error2("Failed to get selector:", error)
+        Promise.resolve(None)
       })
 
       // Fetch screenshot
@@ -561,15 +564,22 @@ let handleEffect = (effect, state: state, dispatch) => {
         })
 
       // Fetch source location (cascading: React fiber first, then Astro annotations)
-      let sourceLocationPromise = switch Selectors.previewFrame(state).contentWindow {
-      | Some(window) =>
-        Bindings__SourceDetection.getElementSourceLocation(~element, ~window)
-        ->Promise.then(sourceLocationOpt => Promise.resolve(sourceLocationOpt))
-        ->Promise.catch(error => {
-          Console.error2("Failed to get source location:", error)
-          Promise.resolve(None)
+      // Race against a timeout to prevent hanging when source map resolution stalls (e.g., CORS on RSC URLs)
+      let sourceLocationPromise = {
+        let detectionPromise = switch Selectors.previewFrame(state).contentWindow {
+        | Some(window) =>
+          Bindings__SourceDetection.getElementSourceLocation(~element, ~window)
+          ->Promise.then(sourceLocationOpt => Promise.resolve(sourceLocationOpt))
+          ->Promise.catch(error => {
+            Console.error2("Failed to get source location:", error)
+            Promise.resolve(None)
+          })
+        | None => Promise.resolve(None)
+        }
+        let timeoutPromise = Promise.make((resolve, _) => {
+          let _ = Js.Global.setTimeout(() => resolve(None), 5000)
         })
-      | None => Promise.resolve(None)
+        Promise.race([detectionPromise, timeoutPromise])
       }
 
       // Wait for all promises and update state once
@@ -621,6 +631,8 @@ let handleEffect = (effect, state: state, dispatch) => {
           )
           Promise.resolve()
         })
+      })->Promise.catch(_ => {
+        Promise.resolve()
       })
     }
   | StartInitializationTimeout({taskId, timeoutMs}) =>

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -352,6 +352,7 @@ let next = (task: Task.t, action: action): Task.t => {
   | (Task.New(_) | Task.Loading(_) | Task.Loaded(_), SetPreviewUrl({url})) =>
     Lens.setPreviewUrl(task, url)
 
+  | (Task.Unloaded(_), SetPreviewFrame(_)) => task
   | (Task.New(_) | Task.Loading(_) | Task.Loaded(_), SetPreviewFrame({contentDocument, contentWindow})) =>
     Lens.setPreviewFrame(task, ~contentDocument, ~contentWindow)
 

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -513,37 +513,65 @@ let makeSelectedComponentMeta: (string, int, int) => JSON.t = %raw(`
 
 // Build a Resource ContentBlock from SelectedElement with _meta annotation
 // Contains the source location as structured data in _meta for safe extraction
+// Falls back to selector info when source location is unavailable (e.g., CORS failures with RSC)
 let selectedElementToContentBlock = (sel: SelectedElement.t): option<ACPTypes.contentBlock> => {
-  sel.sourceLocation->Option.map(loc => {
-    // Strip file:// prefix to get clean filesystem path for the agent
-    let cleanFilePath = stripFileUriPrefix(loc.file)
+  switch sel.sourceLocation {
+  | Some(loc) => {
+      // Strip file:// prefix to get clean filesystem path for the agent
+      let cleanFilePath = stripFileUriPrefix(loc.file)
 
-    // Build URI with the original file path (preserve for display purposes)
-    let uri = `file://${cleanFilePath}:${loc.line->Int.toString}:${loc.column->Int.toString}`
+      // Build URI with the original file path (preserve for display purposes)
+      let uri = `file://${cleanFilePath}:${loc.line->Int.toString}:${loc.column->Int.toString}`
 
-    let textResource: ACPTypes.textResourceContents = {
-      uri,
-      mimeType: Some("text/plain"),
-      text: `Selected component: ${loc.tagName} at ${cleanFilePath}:${loc.line->Int.toString}:${loc.column->Int.toString}`,
+      let textResource: ACPTypes.textResourceContents = {
+        uri,
+        mimeType: Some("text/plain"),
+        text: `Selected component: ${loc.tagName} at ${cleanFilePath}:${loc.line->Int.toString}:${loc.column->Int.toString}`,
+      }
+
+      // Create _meta with selected_component annotation containing the clean path
+      let _meta = makeSelectedComponentMeta(cleanFilePath, loc.line, loc.column)
+
+      let embeddedResource: ACPTypes.embeddedResource = {
+        _meta: Some(_meta),
+        annotations: None,
+        resource: ACPTypes.TextResourceContents(textResource),
+      }
+
+      Some({
+        ACPTypes.type_: "resource",
+        text: None,
+        uri: None,
+        resource: Some(embeddedResource),
+        content: None,
+      })
     }
+  | None =>
+    // Fallback: include selector when source location is unavailable
+    sel.selector->Option.map(selector => {
+      let textResource: ACPTypes.textResourceContents = {
+        uri: `selector://${selector}`,
+        mimeType: Some("text/plain"),
+        text: `Selected element: ${selector}`,
+      }
 
-    // Create _meta with selected_component annotation containing the clean path
-    let _meta = makeSelectedComponentMeta(cleanFilePath, loc.line, loc.column)
+      let _meta: JSON.t = %raw(`{"selected_component": true}`)
 
-    let embeddedResource: ACPTypes.embeddedResource = {
-      _meta: Some(_meta),
-      annotations: None,
-      resource: ACPTypes.TextResourceContents(textResource),
-    }
+      let embeddedResource: ACPTypes.embeddedResource = {
+        _meta: Some(_meta),
+        annotations: None,
+        resource: ACPTypes.TextResourceContents(textResource),
+      }
 
-    {
-      ACPTypes.type_: "resource",
-      text: None,
-      uri: None,
-      resource: Some(embeddedResource),
-      content: None,
-    }
-  })
+      {
+        ACPTypes.type_: "resource",
+        text: None,
+        uri: None,
+        resource: Some(embeddedResource),
+        content: None,
+      }
+    })
+  }
 }
 
 // Build an Image ContentBlock from SelectedElement screenshot

--- a/libs/client/src/webpreview/Client__WebPreview__Body.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Body.res
@@ -37,10 +37,14 @@ let make = (~taskId, ~url, ~isActive) => {
       ->Nullable.toOption
       ->Option.forEach(iframe => {
         let iframeElement = iframe->Obj.magic
-        let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
-        let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
-
-        Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
+        try {
+          let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
+          let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
+          Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
+        } catch {
+        // Cross-origin iframes throw SecurityError when accessing contentDocument/contentWindow
+        | _ => ()
+        }
       })
     }
   }
@@ -52,12 +56,17 @@ let make = (~taskId, ~url, ~isActive) => {
       ->Nullable.toOption
       ->Option.forEach(iframe => {
         let iframeElement = iframe->Obj.magic
-        let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
-        let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
+        try {
+          let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
+          let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
 
-        // Only update if the iframe has content loaded
-        if contentDocument->Option.isSome {
-          Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
+          // Only update if the iframe has content loaded
+          if contentDocument->Option.isSome {
+            Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
+          }
+        } catch {
+        // Cross-origin iframes throw SecurityError when accessing contentDocument/contentWindow
+        | _ => ()
         }
       })
     }


### PR DESCRIPTION
## Summary

- Wrap iframe `contentDocument`/`contentWindow` access in try/catch to handle `SecurityError` from cross-origin iframes
- Add 5s timeout racing source location detection to prevent hanging when source map resolution stalls (e.g., CORS on RSC URLs)
- Add error catch on selector promise in element selection flow
- Fall back to CSS selector content block when source location is unavailable instead of producing no content block
- Handle `SetPreviewFrame` on `Unloaded` task state as no-op instead of crash
- Parse `selected_component` into structured atom-keyed map in `InteractionSchema` (was passing raw JSON map through)
- Add JSONB round-trip test for `selected_component`

## Test plan

- [x] New test: `selected_component location survives DB round-trip and appears in LLM messages`
- [ ] Manual: open a cross-origin iframe project, select a component — should not crash or hang
- [ ] Manual: verify fallback selector content block appears when source location fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
