### PR TITLE
fix: stream tool_call_start to client for immediate UI feedback (#247)

### DIFF
--- a/.changeset/stream-tool-call-start.md
+++ b/.changeset/stream-tool-call-start.md
@@ -1,0 +1,9 @@
+---
+"@frontman-ai/frontman-server": patch
+"@frontman-ai/client": patch
+---
+
+### Fixed
+- Stream `tool_call_start` events to client for immediate UI feedback when the LLM begins generating tool calls (e.g., `write_file`), eliminating multi-second blank gaps
+- Show "Waiting for file path..." / "Waiting for URL..." shimmer placeholder while tool arguments stream in
+- Display navigate tool URL/action inline instead of hiding it in an expandable body

--- a/apps/frontman_server/lib/frontman_server/agents.ex
+++ b/apps/frontman_server/lib/frontman_server/agents.ex
@@ -323,6 +323,9 @@ defmodule FrontmanServer.Agents do
       {:thinking, text} ->
         broadcast(task_id, {:stream_thinking, text})
 
+      {:tool_call_start, tool_call_id, tool_name} ->
+        broadcast(task_id, {:tool_call_start, tool_call_id, tool_name})
+
       {:response, text, metadata} ->
         Tasks.add_agent_response(scope, task_id, text, metadata)
 
@@ -458,18 +461,7 @@ defmodule FrontmanServer.Agents do
       Swarm.run_streaming(agent, messages,
         metadata: %{task_id: task_id},
         tool_executor: tool_executor,
-        on_chunk: fn chunk ->
-          case chunk do
-            %Chunk{type: :token, text: text} when is_binary(text) and text != "" ->
-              on_event.({:token, text})
-
-            %Chunk{type: :thinking, text: text} when is_binary(text) and text != "" ->
-              on_event.({:thinking, text})
-
-            _ ->
-              :ok
-          end
-        end,
+        on_chunk: &handle_stream_chunk(&1, on_event),
         on_response: fn response ->
           metadata = build_response_metadata(response)
           on_event.({:response, response.content || "", metadata})
@@ -500,6 +492,23 @@ defmodule FrontmanServer.Agents do
     TelemetryEvents.task_stop(task_id)
 
     result
+  end
+
+  defp handle_stream_chunk(chunk, on_event) do
+    case chunk do
+      %Chunk{type: :token, text: text} when is_binary(text) and text != "" ->
+        on_event.({:token, text})
+
+      %Chunk{type: :thinking, text: text} when is_binary(text) and text != "" ->
+        on_event.({:thinking, text})
+
+      %Chunk{type: :tool_call_start, tool_call_id: id, tool_call_name: name}
+      when is_binary(id) and is_binary(name) ->
+        on_event.({:tool_call_start, id, name})
+
+      _ ->
+        :ok
+    end
   end
 
   defp build_response_metadata(%Swarm.LLM.Response{} = response) do

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -508,16 +508,38 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
   end
 
+  def handle_info({:tool_call_start, tool_call_id, tool_name}, socket) do
+    # Early notification: the LLM has started generating a tool call.
+    # This fires as soon as the tool_call_start chunk arrives from the LLM stream,
+    # BEFORE the full arguments are generated. For tools with large arguments
+    # (e.g., write_file with full file content), this provides immediate UI feedback
+    # instead of waiting for the entire response to be accumulated.
+    task_id = socket.assigns.task_id
+    notification = ACP.tool_call_create(task_id, tool_call_id, tool_name, "other", "pending")
+    push(socket, "acp:message", notification)
+
+    # Track that we already announced this tool call to avoid duplicate notifications
+    announced = socket.assigns[:announced_tool_calls] || MapSet.new()
+    socket = assign(socket, :announced_tool_calls, MapSet.put(announced, tool_call_id))
+
+    {:noreply, socket}
+  end
+
   def handle_info({:interaction, %Tasks.Interaction.ToolCall{} = tool_call}, socket) do
     task_id = socket.assigns.task_id
 
-    # Send ACP notification: pending with tool arguments in content
-    pending_notification =
-      ACP.build_tool_call_notification(task_id, tool_call, "pending", [])
+    # Only send tool_call_create if we haven't already announced this tool call
+    # via the streaming :tool_call_start event (which fires earlier during LLM streaming).
+    announced = socket.assigns[:announced_tool_calls] || MapSet.new()
 
-    push(socket, "acp:message", pending_notification)
+    unless MapSet.member?(announced, tool_call.tool_call_id) do
+      pending_notification =
+        ACP.build_tool_call_notification(task_id, tool_call, "pending", [])
 
-    # Send tool arguments immediately so the UI can display them
+      push(socket, "acp:message", pending_notification)
+    end
+
+    # Always send tool arguments so the UI can display them
     args_content = ACP.Content.from_tool_result(tool_call.arguments)
 
     args_notification =

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1036,6 +1036,177 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
   end
 
+  describe "tool_call_start streaming" do
+    setup %{scope: scope} do
+      task_id = Ecto.UUID.generate()
+      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "test-framework")
+
+      {:ok, _reply, socket} =
+        UserSocket
+        |> socket("user_id", %{scope: scope})
+        |> subscribe_and_join("task:#{task_id}", %{})
+
+      complete_mcp_handshake(socket)
+
+      {:ok, socket: socket, task_id: task_id}
+    end
+
+    test "broadcasts early ACP tool_call notification on tool_call_start", %{
+      socket: _socket,
+      task_id: task_id
+    } do
+      tool_call_id = "call_early_#{:rand.uniform(1_000_000)}"
+
+      Phoenix.PubSub.broadcast(
+        FrontmanServer.PubSub,
+        Tasks.topic(task_id),
+        {:tool_call_start, tool_call_id, "write_file"}
+      )
+
+      assert_push("acp:message", %{
+        "method" => "session/update",
+        "params" => %{
+          "sessionId" => ^task_id,
+          "update" => %{
+            "sessionUpdate" => "tool_call",
+            "toolCallId" => ^tool_call_id,
+            "title" => "write_file",
+            "status" => "pending"
+          }
+        }
+      })
+    end
+
+    test "deduplicates tool_call_create when interaction arrives after tool_call_start", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      tool_call_id = "call_dedup_#{:rand.uniform(1_000_000)}"
+
+      # Step 1: Send tool_call_start (early streaming notification)
+      send(socket.channel_pid, {:tool_call_start, tool_call_id, "write_file"})
+      :sys.get_state(socket.channel_pid)
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call",
+            "toolCallId" => ^tool_call_id
+          }
+        }
+      })
+
+      # Step 2: Send the full interaction (which normally would also send tool_call_create)
+      tool_call = %Interaction.ToolCall{
+        id: Interaction.new_id(),
+        sequence: Interaction.new_sequence(),
+        tool_call_id: tool_call_id,
+        tool_name: "write_file",
+        arguments: %{"target_file" => "test.txt", "content" => "hello"},
+        timestamp: Interaction.now()
+      }
+
+      send(socket.channel_pid, {:interaction, tool_call})
+      :sys.get_state(socket.channel_pid)
+
+      # Should get a tool_call_update with args, but NOT a duplicate tool_call create
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call_update",
+            "toolCallId" => ^tool_call_id,
+            "status" => "pending"
+          }
+        }
+      })
+
+      # Verify no duplicate tool_call create was sent
+      refute_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call",
+            "toolCallId" => ^tool_call_id
+          }
+        }
+      })
+    end
+
+    test "sends tool_call_create for interactions without prior tool_call_start", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      # Tool calls that arrive without a prior tool_call_start should still get
+      # the normal tool_call_create notification
+      tool_call_id = "call_no_start_#{:rand.uniform(1_000_000)}"
+
+      tool_call = %Interaction.ToolCall{
+        id: Interaction.new_id(),
+        sequence: Interaction.new_sequence(),
+        tool_call_id: tool_call_id,
+        tool_name: "take_screenshot",
+        arguments: %{},
+        timestamp: Interaction.now()
+      }
+
+      send(socket.channel_pid, {:interaction, tool_call})
+      :sys.get_state(socket.channel_pid)
+
+      # Should get the standard tool_call create notification
+      assert_push("acp:message", %{
+        "params" => %{
+          "sessionId" => ^task_id,
+          "update" => %{
+            "sessionUpdate" => "tool_call",
+            "toolCallId" => ^tool_call_id
+          }
+        }
+      })
+
+      # And the tool_call_update with arguments
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call_update",
+            "toolCallId" => ^tool_call_id
+          }
+        }
+      })
+    end
+
+    test "tracks multiple tool calls independently", %{
+      socket: socket
+    } do
+      call_id_1 = "call_multi_1_#{:rand.uniform(1_000_000)}"
+      call_id_2 = "call_multi_2_#{:rand.uniform(1_000_000)}"
+
+      # Announce first tool call via streaming
+      send(socket.channel_pid, {:tool_call_start, call_id_1, "write_file"})
+      :sys.get_state(socket.channel_pid)
+
+      assert_push("acp:message", %{
+        "params" => %{"update" => %{"toolCallId" => ^call_id_1, "sessionUpdate" => "tool_call"}}
+      })
+
+      # Second tool call arrives without prior tool_call_start
+      tool_call_2 = %Interaction.ToolCall{
+        id: Interaction.new_id(),
+        sequence: Interaction.new_sequence(),
+        tool_call_id: call_id_2,
+        tool_name: "read_file",
+        arguments: %{"target_file" => "other.txt"},
+        timestamp: Interaction.now()
+      }
+
+      send(socket.channel_pid, {:interaction, tool_call_2})
+      :sys.get_state(socket.channel_pid)
+
+      # Second tool call should still get its own tool_call create
+      assert_push("acp:message", %{
+        "params" => %{"update" => %{"toolCallId" => ^call_id_2, "sessionUpdate" => "tool_call"}}
+      })
+    end
+  end
+
   # Completes the MCP handshake (initialize + tools/list + load_agent_instructions).
   #
   # Uses :sys.get_state/1 as a synchronization barrier after each push to ensure

--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -21,19 +21,54 @@ let cleanToolName = (toolName: string): string => {
   }
 }
 
-// File tools show as links, others are expandable
-let isFileTool = (toolName: string): bool => {
+// Tools that show a target inline (path, URL, etc.) instead of expandable body
+let isInlineTool = (toolName: string): bool => {
   let name = cleanToolName(toolName)
-  name == "read_file" || name == "write_file" || name == "list_files" || name == "list_dir"
+  switch name {
+  | "read_file" | "write_file" | "list_files" | "list_dir" | "navigate" => true
+  | _ => false
+  }
 }
 
-// Extract target path, defaulting to "./" for list operations
-let getTarget = (toolName: string, input: option<JSON.t>): option<string> => {
-  switch ToolLabels.extractTargetFromInput(input) {
-  | Some(".") => Some("./")
-  | Some(t) => Some(t)
-  | None if isFileTool(toolName) => Some("./")
+let isFileTool = (toolName: string): bool => {
+  let name = cleanToolName(toolName)
+  switch name {
+  | "read_file" | "write_file" | "list_files" | "list_dir" => true
+  | _ => false
+  }
+}
+
+// Extract navigate-specific target: URL for goto, action name for back/forward/refresh
+let getNavigateTarget = (input: option<JSON.t>): option<string> => {
+  switch input {
   | None => None
+  | Some(json) =>
+    switch JSON.Decode.object(json) {
+    | None => None
+    | Some(dict) =>
+      let action = dict->Dict.get("action")->Option.flatMap(JSON.Decode.string)
+      let url = dict->Dict.get("url")->Option.flatMap(JSON.Decode.string)
+      switch (action, url) {
+      | (Some("goto"), Some(u)) => Some(u)
+      | (Some(a), _) => Some(a)
+      | _ => None
+      }
+    }
+  }
+}
+
+// Extract target path/URL, defaulting to "./" for list/file operations
+let getTarget = (toolName: string, input: option<JSON.t>): option<string> => {
+  let name = cleanToolName(toolName)
+  switch name {
+  | "navigate" => getNavigateTarget(input)
+  | _ =>
+    switch ToolLabels.extractTargetFromInput(input) {
+    | Some(".") => Some("./")
+    | Some(t) => Some(t)
+    | None if isFileTool(toolName) => Some("./")
+    | None => None
+    }
   }
 }
 
@@ -49,7 +84,7 @@ let make = (
   ~compact: bool=false,
   ~messageId as _: string,
 ) => {
-  let isLink = isFileTool(toolName)
+  let isLink = isInlineTool(toolName)
   let (isExpanded, setIsExpanded) = React.useState(() => defaultExpanded)
   let (wasManuallyToggled, setWasManuallyToggled) = React.useState(() => false)
 
@@ -110,16 +145,29 @@ let make = (
         </span>
       </div>
       
-      // Target path as purple link
-      {target->Option.mapOr(React.null, t =>
+      // Target path as purple link, or shimmer placeholder while streaming
+      {switch (target, state, input) {
+      | (_, InputStreaming, None) if isLink => {
+        let placeholder = switch cleanToolName(toolName) {
+        | "navigate" => "Waiting for URL..."
+        | _ => "Waiting for file path..."
+        }
         <div className={`mt-1 ${compact ? "text-[11px]" : "text-[12px]"}`}>
-          <span 
+          <span className="font-mono shimmer-text text-zinc-500">
+            {React.string(placeholder)}
+          </span>
+        </div>
+      }
+      | (Some(t), _, _) =>
+        <div className={`mt-1 ${compact ? "text-[11px]" : "text-[12px]"}`}>
+          <span
             className={`font-mono ${hasError ? "text-red-400" : "text-[#8051CD] hover:text-[#9d7be0]"}`}
           >
             {React.string(t)}
           </span>
         </div>
-      )}
+      | _ => React.null
+      }}
       
       // Error message if present (inline)
       {switch errorText {

--- a/libs/client/test/Client__ToolCallBlock.test.res
+++ b/libs/client/test/Client__ToolCallBlock.test.res
@@ -1,0 +1,125 @@
+open Vitest
+
+module ToolCallBlock = Client__ToolCallBlock
+
+describe("cleanToolName", _t => {
+  test("strips 'Calling ' prefix and lowercases", t => {
+    t->expect(ToolCallBlock.cleanToolName("Calling write_file"))->Expect.toBe("write_file")
+  })
+
+  test("lowercases without prefix", t => {
+    t->expect(ToolCallBlock.cleanToolName("Write_File"))->Expect.toBe("write_file")
+  })
+
+  test("handles already clean names", t => {
+    t->expect(ToolCallBlock.cleanToolName("navigate"))->Expect.toBe("navigate")
+  })
+})
+
+describe("isInlineTool", _t => {
+  test("returns true for file tools", t => {
+    t->expect(ToolCallBlock.isInlineTool("read_file"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isInlineTool("write_file"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isInlineTool("list_files"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isInlineTool("list_dir"))->Expect.toBe(true)
+  })
+
+  test("returns true for navigate", t => {
+    t->expect(ToolCallBlock.isInlineTool("navigate"))->Expect.toBe(true)
+  })
+
+  test("returns false for other tools", t => {
+    t->expect(ToolCallBlock.isInlineTool("take_screenshot"))->Expect.toBe(false)
+    t->expect(ToolCallBlock.isInlineTool("get_logs"))->Expect.toBe(false)
+    t->expect(ToolCallBlock.isInlineTool("consoleLog"))->Expect.toBe(false)
+  })
+
+  test("handles legacy 'Calling ' prefix", t => {
+    t->expect(ToolCallBlock.isInlineTool("Calling write_file"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isInlineTool("Calling navigate"))->Expect.toBe(true)
+  })
+})
+
+describe("isFileTool", _t => {
+  test("returns true for file tools only", t => {
+    t->expect(ToolCallBlock.isFileTool("read_file"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isFileTool("write_file"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isFileTool("list_files"))->Expect.toBe(true)
+    t->expect(ToolCallBlock.isFileTool("list_dir"))->Expect.toBe(true)
+  })
+
+  test("returns false for navigate", t => {
+    t->expect(ToolCallBlock.isFileTool("navigate"))->Expect.toBe(false)
+  })
+})
+
+describe("getNavigateTarget", _t => {
+  test("returns URL for goto action", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "goto", "url": "/about"}`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(Some("/about"))
+  })
+
+  test("returns action name for back action", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "back"}`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(Some("back"))
+  })
+
+  test("returns action name for forward action", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "forward"}`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(Some("forward"))
+  })
+
+  test("returns action name for refresh action", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "refresh"}`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(Some("refresh"))
+  })
+
+  test("returns None when input is None", t => {
+    t->expect(ToolCallBlock.getNavigateTarget(None))->Expect.toEqual(None)
+  })
+
+  test("returns None for non-object JSON", t => {
+    let input = Some(JSON.parseOrThrow(`"just a string"`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(None)
+  })
+
+  test("returns None when action is missing", t => {
+    let input = Some(JSON.parseOrThrow(`{"url": "/test"}`))
+    t->expect(ToolCallBlock.getNavigateTarget(input))->Expect.toEqual(None)
+  })
+})
+
+describe("getTarget", _t => {
+  test("returns file path from tool input", t => {
+    let input = Some(JSON.parseOrThrow(`{"target_file": "src/app.tsx"}`))
+    t->expect(ToolCallBlock.getTarget("write_file", input))->Expect.toEqual(Some("src/app.tsx"))
+  })
+
+  test("normalizes '.' to './' for file tools", t => {
+    let input = Some(JSON.parseOrThrow(`{"path": "."}`))
+    t->expect(ToolCallBlock.getTarget("list_dir", input))->Expect.toEqual(Some("./"))
+  })
+
+  test("defaults to './' when file tool has no input", t => {
+    t->expect(ToolCallBlock.getTarget("read_file", None))->Expect.toEqual(Some("./"))
+    t->expect(ToolCallBlock.getTarget("list_dir", None))->Expect.toEqual(Some("./"))
+  })
+
+  test("returns None for non-inline tools without input", t => {
+    t->expect(ToolCallBlock.getTarget("take_screenshot", None))->Expect.toEqual(None)
+  })
+
+  test("delegates to getNavigateTarget for navigate", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "goto", "url": "/products"}`))
+    t->expect(ToolCallBlock.getTarget("navigate", input))->Expect.toEqual(Some("/products"))
+  })
+
+  test("returns None for navigate without input", t => {
+    t->expect(ToolCallBlock.getTarget("navigate", None))->Expect.toEqual(None)
+  })
+
+  test("returns action for navigate back", t => {
+    let input = Some(JSON.parseOrThrow(`{"action": "back"}`))
+    t->expect(ToolCallBlock.getTarget("navigate", input))->Expect.toEqual(Some("back"))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #247 — Eliminates the multi-second blank gap when the LLM generates tool calls with large arguments (e.g., `write_file` with full file content).

## Changes

### Server (`agents.ex`, `task_channel.ex`)
- Forward `tool_call_start` chunks from the LLM stream to the client immediately, as soon as the LLM begins generating a tool call
- Send an early ACP `tool_call_create` notification so the client can render the tool block right away
- Track announced tool call IDs in a `MapSet` on socket assigns to prevent duplicate `tool_call_create` when the full interaction arrives later

### Client (`Client__ToolCallBlock.res`)
- Show **"Waiting for file path..."** shimmer placeholder for file tools (`write_file`, `read_file`, etc.) while arguments stream in
- Show **"Waiting for URL..."** shimmer placeholder for `navigate` tool during streaming
- Display navigate tool URL/action inline (same style as file paths) instead of hiding it in an expandable body
- Introduce `isInlineTool` concept to generalize file tools + navigate as tools that show their target inline

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `write_file` starts streaming | Blank gap for several seconds | Immediate "Write File" block with shimmer |
| `write_file` arguments arrive | Tool block appears all at once | Path fades in, replacing shimmer |
| `navigate` tool call | Just shows "Navigate" (no details) | Shows URL inline (e.g., `/about`) |

## Testing

### Server tests (`task_channel_test.exs`) — 4 new tests
- Early ACP `tool_call` notification on `tool_call_start` via PubSub
- Deduplication: no duplicate `tool_call_create` when interaction arrives after `tool_call_start`
- Normal `tool_call_create` still sent for interactions without prior streaming event
- Independent tracking of multiple concurrent tool calls

### Client tests (`Client__ToolCallBlock.test.res`) — 23 new tests
- `cleanToolName`: strips "Calling " prefix, lowercases
- `isInlineTool`: recognizes file tools + navigate, rejects others
- `isFileTool`: file tools only (excludes navigate)
- `getNavigateTarget`: extracts URL for goto, action name for back/forward/refresh
- `getTarget`: delegates correctly per tool type, handles defaults

All existing tests pass (30 server channel tests, 160 client tests).