### PR TITLE
fix: second message fails due to tool_calls string key mismatch

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -654,7 +654,10 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defp to_llm_message(%AgentResponse{content: content, metadata: metadata}) do
     meta = metadata || %{}
-    tool_calls = Map.get(meta, :tool_calls)
+    # Handle both atom and string keys (DB stores string keys, but in-memory uses atoms)
+    raw_tool_calls = get_flexible(meta, :tool_calls)
+    # Convert stored tool_calls (maps with string keys) to ReqLLM.ToolCall structs
+    tool_calls = normalize_tool_calls(raw_tool_calls)
 
     build_assistant_message(content, tool_calls, meta)
   end
@@ -818,8 +821,9 @@ defmodule FrontmanServer.Tasks.Interaction do
   defp build_assistant_message(content, [], _meta), do: ReqLLM.Context.assistant(content)
 
   defp build_assistant_message(content, tool_calls, meta) do
-    response_id = Map.get(meta, :response_id)
-    encrypted_reasoning = filter_encrypted_reasoning(Map.get(meta, :reasoning_details))
+    # Handle both atom and string keys (DB stores string keys, but in-memory uses atoms)
+    response_id = get_flexible(meta, :response_id)
+    encrypted_reasoning = filter_encrypted_reasoning(get_flexible(meta, :reasoning_details))
 
     %ReqLLM.Message{
       role: :assistant,
@@ -896,13 +900,48 @@ defmodule FrontmanServer.Tasks.Interaction do
   defp encode_json(value) when is_binary(value), do: value
   defp encode_json(value), do: Jason.encode!(value)
 
-  # Get field from map, supporting both string and atom keys
+  # Get field from map, supporting both string and atom keys.
+  # This is needed because metadata from DB has string keys, but in-memory uses atoms.
   defp get_field(map, key) when is_atom(key) do
     Map.get(map, Atom.to_string(key)) || Map.get(map, key)
   end
 
   defp get_field(map, key) when is_binary(key) do
     Map.get(map, key) || Map.get(map, String.to_atom(key))
+  end
+
+  # Alias for get_field, used for metadata access to make intent clear
+  defp get_flexible(map, key), do: get_field(map, key)
+
+  # Convert stored tool_calls (maps with string keys in OpenAI wire format) to ReqLLM.ToolCall structs
+  defp normalize_tool_calls(nil), do: nil
+  defp normalize_tool_calls([]), do: []
+
+  defp normalize_tool_calls(tool_calls) when is_list(tool_calls) do
+    Enum.map(tool_calls, &normalize_tool_call/1)
+  end
+
+  # Already a struct, pass through
+  defp normalize_tool_call(%ReqLLM.ToolCall{} = tc), do: tc
+
+  # OpenAI wire format with string keys (from DB JSON)
+  defp normalize_tool_call(%{"id" => id, "function" => %{"name" => name, "arguments" => args}}) do
+    ReqLLM.ToolCall.new(id, name, args)
+  end
+
+  # OpenAI wire format with atom keys (fresh from response)
+  defp normalize_tool_call(%{id: id, function: %{name: name, arguments: args}}) do
+    ReqLLM.ToolCall.new(id, name, args)
+  end
+
+  # Flat format with string keys
+  defp normalize_tool_call(%{"id" => id, "name" => name, "arguments" => args}) do
+    ReqLLM.ToolCall.new(id, name, args)
+  end
+
+  # Flat format with atom keys
+  defp normalize_tool_call(%{id: id, name: name, arguments: args}) do
+    ReqLLM.ToolCall.new(id, name, args)
   end
 
   defp decode_data_url(data_url) do

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -621,6 +621,309 @@ defmodule FrontmanServer.Tasks.InteractionTest do
     end
   end
 
+  describe "to_llm_messages/1 with DB-loaded metadata (string keys)" do
+    # These tests cover the bug where metadata loaded from DB has string keys,
+    # but the code was trying to access with atom keys (e.g., :tool_calls vs "tool_calls").
+    # This caused tool_calls to be nil when reconstructing conversation history,
+    # leading to Anthropic rejecting subsequent requests with:
+    # "unexpected tool_use_id found in tool_result blocks"
+
+    test "converts agent responses with tool_calls stored as string keys (OpenAI wire format)" do
+      # This is exactly how tool_calls are stored in the DB after JSON serialization
+      tool_calls_from_db = [
+        %{
+          "function" => %{
+            "arguments" => ~s({"path": "src/app/page.tsx"}),
+            "name" => "read_file"
+          },
+          "id" => "toolu_012YbdZVHHNLf7EtGWY9m5Gy",
+          "type" => "function"
+        }
+      ]
+
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "I'll read the file",
+          timestamp: DateTime.utc_now(),
+          # Simulating DB-loaded metadata with string keys
+          metadata: %{"tool_calls" => tool_calls_from_db}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      assert length(messages) == 1
+
+      msg = hd(messages)
+      assert msg.role == :assistant
+
+      # Verify tool_calls are present and converted to ReqLLM.ToolCall structs
+      assert msg.tool_calls != nil
+      assert length(msg.tool_calls) == 1
+
+      tc = hd(msg.tool_calls)
+      assert %ReqLLM.ToolCall{} = tc
+      assert tc.id == "toolu_012YbdZVHHNLf7EtGWY9m5Gy"
+      assert tc.function.name == "read_file"
+      assert tc.function.arguments == ~s({"path": "src/app/page.tsx"})
+    end
+
+    test "converts agent responses with multiple tool_calls from DB" do
+      tool_calls_from_db = [
+        %{
+          "function" => %{"arguments" => ~s({"path": "file1.txt"}), "name" => "read_file"},
+          "id" => "toolu_001",
+          "type" => "function"
+        },
+        %{
+          "function" => %{"arguments" => ~s({"pattern": "*.tsx"}), "name" => "glob"},
+          "id" => "toolu_002",
+          "type" => "function"
+        }
+      ]
+
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Let me search for files",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => tool_calls_from_db}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      assert length(msg.tool_calls) == 2
+      assert Enum.all?(msg.tool_calls, &match?(%ReqLLM.ToolCall{}, &1))
+      assert Enum.map(msg.tool_calls, & &1.id) == ["toolu_001", "toolu_002"]
+      assert Enum.map(msg.tool_calls, & &1.function.name) == ["read_file", "glob"]
+    end
+
+    test "handles empty tool_calls list from DB" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Just a text response",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => []}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      # Should be a simple assistant message without tool_calls
+      assert msg.role == :assistant
+      assert [%{type: :text, text: "Just a text response"}] = msg.content
+    end
+
+    test "handles nil tool_calls from DB" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Just a text response",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => nil}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      assert msg.role == :assistant
+      assert [%{type: :text, text: "Just a text response"}] = msg.content
+    end
+
+    test "handles response_id and reasoning_details with string keys from DB" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Thinking...",
+          timestamp: DateTime.utc_now(),
+          metadata: %{
+            "tool_calls" => [
+              %{
+                "function" => %{"arguments" => "{}", "name" => "test_tool"},
+                "id" => "call_123",
+                "type" => "function"
+              }
+            ],
+            "response_id" => "resp_abc123",
+            "reasoning_details" => [
+              %{"type" => "reasoning.encrypted", "data" => "encrypted_data"}
+            ]
+          }
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      # response_id should be in metadata
+      assert msg.metadata == %{response_id: "resp_abc123"}
+
+      # reasoning_details should be preserved (only encrypted ones)
+      assert msg.reasoning_details == [
+               %{"type" => "reasoning.encrypted", "data" => "encrypted_data"}
+             ]
+    end
+
+    test "full conversation round-trip with tool calls from DB" do
+      # Simulates a complete conversation loaded from DB
+      now = DateTime.utc_now()
+
+      interactions = [
+        # User asks a question
+        %UserMessage{
+          id: "1",
+          messages: ["What's in the file?"],
+          timestamp: now,
+          selected_component: nil,
+          selected_component_screenshot: nil,
+          selected_figma_node: nil
+        },
+        # Agent responds with tool call (DB format with string keys)
+        %AgentResponse{
+          id: "2",
+          content: "I'll read the file for you.",
+          timestamp: now,
+          metadata: %{
+            "tool_calls" => [
+              %{
+                "function" => %{"arguments" => ~s({"path": "README.md"}), "name" => "read_file"},
+                "id" => "toolu_read_123",
+                "type" => "function"
+              }
+            ]
+          }
+        },
+        # Tool call record (skipped in LLM messages)
+        %ToolCall{
+          id: "3",
+          tool_call_id: "toolu_read_123",
+          tool_name: "read_file",
+          arguments: %{"path" => "README.md"},
+          timestamp: now
+        },
+        # Tool result
+        %ToolResult{
+          id: "4",
+          tool_call_id: "toolu_read_123",
+          tool_name: "read_file",
+          result: "# README\nThis is a readme file.",
+          is_error: false,
+          timestamp: now
+        },
+        # Agent's final response
+        %AgentResponse{
+          id: "5",
+          content: "The file contains a README header.",
+          timestamp: now,
+          metadata: %{}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+
+      # Should have: UserMessage, AgentResponse with tool, ToolResult, AgentResponse
+      # ToolCall is skipped
+      assert length(messages) == 4
+
+      # Verify message roles
+      [user_msg, assistant_with_tool, tool_result, final_assistant] = messages
+      assert user_msg.role == :user
+      assert assistant_with_tool.role == :assistant
+      assert tool_result.role == :tool
+      assert final_assistant.role == :assistant
+
+      # Verify the assistant message has proper tool_calls
+      assert length(assistant_with_tool.tool_calls) == 1
+      tc = hd(assistant_with_tool.tool_calls)
+      assert %ReqLLM.ToolCall{} = tc
+      assert tc.id == "toolu_read_123"
+      assert tc.function.name == "read_file"
+
+      # Verify the tool_result has matching tool_call_id
+      assert tool_result.tool_call_id == "toolu_read_123"
+    end
+
+    test "handles flat format tool_calls with string keys" do
+      # Some code paths might store tool_calls in flat format
+      tool_calls_flat = [
+        %{"id" => "call_flat_1", "name" => "get_weather", "arguments" => ~s({"city": "NYC"})}
+      ]
+
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Checking weather",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => tool_calls_flat}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      assert length(msg.tool_calls) == 1
+      tc = hd(msg.tool_calls)
+      assert %ReqLLM.ToolCall{} = tc
+      assert tc.id == "call_flat_1"
+      assert tc.function.name == "get_weather"
+    end
+
+    test "handles atom keys (fresh from response, not DB)" do
+      # When tool_calls come fresh from a response (not loaded from DB),
+      # they have atom keys. This should also work.
+      tool_calls_with_atoms = [
+        %{
+          function: %{arguments: ~s({"x": 1}), name: "calculator"},
+          id: "call_atom_1",
+          type: "function"
+        }
+      ]
+
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Calculating",
+          timestamp: DateTime.utc_now(),
+          metadata: %{tool_calls: tool_calls_with_atoms}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      assert length(msg.tool_calls) == 1
+      tc = hd(msg.tool_calls)
+      assert %ReqLLM.ToolCall{} = tc
+      assert tc.function.name == "calculator"
+    end
+
+    test "passes through ReqLLM.ToolCall structs unchanged" do
+      # If tool_calls are already ReqLLM.ToolCall structs, they should pass through
+      existing_struct = ReqLLM.ToolCall.new("call_struct_1", "my_tool", "{}")
+
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          content: "Using tool",
+          timestamp: DateTime.utc_now(),
+          metadata: %{tool_calls: [existing_struct]}
+        }
+      ]
+
+      messages = Interaction.to_llm_messages(interactions)
+      msg = hd(messages)
+
+      assert length(msg.tool_calls) == 1
+      tc = hd(msg.tool_calls)
+      assert tc == existing_struct
+    end
+  end
+
   describe "JSON encoding" do
     test "encodes UserMessage to JSON with messages and selected_component" do
       msg =


### PR DESCRIPTION
## Summary
- Fixes string vs atom key mismatch when loading AgentResponse metadata from database
- Adds `normalize_tool_calls/1` to convert stored tool_call maps to `ReqLLM.ToolCall` structs
- Adds 9 tests covering DB-loaded metadata scenarios

## Root Cause
When `AgentResponse` interactions were loaded from the database, the `metadata` field contained maps with **string keys** (from JSON), but the code accessed `tool_calls` using **atom keys**. This caused `tool_calls` to be `nil` when reconstructing conversation history.

On second prompt, the conversation history was rebuilt without `tool_use` blocks in assistant messages, but `ToolResult` messages still referenced the `tool_call_ids`. Anthropic rejected with:
```
unexpected tool_use_id found in tool_result blocks
```

Fixes #223
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/230">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
