### PR TITLE
fix: add clean step to mprocs ReScript build

### DIFF
--- a/mprocs.yml
+++ b/mprocs.yml
@@ -5,7 +5,7 @@ procs:
       send-keys: ["<C-c>"]
 
   rescript:
-    cmd: ["bash", "-c", "rm -f lib/bs/.compiler.log && make rescript-build && make rescript-watch"]
+    cmd: ["bash", "-c", "rm -f lib/bs/.compiler.log && make clean && make rescript-build && make rescript-watch"]
 
   server:
     cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while [ ! -f lib/bs/.compiler.log ] || ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready. Waiting for Postgres...' && while ! podman exec frontman-postgres pg_isready -U postgres 2>/dev/null; do sleep 2; done && echo 'Postgres ready, starting server...' && make dev-server"]


### PR DESCRIPTION
## Summary
- Adds `make clean` to the mprocs ReScript build process to prevent stale artifacts from causing issues during development

## Changes
- Modified `mprocs.yml` to run `make clean` before `make rescript-build` in the rescript process
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
