### PR TITLE
chore(marketing): add Yandex verification meta tag

### DIFF
--- a/apps/marketing/src/components/blocks/head/Header.astro
+++ b/apps/marketing/src/components/blocks/head/Header.astro
@@ -41,6 +41,7 @@ const {
 	{googleAnalyticsMeasurementID && <GoogleAnalytics />}
 	{googleTagManagerID && <GoogleTagManagerHead />}
 	<GoogleSearchConsole />
+	<meta name="yandex-verification" content="f7cb42505a6da42d" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="preconnect" href="https://www.googletagmanager.com" />
 	<link rel="preconnect" href="https://www.google-analytics.com" />


### PR DESCRIPTION
## Summary
- Adds `<meta name="yandex-verification" content="f7cb42505a6da42d" />` to the marketing site `<head>` for Yandex Webmaster Tools verification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
