### PR TITLE
fix(ci): skip changelog check for marketing-only changes

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -22,6 +22,13 @@ jobs:
         run: |
           CHANGED=$(git diff --name-only origin/main...HEAD)
 
+          # Skip if all changes are in apps/marketing/
+          NON_MARKETING=$(echo "$CHANGED" | grep -v '^apps/marketing/' || true)
+          if [ -z "$NON_MARKETING" ]; then
+            echo "Only marketing changes — skipping changelog check"
+            exit 0
+          fi
+
           # Check for a new changeset file
           if echo "$CHANGED" | grep -q '^\.changeset/.*\.md$'; then
             echo "Found changeset file"


### PR DESCRIPTION
## Summary

- Skip the changelog/changeset requirement when a PR only touches files under `apps/marketing/`
- If any non-marketing files are changed, the existing check runs as before

Marketing site changes don't ship as versioned packages and don't need changelog entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
