### PR TITLE
feat(client): add browser element interaction tools

### DIFF
--- a/.changeset/brave-doors-glow.md
+++ b/.changeset/brave-doors-glow.md
@@ -1,0 +1,5 @@
+---
+"@frontman/client": minor
+---
+
+Add browser element interaction tools: `get_interactive_elements` for discovering interactive elements via accessibility tree analysis, and `interact_with_element` for clicking, hovering, or focusing elements by CSS selector, role+name, or text content.

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -79,6 +79,7 @@
 		"babel-plugin-react-compiler": "^1.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"dom-accessibility-api": "^0.5.16",
 		"dom-element-to-component-source": "^0.5.0",
 		"lucide-react": "^0.548.0",
 		"motion": "^12.23.24",

--- a/libs/client/src/Client__ToolRegistry.res
+++ b/libs/client/src/Client__ToolRegistry.res
@@ -19,6 +19,8 @@ let coreBrowserTools = (): t => {
     module(Client__Tool__TakeScreenshot),
     module(Client__Tool__Navigate),
     module(Client__Tool__SetDeviceMode),
+    module(Client__Tool__GetInteractiveElements),
+    module(Client__Tool__InteractWithElement),
   ],
 }
 

--- a/libs/client/src/bindings/Bindings__DomAccessibilityApi.res
+++ b/libs/client/src/bindings/Bindings__DomAccessibilityApi.res
@@ -1,0 +1,20 @@
+// Bindings for dom-accessibility-api
+// Pure JS implementation of W3C accessible name/description computation
+// https://github.com/eps1lon/dom-accessibility-api
+
+// Compute the accessible name of an element per the W3C accname spec.
+// Handles aria-label, aria-labelledby, <label>, alt, title, etc.
+@module("dom-accessibility-api")
+external computeAccessibleName: WebAPI.DOMAPI.element => string = "computeAccessibleName"
+
+// Get the computed ARIA role of an element.
+// Returns the explicit role attribute if set, otherwise the implicit role
+// derived from the HTML element (e.g. <button> => "button", <a href> => "link").
+// Returns null for elements with no role.
+@module("dom-accessibility-api")
+external getRole: WebAPI.DOMAPI.element => Null.t<string> = "getRole"
+
+// Check whether an element is inaccessible (hidden from assistive technology).
+// Checks display:none, visibility:hidden, aria-hidden="true", hidden attribute.
+@module("dom-accessibility-api")
+external isInaccessible: WebAPI.DOMAPI.element => bool = "isInaccessible"

--- a/libs/client/src/tools/Client__Tool__ElementResolver.res
+++ b/libs/client/src/tools/Client__Tool__ElementResolver.res
@@ -1,0 +1,301 @@
+// Shared helpers for element discovery and resolution in browser tools.
+// Used by GetInteractiveElements and InteractWithElement tools.
+
+// Convert a NodeList to an array of elements. NodeList has no toArray binding
+// in @rescript/webapi, so we use a small typed external for Array.from.
+@val external nodeListToElements: WebAPI.DOMAPI.nodeList => array<WebAPI.DOMAPI.element> = "Array.from"
+
+// Interactive ARIA roles — elements with these roles are inherently interactive
+let interactiveRoles = [
+  "button",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "tab",
+  "checkbox",
+  "radio",
+  "switch",
+  "option",
+  "combobox",
+  "textbox",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "treeitem",
+]
+
+let interactiveRoleSet = interactiveRoles->Array.map(r => (r, true))->Dict.fromArray
+
+type detectionMethod =
+  | Semantic
+  | CursorPointer
+  | Tabindex
+
+let detectionMethodToString = (method: detectionMethod): string =>
+  switch method {
+  | Semantic => "semantic"
+  | CursorPointer => "cursor_pointer"
+  | Tabindex => "tabindex"
+  }
+
+type resolvedElement = {
+  element: WebAPI.DOMAPI.element,
+  role: string,
+  name: string,
+  tag: string,
+  detectionMethod: detectionMethod,
+  visibleText: option<string>,
+}
+
+// Get cursor style for an element. Uses the iframe's window for getComputedStyle.
+let getCursor = (win: WebAPI.DOMAPI.window, el: WebAPI.DOMAPI.element): string =>
+  try {
+    WebAPI.Window.getComputedStyle(win, ~elt=el).cursor
+  } catch {
+  | _ => ""
+  }
+
+// Check if an element has zero dimensions (invisible)
+let hasZeroDimensions = (el: WebAPI.DOMAPI.element): bool => {
+  let rect = el->WebAPI.Element.getBoundingClientRect
+  rect.width <= 0.0 || rect.height <= 0.0
+}
+
+// Truncate text to a reasonable length for LLM context
+let truncateText = (text: string, ~maxLen: int=80): option<string> => {
+  let trimmed = text->String.trim
+  switch trimmed {
+  | "" => None
+  | t if t->String.length > maxLen => Some(t->String.slice(~start=0, ~end=maxLen) ++ "...")
+  | t => Some(t)
+  }
+}
+
+// Get visible text content from an element (innerText preferred, falls back to textContent).
+// Cast to htmlElement for innerText access; textContent is on node.
+let getVisibleText = (el: WebAPI.DOMAPI.element): string =>
+  try {
+    let htmlEl: WebAPI.DOMAPI.htmlElement = el->Obj.magic
+    switch WebAPI.HTMLElement.innerText(htmlEl) {
+    | "" =>
+      (el :> WebAPI.DOMAPI.node)->WebAPI.Node.textContent->Null.toOption->Option.getOr("")
+    | text => text
+    }
+  } catch {
+  | _ => ""
+  }
+
+// Determine how an element was detected as interactive, if at all.
+let detectInteractivity = (
+  ~contentWindow: WebAPI.DOMAPI.window,
+  ~el: WebAPI.DOMAPI.element,
+  ~rawRole: string,
+): option<detectionMethod> =>
+  switch true {
+  | _ if rawRole !== "" && interactiveRoleSet->Dict.get(rawRole)->Option.isSome => Some(Semantic)
+  | _ if getCursor(contentWindow, el) === "pointer" => Some(CursorPointer)
+  | _ if el->WebAPI.Element.hasAttribute("tabindex") =>
+    // Only treat tabindex >= 0 as interactive. tabindex="-1" means
+    // "programmatically focusable but not in the tab order" and is
+    // used on non-interactive containers (modals, scroll targets, etc.)
+    let tabVal =
+      el
+      ->WebAPI.Element.getAttribute("tabindex")
+      ->Null.toOption
+      ->Option.getOr("-1")
+      ->Int.fromString(~radix=10)
+      ->Option.getOr(-1)
+    tabVal >= 0 ? Some(Tabindex) : None
+  | _ => None
+  }
+
+// Check whether an element passes the optional role and name filters.
+let passesFilters = (~role: string, ~name: string, ~roleFilter: option<string>, ~nameFilter: option<string>): bool => {
+  let passesRole = switch roleFilter {
+  | None => true
+  | Some(r) => role === r->String.toLowerCase
+  }
+  let passesName = switch nameFilter {
+  | None => true
+  | Some(n) => name->String.toLowerCase->String.includes(n->String.toLowerCase)
+  }
+  passesRole && passesName
+}
+
+// Collect interactive elements from a document.
+// Walks the DOM and identifies elements that are interactive via:
+// 1. Semantic ARIA role (implicit or explicit)
+// 2. cursor:pointer CSS
+// 3. tabindex attribute
+//
+// Uses a while loop (not Array.filter) so we can stop at maxElements
+// without scanning the entire DOM.
+let collectInteractiveElements = (
+  ~document: WebAPI.DOMAPI.document,
+  ~contentWindow: WebAPI.DOMAPI.window,
+  ~roleFilter: option<string>=?,
+  ~nameFilter: option<string>=?,
+  ~maxElements: int=50,
+): array<resolvedElement> => {
+  let allElements = document->WebAPI.Document.querySelectorAll("*")->nodeListToElements
+  let results: array<resolvedElement> = []
+
+  let i = ref(0)
+  while i.contents < allElements->Array.length && results->Array.length < maxElements {
+    let el = allElements->Array.getUnsafe(i.contents)
+    i := i.contents + 1
+
+    if !Bindings__DomAccessibilityApi.isInaccessible(el) && !hasZeroDimensions(el) {
+      let rawRole = Bindings__DomAccessibilityApi.getRole(el)->Null.toOption->Option.getOr("")
+      let tag = el.tagName->String.toLowerCase
+      // Use tag name as fallback when ARIA role is empty (e.g. cursor:pointer divs).
+      // This "effective role" is used consistently for filtering, resolution, and output
+      // so the agent can target elements by the same role value shown in discovery.
+      let role = rawRole === "" ? tag : rawRole
+
+      switch detectInteractivity(~contentWindow, ~el, ~rawRole) {
+      | None => ()
+      | Some(detectionMethod) =>
+        let name = Bindings__DomAccessibilityApi.computeAccessibleName(el)
+        if passesFilters(~role, ~name, ~roleFilter, ~nameFilter) {
+          results
+          ->Array.push({
+            element: el,
+            role,
+            name,
+            tag,
+            detectionMethod,
+            visibleText: getVisibleText(el)->truncateText,
+          })
+          ->ignore
+        }
+      }
+    }
+  }
+
+  results
+}
+
+// Resolve an element by role + name (both required).
+// Walks all elements, matches by computed role and accessible name.
+let resolveByRoleAndName = (
+  ~document: WebAPI.DOMAPI.document,
+  ~role: string,
+  ~name: string,
+  ~index: int=0,
+): (option<WebAPI.DOMAPI.element>, int) => {
+  let lowerRole = role->String.toLowerCase
+  let lowerName = name->String.toLowerCase
+
+  let matches =
+    document
+    ->WebAPI.Document.querySelectorAll("*")
+    ->nodeListToElements
+    ->Array.filter(el => {
+      if Bindings__DomAccessibilityApi.isInaccessible(el) || hasZeroDimensions(el) {
+        false
+      } else {
+        let rawRole =
+          Bindings__DomAccessibilityApi.getRole(el)
+          ->Null.toOption
+          ->Option.getOr("")
+          ->String.toLowerCase
+        let tag = el.tagName->String.toLowerCase
+        let elRole = rawRole === "" ? tag : rawRole
+        elRole === lowerRole &&
+          Bindings__DomAccessibilityApi.computeAccessibleName(el)
+          ->String.toLowerCase
+          ->String.includes(lowerName)
+      }
+    })
+
+  (matches->Array.get(index), matches->Array.length)
+}
+
+// Check whether any direct child of `el` contains `lowerText` in its visible text.
+// Used to prefer leaf-ish elements over parent containers.
+let childMatchesText = (el: WebAPI.DOMAPI.element, lowerText: string): bool => {
+  let children = el.children
+  let found = ref(false)
+  let j = ref(0)
+  while j.contents < children.length && !found.contents {
+    let child = children->WebAPI.HTMLCollection.item(j.contents)
+    // Only consider visible, accessible children — skip <style>, <script>,
+    // aria-hidden="true", etc. to avoid false positives from hidden text content.
+    if !Bindings__DomAccessibilityApi.isInaccessible(child) && !hasZeroDimensions(child) {
+      if getVisibleText(child)->String.toLowerCase->String.includes(lowerText) {
+        found := true
+      }
+    }
+    j := j.contents + 1
+  }
+  found.contents
+}
+
+// Resolve an element by visible text content.
+// Walks all elements, matches by innerText substring.
+let resolveByText = (
+  ~document: WebAPI.DOMAPI.document,
+  ~text: string,
+  ~index: int=0,
+): (option<WebAPI.DOMAPI.element>, int) => {
+  let lowerText = text->String.toLowerCase
+
+  let matches =
+    document
+    ->WebAPI.Document.querySelectorAll("*")
+    ->nodeListToElements
+    ->Array.filter(el => {
+      if Bindings__DomAccessibilityApi.isInaccessible(el) || hasZeroDimensions(el) {
+        false
+      } else {
+        let visText = getVisibleText(el)->String.toLowerCase
+        // Match text, but prefer leaf-ish elements: skip if a child also matches
+        // (to avoid matching a parent div when a child button has the text)
+        visText->String.includes(lowerText) && !childMatchesText(el, lowerText)
+      }
+    })
+
+  (matches->Array.get(index), matches->Array.length)
+}
+
+// Generate a CSS selector for an element using @medv/finder.
+// Returns None if selector generation fails.
+let generateSelector = (
+  ~element: WebAPI.DOMAPI.element,
+  ~document: option<WebAPI.DOMAPI.document>,
+): option<string> => {
+  try {
+    let selector = Bindings__Finder.finder(
+      ~element,
+      ~options={
+        root: document
+        ->Option.map(doc => doc.documentElement->Obj.magic)
+        ->Option.getOr(element),
+        idName: (~name as _) => true,
+        className: (~name as _) => true,
+        tagName: (~name as _) => true,
+        attr: (~name as _, ~value as _) => false,
+      },
+    )
+    Some(selector)
+  } catch {
+  | _ => None
+  }
+}
+
+// Describe an element for output to the agent.
+// Format: "role 'name'" or "tag 'name'" or "tag" if no name.
+let describeElement = (el: WebAPI.DOMAPI.element): string => {
+  let role =
+    Bindings__DomAccessibilityApi.getRole(el)->Null.toOption->Option.getOr("")
+  let name = Bindings__DomAccessibilityApi.computeAccessibleName(el)
+  let tag = el.tagName->String.toLowerCase
+  let label = role === "" ? tag : role
+
+  switch name {
+  | "" => label
+  | n => `${label} '${n}'`
+  }
+}

--- a/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
+++ b/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
@@ -1,0 +1,124 @@
+// Client tool that discovers interactive elements on the current page.
+// Returns a snapshot of clickable/interactive elements with their roles,
+// accessible names, and CSS selectors for use by interact_with_element.
+
+S.enableJson()
+module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+type toolResult<'a> = Tool.toolResult<'a>
+
+let name = "get_interactive_elements"
+let visibleToAgent = true
+let description = `Discover interactive elements on the current web preview page. Returns a list of clickable/interactive elements with their ARIA roles, accessible names, CSS selectors, and visible text.
+
+Use this tool to understand what elements are available for interaction before calling interact_with_element.
+
+Detection methods:
+- **semantic**: Elements with interactive ARIA roles (button, link, checkbox, etc.) — either from HTML semantics or explicit role attributes
+- **cursor_pointer**: Elements styled with cursor:pointer (catches JS onclick handlers on divs, spans, etc.)
+- **tabindex**: Elements with a tabindex attribute (focusable, likely interactive)
+
+Optional filters:
+- **role**: Only return elements with a specific ARIA role (e.g. "button", "link")
+- **name**: Only return elements whose accessible name contains the given text`
+
+@schema
+type input = {
+  @s.describe("Filter by ARIA role (e.g. 'button', 'link', 'checkbox')")
+  role: option<string>,
+  @s.describe("Filter by accessible name substring (case-insensitive)")
+  name: option<string>,
+}
+
+@schema
+type interactiveElement = {
+  @s.describe("Position in the returned list (0-based)")
+  index: int,
+  @s.describe("ARIA role (computed from HTML semantics or explicit role attribute)")
+  role: string,
+  @s.describe("Accessible name (from aria-label, label element, text content, etc.)")
+  name: string,
+  @s.describe("HTML tag name")
+  tag: string,
+  @s.describe("CSS selector for targeting this element (absent if selector generation failed)")
+  selector: option<string>,
+  @s.describe("How this element was detected as interactive: 'semantic', 'cursor_pointer', or 'tabindex'")
+  detectionMethod: string,
+  @s.describe("Truncated visible text content of the element")
+  visibleText: option<string>,
+}
+
+let maxElements = 50
+
+@schema
+type output = {
+  @s.describe("Whether the discovery was performed successfully")
+  success: bool,
+  @s.describe("List of interactive elements found on the page")
+  elements: option<array<interactiveElement>>,
+  @s.describe("Total number of interactive elements returned")
+  totalCount: option<int>,
+  @s.describe("True if results were capped at the limit and more elements may exist on the page")
+  truncated: option<bool>,
+  @s.describe("Error message if the discovery failed")
+  error: option<string>,
+}
+
+let execute = async (input: input): toolResult<output> => {
+  let state = FrontmanReactStatestore.StateStore.getState(Client__State__Store.store)
+  let previewFrame = Client__State__StateReducer.Selectors.previewFrame(state)
+
+  switch (previewFrame.contentDocument, previewFrame.contentWindow) {
+  | (None, _) | (_, None) =>
+    Ok({
+      success: false,
+      elements: None,
+      totalCount: None,
+      truncated: None,
+      error: Some("Preview frame not available"),
+    })
+  | (Some(doc), Some(win)) =>
+    try {
+      let resolved = Client__Tool__ElementResolver.collectInteractiveElements(
+        ~document=doc,
+        ~contentWindow=win,
+        ~roleFilter=?input.role,
+        ~nameFilter=?input.name,
+        ~maxElements,
+      )
+
+      let elements = resolved->Array.mapWithIndex((el, idx) => {
+        let selector = Client__Tool__ElementResolver.generateSelector(
+          ~element=el.element,
+          ~document=Some(doc),
+        )
+
+        {
+          index: idx,
+          role: el.role,
+          name: el.name,
+          tag: el.tag,
+          selector,
+          detectionMethod: Client__Tool__ElementResolver.detectionMethodToString(el.detectionMethod),
+          visibleText: el.visibleText,
+        }
+      })
+
+      let count = elements->Array.length
+      Ok({
+        success: true,
+        elements: Some(elements),
+        totalCount: Some(count),
+        truncated: Some(count >= maxElements),
+        error: None,
+      })
+    } catch {
+    | exn =>
+      let errorMsg =
+        exn
+        ->JsExn.fromException
+        ->Option.flatMap(JsExn.message)
+        ->Option.getOr("Unknown error discovering interactive elements")
+      Ok({success: false, elements: None, totalCount: None, truncated: None, error: Some(errorMsg)})
+    }
+  }
+}

--- a/libs/client/src/tools/Client__Tool__InteractWithElement.res
+++ b/libs/client/src/tools/Client__Tool__InteractWithElement.res
@@ -1,0 +1,199 @@
+// Client tool that interacts with elements in the web preview.
+// Supports click, hover, and focus actions.
+// Elements can be targeted by CSS selector, role+name, or text content.
+
+S.enableJson()
+module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+type toolResult<'a> = Tool.toolResult<'a>
+
+let name = "interact_with_element"
+let visibleToAgent = true
+let description = `Interact with an element in the web preview. Supports click, hover, and focus actions.
+
+Element targeting (use one strategy):
+1. **selector** (preferred): CSS selector — use when you have a selector from get_interactive_elements or the user's selected element context
+2. **role + name** (both required): ARIA role and accessible name — e.g. role="button", name="Submit Order"
+3. **text**: Visible text content — matches the innermost element containing the text
+
+Actions:
+- **click** (default): Click the element
+- **hover**: Trigger mouseenter/mouseover events on the element
+- **focus**: Focus the element
+
+Examples:
+- Click by selector: {"selector": "#submit-btn", "action": "click"}
+- Click by role+name: {"role": "button", "name": "Submit Order", "action": "click"}
+- Click by text: {"text": "Learn more", "action": "click"}
+- Hover by selector: {"selector": ".dropdown-trigger", "action": "hover"}
+- Focus an input: {"role": "textbox", "name": "Email", "action": "focus"}
+
+When multiple elements match, use the index parameter (0-based) to select which one.`
+
+@schema
+type input = {
+  @s.describe("CSS selector to target the element (preferred — from get_interactive_elements or user context)")
+  selector: option<string>,
+  @s.describe("ARIA role of the target element (e.g. 'button', 'link', 'textbox'). Must be used together with 'name'.")
+  role: option<string>,
+  @s.describe("Accessible name of the target element (e.g. 'Submit Order'). Must be used together with 'role'.")
+  name: option<string>,
+  @s.describe("Visible text content to match (finds the innermost element containing this text)")
+  text: option<string>,
+  @s.describe("Interaction type: 'click' (default), 'hover', or 'focus'")
+  action: option<[#click | #hover | #focus]>,
+  @s.describe("0-based index when multiple elements match (default: 0, i.e. first match)")
+  index: option<int>,
+}
+
+@schema
+type output = {
+  @s.describe("Whether the interaction was performed successfully")
+  success: bool,
+  @s.describe("Description of the element that was interacted with")
+  interactedElement: option<string>,
+  @s.describe("The action that was performed: 'clicked', 'hovered', or 'focused'")
+  action: option<string>,
+  @s.describe("Total number of elements that matched the targeting criteria")
+  matchCount: option<int>,
+  @s.describe("Error message if the interaction failed")
+  error: option<string>,
+}
+
+// Dispatch hover events (mouseenter + mouseover) on an element
+let dispatchHoverEvents = (el: WebAPI.DOMAPI.element): unit => {
+  let enterEvt = WebAPI.MouseEvent.make(
+    ~type_="mouseenter",
+    ~eventInitDict={bubbles: false, cancelable: false},
+  )
+  let overEvt = WebAPI.MouseEvent.make(
+    ~type_="mouseover",
+    ~eventInitDict={bubbles: true, cancelable: true},
+  )
+  let target = (el :> WebAPI.EventAPI.eventTarget)
+  target->WebAPI.EventTarget.dispatchEvent(enterEvt->WebAPI.MouseEvent.asEvent)->ignore
+  target->WebAPI.EventTarget.dispatchEvent(overEvt->WebAPI.MouseEvent.asEvent)->ignore
+}
+
+// Click an element (using HTMLElement.click() for proper event dispatch).
+// Cast to htmlElement since click() lives on HTMLElement, not Element.
+let clickElement = (el: WebAPI.DOMAPI.element): unit => {
+  let htmlEl: WebAPI.DOMAPI.htmlElement = el->Obj.magic
+  htmlEl->WebAPI.HTMLElement.click
+}
+
+// Focus an element.
+// Cast to htmlElement since focus() lives on HTMLElement, not Element.
+let focusElement = (el: WebAPI.DOMAPI.element): unit => {
+  let htmlEl: WebAPI.DOMAPI.htmlElement = el->Obj.magic
+  htmlEl->WebAPI.HTMLElement.focus
+}
+
+let actionToString = (action: [#click | #hover | #focus]): string =>
+  switch action {
+  | #click => "clicked"
+  | #hover => "hovered"
+  | #focus => "focused"
+  }
+
+let performAction = (el: WebAPI.DOMAPI.element, action: [#click | #hover | #focus]): unit =>
+  switch action {
+  | #click => clickElement(el)
+  | #hover => dispatchHoverEvents(el)
+  | #focus => focusElement(el)
+  }
+
+// Result of element resolution: either an error string, or a resolved element + match count.
+type resolution =
+  | Error(string)
+  | Resolved({element: option<WebAPI.DOMAPI.element>, matchCount: int})
+
+// Resolve the target element using the first applicable strategy:
+// 1. CSS selector  2. role + name  3. text content
+let resolveTarget = (
+  ~doc: WebAPI.DOMAPI.document,
+  ~input: input,
+  ~index: int,
+): resolution =>
+  switch input.selector {
+  | Some(selector) =>
+    let elements =
+      doc->WebAPI.Document.querySelectorAll(selector)->Client__Tool__ElementResolver.nodeListToElements
+    Resolved({element: elements->Array.get(index), matchCount: elements->Array.length})
+  | None =>
+    switch (input.role, input.name) {
+    | (Some(role), Some(name)) =>
+      let (element, matchCount) = Client__Tool__ElementResolver.resolveByRoleAndName(
+        ~document=doc,
+        ~role,
+        ~name,
+        ~index,
+      )
+      Resolved({element, matchCount})
+    | (Some(_), None) | (None, Some(_)) =>
+      Error("Both 'role' and 'name' are required when using role-based targeting")
+    | (None, None) =>
+      switch input.text {
+      | Some(text) =>
+        let (element, matchCount) = Client__Tool__ElementResolver.resolveByText(
+          ~document=doc,
+          ~text,
+          ~index,
+        )
+        Resolved({element, matchCount})
+      | None =>
+        Error(
+          "No targeting strategy provided. Use 'selector', 'role'+'name', or 'text' to identify the element.",
+        )
+      }
+    }
+  }
+
+let errorResult = (error: string, ~matchCount: option<int>=?): result<output, _> =>
+  Ok({
+    success: false,
+    interactedElement: None,
+    action: None,
+    matchCount,
+    error: Some(error),
+  })
+
+let execute = async (input: input): toolResult<output> => {
+  let state = FrontmanReactStatestore.StateStore.getState(Client__State__Store.store)
+  let previewFrame = Client__State__StateReducer.Selectors.previewFrame(state)
+  let action = input.action->Option.getOr(#click)
+  let index = Math.Int.max(0, input.index->Option.getOr(0))
+
+  switch previewFrame.contentDocument {
+  | None => errorResult("Preview frame document not available")
+  | Some(doc) =>
+    try {
+      switch resolveTarget(~doc, ~input, ~index) {
+      | Error(msg) => errorResult(msg)
+      | Resolved({element: None, matchCount: 0}) =>
+        errorResult("No element found matching the given criteria", ~matchCount=0)
+      | Resolved({element: None, matchCount}) =>
+        errorResult(
+          `Index ${Int.toString(index)} out of range. Found ${Int.toString(matchCount)} element(s) matching the given criteria`,
+          ~matchCount,
+        )
+      | Resolved({element: Some(el), matchCount}) =>
+        performAction(el, action)
+        Ok({
+          success: true,
+          interactedElement: Some(Client__Tool__ElementResolver.describeElement(el)),
+          action: Some(actionToString(action)),
+          matchCount: Some(matchCount),
+          error: None,
+        })
+      }
+    } catch {
+    | exn =>
+      errorResult(
+        exn
+        ->JsExn.fromException
+        ->Option.flatMap(JsExn.message)
+        ->Option.getOr("Unknown error during element interaction"),
+      )
+    }
+  }
+}

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -12,7 +12,7 @@ describe("ToolRegistry", _t => {
   test("coreBrowserTools returns all browser tools", t => {
     let registry = ToolRegistry.coreBrowserTools()
 
-    t->expect(registry->ToolRegistry.count)->Expect.toBe(3)
+    t->expect(registry->ToolRegistry.count)->Expect.toBe(5)
   })
 
   test("finds tool by name", t => {
@@ -21,6 +21,8 @@ describe("ToolRegistry", _t => {
     t->expect(registry->ToolRegistry.getToolByName("take_screenshot")->Option.isSome)->Expect.toBe(true)
     t->expect(registry->ToolRegistry.getToolByName("navigate")->Option.isSome)->Expect.toBe(true)
     t->expect(registry->ToolRegistry.getToolByName("set_device_mode")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("get_interactive_elements")->Option.isSome)->Expect.toBe(true)
+    t->expect(registry->ToolRegistry.getToolByName("interact_with_element")->Option.isSome)->Expect.toBe(true)
     t->expect(registry->ToolRegistry.getToolByName("nonexistent")->Option.isSome)->Expect.toBe(false)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,7 @@ __metadata:
     canvas-confetti: "npm:^1.9.4"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
+    dom-accessibility-api: "npm:^0.5.16"
     dom-element-to-component-source: "npm:^0.5.0"
     lucide-react: "npm:^0.548.0"
     motion: "npm:^12.23.24"
@@ -11227,7 +11228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.9":
+"dom-accessibility-api@npm:^0.5.16, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053


### PR DESCRIPTION
## Summary

- Adds **`get_interactive_elements`** tool — discovers interactive elements on the web preview page using accessibility tree analysis (computed ARIA roles + accessible names via `dom-accessibility-api`) plus `cursor:pointer` and `tabindex` heuristics
- Adds **`interact_with_element`** tool — click, hover, or focus elements targeted by CSS selector, role+name, or text content matching
- Adds `dom-accessibility-api` dependency for W3C-compliant accessible name computation and role resolution

## Design

**Element discovery** (`get_interactive_elements`): Walks the DOM and identifies interactive elements via three detection methods:
1. **Semantic** — elements with interactive ARIA roles (implicit from HTML tag or explicit `role` attribute)
2. **cursor:pointer** — catches styled JS `onClick` handlers on divs/spans
3. **tabindex** — focusable elements (tabindex >= 0 only)

Each element is returned with its role, accessible name, CSS selector (via `@medv/finder`), tag, and detection method. Capped at 50 elements.

**Element interaction** (`interact_with_element`): Three targeting strategies in priority order:
1. **CSS selector** — works seamlessly with user-selected element context (selector already in ACP content blocks)
2. **role + name** (both required) — accessibility-based matching
3. **text** — visible text content substring match (prefers innermost matching element)

Supports `click` (default), `hover` (mouseenter + mouseover), and `focus` actions. `index` parameter for disambiguation when multiple elements match.

## Files

| File | Change |
|------|--------|
| `libs/client/src/bindings/Bindings__DomAccessibilityApi.res` | New — bindings for `dom-accessibility-api` |
| `libs/client/src/tools/Client__Tool__ElementHelpers.res` | New — shared element resolution and discovery helpers |
| `libs/client/src/tools/Client__Tool__GetInteractiveElements.res` | New — discovery tool |
| `libs/client/src/tools/Client__Tool__InteractWithElement.res` | New — interaction tool |
| `libs/client/src/Client__ToolRegistry.res` | Register both new tools |
| `libs/client/test/Client__ToolRegistry.test.res` | Update test assertions for 5 tools |
| `libs/client/package.json` | Add `dom-accessibility-api` dep |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
