### PR TITLE
fix: enforce required token fields in ChatGPT OAuth exchange and align Dialyzer specs

### DIFF
--- a/.changeset/fix-dialyzer-chatgpt-oauth-spec.md
+++ b/.changeset/fix-dialyzer-chatgpt-oauth-spec.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Dialyzer error in ChatGPT OAuth: pattern match required token fields in `exchange_device_code/2` response instead of silently accepting nil, and align `extract_account_id_from_tokens/1` spec with the actual map shape.

--- a/apps/frontman_server/lib/frontman_server/providers/chatgpt_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/chatgpt_oauth.ex
@@ -173,12 +173,21 @@ defmodule FrontmanServer.Providers.ChatGPTOAuth do
     ]
 
     case Req.post(@token_url, body: body, headers: headers) do
-      {:ok, %Req.Response{status: 200, body: response_body}} ->
+      {:ok,
+       %Req.Response{
+         status: 200,
+         body:
+           %{
+             "access_token" => access_token,
+             "id_token" => id_token,
+             "refresh_token" => refresh_token
+           } = response_body
+       }} ->
         {:ok,
          %{
-           access_token: response_body["access_token"],
-           refresh_token: response_body["refresh_token"],
-           id_token: response_body["id_token"],
+           access_token: access_token,
+           refresh_token: refresh_token,
+           id_token: id_token,
            expires_in: response_body["expires_in"]
          }}
 
@@ -287,8 +296,12 @@ defmodule FrontmanServer.Providers.ChatGPTOAuth do
   @doc """
   Extracts the account ID from token response, trying id_token first, then access_token.
   """
-  @spec extract_account_id_from_tokens(%{id_token: String.t() | nil, access_token: String.t()}) ::
-          String.t() | nil
+  @spec extract_account_id_from_tokens(%{
+          :id_token => String.t(),
+          :access_token => String.t(),
+          :refresh_token => String.t(),
+          :expires_in => integer() | nil
+        }) :: String.t() | nil
   def extract_account_id_from_tokens(%{id_token: id_token, access_token: access_token}) do
     case extract_account_id(id_token) do
       {:ok, id} ->

--- a/apps/frontman_server/test/frontman_server/providers/chatgpt_oauth_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/chatgpt_oauth_test.exs
@@ -1,0 +1,103 @@
+defmodule FrontmanServer.Providers.ChatGPTOAuthTest do
+  use ExUnit.Case, async: true
+
+  alias FrontmanServer.Providers.ChatGPTOAuth
+
+  defp build_jwt(claims) do
+    header = Base.url_encode64(Jason.encode!(%{"alg" => "RS256"}), padding: false)
+    payload = Base.url_encode64(Jason.encode!(claims), padding: false)
+    signature = Base.url_encode64("fake_signature", padding: false)
+    "#{header}.#{payload}.#{signature}"
+  end
+
+  describe "extract_account_id/1" do
+    test "extracts account_id from OpenAI auth claim" do
+      jwt =
+        build_jwt(%{"https://api.openai.com/auth" => %{"chatgpt_account_id" => "acct_123"}})
+
+      assert {:ok, "acct_123"} = ChatGPTOAuth.extract_account_id(jwt)
+    end
+
+    test "extracts account_id from top-level claim" do
+      jwt = build_jwt(%{"chatgpt_account_id" => "acct_456"})
+      assert {:ok, "acct_456"} = ChatGPTOAuth.extract_account_id(jwt)
+    end
+
+    test "extracts account_id from organizations array" do
+      jwt = build_jwt(%{"organizations" => [%{"id" => "org_789"}]})
+      assert {:ok, "org_789"} = ChatGPTOAuth.extract_account_id(jwt)
+    end
+
+    test "returns error for JWT with no account_id" do
+      jwt = build_jwt(%{"sub" => "user_1"})
+      assert {:error, :not_found} = ChatGPTOAuth.extract_account_id(jwt)
+    end
+
+    test "returns error for invalid JWT" do
+      assert {:error, :not_found} = ChatGPTOAuth.extract_account_id("not-a-valid-jwt")
+    end
+  end
+
+  describe "extract_account_id_from_tokens/1" do
+    test "prefers id_token over access_token" do
+      id_jwt = build_jwt(%{"chatgpt_account_id" => "from_id_token"})
+      access_jwt = build_jwt(%{"chatgpt_account_id" => "from_access_token"})
+
+      result =
+        ChatGPTOAuth.extract_account_id_from_tokens(%{
+          id_token: id_jwt,
+          access_token: access_jwt,
+          refresh_token: "rt_xxx",
+          expires_in: 3600
+        })
+
+      assert result == "from_id_token"
+    end
+
+    test "falls back to access_token when id_token has no account_id" do
+      id_jwt = build_jwt(%{"sub" => "user_1"})
+      access_jwt = build_jwt(%{"chatgpt_account_id" => "from_access_token"})
+
+      result =
+        ChatGPTOAuth.extract_account_id_from_tokens(%{
+          id_token: id_jwt,
+          access_token: access_jwt,
+          refresh_token: "rt_xxx",
+          expires_in: 3600
+        })
+
+      assert result == "from_access_token"
+    end
+
+    test "returns nil when neither token contains account_id" do
+      id_jwt = build_jwt(%{"sub" => "user_1"})
+      access_jwt = build_jwt(%{"sub" => "user_1"})
+
+      result =
+        ChatGPTOAuth.extract_account_id_from_tokens(%{
+          id_token: id_jwt,
+          access_token: access_jwt,
+          refresh_token: "rt_xxx",
+          expires_in: 3600
+        })
+
+      assert is_nil(result)
+    end
+
+    test "accepts the full token map shape from exchange_device_code" do
+      # This test captures the invariant: extract_account_id_from_tokens
+      # must accept the exact map shape returned by exchange_device_code/2,
+      # which always includes all four keys.
+      jwt = build_jwt(%{"chatgpt_account_id" => "acct_test"})
+
+      token_map = %{
+        access_token: "at_xxx",
+        refresh_token: "rt_xxx",
+        id_token: jwt,
+        expires_in: 3600
+      }
+
+      assert "acct_test" = ChatGPTOAuth.extract_account_id_from_tokens(token_map)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Pattern match `access_token`, `id_token`, and `refresh_token` in `exchange_device_code/2` response body — a malformed 200 from OpenAI now crashes immediately instead of silently propagating nils
- Update `extract_account_id_from_tokens/1` spec to match the full 4-key map shape returned by `exchange_device_code/2`, resolving the Dialyzer contract violation
- Add unit tests for `extract_account_id/1` (all 3 claim lookup paths) and `extract_account_id_from_tokens/1` (preference chain + token-map shape invariant)

## Context

The Dialyzer error was introduced in #289 and is blocking CI on other PRs (e.g. #300). The root cause was a mismatch between:
1. `exchange_device_code/2` returning a 4-key map with `id_token: String.t()` (never nil per spec)
2. `extract_account_id_from_tokens/1` spec expecting only 2 keys with `id_token: String.t() | nil`

Rather than making the spec permissive, this fix enforces the invariant: `exchange_device_code/2` now pattern matches on the required fields, so they are guaranteed present. The downstream spec is updated to match the actual shape.

## Test plan

- [x] 9 new unit tests pass (`mix test test/frontman_server/providers/chatgpt_oauth_test.exs`)
- [x] Dialyzer passes locally (`make dialyzer`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
