### PR TITLE
feat: upgrade dom-element-to-component-source to v0.5.0 with componen…

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -69,7 +69,10 @@ defmodule FrontmanServer.Tasks.Interaction do
             line: integer(),
             column: integer(),
             source_snippet: String.t() | nil,
-            source_type: String.t() | nil
+            source_type: String.t() | nil,
+            component_name: String.t() | nil,
+            component_props: map() | nil,
+            parent: selected_component() | nil
           }
 
     typedstruct enforce: true do
@@ -125,7 +128,10 @@ defmodule FrontmanServer.Tasks.Interaction do
               line: line,
               column: column,
               source_snippet: Map.get(meta, "source_snippet"),
-              source_type: Map.get(meta, "source_type")
+              source_type: Map.get(meta, "source_type"),
+              component_name: Map.get(meta, "component_name"),
+              component_props: Map.get(meta, "component_props"),
+              parent: parse_parent_chain(Map.get(meta, "parent"))
             }
           else
             nil
@@ -135,6 +141,32 @@ defmodule FrontmanServer.Tasks.Interaction do
           nil
       end)
     end
+
+    # Recursively parse parent chain from _meta
+    defp parse_parent_chain(nil), do: nil
+
+    defp parse_parent_chain(parent) when is_map(parent) do
+      file = Map.get(parent, "file")
+      line = Map.get(parent, "line")
+      column = Map.get(parent, "column")
+
+      if is_binary(file) and is_integer(line) and is_integer(column) do
+        %{
+          file: file,
+          line: line,
+          column: column,
+          source_snippet: nil,
+          source_type: nil,
+          component_name: Map.get(parent, "component_name"),
+          component_props: Map.get(parent, "component_props"),
+          parent: parse_parent_chain(Map.get(parent, "parent"))
+        }
+      else
+        nil
+      end
+    end
+
+    defp parse_parent_chain(_), do: nil
 
     # Extract selected component screenshot from content blocks
     # Looks for _meta.selected_component_screenshot with blob data
@@ -648,13 +680,16 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defp append_component_location(text, %{file: file, line: line, column: column} = sc) do
     source_context = build_source_context(sc)
+    component_name_context = build_component_name_context(sc)
+    props_context = build_props_context(sc)
+    parent_context = build_parent_context(sc)
 
     location_info = """
 
     [Selected Component Location]
     File: #{file}
     Line: #{line}
-    Column: #{column}#{source_context}
+    Column: #{column}#{component_name_context}#{source_context}#{props_context}#{parent_context}
 
     IMPORTANT: The user has selected a specific component at this location.
     Start by reading this exact file and making changes at or near the specified line.
@@ -665,6 +700,66 @@ defmodule FrontmanServer.Tasks.Interaction do
   end
 
   defp append_component_location(text, _), do: text
+
+  defp build_component_name_context(%{component_name: name}) when is_binary(name) do
+    "\nComponent: #{name}"
+  end
+
+  defp build_component_name_context(_), do: ""
+
+  defp build_props_context(%{component_props: props})
+       when is_map(props) and map_size(props) > 0 do
+    props_json = Jason.encode!(props, pretty: true)
+
+    """
+
+    Component Props:
+    ```json
+    #{props_json}
+    ```
+    """
+  end
+
+  defp build_props_context(_), do: ""
+
+  defp build_parent_context(%{parent: parent}) when not is_nil(parent) do
+    parent_chain = format_parent_chain(parent, 1)
+
+    """
+
+    Parent Component Hierarchy:
+    #{parent_chain}
+    """
+  end
+
+  defp build_parent_context(_), do: ""
+
+  defp format_parent_chain(nil, _depth), do: ""
+
+  defp format_parent_chain(%{file: file, line: line, column: column} = parent, depth) do
+    component_name = Map.get(parent, :component_name)
+    props = Map.get(parent, :component_props)
+    nested_parent = Map.get(parent, :parent)
+
+    indent = String.duplicate("  ", depth - 1)
+    name_part = if component_name, do: " (#{component_name})", else: ""
+    location = "#{indent}#{depth}. #{file}:#{line}:#{column}#{name_part}"
+
+    props_part =
+      if is_map(props) and map_size(props) > 0 do
+        props_json = Jason.encode!(props, pretty: false)
+        "\n#{indent}   Props: #{props_json}"
+      else
+        ""
+      end
+
+    nested_part = format_parent_chain(nested_parent, depth + 1)
+    nested_separator = if nested_part != "", do: "\n", else: ""
+
+    location <> props_part <> nested_separator <> nested_part
+  end
+
+  defp format_parent_chain(_, _depth), do: ""
 
   defp build_source_context(sc) do
     case {Map.get(sc, :source_snippet), Map.get(sc, :source_type)} do

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -15,10 +15,10 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "interactions" do
-    field :type, :string
-    field :data, :map
+    field(:type, :string)
+    field(:data, :map)
 
-    belongs_to :task, TaskSchema
+    belongs_to(:task, TaskSchema)
 
     timestamps(type: :utc_datetime, updated_at: false)
   end
@@ -60,12 +60,12 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
 
   @spec for_task(Ecto.Queryable.t(), String.t()) :: Ecto.Query.t()
   def for_task(query \\ __MODULE__, task_id) do
-    from i in query, where: i.task_id == ^task_id
+    from(i in query, where: i.task_id == ^task_id)
   end
 
   @spec ordered_by_inserted(Ecto.Queryable.t()) :: Ecto.Query.t()
   def ordered_by_inserted(query \\ __MODULE__) do
-    from i in query, order_by: [asc: i.inserted_at]
+    from(i in query, order_by: [asc: i.inserted_at])
   end
 
   # --- JSONB to Domain Struct Conversion ---
@@ -165,9 +165,30 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
       line: data["line"],
       column: data["column"],
       source_snippet: data["source_snippet"],
-      source_type: data["source_type"]
+      source_type: data["source_type"],
+      component_name: data["component_name"],
+      component_props: data["component_props"],
+      parent: parse_parent_chain(data["parent"])
     }
   end
+
+  @spec parse_parent_chain(map() | nil) :: map() | nil
+  defp parse_parent_chain(nil), do: nil
+
+  defp parse_parent_chain(parent) when is_map(parent) do
+    %{
+      file: parent["file"],
+      line: parent["line"],
+      column: parent["column"],
+      source_snippet: nil,
+      source_type: nil,
+      component_name: parent["component_name"],
+      component_props: parent["component_props"],
+      parent: parse_parent_chain(parent["parent"])
+    }
+  end
+
+  defp parse_parent_chain(_), do: nil
 
   @spec parse_figma_node(map() | nil) :: Interaction.FigmaNode.t() | nil
   defp parse_figma_node(nil), do: nil

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -33,7 +33,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                line: 42,
                column: 10,
                source_snippet: nil,
-               source_type: nil
+               source_type: nil,
+               component_name: nil,
+               component_props: nil,
+               parent: nil
              }
 
       assert msg.selected_figma_node == nil
@@ -218,7 +221,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                line: 10,
                column: 5,
                source_snippet: nil,
-               source_type: nil
+               source_type: nil,
+               component_name: nil,
+               component_props: nil,
+               parent: nil
              }
 
       assert msg.selected_figma_node != nil
@@ -255,7 +261,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                line: 100,
                column: 50,
                source_snippet: nil,
-               source_type: nil
+               source_type: nil,
+               component_name: nil,
+               component_props: nil,
+               parent: nil
              }
     end
 
@@ -320,7 +329,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                line: 15,
                column: 3,
                source_snippet: nil,
-               source_type: nil
+               source_type: nil,
+               component_name: nil,
+               component_props: nil,
+               parent: nil
              }
 
       assert msg.selected_component_screenshot == "base64screenshotdata"
@@ -639,7 +651,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                "line" => 10,
                "column" => 5,
                "source_snippet" => nil,
-               "source_type" => nil
+               "source_type" => nil,
+               "component_name" => nil,
+               "component_props" => nil,
+               "parent" => nil
              }
 
       assert decoded["selected_figma_node"] == nil

--- a/libs/bindings/package.json
+++ b/libs/bindings/package.json
@@ -8,7 +8,7 @@
 	},
 	"dependencies": {
 		"@rescript/runtime": "12.0.0-beta.14",
-		"dom-element-to-component-source": "^0.4.2",
+		"dom-element-to-component-source": "^0.5.0",
 		"sury": "11.0.0-alpha.4",
 		"sury-ppx": "^11.0.0-alpha.2"
 	},

--- a/libs/bindings/src/DOMElementToComponentSource.res
+++ b/libs/bindings/src/DOMElementToComponentSource.res
@@ -1,12 +1,14 @@
 // Bindings for dom-element-to-component-source server-side functions
 
 // Source location type (used for both input and output)
-@schema
-type sourceLocation = {
+// Note: This is a recursive type to support parent chain
+type rec sourceLocation = {
   componentName: string,
   file: string,
   line: int,
   column: int,
+  componentProps: option<Dict.t<JSON.t>>,
+  parent: option<sourceLocation>,
 }
 
 // The actual JavaScript function returns a sourceLocation object directly,

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -56,7 +56,7 @@
 		"ai": "^5.0.82",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"dom-element-to-component-source": "^0.4.2",
+		"dom-element-to-component-source": "^0.5.0",
 		"lucide-react": "^0.548.0",
 		"motion": "^12.23.24",
 		"nanoid": "^5.1.6",

--- a/libs/client/src/Client__SourceLocationResolver.res
+++ b/libs/client/src/Client__SourceLocationResolver.res
@@ -67,6 +67,7 @@ let resolve = async (sourceLocation: Client__Types.SourceLocation.t): result<
               line,
               column,
               parent: sourceLocation.parent, // Keep parent as-is for now
+              componentProps: sourceLocation.componentProps,
             }: Client__Types.SourceLocation.t
           ),
         )

--- a/libs/client/src/Client__Types.res
+++ b/libs/client/src/Client__Types.res
@@ -8,5 +8,6 @@ module SourceLocation = {
     line: int,
     column: int,
     parent: option<t>,
+    componentProps: option<Dict.t<JSON.t>>,
   }
 }

--- a/libs/client/src/bindings/Bindings__AstroSourceDetection.res
+++ b/libs/client/src/bindings/Bindings__AstroSourceDetection.res
@@ -53,6 +53,7 @@ let getElementSourceLocation = (
       line,
       column,
       parent: None,
+      componentProps: None,
     })
   )
 }

--- a/libs/client/src/state/Client__StateSnapshot.res
+++ b/libs/client/src/state/Client__StateSnapshot.res
@@ -40,6 +40,7 @@ module SourceLocation = {
     line: int,
     column: int,
     parent: option<t>,
+    componentProps: option<Dict.t<JSON.t>>,
   }
 
   let schema: S.t<t> = S.recursive("SourceLocation", schema =>
@@ -50,6 +51,7 @@ module SourceLocation = {
       line: s.field("line", S.int),
       column: s.field("column", S.int),
       parent: s.field("parent", nullableToOption(schema)),
+      componentProps: s.field("componentProps", nullableToOption(S.dict(S.json))),
     })
   )
 }
@@ -332,6 +334,7 @@ let convertSourceLocation = (loc: Client__Types.SourceLocation.t): SourceLocatio
     line: l.line,
     column: l.column,
     parent: l.parent->Option.map(convert),
+    componentProps: l.componentProps,
   }
   convert(loc)
 }

--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -30,6 +30,7 @@ let convertSourceLocation = (loc: Snapshot.SourceLocation.t): Client__Types.Sour
     line: l.line,
     column: l.column,
     parent: l.parent->Option.map(convert),
+    componentProps: l.componentProps,
   }
   convert(loc)
 }

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -499,17 +499,67 @@ let stripFileUriPrefix = (path: string): string => {
   }
 }
 
-// Helper to create _meta JSON for selected component
-let makeSelectedComponentMeta: (string, int, int) => JSON.t = %raw(`
-  function(file, line, column) {
-    return {
-      "selected_component": true,
-      "file": file,
-      "line": line,
-      "column": column
-    };
+// Helper to serialize parent chain to JSON recursively
+let rec serializeParentToJson = (parent: option<Client__Types.SourceLocation.t>): option<JSON.t> => {
+  parent->Option.map(p => {
+    let cleanFilePath = stripFileUriPrefix(p.file)
+    let obj = Dict.make()
+    obj->Dict.set("file", JSON.Encode.string(cleanFilePath))
+    obj->Dict.set("line", JSON.Encode.int(p.line))
+    obj->Dict.set("column", JSON.Encode.int(p.column))
+
+    switch p.componentName {
+    | Some(name) => obj->Dict.set("component_name", JSON.Encode.string(name))
+    | None => ()
+    }
+
+    switch p.componentProps {
+    | Some(props) => obj->Dict.set("component_props", JSON.Encode.object(props))
+    | None => ()
+    }
+
+    // Recursively serialize parent's parent
+    switch serializeParentToJson(p.parent) {
+    | Some(parentJson) => obj->Dict.set("parent", parentJson)
+    | None => ()
+    }
+
+    JSON.Encode.object(obj)
+  })
+}
+
+// Helper to create _meta JSON for selected component with componentProps and parent chain
+let makeSelectedComponentMeta = (
+  ~file: string,
+  ~line: int,
+  ~column: int,
+  ~componentName: option<string>,
+  ~componentProps: option<Dict.t<JSON.t>>,
+  ~parent: option<Client__Types.SourceLocation.t>,
+): JSON.t => {
+  let obj = Dict.make()
+  obj->Dict.set("selected_component", JSON.Encode.bool(true))
+  obj->Dict.set("file", JSON.Encode.string(file))
+  obj->Dict.set("line", JSON.Encode.int(line))
+  obj->Dict.set("column", JSON.Encode.int(column))
+
+  switch componentName {
+  | Some(name) => obj->Dict.set("component_name", JSON.Encode.string(name))
+  | None => ()
   }
-`)
+
+  switch componentProps {
+  | Some(props) => obj->Dict.set("component_props", JSON.Encode.object(props))
+  | None => ()
+  }
+
+  switch serializeParentToJson(parent) {
+  | Some(parentJson) => obj->Dict.set("parent", parentJson)
+  | None => ()
+  }
+
+  JSON.Encode.object(obj)
+}
 
 // Build a Resource ContentBlock from SelectedElement with _meta annotation
 // Contains the source location as structured data in _meta for safe extraction
@@ -529,8 +579,15 @@ let selectedElementToContentBlock = (sel: SelectedElement.t): option<ACPTypes.co
         text: `Selected component: ${loc.tagName} at ${cleanFilePath}:${loc.line->Int.toString}:${loc.column->Int.toString}`,
       }
 
-      // Create _meta with selected_component annotation containing the clean path
-      let _meta = makeSelectedComponentMeta(cleanFilePath, loc.line, loc.column)
+      // Create _meta with selected_component annotation containing the clean path, componentProps, and parent chain
+      let _meta = makeSelectedComponentMeta(
+        ~file=cleanFilePath,
+        ~line=loc.line,
+        ~column=loc.column,
+        ~componentName=loc.componentName,
+        ~componentProps=loc.componentProps,
+        ~parent=loc.parent,
+      )
 
       let embeddedResource: ACPTypes.embeddedResource = {
         _meta: Some(_meta),

--- a/libs/client/test/Client__State__Types.test.res
+++ b/libs/client/test/Client__State__Types.test.res
@@ -21,6 +21,7 @@ describe("Client__State__Types", () => {
         line: 42,
         column: 5,
         parent: None,
+        componentProps: None,
       }
 
       let selectedElement: Types.SelectedElement.t = {
@@ -57,10 +58,11 @@ describe("Client__State__Types", () => {
       let sourceLocation: ClientTypes.SourceLocation.t = {
         componentName: Some("TestComponent"),
         tagName: "div",
-        file: "/home/user/project/src/Component.tsx",
+        file: "file:///home/user/project/src/Component.tsx",
         line: 42,
         column: 5,
         parent: None,
+        componentProps: None,
       }
 
       let selectedElement: Types.SelectedElement.t = {
@@ -95,6 +97,7 @@ describe("Client__State__Types", () => {
         line: 10,
         column: 1,
         parent: None,
+        componentProps: None,
       }
 
       let selectedElement: Types.SelectedElement.t = {
@@ -128,6 +131,7 @@ describe("Client__State__Types", () => {
         line: 42,
         column: 5,
         parent: None,
+        componentProps: None,
       }
 
       let selectedElement: Types.SelectedElement.t = {

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -68,7 +68,7 @@
 		"@rescript/runtime": "12.0.0-beta.14",
 		"@rescript/webapi": "catalog:",
 		"@vitest/ui": "catalog:",
-		"dom-element-to-component-source": "0.4.2",
+		"dom-element-to-component-source": "0.5.0",
 		"rescript": "catalog:",
 		"rescript-vitest": "catalog:",
 		"sentry-testkit": "^5.0.9",

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Server.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Server.res
@@ -144,6 +144,8 @@ let handleResolveSourceLocation = async (
           file,
           line: line->Float.toInt,
           column: column->Float.toInt,
+          componentProps: None,
+          parent: None,
         }
 
         let resolved = await DOMElementToComponentSource.resolveSourceLocationInServer(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
     "@rescript/webapi": "catalog:"
     "@sentry/nextjs": "npm:^8.0.0"
     "@vitest/ui": "catalog:"
-    dom-element-to-component-source: "npm:0.4.2"
+    dom-element-to-component-source: "npm:0.5.0"
     rescript: "catalog:"
     rescript-vitest: "catalog:"
     sentry-testkit: "npm:^5.0.9"
@@ -2075,7 +2075,7 @@ __metadata:
   resolution: "@frontman/bindings@workspace:libs/bindings"
   dependencies:
     "@rescript/runtime": "npm:12.0.0-beta.14"
-    dom-element-to-component-source: "npm:^0.4.2"
+    dom-element-to-component-source: "npm:^0.5.0"
     rescript: "catalog:"
     sentry-testkit: "npm:^5.0.9"
     sury: "npm:11.0.0-alpha.4"
@@ -2148,7 +2148,7 @@ __metadata:
     ai: "npm:^5.0.82"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
-    dom-element-to-component-source: "npm:^0.4.2"
+    dom-element-to-component-source: "npm:^0.5.0"
     lucide-react: "npm:^0.548.0"
     motion: "npm:^12.23.24"
     nanoid: "npm:^5.1.6"
@@ -12150,14 +12150,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-element-to-component-source@npm:0.4.2, dom-element-to-component-source@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "dom-element-to-component-source@npm:0.4.2"
+"dom-element-to-component-source@npm:0.5.0, dom-element-to-component-source@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "dom-element-to-component-source@npm:0.5.0"
   dependencies:
     error-stack-parser: "npm:^2.1.4"
     source-map: "npm:^0.7.6"
     stacktrace-gps: "npm:^3.1.2"
-  checksum: 10c0/8cce5a196224240284e2de95a63a8a2afa5b55d9232314458152054268c9e3d8e643e6766d273adb5bd7004d4bdf2e51ecd63dcfbfe36f087e155a7d474d3b72
+  checksum: 10c0/e2590c15b1149418023bd9b38d8dc5aff8dae85062b9d7870a40801a62cf0115bd35670f7354ed72d21d524f054011cc99b8e6a3fa9db9544120081f86b4c360
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…tProps and parent chain

Closes #221

## Summary
- Upgraded dom-element-to-component-source from v0.4.2 to v0.5.0
- Added componentProps field to SourceLocation type (client-side)
- Added full parent ancestry chain support to LLM prompts

## Changes

### Client-side (ReScript)
- Client__Types.SourceLocation: Added componentProps field
- Client__StateSnapshot: Updated SourceLocation schema with componentProps
- Client__Task__Types: Updated meta builder to serialize componentProps and parent chain
- Bindings__AstroSourceDetection: Added componentProps to constructed locations
- Client__SourceLocationResolver: Preserved componentProps in resolution
- FrontmanNextjs__Server: Added new fields to server binding

### Server-side (Elixir)
- interaction.ex: Extended selected_component type with component_name, component_props, and parent
- interaction.ex: Added recursive parse_parent_chain for extraction
- interaction.ex: Enhanced LLM prompt with component props and full parent hierarchy
- interaction_schema.ex: Updated persistence parsing for new fields

## LLM Prompt Enhancement
The selected component info now includes:
- Component name (when available)
- Component props in JSON format
- Full parent hierarchy with file:line:column, component names, and props for each ancestor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/222">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
