### PR TITLE
marketing: update copy to reflect server-hosted agent architecture

### DIFF
--- a/apps/marketing/src/components/blocks/context/FullContextSection.astro
+++ b/apps/marketing/src/components/blocks/context/FullContextSection.astro
@@ -54,7 +54,7 @@ import clientSvg from '../../../assets/context/client.svg'
 							Cursor, Claude Code, Copilot — they all run in your terminal or IDE, completely disconnected from what's rendering in your browser. They read your code, but they've never seen your UI.
 						</p>
 						<p>
-							Frontman is wired into both your dev server and your browser. It has direct access to your DOM, styles, and component tree in real time. That means fewer hallucinations, faster iterations, and code that matches your intent on the first try.
+							Frontman's agent connects to both your dev server and your browser. It has direct access to your DOM, styles, and component tree in real time. That means fewer hallucinations, faster iterations, and code that matches your intent on the first try.
 						</p>
 					</div>
 				</div>

--- a/apps/marketing/src/components/blocks/install/InstallSteps.astro
+++ b/apps/marketing/src/components/blocks/install/InstallSteps.astro
@@ -60,7 +60,7 @@ const frameworks = [
 					<div class="step-line"></div>
 				</div>
 				<div class="step-card step-card--yellow">
-					<h3 class="step-title">Install locally</h3>
+					<h3 class="step-title">Add to your project</h3>
 					<p class="step-description">Run one command in your project folder</p>
 					<div class="terminal">
 						<div class="terminal-bar">

--- a/apps/marketing/src/data/json-files/faqData.json
+++ b/apps/marketing/src/data/json-files/faqData.json
@@ -19,7 +19,7 @@
 	},
 	{
 		"question": "Is it open source?",
-		"reply": "Yes. Frontman is fully open source under the Apache 2.0 license. The entire codebase is on GitHub at github.com/frontman-ai/frontman. Every prompt, every tool call, every piece of context the agent uses is visible in the source. It runs locally on your machine — your code never leaves your environment.",
+		"reply": "Yes. Frontman is fully open source under the Apache 2.0 license. The entire codebase is on GitHub at github.com/frontman-ai/frontman. Every prompt, every tool call, every piece of context the agent uses is visible in the source.",
 		"category": "general",
 		"open": false
 	},
@@ -43,13 +43,13 @@
 	},
 	{
 		"question": "Which frameworks are supported?",
-		"reply": "Frontman currently supports Next.js, Astro, and Vite. It integrates at the framework level as middleware, turning your app into an MCP server that exposes both client-side and server-side context to the agent.",
+		"reply": "Frontman currently supports Next.js, Astro, and Vite. It integrates at the framework level as middleware, turning your local dev server into an MCP server that our agent connects to for both client-side and server-side context.",
 		"category": "technical",
 		"open": true
 	},
 	{
 		"question": "How does it get context about my app?",
-		"reply": "When you install Frontman, a lightweight middleware hooks into your framework. It exposes tools to the agent via MCP — client-side tools (component tree, performance, logs, click targets) and server-side tools (routes, server logs, query timing, compiled modules). Your app essentially becomes an MCP server that the agent can query in real time.",
+		"reply": "When you install Frontman, a lightweight middleware hooks into your framework and exposes tools via MCP — client-side tools (component tree, performance, logs, click targets) and server-side tools (routes, server logs, query timing, compiled modules). Our agent connects to your local dev server and queries this context in real time, so it always knows what's actually happening in your app.",
 		"category": "technical",
 		"open": false
 	}


### PR DESCRIPTION
Removes "runs locally" messaging and clarifies that Frontman's agent runs on our servers and connects to the user's local dev environment.

## Description

<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
