### PR TITLE
fix: update yarn.lock in release-pr workflow after changeset version bumps

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -72,6 +72,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn changeset version
 
+      - name: Update lockfile after version bumps
+        run: yarn install --no-immutable
+
       - name: Update root CHANGELOG and compute version
         id: version
         shell: bash

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,7 +2547,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@frontman/bindings@npm:*, @frontman/bindings@npm:0.2.0, @frontman/bindings@workspace:*, @frontman/bindings@workspace:libs/bindings":
+"@frontman/bindings@npm:*, @frontman/bindings@npm:0.3.0, @frontman/bindings@workspace:*, @frontman/bindings@workspace:libs/bindings":
   version: 0.0.0-use.local
   resolution: "@frontman/bindings@workspace:libs/bindings"
   dependencies:
@@ -2690,7 +2690,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontman/frontman-core@workspace:libs/frontman-core"
   dependencies:
-    "@frontman/bindings": "npm:0.2.0"
+    "@frontman/bindings": "npm:0.3.0"
     "@frontman/frontman-protocol": "npm:0.3.0"
     "@rescript/runtime": "npm:12.0.0-beta.14"
     "@rescript/webapi": "npm:*"


### PR DESCRIPTION
## Summary

- Adds a `yarn install --no-immutable` step to `release-pr.yml` after `yarn changeset version` runs, so the lockfile is regenerated before committing
- Updates `yarn.lock` to fix the current drift (`@frontman/bindings` 0.2.0 → 0.3.0)

## Problem

Every release has been breaking `main`. The `release-pr.yml` workflow runs `yarn changeset version` which bumps `package.json` versions, but never regenerates `yarn.lock`. The stale lockfile gets committed and merged, then every subsequent CI job on `main` fails with:

> `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.`

This caused the last 3 workflow runs (Deploy Production, Deploy Marketing, Release PR) to all fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
