### PR TITLE
feat: align client tool registry with server-side pattern

### DIFF
--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -5,7 +5,6 @@ module ACP = FrontmanFrontmanClient.FrontmanClient__ACP
 module Types = FrontmanFrontmanClient.FrontmanClient__ACP__Types
 module Relay = FrontmanFrontmanClient.FrontmanClient__Relay
 module MCPServer = FrontmanFrontmanClient.FrontmanClient__MCP__Server
-module ConsoleLogTool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool__ConsoleLog
 module Reducer = Client__ConnectionReducer
 module StateReducer = FrontmanReactStatestore.StateReducer
 module RuntimeConfig = Client__RuntimeConfig
@@ -93,12 +92,9 @@ module Provider = {
       let metadata = RuntimeConfig.toMetadata(runtimeConfig)
 
       let relay = Relay.make(~baseUrl)
-      let mcpServer =
-        MCPServer.make(~relay, ~serverName=clientName, ~serverVersion=clientVersion)
-        ->MCPServer.registerToolModule(module(ConsoleLogTool))
-        ->MCPServer.registerToolModule(module(Client__Tool__GetFigmaNode))
-        ->MCPServer.registerToolModule(module(Client__Tool__TakeScreenshot))
-        ->MCPServer.registerToolModule(module(Client__Tool__Navigate))
+      let toolRegistry = Client__ToolRegistry.coreBrowserTools()
+      let mcpServer = MCPServer.make(~relay, ~serverName=clientName, ~serverVersion=clientVersion)
+      let mcpServer = Client__ToolRegistry.registerAll(toolRegistry, mcpServer)
 
       let config: Reducer.initConfig = {
         endpoint,

--- a/libs/client/src/Client__ToolRegistry.res
+++ b/libs/client/src/Client__ToolRegistry.res
@@ -1,0 +1,54 @@
+// Client-side Tool Registry - composable browser tool collection
+// Mirrors the server-side FrontmanCore__ToolRegistry pattern
+
+module FrontmanClient = FrontmanFrontmanClient
+module MCPServer = FrontmanClient.FrontmanClient__MCP__Server
+module Tool = FrontmanClient.FrontmanClient__MCP__Tool
+
+type tool = module(Tool.Tool)
+
+type t = {tools: array<tool>}
+
+// Create empty registry
+let make = (): t => {
+  tools: [],
+}
+
+let coreBrowserTools = (): t => {
+  tools: [
+    module(FrontmanClient.FrontmanClient__MCP__Tool__ConsoleLog),
+    module(Client__Tool__GetFigmaNode),
+    module(Client__Tool__TakeScreenshot),
+    module(Client__Tool__Navigate),
+  ],
+}
+
+// Add tools to registry
+let addTools = (registry: t, newTools: array<tool>): t => {
+  tools: Array.concat(registry.tools, newTools),
+}
+
+// Merge two registries
+let merge = (a: t, b: t): t => {
+  tools: Array.concat(a.tools, b.tools),
+}
+
+// Get tool by name
+let getToolByName = (registry: t, name: string): option<tool> => {
+  registry.tools->Array.find(m => {
+    module T = unpack(m)
+    T.name == name
+  })
+}
+
+// Register all tools from registry into an MCP server
+let registerAll = (registry: t, mcpServer: MCPServer.t): MCPServer.t => {
+  registry.tools->Array.reduce(mcpServer, (srv, toolModule) =>
+    srv->MCPServer.registerToolModule(toolModule)
+  )
+}
+
+// Get count of tools
+let count = (registry: t): int => {
+  registry.tools->Array.length
+}

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -1,0 +1,51 @@
+open Vitest
+
+module ToolRegistry = Client__ToolRegistry
+
+describe("ToolRegistry", _t => {
+  test("make creates empty registry", t => {
+    let registry = ToolRegistry.make()
+
+    t->expect(registry->ToolRegistry.count)->Expect.toBe(0)
+  })
+
+  test("coreBrowserTools returns all browser tools", t => {
+    let registry = ToolRegistry.coreBrowserTools()
+
+    t->expect(registry->ToolRegistry.count)->Expect.toBe(4)
+  })
+
+  test("finds tool by name", t => {
+    let registry = ToolRegistry.coreBrowserTools()
+
+    t->expect(registry->ToolRegistry.getToolByName("console_log")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("get_figma_node")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("take_screenshot")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("navigate")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("nonexistent")->Option.isSome)->Expect.toBe(false)
+  })
+
+  test("addTools extends registry", t => {
+    let registry = ToolRegistry.make()
+    let extended = registry->ToolRegistry.addTools([
+      module(Client__Tool__Navigate),
+    ])
+
+    t->expect(registry->ToolRegistry.count)->Expect.toBe(0) // original unchanged
+    t->expect(extended->ToolRegistry.count)->Expect.toBe(1)
+  })
+
+  test("merge combines two registries", t => {
+    let a = ToolRegistry.make()->ToolRegistry.addTools([
+      module(Client__Tool__Navigate),
+    ])
+    let b = ToolRegistry.make()->ToolRegistry.addTools([
+      module(Client__Tool__TakeScreenshot),
+    ])
+    let merged = ToolRegistry.merge(a, b)
+
+    t->expect(merged->ToolRegistry.count)->Expect.toBe(2)
+    t->expect(merged->ToolRegistry.getToolByName("navigate")->Option.isSome)->Expect.toBe(true)
+    t->expect(merged->ToolRegistry.getToolByName("take_screenshot")->Option.isSome)->Expect.toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Create `Client__ToolRegistry.res` mirroring `FrontmanCore__ToolRegistry` API (`make`, `coreBrowserTools`, `addTools`, `merge`, `getToolByName`, `count`, `registerAll`)
- Update `Client__FrontmanProvider` to use the new registry instead of inline `registerToolModule` chains
- Remove dead `ConsoleLogTool` module alias from provider

Closes #91

## Test plan
- [x] All 5 new `Client__ToolRegistry` tests pass (empty registry, core tools count, find by name, addTools immutability, merge)
- [x] All 92 existing tests still pass
- [x] ReScript compilation clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/239">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
