### PR TITLE
fix(monitoring): update active slot metric immediately on deploy/rollback

### DIFF
--- a/.changeset/fix-blue-green-monitoring-alerts.md
+++ b/.changeset/fix-blue-green-monitoring-alerts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix false FrontmanServiceDown alerts during blue-green deploys by updating the active slot Prometheus metric immediately after slot switchover.

--- a/infra/production/build-and-deploy.sh
+++ b/infra/production/build-and-deploy.sh
@@ -149,8 +149,9 @@ cp /tmp/Caddyfile.new /etc/caddy/Caddyfile && rm /tmp/Caddyfile.new
 sudo /bin/systemctl reload caddy
 echo "Caddy reloaded. Traffic now routed to ${INACTIVE_SLOT}."
 
-# --- Update active slot marker ---
+# --- Update active slot marker + monitoring metric ---
 echo "${INACTIVE_SLOT}" > "${DEPLOY_ROOT}/active_slot"
+"${DEPLOY_ROOT}/monitoring/update-active-slot.sh" || true
 
 # --- Stop old slot (after brief drain period) ---
 echo ">>> Draining old slot (${ACTIVE_SLOT})..."

--- a/infra/production/deploy.sh
+++ b/infra/production/deploy.sh
@@ -121,8 +121,9 @@ sudo mv /tmp/Caddyfile.new /etc/caddy/Caddyfile
 sudo /usr/bin/systemctl reload caddy
 echo "Caddy reloaded. Traffic now routed to ${INACTIVE_SLOT}."
 
-# --- Update active slot marker ---
+# --- Update active slot marker + monitoring metric ---
 echo "${INACTIVE_SLOT}" > "${DEPLOY_ROOT}/active_slot"
+"${DEPLOY_ROOT}/monitoring/update-active-slot.sh" || true
 
 # --- Stop old slot (after brief drain period) ---
 echo ">>> Draining old slot (${ACTIVE_SLOT})..."

--- a/infra/production/rollback.sh
+++ b/infra/production/rollback.sh
@@ -78,8 +78,9 @@ EOF
 sudo mv /tmp/Caddyfile.new /etc/caddy/Caddyfile
 sudo /usr/bin/systemctl reload caddy
 
-# --- Update active slot ---
+# --- Update active slot + monitoring metric ---
 echo "${ROLLBACK_SLOT}" > "${DEPLOY_ROOT}/active_slot"
+"${DEPLOY_ROOT}/monitoring/update-active-slot.sh" || true
 
 # --- Stop the failed slot ---
 echo ">>> Stopping failed slot (${CURRENT_SLOT})..."


### PR DESCRIPTION
## Summary

- **Fix false `FrontmanServiceDown` alerts** during blue-green deploys by calling `update-active-slot.sh` immediately after writing `active_slot`, rather than waiting up to 60s for the cron

## Problem

Deploy scripts write to `/opt/frontman/active_slot` to record which slot is serving traffic, but never update the Prometheus textfile metric (`node_textfile_frontman_active_slot`). The metric only refreshes on the next cron run (every 60s).

During that stale window, the old slot still appears "active" to Prometheus. When the deploy script stops the old slot moments later, the alert rule sees "the active slot is down" and fires a false `FrontmanServiceDown` → Discord alert.

## Fix

All three deploy scripts (`deploy.sh`, `build-and-deploy.sh`, `rollback.sh`) now call `update-active-slot.sh` immediately after writing `active_slot`. The `|| true` ensures a missing/broken collector script never blocks a deploy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
