### PR TITLE
chore: add postgres and nextjs-bundle to mprocs dev environment

### DIFF
--- a/mprocs.yml
+++ b/mprocs.yml
@@ -1,12 +1,19 @@
 procs:
+  postgres:
+    cmd: ["podman", "run", "--rm", "--name", "frontman-postgres", "-e", "POSTGRES_USER=postgres", "-e", "POSTGRES_PASSWORD=postgres", "-p", "5432:5432", "postgres:16"]
+    stop: { cmd: ["podman", "stop", "frontman-postgres"] }
+
   rescript:
     cmd: ["make", "rescript-watch"]
 
   server:
-    cmd: ["make", "dev-server"]
+    cmd: ["bash", "-c", "echo 'Waiting for Postgres...' && while ! podman exec frontman-postgres pg_isready -U postgres 2>/dev/null; do sleep 2; done && echo 'Postgres ready, starting server...' && make dev-server"]
 
   client:
     cmd: ["make", "dev-client"]
+
+  nextjs-bundle:
+    cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready, starting tsup watch...' && cd libs/frontman-nextjs && yarn tsup --watch"]
 
   nextjs:
     cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready, starting Next.js...' && make dev-nextjs"]


### PR DESCRIPTION
## Summary
- Add **postgres** process using podman with graceful shutdown via `podman stop`
- Make **server** wait for postgres readiness before starting
- Add **nextjs-bundle** process that watches `frontman-nextjs` with tsup (waits for ReScript compiler)

## Test plan
- [ ] Run `mprocs` and verify postgres container starts and becomes healthy
- [ ] Verify server waits for postgres before launching
- [ ] Verify nextjs-bundle waits for ReScript and starts tsup watch
- [ ] Verify stopping mprocs gracefully stops the postgres container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
