### PR TITLE
perf(marketing): inline CSS and optimize hero image to improve LCP

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -13,6 +13,12 @@ export default defineConfig({
   site: "https://frontman.sh",
   // SSR only needed in dev for /frontman/* routes
   ...(isProd ? {} : { output: "server", adapter: node({ mode: "standalone" }) }),
+  build: {
+    // Inline all stylesheets directly into the HTML to eliminate
+    // render-blocking <link> requests (~25 KiB total). Trades a small
+    // increase in HTML size for removing 4 blocking CSS round-trips (~430 ms).
+    inlineStylesheets: "always",
+  },
   integrations: [
     frontmanIntegration(),
     tailwind(),

--- a/apps/marketing/src/components/blocks/hero/HomeCTA.astro
+++ b/apps/marketing/src/components/blocks/hero/HomeCTA.astro
@@ -55,16 +55,17 @@ const youtubeVideoId = '-4GD1GYwH8Y'
 					aria-label="Play demo video"
 					type="button"
 				>
-					<Image
-						src={videoPlaceholder}
-						alt="Frontman demo video"
-						class="hero-section__video-thumbnail"
-						loading="eager"
-						fetchpriority="high"
-						format="webp"
-						widths={[400, 720, 1280]}
-						sizes="(max-width: 1023px) 100vw, 720px"
-					/>
+				<Image
+					src={videoPlaceholder}
+					alt="Frontman demo video"
+					class="hero-section__video-thumbnail"
+					loading="eager"
+					fetchpriority="high"
+					format="webp"
+					quality={80}
+					widths={[400, 720]}
+					sizes="(max-width: 1023px) 100vw, 720px"
+				/>
 					<div class="hero-section__play-button" aria-hidden="true">
 						<svg viewBox="0 0 68 48" width="68" height="48">
 							<path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55C3.97 2.33 2.27 4.81 1.48 7.74.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="#FF0000"/>


### PR DESCRIPTION
## Summary

Addresses two Lighthouse performance audits for frontman.sh homepage:

- **Inline all CSS into HTML** (`build.inlineStylesheets: "always"` in Astro config) — eliminates 4 render-blocking `<link rel="stylesheet">` requests that were adding ~430ms to initial render. Total CSS is only ~25 KiB, well worth inlining vs. 4 separate network round-trips. Also fixes cross-page CSS leaking (blog and changelog styles were being loaded on the homepage).
- **Remove oversized hero image variant** — dropped the 1280w srcset entry from the video placeholder thumbnail since the container caps at 720px. Added `quality={80}` for further savings. Estimated ~53 KiB reduction.

## Changes

| File | What |
|------|------|
| `apps/marketing/astro.config.mjs` | Added `build.inlineStylesheets: "always"` |
| `apps/marketing/src/components/blocks/hero/HomeCTA.astro` | Removed 1280w from `widths`, added `quality={80}` |

## Verification

- `make build` in `apps/marketing/` succeeds
- Built HTML has zero `<link rel="stylesheet">` tags (all CSS inlined as `<style>`)
- Hero image now generates only 400w and 720w WebP variants
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
