### PR TITLE
feat: URL-addressable preview with suffix-based routing

### DIFF
--- a/.changeset/url-addressable-preview.md
+++ b/.changeset/url-addressable-preview.md
@@ -1,0 +1,9 @@
+---
+"@frontman/frontman-core": minor
+"@frontman-ai/astro": minor
+"@frontman-ai/vite": minor
+"@frontman-ai/nextjs": minor
+"@frontman/client": minor
+---
+
+URL-addressable preview: persist iframe URL in browser address bar using suffix-based routing. Navigation within the preview iframe is now reflected in the browser URL, enabling shareable deep links and browser back/forward support.

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -27,11 +27,6 @@ if config_env() in [:dev, :test] do
     openai_api_key: env!("OPENAI_API_KEY", :string, nil)
 end
 
-# Discord webhook for #new-users signup alerts
-config :frontman_server,
-  discord_new_users_webhook_url: env!("DISCORD_NEW_USERS_WEBHOOK_URL", :string!),
-  discord_pg_channel: "new_user"
-
 # WorkOS configuration for OAuth (GitHub, Google)
 config :workos, WorkOS.Client,
   api_key: env!("WORKOS_API_KEY", :string, nil),
@@ -91,6 +86,10 @@ if config_env() in [:dev, :test] do
 end
 
 if config_env() == :prod do
+  config :frontman_server,
+    discord_new_users_webhook_url: env!("DISCORD_NEW_USERS_WEBHOOK_URL", :string!),
+    discord_pg_channel: "new_user"
+
   config :sentry,
     dsn:
       "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296",

--- a/apps/frontman_server/envs/.test.env
+++ b/apps/frontman_server/envs/.test.env
@@ -4,4 +4,3 @@ GOOGLE_API_KEY=test-google-key
 XAI_API_KEY=test-xai-key
 OPENROUTER_API_KEY=test-openrouter-key
 REQ_LLM_FIXTURES_MODE=replay
-DISCORD_NEW_USERS_WEBHOOK_URL=https://discord.com/api/webhooks/test/test

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -32,6 +32,20 @@ defmodule FrontmanServer.Application do
       nil
     )
 
+    # Discord new-user signup alerts (PG LISTEN/NOTIFY → webhook) – prod only
+    discord_children =
+      if Application.get_env(:frontman_server, :discord_new_users_webhook_url) do
+        [
+          {Postgrex.Notifications, [name: FrontmanServer.PGNotifications] ++ pg_notify_opts()},
+          {FrontmanServer.Notifications.Discord,
+           webhook_url: Application.get_env(:frontman_server, :discord_new_users_webhook_url),
+           channel: Application.get_env(:frontman_server, :discord_pg_channel),
+           notifications_pid: FrontmanServer.PGNotifications}
+        ]
+      else
+        []
+      end
+
     children =
       [
         FrontmanServerWeb.Telemetry,
@@ -46,14 +60,8 @@ defmodule FrontmanServer.Application do
         # TaskSupervisor for agent execution tasks
         {Task.Supervisor, name: FrontmanServer.TaskSupervisor},
         # Start to serve requests, typically the last entry
-        FrontmanServerWeb.Endpoint,
-        # Discord new-user signup alerts (PG LISTEN/NOTIFY → webhook)
-        {Postgrex.Notifications, [name: FrontmanServer.PGNotifications] ++ pg_notify_opts()},
-        {FrontmanServer.Notifications.Discord,
-         webhook_url: Application.get_env(:frontman_server, :discord_new_users_webhook_url),
-         channel: Application.get_env(:frontman_server, :discord_pg_channel),
-         notifications_pid: FrontmanServer.PGNotifications}
-      ]
+        FrontmanServerWeb.Endpoint
+      ] ++ discord_children
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/libs/bindings/src/Astro.res
+++ b/libs/bindings/src/Astro.res
@@ -24,6 +24,24 @@ type astroConfig = {
 // Vite plugin type — opaque, we just pass plugin objects through
 type vitePlugin
 
+// Vite dev server connect middleware stack
+type connectMiddlewareStack
+
+@send
+external use: (connectMiddlewareStack, NodeHttp.connectMiddleware) => unit = "use"
+
+// Vite dev server (minimal bindings for astro:server:setup)
+type viteDevServer = {middlewares: connectMiddlewareStack}
+
+// Config for constructing a Vite plugin with typed fields we use.
+// Keeps vitePlugin opaque while avoiding Obj.magic at call sites.
+type vitePluginConfig = {
+  name: string,
+  configureServer?: viteDevServer => unit,
+}
+
+external makeVitePlugin: vitePluginConfig => vitePlugin = "%identity"
+
 // Partial Astro config for updateConfig — only the fields we need
 type partialViteConfig = {plugins?: array<vitePlugin>}
 type partialAstroConfig = {vite?: partialViteConfig}
@@ -37,15 +55,6 @@ type configSetupHookContext = {
   config: astroConfig,
   command: astroCommand,
 }
-
-// Vite dev server connect middleware stack
-type connectMiddlewareStack
-
-@send
-external use: (connectMiddlewareStack, NodeHttp.connectMiddleware) => unit = "use"
-
-// Vite dev server (minimal bindings for astro:server:setup)
-type viteDevServer = {middlewares: connectMiddlewareStack}
 
 // --- Server-side toolbar object (available in astro:server:setup hook) ---
 // Must be defined before serverSetupHookContext which references it.

--- a/libs/bindings/src/LocalStorage.res
+++ b/libs/bindings/src/LocalStorage.res
@@ -1,0 +1,16 @@
+// Bindings for the Web Storage API (localStorage)
+
+@val @scope("localStorage")
+external getItem: string => Nullable.t<string> = "getItem"
+
+@val @scope("localStorage")
+external setItem: (string, string) => unit = "setItem"
+
+@val @scope("localStorage")
+external removeItem: string => unit = "removeItem"
+
+@val @scope("localStorage")
+external key: int => Nullable.t<string> = "key"
+
+@val @scope("localStorage")
+external length: int = "length"

--- a/libs/bindings/src/MutationObserver.res
+++ b/libs/bindings/src/MutationObserver.res
@@ -1,0 +1,28 @@
+type t
+
+type mutationRecord = {
+  @as("type") type_: string,
+  target: WebAPI.DOMAPI.node,
+  addedNodes: array<WebAPI.DOMAPI.node>,
+  removedNodes: array<WebAPI.DOMAPI.node>,
+  attributeName: Null.t<string>,
+  oldValue: Null.t<string>,
+}
+
+type observeOptions = {
+  "childList": bool,
+  "attributes": bool,
+  "characterData": bool,
+  "subtree": bool,
+  "attributeOldValue": bool,
+  "characterDataOldValue": bool,
+}
+
+@new
+external make: (array<mutationRecord> => unit) => t = "MutationObserver"
+
+@send
+external observe: (t, WebAPI.DOMAPI.node, observeOptions) => unit = "observe"
+
+@send
+external disconnect: t => unit = "disconnect"

--- a/libs/bindings/src/NavigateEvent.res
+++ b/libs/bindings/src/NavigateEvent.res
@@ -1,0 +1,6 @@
+type destination
+
+type t
+
+@get external destination: t => destination = "destination"
+@get external url: destination => string = "url"

--- a/libs/client/src/Client__FtueState.res
+++ b/libs/client/src/Client__FtueState.res
@@ -16,18 +16,13 @@ type t =
   | WelcomeShown
   | Completed
 
-@val @scope("localStorage") external getItem: string => Nullable.t<string> = "getItem"
-@val @scope("localStorage") external setItem: (string, string) => unit = "setItem"
-@val @scope("localStorage") external localStorageKey: (int) => Nullable.t<string> = "key"
-@val @scope("localStorage") external localStorageLength: int = "length"
-
 // Check whether any other frontman:* localStorage key exists, indicating a returning user
 let hasExistingFrontmanData = (): bool => {
   try {
-    let len = localStorageLength
+    let len = FrontmanBindings.LocalStorage.length
     let found = ref(false)
     for i in 0 to len - 1 {
-      switch localStorageKey(i)->Nullable.toOption {
+      switch FrontmanBindings.LocalStorage.key(i)->Nullable.toOption {
       | Some(k) =>
         switch k->String.startsWith("frontman:") && k !== storageKey {
         | true => found := true
@@ -44,7 +39,7 @@ let hasExistingFrontmanData = (): bool => {
 
 let get = (): t => {
   try {
-    switch getItem(storageKey)->Nullable.toOption {
+    switch FrontmanBindings.LocalStorage.getItem(storageKey)->Nullable.toOption {
     | Some("welcome_shown") => WelcomeShown
     | Some("completed") => Completed
     | Some(_) | None =>
@@ -52,7 +47,7 @@ let get = (): t => {
       switch hasExistingFrontmanData() {
       | true =>
         // Auto-migrate existing user: write Completed so this check only runs once
-        setItem(storageKey, "completed")
+        FrontmanBindings.LocalStorage.setItem(storageKey, "completed")
         Completed
       | false => New
       }
@@ -63,9 +58,9 @@ let get = (): t => {
 }
 
 let setWelcomeShown = () => {
-  setItem(storageKey, "welcome_shown")
+  FrontmanBindings.LocalStorage.setItem(storageKey, "welcome_shown")
 }
 
 let setCompleted = () => {
-  setItem(storageKey, "completed")
+  FrontmanBindings.LocalStorage.setItem(storageKey, "completed")
 }

--- a/libs/client/src/Client__Hooks.res
+++ b/libs/client/src/Client__Hooks.res
@@ -16,13 +16,15 @@ module EventHelpers = {
         //note(itay): This will return null (None) in case the IFrame is cross-origin to the
         //running script, and not an error like `contentWindow.document`
         let iframeDoc = element->WebAPI.HTMLIFrameElement.contentDocument->Null.toOption
-        let _: option<unit> = iframeExecuteEventListener(eventListener, handler, iframeDoc)
-        let _: option<WebAPI.DOMAPI.document> = iframeDoc->Option.map(
+        iframeExecuteEventListener(eventListener, handler, iframeDoc)->Option.ignore
+        iframeDoc
+        ->Option.map(
           doc => {
             eventListener(doc, handler)
             doc
           },
         )
+        ->Option.ignore
       })
     )
   let getIframeDoc = (iframeRef: Nullable.t<WebAPI.DOMAPI.element>) =>
@@ -33,6 +35,61 @@ module EventHelpers = {
       ->WebAPI.HTMLIFrameElement.contentDocument
       ->Null.toOption
     )
+
+  // Shared hook: subscribes a handler to a DOM event on a document and all its
+  // same-origin iframes, and tears everything down on cleanup.
+  //
+  // Uses ref-based handler pattern to avoid re-subscribing listeners on every
+  // render. The actual DOM listener delegates to the ref, which is always
+  // up-to-date. Effect only re-runs when document/event/withCapture change.
+  let useDocumentEvent = (
+    ~document: option<WebAPI.DOMAPI.document>,
+    ~event: string,
+    ~withCapture: bool,
+    ~handler: WebAPI.EventAPI.event => unit,
+    ~onCleanup: option<unit => unit>=?,
+    (),
+  ) => {
+    let handlerRef = React.useRef(handler)
+    let onCleanupRef = React.useRef(onCleanup)
+
+    // Keep refs current on every render (no effect needed, refs are synchronous)
+    handlerRef.current = handler
+    onCleanupRef.current = onCleanup
+
+    React.useEffect(() => {
+      document->Option.map(doc => {
+        let eventType = WebAPI.EventAPI.Custom(event)
+
+        // Stable wrapper: delegates to the ref so the DOM listener never changes
+        let stableHandler = (ev: WebAPI.EventAPI.event) => handlerRef.current(ev)
+
+        WebAPI.Document.addEventListener(doc, eventType, stableHandler, ~options={capture: withCapture})
+        iframeExecuteEventListener(
+          (d, h) =>
+            WebAPI.Document.addEventListener(d, eventType, h, ~options={capture: withCapture}),
+          stableHandler,
+          Some(doc),
+        )->Option.ignore
+
+        () => {
+          onCleanupRef.current->Option.forEach(fn => fn())
+          WebAPI.Document.removeEventListener(
+            doc,
+            eventType,
+            stableHandler,
+            ~options={capture: withCapture},
+          )
+          iframeExecuteEventListener(
+            (d, h) =>
+              WebAPI.Document.removeEventListener(d, eventType, h, ~options={capture: withCapture}),
+            stableHandler,
+            Some(doc),
+          )->Option.ignore
+        }
+      })
+    }, (document, event, withCapture))
+  }
 }
 
 module MouseMove = {
@@ -47,79 +104,39 @@ module MouseMove = {
       None
     }, [state])
 
-    React.useEffect(() => {
-      // Throttle mousemove events using requestAnimationFrame for better performance
-      let onMouseMove = ev => {
-        let target = WebAPI.MouseEvent.asMouseEvent(ev).target
+    // Throttle mousemove events using requestAnimationFrame for better performance
+    let onMouseMove = (ev: WebAPI.EventAPI.event) => {
+      let target = WebAPI.MouseEvent.asMouseEvent(ev->Obj.magic).target
 
-        if (
-          WebAPI.Element.nodeType(target->Obj.magic) == 1 &&
-            switch stateRef.current {
-            | None => true
-            | Some(el) => el != target
-            }
-        ) {
-          // Store the pending target
-          pendingTargetRef.current = Some(target)
+      if (
+        WebAPI.Element.nodeType(target->Obj.magic) == 1 &&
+          switch stateRef.current {
+          | None => true
+          | Some(el) => el != target
+          }
+      ) {
+        pendingTargetRef.current = Some(target)
+        rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id))
 
-          // Cancel any existing pending update
-          rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id))
-
-          // Schedule update using RAF
-          let rafId = WebAPI.Global.requestAnimationFrame(_timestamp => {
-            pendingTargetRef.current->Option.forEach(pendingTarget => {
-              setState(_ => Some(pendingTarget))
-              pendingTargetRef.current = None
-            })
+        let rafId = WebAPI.Global.requestAnimationFrame(_timestamp => {
+          pendingTargetRef.current->Option.forEach(pendingTarget => {
+            setState(_ => Some(pendingTarget))
+            pendingTargetRef.current = None
           })
-          rafIdRef.current = Some(rafId)
-        }
+        })
+        rafIdRef.current = Some(rafId)
       }
+    }
 
-      document->Option.map(document => {
-        WebAPI.Document.addEventListener(
-          document,
-          Custom("mousemove"),
-          onMouseMove,
-          ~options={capture: withCapture},
-        )
-
-        EventHelpers.iframeExecuteEventListener(
-          (doc, handler) =>
-            WebAPI.Document.addEventListener(
-              doc,
-              Custom("mousemove"),
-              handler,
-              ~options={capture: withCapture},
-            ),
-          onMouseMove,
-          Some(document),
-        )->Option.ignore
-        () => {
-          // Cancel any pending animation frame
-          rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id))
-
-          WebAPI.Document.removeEventListener(
-            document,
-            Custom("mousemove"),
-            onMouseMove,
-            ~options={capture: withCapture},
-          )
-
-          EventHelpers.iframeExecuteEventListener(
-            (doc, handler) =>
-              WebAPI.Document.removeEventListener(
-                doc,
-                Custom("mousemove"),
-                handler,
-                ~options={capture: withCapture},
-              ),
-            onMouseMove,
-            Some(document),
-          )->Option.ignore
-        }
-      })
-    }, (document, withCapture, setState))
+    EventHelpers.useDocumentEvent(
+      ~document,
+      ~event="mousemove",
+      ~withCapture,
+      ~handler=onMouseMove,
+      ~onCleanup=() =>
+        rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id)),
+      (),
+    )
 
     state
   }
@@ -142,63 +159,32 @@ module MouseClick = {
     let (state, setState) = React.useState(() => None)
     let clickCounter = React.useRef(0)
 
-    React.useEffect(() => {
-      let onClick = (ev: WebAPI.EventAPI.event) => {
-        preventDefault ? WebAPI.Event.preventDefault(ev) : ()
-        stopPropagation ? WebAPI.Event.stopPropagation(ev) : ()
-        stopImmediatePropagation ? WebAPI.Event.stopImmediatePropagation(ev) : ()
-        let target = ev.target->Null.toOption
-        clickCounter.current = clickCounter.current + 1
-        let id = clickCounter.current
-        setState(_ => Some({target, clickId: id}))
+    let onClick = (ev: WebAPI.EventAPI.event) => {
+      switch preventDefault {
+      | true => WebAPI.Event.preventDefault(ev)
+      | false => ()
       }
-      document->Option.map(document => {
-        WebAPI.Document.addEventListener(
-          document,
-          Custom(isRightClick ? "contextmenu" : "click"),
-          onClick,
-          ~options={capture: withCapture},
-        )
-        let _: option<unit> = EventHelpers.iframeExecuteEventListener(
-          (doc, handler) =>
-            WebAPI.Document.addEventListener(
-              doc,
-              Custom(isRightClick ? "contextmenu" : "click"),
-              handler,
-              ~options={capture: withCapture},
-            ),
-          onClick,
-          Some(document),
-        )
-        () => {
-          WebAPI.Document.removeEventListener(
-            document,
-            Custom(isRightClick ? "contextmenu" : "click"),
-            onClick,
-            ~options={capture: withCapture},
-          )
-          let _: option<unit> = EventHelpers.iframeExecuteEventListener(
-            (doc, handler) =>
-              WebAPI.Document.removeEventListener(
-                doc,
-                Custom(isRightClick ? "contextmenu" : "click"),
-                handler,
-                ~options={capture: withCapture},
-              ),
-            onClick,
-            Some(document),
-          )
-        }
-      })
-    }, (
-      setState,
-      withCapture,
-      document,
-      preventDefault,
-      stopImmediatePropagation,
-      stopPropagation,
-      isRightClick,
-    ))
+      switch stopPropagation {
+      | true => WebAPI.Event.stopPropagation(ev)
+      | false => ()
+      }
+      switch stopImmediatePropagation {
+      | true => WebAPI.Event.stopImmediatePropagation(ev)
+      | false => ()
+      }
+      let target = ev.target->Null.toOption
+      clickCounter.current = clickCounter.current + 1
+      let id = clickCounter.current
+      setState(_ => Some({target, clickId: id}))
+    }
+
+    let event = switch isRightClick {
+    | true => "contextmenu"
+    | false => "click"
+    }
+
+    EventHelpers.useDocumentEvent(~document, ~event, ~withCapture, ~handler=onClick, ())
+
     state
   }
 }
@@ -209,105 +195,31 @@ module Scroll = {
     let rafIdRef = React.useRef(None)
     let isScheduledRef = React.useRef(false)
 
-    React.useEffect(() => {
-      // Throttle scroll events using requestAnimationFrame for better performance
-      let onScroll = _ev => {
-        if !isScheduledRef.current {
-          isScheduledRef.current = true
-          let rafId = WebAPI.Global.requestAnimationFrame(_timestamp => {
-            setScrollTimestamp(_ => Js.Date.now())
-            isScheduledRef.current = false
-          })
-          rafIdRef.current = Some(rafId)
-        }
+    // Throttle scroll events using requestAnimationFrame for better performance
+    let onScroll = _ev => {
+      switch isScheduledRef.current {
+      | true => ()
+      | false =>
+        isScheduledRef.current = true
+        let rafId = WebAPI.Global.requestAnimationFrame(_timestamp => {
+          setScrollTimestamp(_ => Js.Date.now())
+          isScheduledRef.current = false
+        })
+        rafIdRef.current = Some(rafId)
       }
+    }
 
-      document
-      ->Option.map(document => {
-        WebAPI.Document.addEventListener(
-          document,
-          Custom("scroll"),
-          onScroll,
-          ~options={capture: withCapture},
-        )
-
-        EventHelpers.iframeExecuteEventListener(
-          (doc, handler) =>
-            WebAPI.Document.addEventListener(
-              doc,
-              Custom("scroll"),
-              handler,
-              ~options={capture: withCapture},
-            ),
-          onScroll,
-          Some(document),
-        )->Option.ignore
-
-        () => {
-          // Cancel any pending animation frame
-          rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id))
-
-          WebAPI.Document.removeEventListener(
-            document,
-            Custom("scroll"),
-            onScroll,
-            ~options={capture: withCapture},
-          )
-
-          EventHelpers.iframeExecuteEventListener(
-            (doc, handler) =>
-              WebAPI.Document.removeEventListener(
-                doc,
-                Custom("scroll"),
-                handler,
-                ~options={capture: withCapture},
-              ),
-            onScroll,
-            Some(document),
-          )->Option.ignore
-        }
-      })
-      ->ignore
-
-      None
-    }, (document, withCapture, setScrollTimestamp))
+    EventHelpers.useDocumentEvent(
+      ~document,
+      ~event="scroll",
+      ~withCapture,
+      ~handler=onScroll,
+      ~onCleanup=() =>
+        rafIdRef.current->Option.forEach(id => WebAPI.Global.cancelAnimationFrame(id)),
+      (),
+    )
 
     scrollTimestamp
-  }
-}
-
-module NavigateEvent = {
-  type destination
-  type t
-
-  @get external destination: t => destination = "destination"
-  @get external url: destination => string = "url"
-}
-
-module UrlParsing = {
-  type t
-
-  @new external make: (string, string) => t = "URL"
-  @get external href: t => string = "href"
-  @get external protocol: t => string = "protocol"
-  @get external host: t => string = "host"
-}
-
-let resolveUrlWithBase = (~url: string, ~base: string): option<string> => {
-  try {
-    Some(UrlParsing.make(url, base)->UrlParsing.href)
-  } catch {
-  | _ => None
-  }
-}
-
-let isSameOriginWithBase = (~baseUrl: string, ~targetUrl: string): bool => {
-  try {
-    let base = UrlParsing.make(baseUrl, baseUrl)
-    let target = UrlParsing.make(targetUrl, baseUrl)
-    base->UrlParsing.protocol == target->UrlParsing.protocol && base->UrlParsing.host == target->UrlParsing.host
-  } catch {
-  | _ => false
   }
 }
 
@@ -343,15 +255,32 @@ let useIFrameLocation = (~iframeElement: option<WebAPI.DOMAPI.element>, ~attachm
         setLocation(_ => initialLocation)
 
         let onNavigation = (ev: WebAPI.EventAPI.event) => {
-          let navigateEvent: NavigateEvent.t = ev->Obj.magic
-          let destinationUrl = navigateEvent->NavigateEvent.destination->NavigateEvent.url
+          let navigateEvent: FrontmanBindings.NavigateEvent.t = ev->Obj.magic
+          let destinationUrl =
+            navigateEvent
+            ->FrontmanBindings.NavigateEvent.destination
+            ->FrontmanBindings.NavigateEvent.url
           let currentUrl = iframeWindow->WebAPI.Window.location->WebAPI.Location.href
-          switch resolveUrlWithBase(~url=destinationUrl, ~base=currentUrl) {
+          switch Client__BrowserUrl.resolveUrlWithBase(~url=destinationUrl, ~base=currentUrl) {
           | None => ()
           | Some(resolvedDestinationUrl) =>
-            switch isSameOriginWithBase(~baseUrl=currentUrl, ~targetUrl=resolvedDestinationUrl) {
-            | true => setLocation(_ => Some(resolvedDestinationUrl))
+            switch Client__BrowserUrl.isSameOriginWithBase(
+              ~baseUrl=currentUrl,
+              ~targetUrl=resolvedDestinationUrl,
+            ) {
             | false => WebAPI.Event.preventDefault(ev)
+            | true =>
+              // If the iframe is trying to navigate to a /frontman URL, intercept
+              // and redirect to the stripped version so we never load frontman-in-frontman.
+              let parsed = WebAPI.URL.make(~url=resolvedDestinationUrl)
+              let cleanPath = Client__BrowserUrl.stripSuffix(parsed.pathname)
+              switch cleanPath != parsed.pathname {
+              | false => setLocation(_ => Some(resolvedDestinationUrl))
+              | true =>
+                WebAPI.Event.preventDefault(ev)
+                let cleanUrl = `${parsed.origin}${cleanPath}`
+                iframeWindow->WebAPI.Window.location->WebAPI.Location.assign(cleanUrl)
+              }
             }
           }
         }
@@ -421,38 +350,6 @@ let useDisableIFrameAnchorPointerEvents = (
   }, (iframeRef, activate))
 }
 
-module MutationObserverBindings = {
-  type mutationObserver
-  type mutationRecord = {
-    @as("type") type_: string,
-    target: WebAPI.DOMAPI.node,
-    addedNodes: array<WebAPI.DOMAPI.node>,
-    removedNodes: array<WebAPI.DOMAPI.node>,
-    attributeName: Null.t<string>,
-    oldValue: Null.t<string>,
-  }
-
-  @new
-  external make: (array<mutationRecord> => unit) => mutationObserver = "MutationObserver"
-
-  @send
-  external observe: (
-    mutationObserver,
-    WebAPI.DOMAPI.node,
-    {
-      "childList": bool,
-      "attributes": bool,
-      "characterData": bool,
-      "subtree": bool,
-      "attributeOldValue": bool,
-      "characterDataOldValue": bool,
-    },
-  ) => unit = "observe"
-
-  @send
-  external disconnect: mutationObserver => unit = "disconnect"
-}
-
 module DOMmutations = {
   let useIFrameDocument = (~document: option<WebAPI.DOMAPI.document>, ()) => {
     let (mutationTimestamp, setMutationTimestamp) = React.useState(() => Js.Date.now())
@@ -460,12 +357,12 @@ module DOMmutations = {
     React.useEffect(() => {
       document
       ->Option.map(doc => {
-        let onMutation = (_mutations: array<MutationObserverBindings.mutationRecord>) => {
+        let onMutation = (_mutations: array<FrontmanBindings.MutationObserver.mutationRecord>) => {
           setMutationTimestamp(_ => Js.Date.now())
         }
 
-        let observer = MutationObserverBindings.make(onMutation)
-        MutationObserverBindings.observe(
+        let observer = FrontmanBindings.MutationObserver.make(onMutation)
+        FrontmanBindings.MutationObserver.observe(
           observer,
           doc->Obj.magic,
           {
@@ -479,7 +376,7 @@ module DOMmutations = {
         )
 
         () => {
-          MutationObserverBindings.disconnect(observer)
+          FrontmanBindings.MutationObserver.disconnect(observer)
         }
       })
       ->Option.getOr(() => ())

--- a/libs/client/src/Client__RuntimeConfig.res
+++ b/libs/client/src/Client__RuntimeConfig.res
@@ -1,24 +1,37 @@
 // Runtime config injected by the framework middleware (e.g., Next.js)
 // Reads from window.__frontmanRuntime
 
+@schema
+type parsed = {
+  framework: string,
+  // UIShell always sets this, but tests and non-standard embeddings may omit it.
+  basePath: option<string>,
+  openrouterKeyValue: option<string>,
+}
+
+@schema
 type t = {
   framework: string,
+  basePath: string,
   openrouterKeyValue: option<string>,
 }
 
 let read = (): t => {
-  let getRuntime: unit => Nullable.t<{..}> = %raw(`
+  let getRuntime: unit => Nullable.t<JSON.t> = %raw(`
     function() {
       if (typeof window === 'undefined') return null;
       return window.__frontmanRuntime || null;
     }
   `)
-  let runtimeObj = getRuntime()->Nullable.toOption->Option.getOrThrow
-  let framework: Js.Nullable.t<string> = runtimeObj["framework"]
-  let openrouterKeyValue: Js.Nullable.t<string> = runtimeObj["openrouterKeyValue"]
+  let json = getRuntime()->Nullable.toOption->Option.getOrThrow
+  let config = S.parseOrThrow(json, parsedSchema)
   {
-    framework: framework->Js.Nullable.toOption->Option.getOrThrow,
-    openrouterKeyValue: openrouterKeyValue->Js.Nullable.toOption,
+    framework: config.framework,
+    basePath: switch config.basePath {
+    | Some("") | None => "frontman"
+    | Some(bp) => bp
+    },
+    openrouterKeyValue: config.openrouterKeyValue,
   }
 }
 
@@ -27,19 +40,9 @@ let hasOpenrouterKey = (config: t): bool => {
   config.openrouterKeyValue->Option.isSome
 }
 
-@schema
-type clientMetadata = {
-  framework: string,
-  openrouterKeyValue: option<string>,
-}
-
 // Convert runtime config to metadata JSON for ACP prompt requests
 // Includes framework and openrouterKeyValue so the server knows
 // which framework the client is running in and can use the project's env key
 let toMetadata = (config: t): JSON.t => {
-  let metadata: clientMetadata = {
-    framework: config.framework,
-    openrouterKeyValue: config.openrouterKeyValue,
-  }
-  S.reverseConvertToJsonOrThrow(metadata, clientMetadataSchema)
+  S.reverseConvertToJsonOrThrow(config, schema)
 }

--- a/libs/client/src/hooks/Client__UseResizableWidth.res
+++ b/libs/client/src/hooks/Client__UseResizableWidth.res
@@ -13,13 +13,6 @@ let minWidth = 280
 let maxWidth = 600
 let storageKey = "frontman:chatbox-width"
 
-// localStorage bindings
-@val @scope("localStorage")
-external getItem: string => Nullable.t<string> = "getItem"
-
-@val @scope("localStorage")
-external setItem: (string, string) => unit = "setItem"
-
 // Clamp value between min and max
 let clamp = (~min, ~max, value) => {
   if value < min {
@@ -33,7 +26,7 @@ let clamp = (~min, ~max, value) => {
 
 // Load saved width from localStorage
 let loadSavedWidth = (): int => {
-  switch getItem(storageKey)->Nullable.toOption {
+  switch FrontmanBindings.LocalStorage.getItem(storageKey)->Nullable.toOption {
   | Some(value) =>
     switch Int.fromString(value) {
     | Some(width) => clamp(~min=minWidth, ~max=maxWidth, width)
@@ -45,7 +38,7 @@ let loadSavedWidth = (): int => {
 
 // Save width to localStorage
 let saveWidth = (width: int): unit => {
-  setItem(storageKey, Int.toString(width))
+  FrontmanBindings.LocalStorage.setItem(storageKey, Int.toString(width))
 }
 
 type state = {

--- a/libs/client/src/state/Client__StateSnapshot.res
+++ b/libs/client/src/state/Client__StateSnapshot.res
@@ -409,7 +409,7 @@ let convertTask = (task: Client__State__Types.Task.t, ~defaultUrl: string): Task
 
 /** Capture a snapshot from the live state */
 let captureFromState = (state: Client__State__Types.state): t => {
-  let defaultUrl = Client__State__StateReducer.getInitialUrl()
+  let defaultUrl = Client__BrowserUrl.getInitialUrl()
   let tasks = state.tasks->Dict.valuesToArray->Array.map(task => convertTask(task, ~defaultUrl))
 
   let currentTaskId = switch state.currentTask {

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -143,38 +143,13 @@ module Lens = {
   }
 }
 
-let getInitialUrl = () => {
-  let entrypointUrl =
-    WebAPI.Global.document
-    ->WebAPI.Document.querySelector("#frontman-entrypoint-url")
-    ->Null.toOption
-    ->Option.map(element => {
-      element->WebAPI.Element.asNode->WebAPI.Node.textContent->Null.toOption->Option.getOr("")
-    })
-  let currentUrl =
-    WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href->WebAPI.URL.make(~url=_)
-
-  let originUrl = switch entrypointUrl {
-  | Some(entrypointUrl) => entrypointUrl
-  | None => `${currentUrl.protocol}//${currentUrl.host}`
-  }
-  originUrl
-}
-
-// localStorage key for persisting selected model
+let getInitialUrl = Client__BrowserUrl.getInitialUrl
 let selectedModelStorageKey = "frontman:selectedModel"
-
-// localStorage bindings
-@val @scope("localStorage")
-external getStorageItem: string => Nullable.t<string> = "getItem"
-
-@val @scope("localStorage")
-external setStorageItem: (string, string) => unit = "setItem"
 
 // Load selected model from localStorage
 let loadSelectedModelFromStorage = (): option<Client__State__Types.selectedModel> => {
   try {
-    getStorageItem(selectedModelStorageKey)
+    FrontmanBindings.LocalStorage.getItem(selectedModelStorageKey)
     ->Nullable.toOption
     ->Option.flatMap(jsonString => {
       try {
@@ -195,7 +170,7 @@ let saveSelectedModelToStorage = (model: Client__State__Types.selectedModel): un
       model,
       Client__State__Types.selectedModelSchema,
     )
-    setStorageItem(selectedModelStorageKey, jsonString)
+    FrontmanBindings.LocalStorage.setItem(selectedModelStorageKey, jsonString)
   } catch {
   | exn => Console.error2("[saveSelectedModelToStorage] Failed:", exn)
   }
@@ -354,7 +329,9 @@ module Selectors = {
   // Resolve an image attachment URI from a specific task's accumulated attachments.
   // Used by the MCP server to resolve write_file image_ref before forwarding to relay.
   // Takes taskId (not currentTask) because the agent's task may differ from the viewed tab.
-  let resolveImageRef = (state: state, ~taskId: string, ~uri: string): option<Message.resolvedImageData> => {
+  let resolveImageRef = (state: state, ~taskId: string, ~uri: string): option<
+    Message.resolvedImageData,
+  > => {
     state.tasks
     ->Dict.get(taskId)
     ->Option.flatMap(task => Task.getImageAttachments(task)->Dict.get(uri))
@@ -479,9 +456,9 @@ module Selectors = {
 
 // Build ACP content blocks for image/file attachments
 // Strips the data:mime;base64, prefix and creates resource blocks with BlobResourceContents
-let buildAttachmentContentBlocks = (
-  attachments: array<Client__Message.fileAttachmentData>,
-): array<Client__State__Types.ACPTypes.contentBlock> => {
+let buildAttachmentContentBlocks = (attachments: array<Client__Message.fileAttachmentData>): array<
+  Client__State__Types.ACPTypes.contentBlock,
+> => {
   attachments->Array.map(att => {
     // Strip "data:mime;base64," prefix to get raw base64
     let base64Data = switch att.dataUrl->String.indexOf(";base64,") {
@@ -555,8 +532,8 @@ let sendMessageToAPIImpl = (
       ~additionalBlocks,
       ~onComplete=result => {
         switch result {
-        | Ok({stopReason}) if stopReason == "cancelled" =>
-          // CancelTurn already cleaned up state - don't dispatch TurnCompleted
+        | Ok({stopReason})
+          if stopReason == "cancelled" => // CancelTurn already cleaned up state - don't dispatch TurnCompleted
           ()
         | Ok(_) => dispatch(TaskAction({target: ForTask(taskId), action: TurnCompleted}))
         | Error(_) => dispatch(TaskAction({target: ForTask(taskId), action: TurnCompleted}))
@@ -719,7 +696,11 @@ let handleEffect = (effect, state: state, dispatch) => {
       // Pass env key presence so server can return full or free-tier model list
       let runtimeConfig = Client__RuntimeConfig.read()
       let hasEnvKey = Client__RuntimeConfig.hasOpenrouterKey(runtimeConfig)
-      let envKeyParam = if hasEnvKey { "true" } else { "false" }
+      let envKeyParam = if hasEnvKey {
+        "true"
+      } else {
+        "false"
+      }
       let url = `${apiBaseUrl}/api/models?hasEnvKey=${envKeyParam}`
 
       try {
@@ -882,7 +863,10 @@ let handleEffect = (effect, state: state, dispatch) => {
           dispatch(ChatGPTOAuthStatusReceived({connected, expiresAt}))
         }
       } catch {
-      | _ => dispatch(ChatGPTOAuthError({deviceAuthId: None, error: "Failed to fetch ChatGPT OAuth status"}))
+      | _ =>
+        dispatch(
+          ChatGPTOAuthError({deviceAuthId: None, error: "Failed to fetch ChatGPT OAuth status"}),
+        )
       }
     }
     fetch()->ignore
@@ -910,9 +894,7 @@ let handleEffect = (effect, state: state, dispatch) => {
               o->Dict.get("device_auth_id")->Option.flatMap(JSON.Decode.string)
             )
           let userCode =
-            obj->Option.flatMap(o =>
-              o->Dict.get("user_code")->Option.flatMap(JSON.Decode.string)
-            )
+            obj->Option.flatMap(o => o->Dict.get("user_code")->Option.flatMap(JSON.Decode.string))
           let verificationUrl =
             obj->Option.flatMap(o =>
               o->Dict.get("verification_url")->Option.flatMap(JSON.Decode.string)
@@ -920,13 +902,19 @@ let handleEffect = (effect, state: state, dispatch) => {
           switch (deviceAuthId, userCode, verificationUrl) {
           | (Some(deviceAuthId), Some(userCode), Some(verificationUrl)) =>
             dispatch(ChatGPTDeviceCodeReceived({deviceAuthId, userCode, verificationUrl}))
-          | _ => dispatch(ChatGPTOAuthError({deviceAuthId: None, error: "Invalid response from server"}))
+          | _ =>
+            dispatch(ChatGPTOAuthError({deviceAuthId: None, error: "Invalid response from server"}))
           }
         } else {
-          dispatch(ChatGPTOAuthError({deviceAuthId: None, error: "Failed to initiate authentication"}))
+          dispatch(
+            ChatGPTOAuthError({deviceAuthId: None, error: "Failed to initiate authentication"}),
+          )
         }
       } catch {
-      | _ => dispatch(ChatGPTOAuthError({deviceAuthId: None, error: "Failed to initiate authentication"}))
+      | _ =>
+        dispatch(
+          ChatGPTOAuthError({deviceAuthId: None, error: "Failed to initiate authentication"}),
+        )
       }
     }
     fetch()->ignore
@@ -938,16 +926,20 @@ let handleEffect = (effect, state: state, dispatch) => {
     let poll = async () => {
       let maxAttempts = 180
       let intervalMs = 5000
-      let body =
-        JSON.stringifyAny(
-          dict{
-            "device_auth_id": deviceAuthId,
-            "user_code": userCode,
-          },
-        )->Option.getOr("{}")
-      let rec pollLoop = async (attempt) => {
+      let body = JSON.stringifyAny(
+        dict{
+          "device_auth_id": deviceAuthId,
+          "user_code": userCode,
+        },
+      )->Option.getOr("{}")
+      let rec pollLoop = async attempt => {
         if attempt >= maxAttempts {
-          dispatch(ChatGPTOAuthError({deviceAuthId: Some(deviceAuthId), error: "Authorization timed out. Please try again."}))
+          dispatch(
+            ChatGPTOAuthError({
+              deviceAuthId: Some(deviceAuthId),
+              error: "Authorization timed out. Please try again.",
+            }),
+          )
         } else {
           try {
             let url = `${apiBaseUrl}/api/oauth/chatgpt/poll`
@@ -974,28 +966,35 @@ let handleEffect = (effect, state: state, dispatch) => {
                 let expiresAt =
                   json
                   ->JSON.Decode.object
-                  ->Option.flatMap(obj => obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string))
+                  ->Option.flatMap(obj =>
+                    obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string)
+                  )
                   ->Option.getOr("")
                 dispatch(ChatGPTOAuthConnected({deviceAuthId, expiresAt}))
               | _ =>
                 // "pending" — wait and try again
                 await Promise.make((resolve, _) => {
-                  let _ = Js.Global.setTimeout(() => resolve(.), intervalMs)
+                  let _ = Js.Global.setTimeout(() => resolve(), intervalMs)
                 })
                 await pollLoop(attempt + 1)
               }
             } else if response.status == 403 {
-              dispatch(ChatGPTOAuthError({deviceAuthId: Some(deviceAuthId), error: "Authorization was declined."}))
+              dispatch(
+                ChatGPTOAuthError({
+                  deviceAuthId: Some(deviceAuthId),
+                  error: "Authorization was declined.",
+                }),
+              )
             } else {
               await Promise.make((resolve, _) => {
-                let _ = Js.Global.setTimeout(() => resolve(.), intervalMs)
+                let _ = Js.Global.setTimeout(() => resolve(), intervalMs)
               })
               await pollLoop(attempt + 1)
             }
           } catch {
           | _ =>
             await Promise.make((resolve, _) => {
-              let _ = Js.Global.setTimeout(() => resolve(.), intervalMs)
+              let _ = Js.Global.setTimeout(() => resolve(), intervalMs)
             })
             await pollLoop(attempt + 1)
           }
@@ -1343,8 +1342,7 @@ let next = (state: state, action) => {
     | None =>
       switch state.selectedModel {
       | Some(model) => (Some(model), false)
-      | None =>
-        // Use default model from config
+      | None => // Use default model from config
         (
           Some(
             (
@@ -1508,7 +1506,9 @@ let next = (state: state, action) => {
     | AcpSessionActive({apiBaseUrl}) => [FetchModelsConfigEffect({apiBaseUrl: apiBaseUrl})]
     | NoAcpSession => []
     }
-    {...state, chatgptOAuthStatus: status}->FrontmanReactStatestore.StateReducer.update(~sideEffects=effects)
+    {...state, chatgptOAuthStatus: status}->FrontmanReactStatestore.StateReducer.update(
+      ~sideEffects=effects,
+    )
 
   | InitiateChatGPTOAuth =>
     switch state.acpSession {
@@ -1528,14 +1528,22 @@ let next = (state: state, action) => {
     | AcpSessionActive({apiBaseUrl}) =>
       {
         ...state,
-        chatgptOAuthStatus: Client__State__Types.ChatGPTShowingCode({deviceAuthId, userCode, verificationUrl}),
+        chatgptOAuthStatus: Client__State__Types.ChatGPTShowingCode({
+          deviceAuthId,
+          userCode,
+          verificationUrl,
+        }),
       }->FrontmanReactStatestore.StateReducer.update(
         ~sideEffects=[PollChatGPTDeviceAuthEffect({apiBaseUrl, deviceAuthId, userCode})],
       )
     | NoAcpSession =>
       {
         ...state,
-        chatgptOAuthStatus: Client__State__Types.ChatGPTShowingCode({deviceAuthId, userCode, verificationUrl}),
+        chatgptOAuthStatus: Client__State__Types.ChatGPTShowingCode({
+          deviceAuthId,
+          userCode,
+          verificationUrl,
+        }),
       }->FrontmanReactStatestore.StateReducer.update
     }
 
@@ -1543,7 +1551,8 @@ let next = (state: state, action) => {
     // Only accept if the current state is showing the same deviceAuthId
     // (ignores stale results from old polling loops after retry)
     switch state.chatgptOAuthStatus {
-    | Client__State__Types.ChatGPTShowingCode({deviceAuthId: currentId}) if currentId == deviceAuthId =>
+    | Client__State__Types.ChatGPTShowingCode({deviceAuthId: currentId})
+      if currentId == deviceAuthId =>
       let expiresAtMs = Date.fromString(expiresAt)->Date.getTime
       // Refresh models when connected (adds ChatGPT provider)
       let effects = switch state.acpSession {

--- a/libs/client/src/webpreview/Client__BrowserUrl.res
+++ b/libs/client/src/webpreview/Client__BrowserUrl.res
@@ -1,0 +1,111 @@
+// Browser URL sync for suffix-based routing.
+//
+// Keeps the browser URL in sync with the preview iframe URL by appending
+// /<basePath> to the preview pathname via replaceState (avoids polluting
+// browser history — the iframe manages its own back/forward).
+//
+// The basePath is read from window.__frontmanRuntime.basePath (injected by
+// the server's HTML shell). Falls back to "frontman" if not present.
+//
+// NOTE: The URL construction logic in syncBrowserUrl (trailing-slash strip,
+// suffix append) is intentionally duplicated in
+// FrontmanAstro__ToolbarApp in libs/frontman-astro. The two files cannot
+// share code because frontman-core is server-only. Keep the two
+// implementations aligned — if you change one, update the other.
+
+// Read basePath from runtime config. Lazy — reads once on first access.
+// Falls back to "frontman" if runtime config is unavailable (e.g. in tests).
+let _getBasePath: unit => string = {
+  let cached = ref(None)
+  () =>
+    switch cached.contents {
+    | Some(bp) => bp
+    | None =>
+      let bp = try {
+        Client__RuntimeConfig.read().basePath
+      } catch {
+      | _ =>
+        Console.warn("BrowserUrl: RuntimeConfig.basePath unavailable, falling back to \"frontman\"")
+        "frontman"
+      }
+      cached := Some(bp)
+      bp
+    }
+}
+
+// Returns the URL suffix including the leading slash (e.g. "/frontman").
+let suffix = () => `/${_getBasePath()}`
+
+// Escape regex metacharacters in a string so it can be safely interpolated
+// into a dynamically-built RegExp.
+let _escapeRegex = s =>
+  s->String.replaceRegExp(%re("/[.*+?^${}()|[\\]\\\\]/g"), "\\$&")
+
+// Strip trailing /<basePath> segments (including trailing slash) from a pathname.
+// Uses a regex to replace one or more repeated suffix segments in one pass.
+let stripSuffix = pathname => {
+  let sfx = _getBasePath()->_escapeRegex
+  let re = RegExp.fromString(`(\\/${sfx})+\\/?$`)
+  switch pathname->String.replaceRegExp(re, "") {
+  | "" => "/"
+  | p => p
+  }
+}
+
+// Derive the initial preview URL from the browser location.
+// Reads the entrypoint URL from the DOM if present (#frontman-entrypoint-url),
+// otherwise builds it from the current browser URL with the suffix stripped.
+let getInitialUrl = () => {
+  let currentUrl =
+    WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href->WebAPI.URL.make(~url=_)
+  let previewPath = WebAPI.Global.location.pathname->stripSuffix
+  let default = `${currentUrl.protocol}//${currentUrl.host}${previewPath}`
+
+  WebAPI.Global.document
+  ->WebAPI.Document.querySelector("#frontman-entrypoint-url")
+  ->Null.flatMap(element => {
+    element->WebAPI.Element.asNode->WebAPI.Node.textContent
+  })
+  ->Null.toOption
+  ->Option.getOr(default)
+}
+
+// Resolve a (potentially relative) URL against a base, returning None on failure.
+let resolveUrlWithBase = (~url: string, ~base: string): option<string> => {
+  try {
+    Some(WebAPI.URL.make(~url, ~base).href)
+  } catch {
+  | _ => None
+  }
+}
+
+// Check whether two URLs share the same origin (protocol + host).
+let isSameOriginWithBase = (~baseUrl: string, ~targetUrl: string): bool => {
+  try {
+    let base = WebAPI.URL.make(~url=baseUrl)
+    let target = WebAPI.URL.make(~url=targetUrl, ~base=baseUrl)
+    base.protocol == target.protocol && base.host == target.host
+  } catch {
+  | _ => false
+  }
+}
+
+// Sync browser URL to reflect the current preview URL.
+// The preview URL is guaranteed clean (no /<basePath> suffix) by useIFrameLocation.
+let syncBrowserUrl = (~previewUrl) => {
+  let basePath = _getBasePath()
+  let pathname = WebAPI.URL.make(~url=previewUrl).pathname->String.replaceRegExp(%re("/\/$/"), "")
+  let newPath = switch pathname {
+  | "" => `/${basePath}`
+  | p => `${p}/${basePath}`
+  }
+  switch WebAPI.Global.location.pathname == newPath {
+  | true => ()
+  | false =>
+    WebAPI.Global.history->WebAPI.History.replaceState(
+      ~data=JSON.Encode.null,
+      ~unused="",
+      ~url=newPath,
+    )
+  }
+}

--- a/libs/client/src/webpreview/Client__DeviceMode.res
+++ b/libs/client/src/webpreview/Client__DeviceMode.res
@@ -156,16 +156,13 @@ let orientationToString = (orientation: orientation): string =>
 // localStorage Persistence
 // ============================================================================
 
-@val @scope("localStorage")
-external setItem: (string, string) => unit = "setItem"
-
 let storageKeyDeviceMode = "frontman:device-mode"
 let storageKeyOrientation = "frontman:device-orientation"
 
 let persist = (deviceMode: deviceMode, orientation: orientation): unit => {
   try {
-    setItem(storageKeyDeviceMode, JSON.stringify(deviceModeToJson(deviceMode)))
-    setItem(storageKeyOrientation, JSON.stringify(orientationToJson(orientation)))
+    FrontmanBindings.LocalStorage.setItem(storageKeyDeviceMode, JSON.stringify(deviceModeToJson(deviceMode)))
+    FrontmanBindings.LocalStorage.setItem(storageKeyOrientation, JSON.stringify(orientationToJson(orientation)))
   } catch {
   | _ => ()
   }

--- a/libs/client/src/webpreview/Client__WebPreview.res
+++ b/libs/client/src/webpreview/Client__WebPreview.res
@@ -166,10 +166,10 @@ let make = () => {
   let handleUrlKeyDown = (e: ReactEvent.Keyboard.t) => {
     switch ReactEvent.Keyboard.key(e) {
     | "Enter" =>
-      switch Client__Hooks.resolveUrlWithBase(~url=editableUrl, ~base=previewUrl) {
+      switch Client__BrowserUrl.resolveUrlWithBase(~url=editableUrl, ~base=previewUrl) {
       | None => ()
       | Some(resolvedUrl) =>
-        switch Client__Hooks.isSameOriginWithBase(~baseUrl=previewUrl, ~targetUrl=resolvedUrl) {
+        switch Client__BrowserUrl.isSameOriginWithBase(~baseUrl=previewUrl, ~targetUrl=resolvedUrl) {
         | false => ()
         | true =>
           previewFrame.contentWindow->Option.forEach(contentWindow => {
@@ -177,6 +177,7 @@ let make = () => {
           })
           Client__State.Actions.setPreviewUrl(~url=resolvedUrl)
           Client__State.Actions.setSelectedElement(~selectedElement=None)
+          Client__BrowserUrl.syncBrowserUrl(~previewUrl=resolvedUrl)
         }
       }
       let target: Dom.element = ReactEvent.Keyboard.target(e)->Obj.magic
@@ -286,7 +287,7 @@ let make = () => {
         // Unified array of all iframes - keeps React keys in the same sibling position
         // so switching tasks just toggles isActive prop without unmounting/remounting
         {
-          let defaultUrl = Client__State__StateReducer.getInitialUrl()
+          let defaultUrl = Client__BrowserUrl.getInitialUrl()
           
           // Build array of all tasks including New task if present
           let allTasks = if isNewTask {

--- a/libs/client/src/webpreview/Client__WebPreview__Body.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Body.res
@@ -36,6 +36,7 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
           | true =>
             lastLocationRef.current = Some(location)
             Client__State.Actions.setPreviewUrl(~url=location)
+            Client__BrowserUrl.syncBrowserUrl(~previewUrl=location)
           }
         }
       | None => ()

--- a/libs/frontman-astro/src/FrontmanAstro__Config.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Config.res
@@ -21,6 +21,7 @@ type t = {
   host: string,
   clientUrl: string,
   clientCssUrl: option<string>,
+  entrypointUrl: option<string>,
   isLightTheme: bool,
 }
 
@@ -34,6 +35,7 @@ type jsConfigInput = {
   host?: string,
   clientUrl?: string,
   clientCssUrl?: string,
+  entrypointUrl?: string,
   isLightTheme?: bool,
 }
 
@@ -116,6 +118,7 @@ let makeFromObject = (rawConfig: jsConfigInput): t => {
       | false => Some(Hosts.clientCss)
       },
     ),
+    entrypointUrl: config.entrypointUrl,
     isLightTheme,
   }
 }

--- a/libs/frontman-astro/src/FrontmanAstro__Integration.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Integration.res
@@ -59,13 +59,30 @@ let make = (configInput: Config.jsConfigInput): Bindings.astroIntegration => {
               )
             }
 
+            // Create our Web API middleware and adapt it to Vite's Connect middleware.
+            // Registered as a Vite plugin via configureServer so it runs BEFORE Astro's
+            // own page routing. If registered via astro:server:setup instead, Astro's
+            // catch-all dynamic routes (e.g. blog/[...id]) would match suffix URLs
+            // like /blog/frontman and return 404 before our middleware gets the request.
+            let webMiddleware = Middleware.createMiddleware(config)
+            let connectMiddleware =
+              ViteAdapter.adaptToConnect(webMiddleware, ~basePath=config.basePath)
+            let middlewarePlugin = Bindings.makeVitePlugin({
+              name: "frontman-middleware",
+              configureServer: ?Some(
+                server => {
+                  server.middlewares->Bindings.use(connectMiddleware)
+                },
+              ),
+            })
+
             // Register Vite plugin that monkey-patches renderComponent to inject
             // component props as HTML comments into the SSR output.
             // This lets the client-side annotation capture script associate
             // props with each component instance for AI agent context.
             ctx.updateConfig({
               vite: ?Some({
-                plugins: ?Some([frontmanPropsInjectionPlugin()]),
+                plugins: ?Some([middlewarePlugin, frontmanPropsInjectionPlugin()]),
               }),
             })
 
@@ -93,17 +110,10 @@ let make = (configInput: Config.jsConfigInput): Bindings.astroIntegration => {
         },
       ),
       serverSetup: ?Some(
-        ({server, toolbar}) => {
+        ({toolbar}) => {
           // Initialize core LogCapture to intercept console/stdout for the
           // get_logs tool and post-edit error checking in edit_file
           FrontmanFrontmanCore.FrontmanCore__LogCapture.initialize()
-
-          // Create our Web API middleware and adapt it to Vite's Connect middleware
-          let webMiddleware = Middleware.createMiddleware(config)
-          let connectMiddleware = ViteAdapter.adaptToConnect(webMiddleware, ~basePath=config.basePath)
-
-          // Register with Vite's dev server
-          server.middlewares->Bindings.use(connectMiddleware)
 
           // Log when the toolbar app is initialized
           toolbar->Bindings.toolbarOnAppInitialized("frontman:toolbar", () => {

--- a/libs/frontman-astro/src/FrontmanAstro__Middleware.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Middleware.res
@@ -2,17 +2,14 @@
 //
 // Handles /frontman/* routes: UI serving, tool endpoints, source location resolution.
 // Returns option<Response>: Some(response) for handled routes, None for pass-through.
-// This middleware is designed to be adapted to Vite's Connect middleware via ViteAdapter.
 //
-// Delegates shared logic (CORS, UI shell, request handling) to frontman-core modules.
+// Delegates all routing and request handling to the shared core middleware.
 
 module Config = FrontmanAstro__Config
-module Server = FrontmanAstro__Server
 module ToolRegistry = FrontmanAstro__ToolRegistry
 module Core = FrontmanFrontmanCore
+module CoreMiddleware = Core.FrontmanCore__Middleware
 module CoreMiddlewareConfig = Core.FrontmanCore__MiddlewareConfig
-module CoreUIShell = Core.FrontmanCore__UIShell
-module CoreCORS = Core.FrontmanCore__CORS
 
 // Convert Astro config to core middleware config
 let toMiddlewareConfig = (config: Config.t): CoreMiddlewareConfig.t => {
@@ -23,7 +20,7 @@ let toMiddlewareConfig = (config: Config.t): CoreMiddlewareConfig.t => {
   serverVersion: config.serverVersion,
   clientUrl: config.clientUrl,
   clientCssUrl: config.clientCssUrl,
-  entrypointUrl: None,
+  entrypointUrl: config.entrypointUrl,
   isLightTheme: config.isLightTheme,
   frameworkLabel: "Astro",
 }
@@ -35,41 +32,5 @@ let toMiddlewareConfig = (config: Config.t): CoreMiddlewareConfig.t => {
 let createMiddleware = (config: Config.t) => {
   let registry = ToolRegistry.make()
   let middlewareConfig = toMiddlewareConfig(config)
-
-  async (request: WebAPI.FetchAPI.request): option<WebAPI.FetchAPI.response> => {
-    let url = WebAPI.URL.make(~url=request.url)
-    let pathname = url.pathname
-    let method = request.method
-
-    let basePath = `/${config.basePath}`
-
-    // Only handle frontman routes
-    if !(pathname == basePath || pathname->String.startsWith(`${basePath}/`)) {
-      None
-    } else if method == "OPTIONS" {
-      Some(CoreCORS.handlePreflight())
-    } else {
-      switch pathname {
-      | p if p == basePath || p == `${basePath}/` =>
-        Some(CoreUIShell.serve(middlewareConfig)->CoreCORS.withCors)
-
-      | p if p == `${basePath}/tools` && method == "GET" =>
-        Some(Server.handleGetTools(~registry, ~config)->CoreCORS.withCors)
-
-      | p if p == `${basePath}/tools/call` && method == "POST" =>
-        Some((await Server.handleToolCall(~registry, ~config, request))->CoreCORS.withCors)
-
-      | p if p == `${basePath}/resolve-source-location` && method == "POST" =>
-        Some((await Server.handleResolveSourceLocation(~config, request))->CoreCORS.withCors)
-
-      | _ =>
-        Some(
-          WebAPI.Response.jsonR(
-            ~data=JSON.Encode.object(Dict.fromArray([("error", JSON.Encode.string("Not found"))])),
-            ~init={status: 404},
-          ),
-        )
-      }
-    }
-  }
+  CoreMiddleware.createMiddleware(~config=middlewareConfig, ~registry)
 }

--- a/libs/frontman-astro/src/FrontmanAstro__ToolbarApp.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ToolbarApp.res
@@ -1,39 +1,56 @@
 // Frontman Dev Toolbar App
 //
-// Clicking the Frontman icon in the Astro dev toolbar navigates to /<basePath>/
-// where the full Frontman UI is served by the middleware.
+// Clicking the Frontman icon in the Astro dev toolbar navigates to
+// {currentPage}/<basePath> using suffix-based routing, so the preview
+// loads the page the user was already on.
+//
+// NOTE: The URL construction logic here (trailing-slash strip, suffix
+// append, already-at-path check) is intentionally duplicated from
+// Client__BrowserUrl.syncBrowserUrl in libs/client. The two files
+// cannot share code because frontman-core is server-only and the client
+// bundle cannot depend on it. Keep the two implementations aligned —
+// if you change one, update the other.
 
-module Bindings = FrontmanBindings.Astro
+open FrontmanBindings.Astro
 
-// The toolbar app definition
-let app: Bindings.toolbarAppConfig = {
+let defaultBasePath = "frontman"
+
+// Read basePath from the <meta name="frontman-base-path"> tag injected
+// by FrontmanAstro__Integration. Falls back to defaultBasePath.
+let _getBasePath = () => {
+  WebAPI.Global.document
+  ->WebAPI.Document.querySelector(`meta[name="frontman-base-path"]`)
+  ->Null.flatMap(el => el->WebAPI.Element.getAttribute("content"))
+  ->Null.toOption
+  ->Option.getOr(defaultBasePath)
+}
+
+let app: toolbarAppConfig = {
   init: (_canvas, app, _server) => {
-    app->Bindings.onToggled(({state}) => {
+    app->onToggled(({state}) => {
       switch state {
       | true =>
-        // Read basePath from the meta tag injected by the integration
-        let basePath = {
-          let meta =
-            WebAPI.Global.document
-            ->WebAPI.Document.querySelector(`meta[name="frontman-base-path"]`)
-            ->Null.toOption
-          switch meta {
-          | Some(el) =>
-            el->WebAPI.Element.getAttribute("content")->Null.toOption->Option.getOr("frontman")
-          | None => "frontman"
+        let basePath = _getBasePath()
+        // Strip trailing slash to normalize, matching BrowserUrl.syncBrowserUrl.
+        let pathname =
+          WebAPI.Global.location.pathname->String.replaceRegExp(%re("/\/$/"), "")
+        // If already inside /<basePath>, stay put. Otherwise append it.
+        let alreadyInFrontman =
+          pathname == `/${basePath}` || pathname->String.endsWith(`/${basePath}`)
+        let url = switch alreadyInFrontman {
+        | true => pathname
+        | false =>
+          switch pathname {
+          | "" => `/${basePath}`
+          | p => `${p}/${basePath}`
           }
         }
-
-        // Navigate to the Frontman UI
-        WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(`/${basePath}/`)
-
-        // Immediately toggle off so the icon doesn't stay "active"
-        app->Bindings.toggleState({state: false})
+        WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(url)
+        app->toggleState({state: false})
       | false => ()
       }
     })
   },
 }
 
-// Export as default for Astro to pick up
-let default = Bindings.defineToolbarApp(app)
+let default = defineToolbarApp(app)

--- a/libs/frontman-astro/src/FrontmanAstro__ViteAdapter.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ViteAdapter.res
@@ -6,6 +6,7 @@
 
 module NodeHttp = FrontmanBindings.NodeHttp
 module WebStreams = FrontmanBindings.WebStreams
+module CoreMiddleware = FrontmanFrontmanCore.FrontmanCore__Middleware
 
 // Copy headers from a Web API Headers object to a Node.js ServerResponse
 let copyHeaders: (WebAPI.FetchAPI.headers, NodeHttp.serverResponse) => unit = %raw(`
@@ -103,7 +104,6 @@ let writeWebResponse = async (
 // requests to non-Frontman routes would have their body stream drained before
 // next() is called, causing downstream handlers to receive an empty body.
 let adaptToConnect = (middleware: webMiddleware, ~basePath: string): NodeHttp.connectMiddleware => {
-  let prefix = `/${basePath}`
   (req, res, next) => {
     // Fast path: skip non-Frontman routes without consuming the request body.
     // Strip query string first — Node.js req.url includes it (e.g. "/frontman?x=1")
@@ -114,7 +114,12 @@ let adaptToConnect = (middleware: webMiddleware, ~basePath: string): NodeHttp.co
       ->String.split("?")
       ->Array.get(0)
       ->Option.getOr(req->NodeHttp.url)
-    if !(reqPath == prefix || reqPath->String.startsWith(`${prefix}/`)) {
+    let isFrontmanRoute = CoreMiddleware.isFrontmanRoute(
+      ~pathname=reqPath,
+      ~basePath,
+      ~method=req->NodeHttp.method,
+    )
+    if !isFrontmanRoute {
       next()
     } else {
       let handleRequest = async () => {

--- a/libs/frontman-astro/src/toolbar.js
+++ b/libs/frontman-astro/src/toolbar.js
@@ -1,0 +1,5 @@
+// Thin re-export so the Integration module can reference ./toolbar.js
+// and Astro/Vite can resolve it at dev time.
+// In production builds, tsup bundles FrontmanAstro__ToolbarApp.res.mjs
+// directly into dist/toolbar.js.
+export { default } from './FrontmanAstro__ToolbarApp.res.mjs';

--- a/libs/frontman-core/src/FrontmanCore__Middleware.res
+++ b/libs/frontman-core/src/FrontmanCore__Middleware.res
@@ -1,17 +1,103 @@
-// Shared middleware factory for all framework adapters
+// Shared middleware factory: Request => Promise<Option<Response>>
 //
-// Creates a standard Web API middleware: Request => Promise<Option<Response>>
-// Returns None for non-frontman routes (pass-through to next middleware)
-// Returns Some(response) for frontman routes
-//
-// This is used directly by Vite and Next.js adapters.
-// Astro wraps this with its own (context, next) adapter signature.
+// Supports suffix-based URL routing: /products/123/frontman serves the UI
+// with the preview pointing at /products/123. API routes stay at fixed paths.
+// Used by Vite, Next.js, and Astro adapters.
 
 module CORS = FrontmanCore__CORS
 module RequestHandlers = FrontmanCore__RequestHandlers
 module UIShell = FrontmanCore__UIShell
 module MiddlewareConfig = FrontmanCore__MiddlewareConfig
 module ToolRegistry = FrontmanCore__ToolRegistry
+
+// Check if a normalized path (no leading slash) is a suffix-based UI route.
+// Returns the prefix (everything before /basePath) if it matches, None otherwise.
+let getSuffixRoutePrefix = (~path: string, ~basePath: string): option<string> => {
+  switch path == basePath {
+  | true => Some("")
+  | false =>
+    let suffix = "/" ++ basePath
+    switch path->String.endsWith(suffix) {
+    | true => Some(path->String.slice(~start=0, ~end=path->String.length - suffix->String.length))
+    | false => None
+    }
+  }
+}
+
+// Check whether a raw pathname (with leading slash) is a frontman route.
+// Suffix routes (path ending with /basePath) only match GET — for other
+// methods the core middleware won't handle them, so returning true would
+// cause adapters to drain the request body for nothing.
+let isFrontmanRoute = (~pathname: string, ~basePath: string, ~method: string): bool => {
+  let prefix = "/" ++ basePath->String.toLowerCase
+  let path = pathname->String.toLowerCase
+  let isPrefixRoute = path == prefix || path->String.startsWith(prefix ++ "/")
+  let isSuffixRoute = path->String.endsWith(prefix) || path->String.endsWith(prefix ++ "/")
+  isPrefixRoute || (method->String.toUpperCase == "GET" && isSuffixRoute)
+}
+
+// Build the canonical path for a suffix route prefix.
+// Returns None if already canonical, Some(path) if a redirect is needed.
+// Only detects actual frontman-in-frontman nesting — does NOT strip legitimate
+// user URL segments that happen to match basePath.
+//
+// Cases detected:
+//   prefixPath == basePath (e.g. "frontman" from /frontman/frontman)
+//   prefixPath ends with /basePath (e.g. "blog/frontman" from /blog/frontman/frontman)
+//   prefixPath starts with basePath/ (e.g. "frontman/page" from /frontman/page/frontman)
+let getCanonicalRedirect = (~prefixPath: string, ~basePath: string): option<string> => {
+  let suffix = "/" ++ basePath
+  // Exact match: prefix IS the basePath (e.g. /frontman/frontman -> prefix "frontman")
+  switch prefixPath == basePath {
+  | true => Some("/" ++ basePath)
+  | false =>
+    // Trailing nested suffix: strip one trailing /basePath from prefix
+    switch prefixPath->String.endsWith(suffix) {
+    | true =>
+      let stripped = prefixPath->String.slice(~start=0, ~end=prefixPath->String.length - suffix->String.length)
+      let cleanPrefix = switch stripped {
+      | "" => ""
+      | p => p
+      }
+      let canonical = switch cleanPrefix {
+      | "" => "/" ++ basePath
+      | p => "/" ++ p ++ "/" ++ basePath
+      }
+      Some(canonical)
+    | false =>
+      // Leading basePath/ prefix: strip leading basePath/ from prefix
+      switch prefixPath->String.startsWith(basePath ++ "/") {
+      | true =>
+        let rest = prefixPath->String.sliceToEnd(~start=basePath->String.length + 1)
+        let canonical = switch rest {
+        | "" => "/" ++ basePath
+        | p => "/" ++ p ++ "/" ++ basePath
+        }
+        Some(canonical)
+      | false => None
+      }
+    }
+  }
+}
+
+// Build entrypoint URL from request origin + prefix. Config override takes precedence.
+let buildEntrypointUrl = (
+  ~config: MiddlewareConfig.t,
+  ~requestUrl: string,
+  ~prefixPath: string,
+): option<string> => {
+  switch config.entrypointUrl {
+  | Some(_) as override => override
+  | None =>
+    let url = WebAPI.URL.make(~url=requestUrl)
+    let origin = url.origin
+    let pagePath = switch prefixPath {
+    | "" => "/"
+    | p => "/" ++ p
+    }
+    Some(origin ++ pagePath)
+  }
+}
 
 // Create middleware from config and registry
 // Returns request => promise<option<response>>
@@ -31,32 +117,49 @@ let createMiddleware = (
     option<WebAPI.FetchAPI.response>,
   > = async req => {
     let method = req.method->String.toLowerCase
-    let pathname = WebAPI.URL.make(~url=req.url).pathname
+    let url = WebAPI.URL.make(~url=req.url)
+    let pathname = url.pathname
 
-    // Normalize path: remove leading slash, lowercase
-    let path =
+    // Normalize path segments — keep original case for URL construction,
+    // lowercase copy for case-insensitive route matching.
+    let pathSegments =
       pathname
       ->String.split("/")
       ->Array.filter(p => !String.isEmpty(p))
-      ->Array.join("/")
-      ->String.toLowerCase
+    let originalPath = pathSegments->Array.join("/")
+    let path = originalPath->String.toLowerCase
 
     let basePath = config.basePath->String.toLowerCase
     let toolsPath = basePath ++ "/tools"
     let toolsCallPath = basePath ++ "/tools/call"
     let resolveSourceLocationPath = basePath ++ "/resolve-source-location"
-    let uiPath = basePath
 
-    // Check if this is a frontman route (for CORS preflight)
-    let isFrontmanRoute =
+    let isApiRoute =
       path == toolsPath ||
       path == toolsCallPath ||
-      path == resolveSourceLocationPath ||
-      path == uiPath
+      path == resolveSourceLocationPath
+
+    let suffixPrefix = switch isApiRoute {
+    | true => None
+    | false => getSuffixRoutePrefix(~path, ~basePath)
+    }
+
+    // Original-case prefix for entrypoint URL construction (avoids lowercasing user paths).
+    let originalSuffixPrefix = suffixPrefix->Option.map(loweredPrefix =>
+      switch loweredPrefix {
+      | "" => ""
+      | _ =>
+        // Slice originalPath to the same length as the lowered prefix
+        originalPath->String.slice(~start=0, ~end=loweredPrefix->String.length)
+      }
+    )
+
+    let isFrontmanRoute = isApiRoute || suffixPrefix->Option.isSome
 
     switch (method, path) {
     | ("options", _) if isFrontmanRoute => Some(CORS.handlePreflight())
-    | ("get", p) if p == uiPath => Some(UIShell.serve(config)->CORS.withCors)
+
+    // API routes
     | ("get", p) if p == toolsPath =>
       Some(RequestHandlers.handleGetTools(~registry, ~config=handlerConfig)->CORS.withCors)
     | ("post", p) if p == toolsCallPath =>
@@ -70,6 +173,30 @@ let createMiddleware = (
           req,
         ))->CORS.withCors,
       )
+
+    // UI route (suffix match) — redirect nested basePath segments to canonical URL
+    | ("get", _) if suffixPrefix->Option.isSome =>
+      let prefixPath = suffixPrefix->Option.getOrThrow
+      switch getCanonicalRedirect(~prefixPath, ~basePath) {
+      | Some(canonicalPath) =>
+        Some(
+          WebAPI.Response.fromString(
+            "",
+            ~init={
+              status: 302,
+              headers: WebAPI.HeadersInit.fromDict(
+                Dict.fromArray([("Location", canonicalPath)]),
+              ),
+            },
+          ),
+        )
+      | None =>
+        // Use original-case prefix to preserve URL casing for case-sensitive frameworks
+        let originalPrefix = originalSuffixPrefix->Option.getOrThrow
+        let entrypointUrl = buildEntrypointUrl(~config, ~requestUrl=req.url, ~prefixPath=originalPrefix)
+        Some(UIShell.serveWithEntrypoint(~config, ~entrypointUrl)->CORS.withCors)
+      }
+
     | _ => None
     }
   }

--- a/libs/frontman-core/src/FrontmanCore__UIShell.res
+++ b/libs/frontman-core/src/FrontmanCore__UIShell.res
@@ -32,7 +32,10 @@ let generateHTML = (config: MiddlewareConfig.t): string => {
         }
       )
     // Build JSON payload using proper JSON encoding to handle special characters
-    let configObj = Dict.fromArray([("framework", JSON.Encode.string(config.frameworkLabel))])
+    let configObj = Dict.fromArray([
+      ("framework", JSON.Encode.string(config.frameworkLabel)),
+      ("basePath", JSON.Encode.string(config.basePath)),
+    ])
     // Add key value if present and non-empty
     openrouterKey->Option.forEach(key => {
       configObj->Dict.set("openrouterKeyValue", JSON.Encode.string(key))
@@ -72,4 +75,16 @@ let serve = (config: MiddlewareConfig.t): WebAPI.FetchAPI.response => {
   let html = generateHTML(config)
   let headers = WebAPI.HeadersInit.fromDict(Dict.fromArray([("Content-Type", "text/html")]))
   WebAPI.Response.fromString(html, ~init={headers: headers})
+}
+
+// Serve with a dynamic entrypoint URL override for suffix-based routing.
+let serveWithEntrypoint = (
+  ~config: MiddlewareConfig.t,
+  ~entrypointUrl: option<string>,
+): WebAPI.FetchAPI.response => {
+  let effectiveConfig = switch entrypointUrl {
+  | Some(_) => {...config, entrypointUrl}
+  | None => config
+  }
+  serve(effectiveConfig)
 }

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
@@ -36,7 +36,7 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/frontman', '/frontman/:path*'],
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman'],
 };
 `
 
@@ -50,14 +50,14 @@ const frontman = createMiddleware({
 });
 
 export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
-  if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/')) {
+  if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {
     return frontman(req) || NextResponse.next();
   }
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ['/frontman', '/frontman/:path*'],
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman'],
 };
 `
 
@@ -103,7 +103,7 @@ module ManualInstructions = {
   ${bar}
   ${bar}  ${s("4.")} Update your matcher config to include Frontman routes:
   ${bar}
-  ${bar}     ${d("matcher: ['/frontman', '/frontman/:path*', ...yourExistingMatchers]")}
+   ${bar}     ${d("matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers]")}
   ${bar}
   ${bar}  ${b("Docs:")} ${d("https://frontman.sh/docs/nextjs")}
   ${bar}`
@@ -129,13 +129,13 @@ module ManualInstructions = {
   ${bar}
   ${bar}  ${s("3.")} In your proxy function, add Frontman handler at the beginning:
   ${bar}
-  ${bar}     ${d("if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/')) {")}
+     ${bar}     ${d("if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {")}
   ${bar}     ${d("  return frontman(req) || NextResponse.next();")}
   ${bar}     ${d("}")}
   ${bar}
   ${bar}  ${s("4.")} Update your matcher config to include Frontman routes:
   ${bar}
-  ${bar}     ${d("matcher: ['/frontman', '/frontman/:path*', ...yourExistingMatchers]")}
+  ${bar}     ${d("matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers]")}
   ${bar}
   ${bar}  ${b("Docs:")} ${d("https://frontman.sh/docs/nextjs")}
   ${bar}`
@@ -200,7 +200,7 @@ Add the following to your ${fileName}:
   4. Update your matcher config to include Frontman routes:
 
       export const config = {
-        matcher: ['/frontman', '/frontman/:path*', ...yourExistingMatchers],
+        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],
       };
 
 For full documentation, see: https://frontman.sh/docs/nextjs
@@ -226,7 +226,7 @@ Add the following to your ${fileName}:
 
       export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
         // Add Frontman handler first
-        if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/')) {
+        if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {
          return frontman(req) || NextResponse.next();
        }
 
@@ -236,7 +236,7 @@ Add the following to your ${fileName}:
   4. Update your matcher config to include Frontman routes:
 
       export const config = {
-        matcher: ['/frontman', '/frontman/:path*', ...yourExistingMatchers],
+        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],
       };
 
 For full documentation, see: https://frontman.sh/docs/nextjs

--- a/libs/frontman-vite/src/FrontmanVite__Plugin.res
+++ b/libs/frontman-vite/src/FrontmanVite__Plugin.res
@@ -3,6 +3,7 @@
 
 module Config = FrontmanVite__Config
 module Middleware = FrontmanVite__Middleware
+module Core = FrontmanFrontmanCore
 
 // Minimal Node.js http bindings for Vite's dev server
 
@@ -86,8 +87,6 @@ let adaptMiddlewareToVite = (
   ~basePath: string,
   middleware: WebAPI.FetchAPI.request => promise<option<WebAPI.FetchAPI.response>>,
 ): ((incomingMessage, serverResponse, unit => unit) => promise<unit>) => {
-  let prefix = "/" ++ basePath->String.toLowerCase
-
   async (req, res, next) => {
     // Short-circuit: only process requests under the frontman basePath.
     // This avoids draining the IncomingMessage body stream for non-frontman
@@ -99,7 +98,12 @@ let adaptMiddlewareToVite = (
     | -1 => pathname
     | idx => pathname->String.slice(~start=0, ~end=idx)
     }
-    switch pathOnly == prefix || pathOnly->String.startsWith(prefix ++ "/") {
+    let isFrontmanRoute = Core.FrontmanCore__Middleware.isFrontmanRoute(
+      ~pathname=pathOnly,
+      ~basePath,
+      ~method=req.method->Null.toOption->Option.getOr("GET"),
+    )
+    switch isFrontmanRoute {
     | false => next()
     | true =>
       // Collect request body (safe — this is a frontman route)


### PR DESCRIPTION
## Summary

- Browser URL now reflects the preview iframe's current page using a suffix pattern: `/products/123/frontman` loads `/products/123` in the preview iframe — enables bookmarking, sharing, and refresh without losing preview state
- Migrated Astro adapter from hand-rolled routing to shared core middleware, and moved middleware registration to a Vite plugin (`configureServer`) so it runs before Astro's catch-all page routing
- Prevents frontman-in-frontman by intercepting iframe navigations to `/frontman` URLs (client-side) and 302-redirecting nested `/frontman/frontman` paths (server-side)

## Changes

### Core (`libs/frontman-core`)
- **Middleware**: Suffix route matching (`/products/123/frontman`), API routes exact-matched first. Nested `/frontman` segments get 302-redirected to canonical URL.
- **UIShell**: New `serveWithEntrypoint` for dynamic entrypoint URL override.

### Astro (`libs/frontman-astro`)
- **Middleware**: Replaced ~35 lines of hand-rolled routing with single `CoreMiddleware.createMiddleware` call.
- **Integration**: Moved middleware from `astro:server:setup` to `astro:config:setup` via Vite plugin `configureServer` hook (runs before Astro's page routing).
- **ToolbarApp**: Navigates to `{currentPage}/frontman` with guard against re-opening when already inside frontman. Fixed `module Bindings` alias that compiled to `undefined` export.
- **toolbar.js**: New dev-mode re-export shim for the toolbar entrypoint.

### Vite / Next.js
- **Vite plugin**: Updated prefix guard to also match suffix routes.
- **Next.js templates**: Updated all matcher configs and path checks for suffix patterns.

### Client (`libs/client`)
- **BrowserUrl**: New module — `syncBrowserUrl` updates browser URL via `replaceState`; `stripSuffix` strips `/frontman` from pathnames.
- **useIFrameLocation**: Intercepts iframe `navigate` events targeting `/frontman` URLs, prevents the navigation, and redirects to the stripped URL.
- **StateReducer**: `getInitialUrl()` derives preview path from browser URL by stripping `/frontman` suffix.

Closes #424
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
