### PR TITLE
fix: remove dead initialization timeout code

### DIFF
--- a/.changeset/fix-stale-closure-timeout.md
+++ b/.changeset/fix-stale-closure-timeout.md
@@ -2,4 +2,4 @@
 "@frontman/client": patch
 ---
 
-Fix stale closure bug in initialization timeout that caused `sessionInitialized` to always read as `false` even after being set to `true`
+Remove dead initialization timeout code (`StartInitializationTimeout`, `InitializationTimeoutExpired`, `ReceivedDiscoveredProjectRule`) that was never wired up — `sessionInitialized` is set via `SetAcpSession` on connection

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -77,10 +77,6 @@ module Actions = {
   let taskLoadError = (~taskId, ~error) =>
     Client__State__Store.dispatch(TaskAction({target: ForTask(taskId), action: LoadError({error: error})}))
 
-  // Initialization action creators
-  let receivedDiscoveredProjectRule = (~taskId: string) =>
-    Client__State__Store.dispatch(ReceivedDiscoveredProjectRule({taskId: taskId}))
-
   // Turn completion action creators (ForTask)
   let turnCompleted = (~taskId: string) =>
     Client__State__Store.dispatch(TaskAction({target: ForTask(taskId), action: TurnCompleted}))

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -40,9 +40,6 @@ type action =
       apiBaseUrl: string,
     })
   | ClearAcpSession
-  // Initialization actions
-  | InitializationTimeoutExpired({taskId: string})
-  | ReceivedDiscoveredProjectRule({taskId: string})
   // Usage info actions
   | UsageInfoReceived({usageInfo: Client__State__Types.usageInfo})
   // API key settings actions
@@ -87,7 +84,6 @@ type action =
 
 type effect =
   | TaskEffect({target: taskTarget, effect: TaskReducer.effect})
-  | StartInitializationTimeout({taskId: string, timeoutMs: int})
   | FetchUsageInfo({apiBaseUrl: string})
   | FetchApiKeySettingsEffect({apiBaseUrl: string})
   | SaveOpenRouterKeyEffect({apiBaseUrl: string, key: string})
@@ -235,8 +231,6 @@ let actionToString = action => {
   | UpdateTaskTitle({taskId, title}) => `UpdateTaskTitle(${taskId}, "${title}")`
   | SetAcpSession(_) => `SetAcpSession`
   | ClearAcpSession => `ClearAcpSession`
-  | InitializationTimeoutExpired({taskId}) => `InitializationTimeoutExpired(${taskId})`
-  | ReceivedDiscoveredProjectRule({taskId}) => `ReceivedDiscoveredProjectRule(${taskId})`
   | UsageInfoReceived(_) => `UsageInfoReceived`
   | FetchApiKeySettings => `FetchApiKeySettings`
   | ApiKeySettingsReceived({source}) =>
@@ -601,11 +595,6 @@ let handleEffect = (effect, state: state, dispatch) => {
 
       TaskReducer.handleEffect(taskEffect, ~dispatch=taskDispatch, ~delegate)
     }
-  | StartInitializationTimeout({taskId, timeoutMs}) =>
-    let taskId = taskId
-    let _ = Js.Global.setTimeout(() => {
-      dispatch(InitializationTimeoutExpired({taskId: taskId}))
-    }, timeoutMs)
   | FetchApiKeySettingsEffect({apiBaseUrl}) =>
     let fetch = async () => {
       let url = `${apiBaseUrl}/api/user/api-key-usage`
@@ -1170,23 +1159,6 @@ let next = (state: state, action) => {
 
   | ClearAcpSession =>
     {...state, acpSession: NoAcpSession}->FrontmanReactStatestore.StateReducer.update
-
-  | InitializationTimeoutExpired({taskId: _}) =>
-    if !state.sessionInitialized {
-      {
-        ...state,
-        sessionInitialized: true,
-      }->FrontmanReactStatestore.StateReducer.update
-    } else {
-      state->FrontmanReactStatestore.StateReducer.update
-    }
-
-  | ReceivedDiscoveredProjectRule({taskId: _}) =>
-    // Mark initialization complete
-    {
-      ...state,
-      sessionInitialized: true,
-    }->FrontmanReactStatestore.StateReducer.update
 
   // ============================================================================
   // Global state actions


### PR DESCRIPTION
## Summary

Closes #220

- Remove unreachable `StartInitializationTimeout` effect, `InitializationTimeoutExpired` and `ReceivedDiscoveredProjectRule` actions, and the `receivedDiscoveredProjectRule` action creator
- This was scaffolding for a per-task MCP initialization notification flow that was never wired up — `sessionInitialized` is set via `SetAcpSession` on connection instead
- Update changeset to reflect the actual fix (dead code removal)

## Context

The issue reported a stale closure bug in the `StartInitializationTimeout` effect handler. Investigation revealed the entire initialization timeout mechanism is dead code:

- `StartInitializationTimeout` effect is defined and handled, but no reducer case ever emits it
- `InitializationTimeoutExpired` is only dispatched from that dead effect handler
- `ReceivedDiscoveredProjectRule` has an action creator but zero call sites
- The server pushes `project_rules_initialized` but the client explicitly ignores it at the protocol layer

The functionality was superseded by a simpler approach: `sessionInitialized` is set to `true` immediately when ACP + Relay connections succeed (`SetAcpSession` in `Client__App.res`). MCP readiness is enforced server-side (prompts are queued until `mcp_status: :ready`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
