### PR TITLE
feat: enable write_file tool to save user-attached images to disk

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -310,7 +310,8 @@ defmodule FrontmanServer.Tasks.Interaction do
         %{
           blob: Map.get(inner, "blob", ""),
           mime_type: Map.get(inner, "mimeType", "image/png"),
-          filename: Map.get(meta, "filename", "attachment")
+          filename: Map.get(meta, "filename", "attachment"),
+          uri: Map.get(inner, "uri")
         }
       end)
     end
@@ -755,6 +756,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       |> Enum.join("\n\n")
       |> append_current_page_context(msg.current_page)
       |> append_component_location(msg.selected_component)
+      |> append_image_attachment_context(msg.images)
 
     content_parts =
       text_content
@@ -835,6 +837,32 @@ defmodule FrontmanServer.Tasks.Interaction do
   end
 
   defp append_current_page_context(text, _), do: text
+
+  # Append image attachment URIs so the LLM knows it can save them via write_file's image_ref
+  defp append_image_attachment_context(text, images) when is_list(images) and images != [] do
+    uris =
+      images
+      |> Enum.filter(fn img -> is_binary(Map.get(img, :uri)) end)
+      |> Enum.map(fn img -> "- #{img.uri} (#{img.filename}, #{img.mime_type})" end)
+
+    case uris do
+      [] ->
+        text
+
+      _ ->
+        uri_list = Enum.join(uris, "\n")
+
+        text <>
+          """
+
+          [Available Image Attachments]
+          The following images were attached by the user and can be saved to disk using the write_file tool with the image_ref parameter:
+          #{uri_list}
+          """
+    end
+  end
+
+  defp append_image_attachment_context(text, _), do: text
 
   defp build_viewport_context(%{viewport_width: w, viewport_height: h})
        when is_integer(w) and is_integer(h) do

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -254,7 +254,8 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
       %{
         blob: img["blob"],
         mime_type: img["mime_type"] || "image/png",
-        filename: img["filename"] || "attachment"
+        filename: img["filename"] || "attachment",
+        uri: img["uri"]
       }
     end)
   end

--- a/libs/bindings/src/Fs.res
+++ b/libs/bindings/src/Fs.res
@@ -14,6 +14,10 @@ module Promises = {
   @module("fs") @scope("promises")
   external writeFile: (string, string, @as("utf8") _) => promise<unit> = "writeFile"
 
+  // Write binary data (e.g. decoded base64 images) to a file
+  @module("fs") @scope("promises")
+  external writeFileBuffer: (string, NodeBuffer.t) => promise<unit> = "writeFile"
+
   @module("fs") @scope("promises")
   external readdir: string => promise<array<string>> = "readdir"
 

--- a/libs/bindings/src/NodeBuffer.res
+++ b/libs/bindings/src/NodeBuffer.res
@@ -1,0 +1,11 @@
+// Node.js Buffer bindings for binary data operations
+
+type t
+
+// Create a Buffer from a base64-encoded string
+@module("node:buffer") @scope("Buffer")
+external fromBase64: (string, @as("base64") _) => t = "from"
+
+// Create a Buffer from a utf8 string
+@module("node:buffer") @scope("Buffer")
+external fromString: (string, @as("utf8") _) => t = "from"

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -143,8 +143,8 @@ let make = (
     // Build file attachment content parts (images + PDFs)
     let fileParts = inputItems->Array.filterMap(item =>
       switch item {
-      | Client__PromptInput.FileAttachment({name, dataUrl, mediaType}) =>
-        Some(Client__State.UserContentPart.Image({image: dataUrl, mediaType: Some(mediaType), name: Some(name)}))
+      | Client__PromptInput.FileAttachment({id, name, dataUrl, mediaType}) =>
+        Some(Client__State.UserContentPart.Image({id: Some(id), image: dataUrl, mediaType: Some(mediaType), name: Some(name)}))
       | Client__PromptInput.PastedText(_) => None
       }
     )

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -100,6 +100,23 @@ module Provider = {
       let mcpServer = MCPServer.make(~relay, ~serverName=clientName, ~serverVersion=clientVersion)
       let mcpServer = Client__ToolRegistry.registerAll(toolRegistry, mcpServer)
 
+      // Wire up image ref resolver so write_file can save user-attached images
+      MCPServer.setImageRefResolver(mcpServer, uri => {
+        let state = FrontmanReactStatestore.StateStore.getState(Client__State__Store.store)
+        let currentTask = Client__State__StateReducer.Selectors.currentTask(state)
+        let attachments = Client__State__Types.Task.getImageAttachments(currentTask)
+        switch attachments->Dict.get(uri) {
+        | None => None
+        | Some(att) =>
+          // Strip "data:mime;base64," prefix to get raw base64
+          let base64 = switch att.dataUrl->String.indexOf(";base64,") {
+          | -1 => att.dataUrl
+          | idx => att.dataUrl->String.slice(~start=idx + 8, ~end=String.length(att.dataUrl))
+          }
+          Some({MCPServer.base64, mediaType: att.mediaType})
+        }
+      })
+
       let config: Reducer.initConfig = {
         endpoint,
         tokenUrl,

--- a/libs/client/src/Client__TaskTabs.story.res
+++ b/libs/client/src/Client__TaskTabs.story.res
@@ -54,6 +54,7 @@ module Fixtures = {
       isAgentRunning: false,
       planEntries: [],
       turnError: None,
+      imageAttachments: Dict.make(),
     })
   }
 

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -16,7 +16,7 @@ let make = (~content: array<UserContentPart.t>, ~messageId: string, ~isNew: bool
   // Separate image parts from text parts for layout
   let imageParts = content->Array.filterMap(part =>
     switch part {
-    | UserContentPart.Image({image, mediaType, name: _}) => Some((image, mediaType))
+    | UserContentPart.Image({image, mediaType, name: _, id: _}) => Some((image, mediaType))
     | _ => None
     }
   )

--- a/libs/client/src/state/Client__Message.res
+++ b/libs/client/src/state/Client__Message.res
@@ -2,6 +2,7 @@
 
 // Data for file/image attachments extracted from user content parts
 type fileAttachmentData = {
+  id: string,
   dataUrl: string,
   mediaType: string,
   filename: string,
@@ -11,7 +12,7 @@ type fileAttachmentData = {
 module UserContentPart = {
   type t =
     | Text({text: string})
-    | Image({image: string, mediaType: option<string>, name: option<string>})
+    | Image({id: option<string>, image: string, mediaType: option<string>, name: option<string>})
     | File({file: string})
 
   let text = (text: string): t => Text({text: text})

--- a/libs/client/src/state/Client__StateSnapshot.res
+++ b/libs/client/src/state/Client__StateSnapshot.res
@@ -310,7 +310,7 @@ let convertSelectedElement = (sel: Client__State__Types.SelectedElement.t): Sele
 let convertUserContentPart = (part: Client__State__Types.UserContentPart.t): UserContentPart.t => {
   switch part {
   | Text({text}) => Text({text: text})
-  | Image({image, mediaType, name}) => Image({image, mediaType, name})
+  | Image({image, mediaType, name, id: _}) => Image({image, mediaType, name})
   | File({file}) => File({file: file})
   }
 }

--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -38,7 +38,7 @@ let convertSourceLocation = (loc: Snapshot.SourceLocation.t): Client__Types.Sour
 let convertUserContentPart = (part: Snapshot.UserContentPart.t): StateTypes.UserContentPart.t => {
   switch part {
   | Text({text}) => Text({text: text})
-  | Image({image, mediaType, name}) => Image({image, mediaType, name})
+  | Image({image, mediaType, name}) => Image({id: None, image, mediaType, name})
   | File({file}) => File({file: file})
   }
 }
@@ -126,6 +126,7 @@ let convertTask = (task: Snapshot.Task.t): StateTypes.Task.t => {
     isAgentRunning: false, // Default to not running when restoring from snapshot
     planEntries: [], // Plan entries not stored in snapshots yet
     turnError: None, // No error when restoring from snapshot
+    imageAttachments: Dict.make(),
   })
 }
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -492,7 +492,7 @@ let buildAttachmentContentBlocks = (
         _meta: Some(meta),
         annotations: None,
         resource: Client__State__Types.ACPTypes.BlobResourceContents({
-          uri: `attachment://${att.filename}`,
+          uri: `attachment://${att.id}/${att.filename}`,
           mimeType: Some(att.mediaType),
           blob: base64Data,
         }),

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -420,15 +420,17 @@ let extractAttachmentsFromUserContent = (
 ): array<Message.fileAttachmentData> => {
   content->Array.filterMap(part => {
     switch part {
-    | Image({image, mediaType, name}) =>
+    | Image({id, image, mediaType, name}) =>
       Some({
-        Message.dataUrl: image,
+        Message.id: id->Option.getOr(WebAPI.Global.crypto->WebAPI.Crypto.randomUUID),
+        dataUrl: image,
         mediaType: mediaType->Option.getOrThrow,
         filename: name->Option.getOr("attachment"),
       })
     | File({file}) =>
       Some({
-        Message.dataUrl: file,
+        Message.id: WebAPI.Global.crypto->WebAPI.Crypto.randomUUID,
+        dataUrl: file,
         mediaType: "application/octet-stream",
         filename: "file",
       })
@@ -650,12 +652,21 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     let text = extractTextFromUserContent(content)
     let attachments = extractAttachmentsFromUserContent(content)
     let message = Message.User({id, content, createdAt: Date.now()})
+
+    // Accumulate image attachments keyed by URI for write_file image_ref resolution
+    let updatedImageAttachments = data.imageAttachments->Dict.copy
+    attachments->Array.forEach(att => {
+      let uri = `attachment://${att.id}/${att.filename}`
+      updatedImageAttachments->Dict.set(uri, att)
+    })
+
     (
       Task.Loaded({
         ...data,
         messages: MessageStore.insert(data.messages, message),
         isAgentRunning: true,
         turnError: None, // Clear any previous error when sending a new message
+        imageAttachments: updatedImageAttachments,
       }),
       [SendMessage({text, attachments})],
     )
@@ -757,6 +768,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
           isAgentRunning: false,
           planEntries: [],
           turnError: None,
+          imageAttachments: Dict.make(),
         }),
         [],
       )

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -157,6 +157,9 @@ module Task = {
         isAgentRunning: bool,
         planEntries: array<ACPTypes.planEntry>,
         turnError: option<string>,
+        // User-attached images keyed by URI (e.g., "attachment://att_abc123/image.png")
+        // Accumulated across messages so the agent can save them to disk via write_file
+        imageAttachments: Dict.t<Client__Message.fileAttachmentData>,
       })
 
   // What user is currently viewing
@@ -240,6 +243,12 @@ module Task = {
     | New({selectedElement}) => selectedElement
     | Unloaded(_) => None
     | Loading({selectedElement}) | Loaded({selectedElement}) => selectedElement
+    }
+
+  let getImageAttachments = (task: t): Dict.t<Client__Message.fileAttachmentData> =>
+    switch task {
+    | Loaded({imageAttachments}) => imageAttachments
+    | New(_) | Unloaded(_) | Loading(_) => Dict.make()
     }
 
   // State predicates
@@ -351,6 +360,7 @@ module Task = {
         isAgentRunning: false,
         planEntries: [],
         turnError: None,
+        imageAttachments: Dict.make(),
       })
     | Unloaded(_) | Loading(_) | Loaded(_) =>
       failwith("[Task.newToLoaded] Can only transition from New state")
@@ -379,6 +389,7 @@ module Task = {
       isAgentRunning,
       planEntries: [],
       turnError: None,
+      imageAttachments: Dict.make(),
     })
   }
 
@@ -437,7 +448,7 @@ module Task = {
 
   let updateLoadedData = (task: t, fn: loadedData => loadedData): t => {
     switch task {
-    | Loaded({id, clientId, title, createdAt, updatedAt, messages, previewFrame, webPreviewIsSelecting, selectedElement, isAgentRunning, planEntries, turnError}) => {
+    | Loaded({id, clientId, title, createdAt, updatedAt, messages, previewFrame, webPreviewIsSelecting, selectedElement, isAgentRunning, planEntries, turnError, imageAttachments}) => {
         let data = {messages: Client__MessageStore.toArray(messages), webPreviewIsSelecting, selectedElement, isAgentRunning, planEntries, turnError}
         let updated = fn(data)
         Loaded({
@@ -453,6 +464,7 @@ module Task = {
           isAgentRunning: updated.isAgentRunning,
           planEntries: updated.planEntries,
           turnError: updated.turnError,
+          imageAttachments,
         })
       }
     | Loading({id, title, createdAt, updatedAt, messages, previewFrame, webPreviewIsSelecting, selectedElement}) => {

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -8,10 +8,19 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #MCPServer
 })
 
+// Resolved image data for write_file image_ref interception
+type resolvedImage = {
+  base64: string,
+  mediaType: string,
+}
+
 type t = {
   tools: array<module(Tool.Tool)>,
   relay: Relay.t,
   serverInfo: Types.info,
+  // Optional callback to resolve an image_ref URI to base64 data.
+  // Set by the client layer which has access to the state store.
+  mutable resolveImageRef: option<string => option<resolvedImage>>,
 }
 
 let make = (~relay: Relay.t, ~serverName="frontman-browser", ~serverVersion="1.0.0"): t => {
@@ -19,7 +28,13 @@ let make = (~relay: Relay.t, ~serverName="frontman-browser", ~serverVersion="1.0
     tools: [],
     relay,
     serverInfo: {name: serverName, version: serverVersion},
+    resolveImageRef: None,
   }
+}
+
+// Set the image ref resolver (called from client layer after store is available)
+let setImageRefResolver = (server: t, resolver: string => option<resolvedImage>): unit => {
+  server.resolveImageRef = Some(resolver)
 }
 
 let registerToolModule = (server: t, toolModule: module(Tool.Tool)): t => {
@@ -102,6 +117,50 @@ let executeLocalTool = async (
   }
 }
 
+// Resolve image_ref in write_file arguments before forwarding to relay.
+// Replaces image_ref with content (base64) and encoding ("base64").
+let resolveWriteFileImageRef = (
+  server: t,
+  arguments: option<Dict.t<JSON.t>>,
+): result<option<Dict.t<JSON.t>>, string> => {
+  switch arguments {
+  | None => Ok(None)
+  | Some(args) =>
+    switch args->Dict.get("image_ref") {
+    | None => Ok(Some(args)) // No image_ref, pass through
+    | Some(imageRefJson) =>
+      let imageRef = switch imageRefJson {
+      | String(s) => s
+      | _ => ""
+      }
+      if imageRef == "" {
+        Error("image_ref must be a non-empty string")
+      } else {
+        switch server.resolveImageRef {
+        | None =>
+          Error("Cannot resolve image_ref: no resolver configured")
+        | Some(resolve) =>
+          switch resolve(imageRef) {
+          | None =>
+            Error(`Image not found for URI: ${imageRef}. Available images may have expired or the URI is incorrect.`)
+          | Some({base64}) =>
+            // Build new arguments: remove image_ref, add content + encoding
+            let newArgs = Dict.make()
+            args->Dict.forEachWithKey((value, key) => {
+              if key != "image_ref" {
+                newArgs->Dict.set(key, value)
+              }
+            })
+            newArgs->Dict.set("content", JSON.Encode.string(base64))
+            newArgs->Dict.set("encoding", JSON.Encode.string("base64"))
+            Ok(Some(newArgs))
+          }
+        }
+      }
+    }
+  }
+}
+
 // Execute tool - tries local first, then relay
 let executeTool = async (
   server: t,
@@ -115,12 +174,29 @@ let executeTool = async (
   | None =>
     // Try relay if it has this tool
     if server.relay->Relay.hasTool(name) {
-      let result = await server.relay->Relay.executeTool(~name, ~arguments?, ~onProgress?)
-      switch result {
-      | Ok(toolResult) => toolResult
+      // Intercept write_file with image_ref to resolve from state
+      let resolvedArgs = if name == "write_file" {
+        switch resolveWriteFileImageRef(server, arguments) {
+        | Ok(args) => Ok(args)
+        | Error(msg) => Error(msg)
+        }
+      } else {
+        Ok(arguments)
+      }
+
+      switch resolvedArgs {
       | Error(msg) => {
           content: [{type_: "text", text: msg}],
           isError: Some(true),
+        }
+      | Ok(finalArgs) =>
+        let result = await server.relay->Relay.executeTool(~name, ~arguments=?finalArgs, ~onProgress?)
+        switch result {
+        | Ok(toolResult) => toolResult
+        | Error(msg) => {
+            content: [{type_: "text", text: msg}],
+            isError: Some(true),
+          }
         }
       }
     } else {

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
@@ -1,6 +1,7 @@
-// Write file tool - writes content to a file
+// Write file tool - writes content to a file (text or binary via image_ref)
 
 module Fs = FrontmanBindings.Fs
+module NodeBuffer = FrontmanBindings.NodeBuffer
 module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
@@ -10,15 +11,22 @@ let description = `Writes content to a file.
 
 Parameters:
 - path (required): Path to file - either relative to source root or absolute (must be under source root)
-- content (required): Content to write
+- content: Text content to write (mutually exclusive with image_ref)
+- image_ref: URI of a user-attached image to save (e.g., "attachment://att_abc123/photo.png"). Use this to save images the user has pasted into the chat. Mutually exclusive with content.
+- encoding: Set to "base64" when writing binary data (used internally when image_ref is resolved)
 
+Provide either content OR image_ref, not both.
 Creates parent directories if they don't exist. Overwrites existing files.
 The _context field provides path resolution details for debugging.`
 
 @schema
 type input = {
   path: string,
-  content: string,
+  content?: string,
+  @s.describe("URI of a user-attached image to save to disk")
+  image_ref?: string,
+  @s.describe("Set to 'base64' for binary content (used when image_ref is resolved)")
+  encoding?: string,
 }
 
 @schema
@@ -35,24 +43,41 @@ type output = {
 }
 
 let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolResult<output> => {
-  switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
-  | Error(err) => Error(PathContext.formatError(err))
-  | Ok(result) =>
-    let dirPath = PathContext.dirname(result)
-    try {
-      let _ = await Fs.Promises.mkdir(dirPath, {recursive: true})
-      await Fs.Promises.writeFile(result.resolvedPath, input.content)
-      Ok({
-        _context: {
-          sourceRoot: result.sourceRoot,
-          resolvedPath: result.resolvedPath,
-          relativePath: result.relativePath,
-        },
-      })
-    } catch {
-    | exn =>
-      let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
-      Error(`Failed to write file ${input.path}: ${msg}`)
+  // Validate: must have content or image_ref, not both
+  switch (input.content, input.image_ref) {
+  | (None, None) => Error("Either content or image_ref must be provided")
+  | (Some(_), Some(_)) => Error("Provide either content or image_ref, not both")
+  | _ =>
+    switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
+    | Error(err) => Error(PathContext.formatError(err))
+    | Ok(result) =>
+      let dirPath = PathContext.dirname(result)
+      try {
+        let _ = await Fs.Promises.mkdir(dirPath, {recursive: true})
+
+        // If encoding is base64, write as binary; otherwise write as text
+        switch input.encoding {
+        | Some("base64") =>
+          let base64Content = input.content->Option.getOrThrow
+          let buffer = NodeBuffer.fromBase64(base64Content)
+          await Fs.Promises.writeFileBuffer(result.resolvedPath, buffer)
+        | _ =>
+          let textContent = input.content->Option.getOrThrow
+          await Fs.Promises.writeFile(result.resolvedPath, textContent)
+        }
+
+        Ok({
+          _context: {
+            sourceRoot: result.sourceRoot,
+            resolvedPath: result.resolvedPath,
+            relativePath: result.relativePath,
+          },
+        })
+      } catch {
+      | exn =>
+        let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+        Error(`Failed to write file ${input.path}: ${msg}`)
+      }
     }
   }
 }

--- a/mprocs.yml
+++ b/mprocs.yml
@@ -20,13 +20,16 @@ procs:
   nextjs-bundle:
     cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while [ ! -f lib/bs/.compiler.log ] || ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready, starting tsup watch...' && cd libs/frontman-nextjs && yarn tsup --watch"]
 
+  astro-bundle:
+    cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while [ ! -f lib/bs/.compiler.log ] || ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready, starting tsup watch...' && cd libs/frontman-astro && yarn tsup --watch"]
+
   nextjs:
     cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while [ ! -f lib/bs/.compiler.log ] || ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready. Waiting for nextjs bundle...' && while [ ! -f libs/frontman-nextjs/dist/index.js ]; do sleep 1; done && echo 'Bundle ready, starting Next.js...' && make dev-nextjs"]
     env:
       FRONTMAN_INTERNAL_DEV: "true"
 
   marketing:
-    cmd: ["make", "dev-marketing"]
+    cmd: ["bash", "-c", "echo 'Waiting for ReScript compiler...' && while [ ! -f lib/bs/.compiler.log ] || ! tail -1 lib/bs/.compiler.log 2>/dev/null | grep -q '^#Done'; do sleep 1; done && echo 'ReScript ready. Waiting for astro bundle...' && while [ ! -f libs/frontman-astro/dist/integration.js ]; do sleep 1; done && echo 'Bundle ready, starting marketing...' && make dev-marketing"]
     env:
       FRONTMAN_CLIENT_URL: "http://localhost:5173/src/Main.res.mjs"
       FRONTMAN_HOST: "frontman.local:4000"


### PR DESCRIPTION
## Summary

- **Enable LLM to save user-pasted images to disk** via `write_file` with a new `image_ref` parameter that references attachment URIs (`attachment://{id}/{filename}`)
- **Browser MCP server intercepts** `write_file` calls containing `image_ref`, resolves image data from client state, and rewrites to `{content: base64, encoding: "base64"}` before forwarding to the relay dev-server
- **Fix stale Astro bundles** by adding `astro-bundle` tsup watch process to `mprocs.yml` (was missing — caused the dev-server to run old tool schemas)

## Architecture

```
LLM → write_file({path, image_ref: "attachment://att_abc123/image.png"})
  ↓ Browser MCP server intercepts
  ↓ Resolves image_ref from client state → rewrites to {path, content: <base64>, encoding: "base64"}
  ↓ Forwards to relay dev-server via HTTP POST
  ↓ Dev-server decodes base64 → writes binary file
  ✓ File written
```

## Changes

### Tool layer
- `FrontmanCore__Tool__WriteFile.res` — Added `image_ref` and `encoding` optional params; `encoding: "base64"` triggers `Buffer.from(base64, "base64")` for binary writes; mutual exclusion validation between `content` and `image_ref`
- `NodeBuffer.res` (new) — Node.js Buffer bindings for base64 decode
- `Fs.res` — Added `writeFileBuffer` binding

### Browser MCP server
- `FrontmanClient__MCP__Server.res` — Added `resolveImageRef` callback and `resolveWriteFileImageRef` interception that rewrites `image_ref` → `content` + `encoding` before relay forwarding
- `Client__FrontmanProvider.res` — Wires up the image ref resolver from client state store

### Client state
- `Client__Message.res` — Added `id` field to `fileAttachmentData` and `UserContentPart.Image`
- `Client__Task__Types.res` — Added `imageAttachments` dict to track images across task lifecycle
- `Client__Task__Reducer.res` — Accumulates attachments from user messages into `imageAttachments`
- `Client__State__StateReducer.res` — Updated attachment URI format to `attachment://{att_id}/{filename}`

### Server
- `interaction.ex` — `extract_user_images` now captures the `uri` field; new `append_image_attachment_context` injects available attachment URIs into LLM messages
- `interaction_schema.ex` — Fixed `parse_images` to preserve `uri` field through DB roundtrip

### Dev tooling
- `mprocs.yml` — Added `astro-bundle` tsup watch process (mirrors `nextjs-bundle`); updated `marketing` process to wait for astro bundle before starting
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
