### PR TITLE
fix: contain selection overlay stacking context to prevent modal overlap

### DIFF
--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -87,7 +87,7 @@ let make = (~document) => {
   }, [webPreviewIsSelecting])
 
   // Selection overlay container
-  <div className="pointer-events-none flex-1 absolute top-0 left-0 w-full h-full">
+  <div className="pointer-events-none flex-1 absolute top-0 left-0 w-full h-full isolate">
     // Selection mode indicator - subtle border around the preview
     {webPreviewIsSelecting
       ? <div


### PR DESCRIPTION
## Summary
- Adds `isolate` to the Stage overlay container to create a proper stacking context
- Selection indicators (`z-[9998]`/`z-[9999]`) were rendering above the settings modal (`z-50`) because they shared the root stacking context
- With `isolate`, the entire Stage context sits at level 0, so the Radix Dialog portal at `z-50` correctly renders above it

Closes #225

## Test plan
- [ ] Select an element on the canvas
- [ ] Open the settings panel
- [ ] Verify the selection indicator no longer overlaps the settings panel
- [ ] Verify selection indicators still display correctly on the canvas when the modal is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
