### PR TITLE
fix: add returning: true to increment_usage upsert

### DIFF
--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -241,7 +241,8 @@ defmodule FrontmanServer.Providers do
 
     Repo.insert(changeset,
       on_conflict: [inc: [count: 1], set: [last_used_at: now, updated_at: now]],
-      conflict_target: [:user_id, :provider]
+      conflict_target: [:user_id, :provider],
+      returning: true
     )
   end
 


### PR DESCRIPTION
## Summary

Adds `returning: true` to the `Repo.insert` upsert in `increment_usage/2` so that on conflict, the returned struct reflects the actual database row (with the incremented count) rather than the stale changeset values.

- Follow-up from [PR #347 review comment](https://github.com/frontman-ai/frontman/pull/347#discussion_r2809559172)
- No current caller reads the returned struct (`{:ok, _} -> :ok`), so this is a defensive fix for future callers
- All 515 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
