### PR TITLE
fix: increase chat panel minimum width

### DIFF
--- a/.changeset/increase-chat-panel-min-width.md
+++ b/.changeset/increase-chat-panel-min-width.md
@@ -1,0 +1,5 @@
+---
+"@frontman/client": patch
+---
+
+Increase chat panel minimum width from 280px to 380px to prevent cramped layout on small screens

--- a/libs/client/src/hooks/Client__UseResizableWidth.res
+++ b/libs/client/src/hooks/Client__UseResizableWidth.res
@@ -9,7 +9,7 @@
 
 // Constants
 let defaultWidth = 384 // w-96 equivalent
-let minWidth = 280
+let minWidth = 380
 let maxWidth = 600
 let storageKey = "frontman:chatbox-width"
 


### PR DESCRIPTION
## Summary

- Increases the chat panel minimum width from 280px to 380px to prevent cramped layout on small screens
- The input field and model selector row were getting squeezed at the previous minimum, making the panel hard to use

## Changed

- `libs/client/src/hooks/Client__UseResizableWidth.res` — `minWidth` constant: 280 -> 380
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
