### PR TITLE
fix: add catch-all clause to OAuth callback to handle empty params

### DIFF
--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -7,7 +7,7 @@ defmodule FrontmanServerWeb.OAuthController do
 
   import FrontmanServerWeb.UserAuth, only: [require_sudo_mode: 2]
 
-  plug :require_sudo_mode when action in [:link_request, :link_callback, :unlink]
+  plug(:require_sudo_mode when action in [:link_request, :link_callback, :unlink])
 
   def request(conn, %{"provider" => provider}) do
     redirect_uri = url(~p"/auth/callback")
@@ -51,6 +51,12 @@ defmodule FrontmanServerWeb.OAuthController do
   def callback(conn, %{"error" => "access_denied"}) do
     conn
     |> put_flash(:error, "Sign in was cancelled.")
+    |> redirect(to: ~p"/users/log-in")
+  end
+
+  def callback(conn, _params) do
+    conn
+    |> put_flash(:error, "Authentication failed. Please try again.")
     |> redirect(to: ~p"/users/log-in")
   end
 


### PR DESCRIPTION
## Summary

- Adds a catch-all `callback/2` clause to `OAuthController` so requests to `/auth/callback` without expected query params (`code` or `error`) redirect gracefully to login instead of crashing with a 500
- Fixes [ELIXIR-27](https://frontman-gm.sentry.io/issues/96814423/) — triggered by bots/crawlers or direct navigation hitting the callback URL with an empty query string

## What changed

`apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex` — new final clause:

```elixir
def callback(conn, _params) do
  conn
  |> put_flash(:error, "Authentication failed. Please try again.")
  |> redirect(to: ~p"/users/log-in")
end
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
