### PR TITLE
fix: show streaming/thinking indication for standalone tool calls

### DIFF
--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -121,7 +121,7 @@ let make = (
         </span>
       </div>
       <div className="flex items-center gap-0.5 shrink-0">
-        <ToolStatus state compact=true />
+        <ToolStatus state compact />
         {hasBody
           ? <button
               type_="button"


### PR DESCRIPTION
## Summary

Closes #247

- Forward the component's `compact` prop to `ToolStatus` instead of hardcoding `compact=true` in `Client__ToolCallBlock.res`
- Standalone tool calls like `write_file` now show status text ("Executing...", "Done") instead of appearing idle
- Grouped tool calls (e.g. `read_file` in explore groups) are unaffected since `ToolGroupBlock` already passes `compact=true` explicitly

## Test plan

- [ ] `cd libs/client && make build` compiles successfully
- [ ] Trigger a `write_file` tool call — verify "Executing..." text appears during execution and "Done" after completion
- [ ] Verify grouped tools (read_file in explore groups) still show compact status (icon only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
