### PR TITLE
fix: resolve Google Search Console indexing issues

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -12,6 +12,7 @@ const monorepoRoot = path.resolve(appRoot, "../..");
 // https://astro.build/config
 export default defineConfig({
   site: "https://frontman.sh",
+  trailingSlash: "always",
   build: {
     // Inline all stylesheets directly into the HTML to eliminate
     // render-blocking <link> requests (~25 KiB total). Trades a small
@@ -31,9 +32,9 @@ export default defineConfig({
     sitemap({
       filter: (page) =>
         // Exclude empty placeholder pages and internal-only pages
-        !page.includes('/features') &&
-        !page.includes('/pricing') &&
-        !page.includes('/design-system'),
+        !page.includes("/features") &&
+        !page.includes("/pricing") &&
+        !page.includes("/design-system"),
       serialize: (item) => {
         // Set lastmod so Google knows when pages were last updated.
         // Blog posts get their pubDate via the content collection, but the

--- a/apps/marketing/src/components/blocks/comparison/ComparisonTable.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonTable.astro
@@ -200,10 +200,10 @@ function toolKey(tool: string): keyof Feature {
 		<Row>
 			<Col span="12" align="center" classes="mt-10 lg:mt-14">
 				<div class="comparison-links">
-					<a href="/vs/cursor" class="comparison-link">Frontman vs Cursor &rarr;</a>
-					<a href="/vs/copilot" class="comparison-link">Frontman vs Copilot &rarr;</a>
-					<a href="/vs/stagewise" class="comparison-link">Frontman vs Stagewise &rarr;</a>
-					<a href="/vs/v0" class="comparison-link">Frontman vs v0 &rarr;</a>
+				<a href="/vs/cursor/" class="comparison-link">Frontman vs Cursor &rarr;</a>
+				<a href="/vs/copilot/" class="comparison-link">Frontman vs Copilot &rarr;</a>
+				<a href="/vs/stagewise/" class="comparison-link">Frontman vs Stagewise &rarr;</a>
+				<a href="/vs/v0/" class="comparison-link">Frontman vs v0 &rarr;</a>
 				</div>
 			</Col>
 		</Row>

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -57,11 +57,11 @@ export const footerNavigationData: FooterData = {
 			subCategories: [
 				{
 					subCategory: 'Changelog',
-					subCategoryLink: '/changelog'
+					subCategoryLink: '/changelog/'
 				},
 				{
 					subCategory: 'FAQ',
-					subCategoryLink: '/faq'
+					subCategoryLink: '/faq/'
 				}
 			]
 		},
@@ -70,22 +70,22 @@ export const footerNavigationData: FooterData = {
 			subCategories: [
 				{
 					subCategory: 'Frontman vs Cursor',
-					subCategoryLink: '/vs/cursor'
+					subCategoryLink: '/vs/cursor/'
 				},
-			{
-				subCategory: 'Frontman vs Copilot',
-				subCategoryLink: '/vs/copilot'
-			},
-			{
-				subCategory: 'Frontman vs Stagewise',
-				subCategoryLink: '/vs/stagewise'
-			},
-			{
-				subCategory: 'Frontman vs v0',
-				subCategoryLink: '/vs/v0'
-			}
-		]
-	},
+				{
+					subCategory: 'Frontman vs Copilot',
+					subCategoryLink: '/vs/copilot/'
+				},
+				{
+					subCategory: 'Frontman vs Stagewise',
+					subCategoryLink: '/vs/stagewise/'
+				},
+				{
+					subCategory: 'Frontman vs v0',
+					subCategoryLink: '/vs/v0/'
+				}
+			]
+		},
 		{
 			category: 'Developers',
 			subCategories: [
@@ -121,7 +121,7 @@ export const footerNavigationData: FooterData = {
 				},
 				{
 					subCategory: 'Blog',
-					subCategoryLink: '/blog'
+					subCategoryLink: '/blog/'
 				}
 			]
 		}
@@ -129,8 +129,8 @@ export const footerNavigationData: FooterData = {
 	subFooter: {
 		copywriteText: `© ${new Date().getFullYear()} Frontman. All rights reserved.`,
 		links: [
-			{ label: 'Terms of Service', href: '/terms' },
-			{ label: 'Privacy Policy', href: '/privacy' }
+			{ label: 'Terms of Service', href: '/terms/' },
+			{ label: 'Privacy Policy', href: '/privacy/' }
 		]
 	}
 }

--- a/apps/marketing/src/config/navigationBar.ts
+++ b/apps/marketing/src/config/navigationBar.ts
@@ -39,9 +39,9 @@ export const navigationBarData: NavData = {
 	},
 	navItems: [
 		{ name: 'Home', link: '/' },
-		{ name: 'Blog', link: '/blog' },
-		{ name: 'Changelog', link: '/changelog' },
-		{ name: 'FAQ', link: '/faq' }
+		{ name: 'Blog', link: '/blog/' },
+		{ name: 'Changelog', link: '/changelog/' },
+		{ name: 'FAQ', link: '/faq/' }
 	],
 	navActions: [{ name: 'Try it now', link: '/#install', style: 'white', size: 'lg' }]
 }

--- a/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
+++ b/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
@@ -9,9 +9,9 @@ tags: ['ai', 'developer-tools']
 
 You ask your agent to fix the padding on the hero section. It opens `Hero.tsx`, reads the JSX, finds a className with padding utilities, and changes `p-4` to `p-6`. The file saves. You switch to the browser. The padding changed on the outer wrapper, not the inner content area. The hero now has 24px of dead space around a card that has its own 16px, and the whole thing looks like it is floating in a swimming pool.
 
-You switch back to your editor. "No, the *inner* padding. The content container, not the wrapper." The agent reads the file again, burns more context, edits a different line. You switch to the browser. Better, but now the mobile layout broke because the agent did not know that `p-6` collides with a responsive `md:p-8` two lines down. It could not know. It never saw the page.
+You switch back to your editor. "No, the _inner_ padding. The content container, not the wrapper." The agent reads the file again, burns more context, edits a different line. You switch to the browser. Better, but now the mobile layout broke because the agent did not know that `p-6` collides with a responsive `md:p-8` two lines down. It could not know. It never saw the page.
 
-This is not a failure of intelligence. This is a failure of *sight*.
+This is not a failure of intelligence. This is a failure of _sight_.
 
 ### The Agent Blindspot
 
@@ -19,7 +19,7 @@ Every coding agent you use today — Cursor, Claude Code, Windsurf, Copilot — 
 
 That means every visual change is a guess.
 
-The agent sees two `className` attributes that both contain padding utilities. It picks one. It has a 50/50 shot. Sometimes it wins. Sometimes you burn three rounds of agent context correcting it, describing the problem in text that would take zero seconds to communicate if the agent could just *look at the screen*.
+The agent sees two `className` attributes that both contain padding utilities. It picks one. It has a 50/50 shot. Sometimes it wins. Sometimes you burn three rounds of agent context correcting it, describing the problem in text that would take zero seconds to communicate if the agent could just _look at the screen_.
 
 The runtime information your agent needs — the live DOM, the computed styles, the component tree, which element maps to which source file — exists only in the browser. It is not in any file. No amount of file-reading will produce it. The agent is reconstructing a building from blueprints when it could just walk inside.
 
@@ -67,7 +67,7 @@ One click, one sentence. The agent did not guess because it did not need to. It 
 ### Common Objections
 
 **"Good developers write precise enough prompts."**
-They do. "Change the padding on the Tailwind `p-3` class in the inner `div` of `HeroCTA` on line 18 of `src/components/blocks/Hero.tsx`." That works. It is also just editing the file yourself with extra steps. The real question is not whether *you* can write that prompt — it is whether the agent should need it at all. Frontman does not need you to describe the element because you already clicked it. The visual context *is* the prompt.
+They do. "Change the padding on the Tailwind `p-3` class in the inner `div` of `HeroCTA` on line 18 of `src/components/blocks/Hero.tsx`." That works. It is also just editing the file yourself with extra steps. The real question is not whether _you_ can write that prompt — it is whether the agent should need it at all. Frontman does not need you to describe the element because you already clicked it. The visual context _is_ the prompt.
 
 **"Agents are getting better at multi-file reasoning."**
 They are. And multi-file reasoning is exactly what you want for backend work — tracing data flow through services, understanding import chains, refactoring across modules. But frontend visual work is not a reasoning problem. It is a perception problem. No amount of reasoning about class names tells the agent what `gap-4 lg:gap-8` looks like at 768px. Seeing the rendered output does.
@@ -83,4 +83,4 @@ When the agent can see the rendered UI, a designer does not need to know that th
 
 The wall between "people who can describe a change" and "people who can make a change" disappears. Not because we lowered the bar — because we gave the agent eyes.
 
-[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started), works with your existing project. Read about [how Frontman keeps your code safe](/blog/security), see [how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code), or read the detailed [Frontman vs Cursor](/vs/cursor) breakdown.
+[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started/), works with your existing project. Read about [how Frontman keeps your code safe](/blog/security/), see [how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/), or read the detailed [Frontman vs Cursor](/vs/cursor/) breakdown.

--- a/apps/marketing/src/content/blog/browser-aware-ai-tools-2026.md
+++ b/apps/marketing/src/content/blog/browser-aware-ai-tools-2026.md
@@ -21,13 +21,13 @@ Runtime-aware tools try to close this gap. Here's how each one does it.
 
 **Website:** [frontman.sh](https://frontman.sh) | **License:** Apache 2.0 / AGPL-3.0 | **Stars:** ~131
 
-Framework middleware for Next.js, Astro, and Vite. Installs *inside* the framework's dev server, so it has native access to both client-side context (DOM, component tree, computed styles) and server-side context (routes, compiled module graph, server logs). Both exposed via MCP.
+Framework middleware for Next.js, Astro, and Vite. Installs _inside_ the framework's dev server, so it has native access to both client-side context (DOM, component tree, computed styles) and server-side context (routes, compiled module graph, server logs). Both exposed via MCP.
 
 **Strengths:** Deepest framework integration. Fully free, no prompt limits, no account. BYOK — connect Claude, OpenAI, or OpenRouter directly. Open source with permissive client library licensing.
 
 **Weaknesses:** Early stage. Rough edges, incomplete documentation, small community. Limited to supported frameworks. Source mapping breaks on deeply abstracted component libraries.
 
-*Disclosure: We built this.*
+_Disclosure: We built this._
 
 ### Stagewise
 
@@ -65,19 +65,19 @@ Google's experimental MCP server exposing DevTools state to AI agents. Your agen
 
 ### Comparison Table
 
-| Feature | Frontman | Stagewise | Tidewave | Chrome MCP |
-|---------|----------|-----------|----------|------------|
-| Architecture | Framework middleware | Browser proxy | MCP server | MCP server |
-| Client runtime | Yes | Yes | Yes | Yes |
-| Server runtime | Yes | Limited | Yes (deep) | No |
-| Standalone agent | Yes | Yes | No | No |
-| Free (no limits) | Yes | No (10/day) | No ($10/mo) | Yes |
-| BYOK | Yes | No | Yes | Yes |
-| Next.js | Yes | Yes | Thin | Yes |
-| Astro | Yes | No | No | Yes |
-| Svelte | Yes | No | No | Yes |
-| Vue | Yes | Yes | No | Yes |
-| Account required | No | Yes | Yes | No |
+| Feature          | Frontman             | Stagewise     | Tidewave    | Chrome MCP |
+| ---------------- | -------------------- | ------------- | ----------- | ---------- |
+| Architecture     | Framework middleware | Browser proxy | MCP server  | MCP server |
+| Client runtime   | Yes                  | Yes           | Yes         | Yes        |
+| Server runtime   | Yes                  | Limited       | Yes (deep)  | No         |
+| Standalone agent | Yes                  | Yes           | No          | No         |
+| Free (no limits) | Yes                  | No (10/day)   | No ($10/mo) | Yes        |
+| BYOK             | Yes                  | No            | Yes         | Yes        |
+| Next.js          | Yes                  | Yes           | Thin        | Yes        |
+| Astro            | Yes                  | No            | No          | Yes        |
+| Svelte           | Yes                  | No            | No          | Yes        |
+| Vue              | Yes                  | Yes           | No          | Yes        |
+| Account required | No                   | Yes           | Yes         | No         |
 
 ### Which One Should You Use?
 
@@ -91,4 +91,4 @@ Google's experimental MCP server exposing DevTools state to AI agents. Your agen
 
 **Designer who wants a visual editor:** Onlook. Different category entirely.
 
-The category is real. Six months ago this wasn't a thing. Now there are five projects with different architectures attacking the same problem. Some will be dead in a year. Some will be table stakes. Try them on a real project and decide for yourself. [Get started with Frontman](/blog/getting-started), [see how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code), or read the detailed [Frontman vs Cursor](/vs/cursor) and [Frontman vs Stagewise](/vs/stagewise) comparisons.
+The category is real. Six months ago this wasn't a thing. Now there are five projects with different architectures attacking the same problem. Some will be dead in a year. Some will be table stakes. Try them on a real project and decide for yourself. [Get started with Frontman](/blog/getting-started/), [see how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/), or read the detailed [Frontman vs Cursor](/vs/cursor/) and [Frontman vs Stagewise](/vs/stagewise/) comparisons.

--- a/apps/marketing/src/content/blog/frontman-launch.md
+++ b/apps/marketing/src/content/blog/frontman-launch.md
@@ -9,7 +9,7 @@ tags: ['announcement', 'open-source', 'ai', 'developer-tools']
 
 Every AI coding tool I've used has the same blind spot: it edits source files without ever seeing the running application. You describe a layout bug. The AI reads your JSX, guesses what the DOM looks like, and generates a fix. You switch to the browser. Wrong. The AI didn't know about the inherited padding, the conditional render that adds a third child, or the CSS variable that resolves differently at this breakpoint. Switch back, describe it again. Repeat.
 
-This loop — describe, edit, check, re-describe — is where a surprising amount of AI-assisted development time goes. Not on the AI generating code. On *you* being the bridge between what the AI thinks the app looks like and what it actually looks like.
+This loop — describe, edit, check, re-describe — is where a surprising amount of AI-assisted development time goes. Not on the AI generating code. On _you_ being the bridge between what the AI thinks the app looks like and what it actually looks like.
 
 The same thing happens server-side. Your AI edits a Next.js API route but doesn't know what middleware is active, what the compiled module graph looks like, or what's in the server logs.
 
@@ -27,7 +27,7 @@ The workflow: open your app in the browser, click any element, describe what you
 
 Frontman installs as **actual middleware** inside your framework's dev server — not as an external proxy or browser extension.
 
-This matters because the dev server already knows everything about both sides of your application. Next.js knows its route table and server/client component boundaries. Vite knows its HMR module graph and compiled output. Astro knows which islands hydrated. By running *inside* the framework, Frontman gets native access to all of this without reimplementing it.
+This matters because the dev server already knows everything about both sides of your application. Next.js knows its route table and server/client component boundaries. Vite knows its HMR module graph and compiled output. Astro knows which islands hydrated. By running _inside_ the framework, Frontman gets native access to all of this without reimplementing it.
 
 ```bash
 npx @frontman-ai/nextjs install   # for Next.js
@@ -46,13 +46,15 @@ The hardest part isn't getting runtime data — it's mapping it back to source c
 ### Honest Tradeoffs
 
 **What works well:**
-- CSS and layout fixes — the AI can see computed styles, so it knows *why* something looks wrong
+
+- CSS and layout fixes — the AI can see computed styles, so it knows _why_ something looks wrong
 - Visual debugging — click the broken element instead of describing it
 - Server-side debugging — the AI sees the actual error in server logs alongside the component that triggered it
 - Onboarding — "what component renders this section?" is answered instantly
 - Designer/PM collaboration — non-engineers can click elements and describe changes without opening an IDE
 
 **What doesn't work well yet:**
+
 - Complex state management changes — the visual output doesn't tell you if the logic is correct
 - Performance optimization — Frontman sees the DOM and server state, not render cycles or bundle sizes
 - Large refactors — runtime context helps with surgical edits, not architectural changes
@@ -68,4 +70,4 @@ This isn't altruism. Open source is the only credible model for a tool that sits
 
 Full setup instructions: [frontman.sh](https://frontman.sh). Source code: [github.com/frontman-ai/frontman](https://github.com/frontman-ai/frontman).
 
-Frontman is early-stage. There are rough edges. The documentation could be better. But the runtime context gap is real, and closing it saves real time on a specific class of problems. [Get started in under 5 minutes](/blog/getting-started).
+Frontman is early-stage. There are rough edges. The documentation could be better. But the runtime context gap is real, and closing it saves real time on a specific class of problems. [Get started in under 5 minutes](/blog/getting-started/).

--- a/apps/marketing/src/content/blog/frontman-vs-cursor-vs-claude-code.md
+++ b/apps/marketing/src/content/blog/frontman-vs-cursor-vs-claude-code.md
@@ -9,7 +9,7 @@ tags: ['comparison', 'ai']
 
 You are in Cursor. You ask the agent to fix a visual bug — a card component that overflows its container on mobile. The agent reads the file, finds the component, changes a width class. You `Cmd+Tab` to the browser. Still overflowing. You switch back, give more context: "It's the inner wrapper, not the outer one. And the issue is on viewports below 640px." The agent tries again. You switch to the browser. Fixed on mobile, but now the desktop layout has a weird gap. Three rounds. Six tab switches. The agent read the file each time. It just never saw the page.
 
-This is not a knock on Cursor. Cursor is excellent at code problems. The issue is that you used a file-level agent for a *visual* problem, and file-level agents are blind to the rendered UI.
+This is not a knock on Cursor. Cursor is excellent at code problems. The issue is that you used a file-level agent for a _visual_ problem, and file-level agents are blind to the rendered UI.
 
 ![Table comparing file-level AI agents and browser-level AI agents across key capabilities: file access, terminal access, DOM access, computed styles, and visual verification.](/blog/post-06.png)
 
@@ -31,12 +31,13 @@ For backend code, this is fine. A database query does not have a visual output. 
 Frontman hooks into your framework's build pipeline and connects to your running browser. It operates on the rendered output, not the source files. This is not a convenience — it is a fundamentally different feedback loop.
 
 When you click an element in Frontman:
+
 - It reads the **live DOM**, not the source file
 - It resolves **computed styles**, not class name strings
 - It traces the element back through the **component tree** to the source file and line number
 - It verifies the change via **hot-reload** in the same action — no tab switch
 
-Frontman does not guess which file to edit. It knows, because it can see the element you selected and trace it to its origin. The visual context *is* the context. You do not need to describe it in a prompt.
+Frontman does not guess which file to edit. It knows, because it can see the element you selected and trace it to its origin. The visual context _is_ the context. You do not need to describe it in a prompt.
 
 ### The Same Change, Two Ways
 
@@ -71,16 +72,16 @@ Three rounds vs. one. The difference is not intelligence — it is whether the a
 
 ### The Honest Comparison
 
-| Task | Right tool | Why |
-|---|---|---|
-| Write a new API endpoint | Cursor, Claude Code | Pure code, no visual output |
-| Fix padding on the hero section | **Frontman** | Visual problem, needs DOM access |
-| Refactor a database query | Cursor, Claude Code | Structural code change |
-| Change button colors across the app | **Frontman** | Visual, needs computed style awareness |
-| Implement auth logic | Claude Code, Cursor | Complex multi-file code |
-| Let a designer tweak the landing page | **Frontman** | Non-developer, visual task |
-| Debug a state management bug | Cursor, Claude Code | Deep code reasoning |
-| Update copy and CTAs | **Frontman** | Content change, visual verification |
+| Task                                  | Right tool          | Why                                    |
+| ------------------------------------- | ------------------- | -------------------------------------- |
+| Write a new API endpoint              | Cursor, Claude Code | Pure code, no visual output            |
+| Fix padding on the hero section       | **Frontman**        | Visual problem, needs DOM access       |
+| Refactor a database query             | Cursor, Claude Code | Structural code change                 |
+| Change button colors across the app   | **Frontman**        | Visual, needs computed style awareness |
+| Implement auth logic                  | Claude Code, Cursor | Complex multi-file code                |
+| Let a designer tweak the landing page | **Frontman**        | Non-developer, visual task             |
+| Debug a state management bug          | Cursor, Claude Code | Deep code reasoning                    |
+| Update copy and CTAs                  | **Frontman**        | Content change, visual verification    |
 
 The pattern is clear. If the definition of "correct" is "it looks right in the browser," you need an agent that can see the browser. If the definition of "correct" is "the tests pass" or "the types check," you need an agent that reasons about code.
 
@@ -88,9 +89,9 @@ The pattern is clear. If the definition of "correct" is "it looks right in the b
 
 Frontman does not write your API routes. It does not refactor your state management. It does not debug race conditions in your data fetching layer. It should not. Trying to build one agent that handles both code reasoning and visual perception is how you end up with an agent that is mediocre at both.
 
-Frontman handles the visual layer. Spacing, typography, colors, layout, responsive behavior, copy. The changes where the acceptance criterion is *how it looks*, and the only way to verify is a browser. That is a large category of work — easily 30-40% of frontend time — and it requires a fundamentally different kind of context than code reasoning does. It requires eyes.
+Frontman handles the visual layer. Spacing, typography, colors, layout, responsive behavior, copy. The changes where the acceptance criterion is _how it looks_, and the only way to verify is a browser. That is a large category of work — easily 30-40% of frontend time — and it requires a fundamentally different kind of context than code reasoning does. It requires eyes.
 
-Trying to use Cursor for visual work is like debugging CSS by reading the stylesheet without opening the page. You *can* do it. Experienced developers do it all the time. But it is slower, less reliable, and completely inaccessible to anyone who does not already know the codebase.
+Trying to use Cursor for visual work is like debugging CSS by reading the stylesheet without opening the page. You _can_ do it. Experienced developers do it all the time. But it is slower, less reliable, and completely inaccessible to anyone who does not already know the codebase.
 
 ### Common Objections
 
@@ -112,6 +113,6 @@ Stop using file-level agents for visual problems. Stop asking your coding agent 
 
 Use Cursor or Claude Code when the source code is the artifact. Use Frontman when the rendered page is the artifact. Let your developers use their preferred agent for complex work. Let your designers and PMs use Frontman for the visual layer. Everyone reviews PRs through the same process.
 
-The question is not "which AI agent is best." The question is "which agent can *see* what I need it to see."
+The question is not "which AI agent is best." The question is "which agent can _see_ what I need it to see."
 
-[Try Frontman](https://frontman.sh) — open source, free during beta. [Install in one command](/blog/getting-started), or read about [how designers and PMs can use it alongside your team](/blog/team-collaboration). For a detailed feature-by-feature breakdown, see [Frontman vs Cursor](/vs/cursor).
+[Try Frontman](https://frontman.sh) — open source, free during beta. [Install in one command](/blog/getting-started/), or read about [how designers and PMs can use it alongside your team](/blog/team-collaboration/). For a detailed feature-by-feature breakdown, see [Frontman vs Cursor](/vs/cursor/).

--- a/apps/marketing/src/content/blog/getting-started.md
+++ b/apps/marketing/src/content/blog/getting-started.md
@@ -74,7 +74,7 @@ One description, one edit, one diff. No tab-switching to verify. No "which file 
 
 ### It Reads Your Conventions
 
-This is the part most people miss. Frontman is not a generic code generator. It reads your `agents.md` or `claude.md` file to understand your project's coding conventions — naming patterns, component structure, preferred utilities. When it edits code, it follows *your* patterns, not some default template.
+This is the part most people miss. Frontman is not a generic code generator. It reads your `agents.md` or `claude.md` file to understand your project's coding conventions — naming patterns, component structure, preferred utilities. When it edits code, it follows _your_ patterns, not some default template.
 
 If your team uses a specific Tailwind preset, Frontman uses those classes. If you have a design token system, Frontman references those tokens. The output looks like code your team wrote, because it was informed by the same rules your team follows.
 
@@ -95,4 +95,4 @@ That is the honest setup. One command to install, connect your AI provider, and 
 
 No configuration guide. No "recommended settings." No second blog post explaining why the defaults are wrong. No step seven. It is a dev tool. It runs in dev. You install it in one command and it works.
 
-[Visit frontman.sh](https://frontman.sh) for full documentation. Learn [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui), or read about [how Frontman keeps your code safe](/blog/security).
+[Visit frontman.sh](https://frontman.sh) for full documentation. Learn [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/), or read about [how Frontman keeps your code safe](/blog/security/).

--- a/apps/marketing/src/content/blog/introducing-frontman.md
+++ b/apps/marketing/src/content/blog/introducing-frontman.md
@@ -9,17 +9,17 @@ tags: ['announcement', 'open-source']
 
 You tell Cursor to fix the spacing on your hero section. It reads the file, picks a Tailwind class that looks right, and saves. You switch to the browser. Wrong element. You switch back, add more context — the exact file path, the line number, maybe a hint about the component tree. The agent tries again. You switch to the browser again. Closer. One more round.
 
-Three iterations and six tab switches to change a padding value. Your agent had full access to the source code the entire time. It read every file. It just could not *see* the page.
+Three iterations and six tab switches to change a padding value. Your agent had full access to the source code the entire time. It read every file. It just could not _see_ the page.
 
 ### Why AI Agents Cannot See Your Frontend
 
 Claude is not stupid. Cursor is not broken. The agent genuinely cannot see what your page looks like. It reads source files. It reads terminal output. It reads build errors. None of that tells it what `p-4 md:p-8` resolves to at your current viewport width, or which of three nested `div`s with padding classes is the one you are staring at in the browser.
 
-Every coding agent on the market today is *blind to the rendered UI*. They edit files and hope the visual result matches your intent. For backend code, this is fine. For frontend work, hope is not a methodology.
+Every coding agent on the market today is _blind to the rendered UI_. They edit files and hope the visual result matches your intent. For backend code, this is fine. For frontend work, hope is not a methodology.
 
 **Other agents guess. Frontman sees.**
 
-Frontman connects to both your dev server *and* your browser. It has direct access to the live DOM, computed styles, your component tree, your routes, and your compilation errors. When you click an element and describe a change, Frontman knows exactly which file and which line to edit — because it can verify the result immediately.
+Frontman connects to both your dev server _and_ your browser. It has direct access to the live DOM, computed styles, your component tree, your routes, and your compilation errors. When you click an element and describe a change, Frontman knows exactly which file and which line to edit — because it can verify the result immediately.
 
 ### What That Looks Like
 
@@ -44,10 +44,10 @@ If you have ever burned fifteen minutes of agent context trying to describe whic
 ### Common Objections
 
 **"My agent can read files and edit them directly. That's basically the same thing."**
-It is not. Your agent reads the *source*. Frontman reads the *rendered output*. The source says `className="p-4 md:p-8 lg:p-12"`. The rendered output says "this element has 32px of padding at the current viewport." The source has three nested divs with padding. The rendered output shows you which one the user is actually pointing at. Your agent is working from a blueprint. Frontman is standing in the room.
+It is not. Your agent reads the _source_. Frontman reads the _rendered output_. The source says `className="p-4 md:p-8 lg:p-12"`. The rendered output says "this element has 32px of padding at the current viewport." The source has three nested divs with padding. The rendered output shows you which one the user is actually pointing at. Your agent is working from a blueprint. Frontman is standing in the room.
 
 **"What about v0 or Bolt? They generate full UIs."**
-They do. From scratch. In a sandbox. Frontman works with *your existing codebase*, your component library, your design tokens, your file conventions. It reads your `agents.md`. It follows your patterns. Generated UIs are demos. Frontman edits production code.
+They do. From scratch. In a sandbox. Frontman works with _your existing codebase_, your component library, your design tokens, your file conventions. It reads your `agents.md`. It follows your patterns. Generated UIs are demos. Frontman edits production code.
 
 **"AI-generated code changes are risky."**
 Every change Frontman makes is a file edit in your working directory. It shows up in `git diff`. It goes through your normal PR review. If it is wrong, `git checkout` fixes it. This is not riskier than accepting a diff from Cursor or Claude Code — it is the same workflow you already trust.
@@ -58,4 +58,4 @@ A designer opens the app in their browser, clicks the hero section, types "reduc
 
 That is not a fantasy. That is Frontman running on localhost.
 
-**Frontman sees.** [Get started in under 5 minutes](/blog/getting-started). Open source, Apache 2.0, free during beta. Want to understand [how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code)? See the full [Frontman vs Cursor](/vs/cursor) comparison.
+**Frontman sees.** [Get started in under 5 minutes](/blog/getting-started/). Open source, Apache 2.0, free during beta. Want to understand [how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/)? See the full [Frontman vs Cursor](/vs/cursor/) comparison.

--- a/apps/marketing/src/content/blog/lighthouse-audits-without-leaving-the-browser.md
+++ b/apps/marketing/src/content/blog/lighthouse-audits-without-leaving-the-browser.md
@@ -57,7 +57,7 @@ No tab switching. No copy-pasting issue descriptions. No translating Lighthouse 
 
 ### Why This Matters More Than You Think
 
-Running Lighthouse from the terminal is possible. Running it from a CI pipeline is common. But neither of those gives the agent what it needs: the audit results *and* the ability to fix them in the same session.
+Running Lighthouse from the terminal is possible. Running it from a CI pipeline is common. But neither of those gives the agent what it needs: the audit results _and_ the ability to fix them in the same session.
 
 Here is the standard coding-agent workflow for performance optimization:
 
@@ -104,8 +104,8 @@ The agent audits what you are seeing. Not a default it picked.
 
 Performance optimization has always been a feedback loop: measure, identify the issue, fix it, measure again. The problem was never the fixing — it was the measuring, and the translation layer between measurement and action.
 
-When the agent can run Lighthouse itself, that translation layer disappears. The measurement *is* the context. The agent reads the failing audit, traces it to the source, makes the change, and verifies the improvement — all in one continuous action.
+When the agent can run Lighthouse itself, that translation layer disappears. The measurement _is_ the context. The agent reads the failing audit, traces it to the source, makes the change, and verifies the improvement — all in one continuous action.
 
 Your performance scores stop being a report you read and start being a problem the agent solves.
 
-[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started), works with your existing project. Read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui), see [how Frontman compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code), or read the full [Frontman vs Cursor](/vs/cursor) comparison.
+[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started/), works with your existing project. Read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/), see [how Frontman compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/), or read the full [Frontman vs Cursor](/vs/cursor/) comparison.

--- a/apps/marketing/src/content/blog/runtime-context-gap.md
+++ b/apps/marketing/src/content/blog/runtime-context-gap.md
@@ -13,18 +13,20 @@ It falls apart when the source code isn't the whole story. And for any applicati
 
 This isn't just a frontend problem. The browser has computed styles and a rendered DOM that don't exist in your source files. But the server side has its own runtime context that source code alone can't capture: which routes are registered, what the compiled module graph looks like, what's in the server logs, what middleware is active and in what order.
 
-The question is whether connecting AI tools to this runtime state — both client and server — is a meaningful improvement or just a debugger hook with extra steps. Having worked on this problem, the honest answer is: it's a debugger hook with extra steps, *and* it's a meaningful improvement. Those aren't contradictory.
+The question is whether connecting AI tools to this runtime state — both client and server — is a meaningful improvement or just a debugger hook with extra steps. Having worked on this problem, the honest answer is: it's a debugger hook with extra steps, _and_ it's a meaningful improvement. Those aren't contradictory.
 
 ### The Gap Is Real (But Let's Be Precise)
 
 When an AI coding tool edits your project, it's working from source text. Here's what it doesn't have:
 
 **Client-side runtime (the browser):**
+
 - **Computed styles.** The final CSS applied to an element is the product of specificity, cascade order, media queries, CSS variables, container queries, and inheritance. The AI sees class names. The browser computes actual values.
 - **The rendered DOM.** Your JSX is not your DOM. Conditional rendering, portals, fragments, and framework transformations mean the actual tree looks different from what the source suggests.
 - **Layout geometry.** Is there 16px or 24px between the sidebar and content area? The AI can read `gap-4` in a Tailwind class but can't see that a parent's padding also contributes to the visual spacing.
 
 **Server-side runtime (the dev server):**
+
 - **Compiled module graph.** Frameworks like Next.js, Vite, and Astro transform your source before serving it. The AI sees source files; the dev server sees the compiled, bundled, tree-shaken output.
 - **Registered routes and middleware.** File-based routing means the route table is a runtime artifact. Middleware ordering, redirect chains, and rewrite rules exist in the server's state, not in any single source file.
 - **Server logs and errors.** A component that renders fine might be throwing warnings server-side. The AI editing your code doesn't see `stdout`.
@@ -38,7 +40,7 @@ This doesn't invalidate the tooling argument. Even well-structured codebases hav
 
 ### What "Runtime-Aware" Actually Means
 
-Strip away the marketing and the architecture is straightforward: you give an AI agent access to runtime information from both the browser *and* the dev server, then let it correlate that information back to source files.
+Strip away the marketing and the architecture is straightforward: you give an AI agent access to runtime information from both the browser _and_ the dev server, then let it correlate that information back to source files.
 
 Modern web frameworks already bridge client and server — Next.js, Astro, and Vite all have dev servers that know about your component tree, module graph, and build output. A tool that hooks into the framework middleware gets both sides for free.
 
@@ -65,7 +67,7 @@ The critical piece is the **source mapping** — connecting "this DOM element at
 
 ### The Tools Building This
 
-A few projects are working on this, each with different tradeoffs. [Frontman](https://frontman.sh) hooks into the framework as middleware for the deepest integration. [Stagewise](https://stagewise.io) uses a browser proxy approach with more polish. [Tidewave](https://tidewave.ai) goes deep on backend runtime for Phoenix/Rails/Django. Chrome DevTools MCP exposes browser state to any agent. For a detailed comparison, see our [roundup of browser-aware AI tools](/blog/browser-aware-ai-tools-2026).
+A few projects are working on this, each with different tradeoffs. [Frontman](https://frontman.sh) hooks into the framework as middleware for the deepest integration. [Stagewise](https://stagewise.io) uses a browser proxy approach with more polish. [Tidewave](https://tidewave.ai) goes deep on backend runtime for Phoenix/Rails/Django. Chrome DevTools MCP exposes browser state to any agent. For a detailed comparison, see our [roundup of browser-aware AI tools](/blog/browser-aware-ai-tools-2026/).
 
 ### The Maintenance Trap
 

--- a/apps/marketing/src/content/blog/security.md
+++ b/apps/marketing/src/content/blog/security.md
@@ -9,7 +9,7 @@ tags: ['security', 'open-source']
 
 You already let AI agents edit your codebase. Cursor writes directly to your files. Claude Code runs shell commands. Copilot suggests code inline and you tab-accept it without reading every line. That is the reality of how developers work now.
 
-So when you hear "Frontman edits your source files," the question is not *whether* you trust an agent to touch your code. You already made that call. The question is what constraints are in place when it does.
+So when you hear "Frontman edits your source files," the question is not _whether_ you trust an agent to touch your code. You already made that call. The question is what constraints are in place when it does.
 
 Here is every hard question you should ask, and our answers.
 
@@ -19,7 +19,7 @@ Frontman runs exclusively in your local development environment. It is a dev dep
 
 The framework integrations — Next.js, Astro, Vite — activate only when `NODE_ENV=development`. In a production build, Frontman's code is not included. Not disabled. Not present. The tree-shaker removes it because nothing imports it outside of dev mode.
 
-This is not a toggle. It is a compile-time guarantee. Frontman *cannot* run in production because the code does not exist in the production bundle.
+This is not a toggle. It is a compile-time guarantee. Frontman _cannot_ run in production because the code does not exist in the production bundle.
 
 ### What Can It Change?
 
@@ -40,7 +40,7 @@ index 3a1f2c8..7b4e9d1 100644
 
 That diff shows up in `git status`. It goes through your normal PR review. If it is wrong, `git checkout -- src/components/Hero.tsx` undoes it. No hidden state, no shadow copies, no parallel universe where the agent's version of your code diverges from yours.
 
-**The change *is* the code.** It cannot drift because it is not stored anywhere else.
+**The change _is_ the code.** It cannot drift because it is not stored anywhere else.
 
 ### What Does the AI Agent See?
 
@@ -94,8 +94,8 @@ Yes. Frontman edits source files in your project directory. It does not touch `n
 
 Frontman is a dev tool that produces diffs. It runs locally, sends context to your chosen AI provider, edits your source files, and gets out of the way. Everything else — review, testing, deployment — is your existing workflow, unchanged.
 
-The better world looks like this: a designer changes the hero padding, a developer reviews a one-line diff in the PR, and nobody spent a single second worrying about whether the AI touched something it should not have. Because the constraints are structural, not behavioral. The agent *cannot* deploy. It *cannot* push. It produces a diff. You review it. Same as everything else.
+The better world looks like this: a designer changes the hero padding, a developer reviews a one-line diff in the PR, and nobody spent a single second worrying about whether the AI touched something it should not have. Because the constraints are structural, not behavioral. The agent _cannot_ deploy. It _cannot_ push. It produces a diff. You review it. Same as everything else.
 
 Security model changes do not page anyone at 3am.
 
-[Get started with Frontman](/blog/getting-started) in under five minutes, or read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui).
+[Get started with Frontman](/blog/getting-started/) in under five minutes, or read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/).

--- a/apps/marketing/src/content/blog/team-collaboration.md
+++ b/apps/marketing/src/content/blog/team-collaboration.md
@@ -30,7 +30,7 @@ One character. Three days. This is not a process failure. This is what happens w
 
 ### The Frontend Collaboration Bottleneck
 
-Look at that nine-step workflow again. The actual work — changing a class name — takes thirty seconds. The other two days and twenty-nine minutes are *communication*. Filing the ticket. Explaining the ticket. Clarifying the ticket. Reviewing the result. Requesting a tweak. Reviewing again.
+Look at that nine-step workflow again. The actual work — changing a class name — takes thirty seconds. The other two days and twenty-nine minutes are _communication_. Filing the ticket. Explaining the ticket. Clarifying the ticket. Reviewing the result. Requesting a tweak. Reviewing again.
 
 The complexity of the change is near zero. The overhead of routing it through the right person is enormous. This is not a problem you solve with better ticketing software. You solve it by letting the person who sees the problem fix the problem.
 
@@ -45,7 +45,7 @@ With Frontman, the same scenario plays out differently:
 5. Designer sees the result, adjusts if needed, commits
 6. Developer reviews a clean one-line diff in the PR
 
-Five minutes. One person. Zero tickets. The developer still reviews the code — quality does not drop. But the developer reviews a *finished change* instead of playing telephone across Slack and Jira for three days.
+Five minutes. One person. Zero tickets. The developer still reviews the code — quality does not drop. But the developer reviews a _finished change_ instead of playing telephone across Slack and Jira for three days.
 
 ### Who Does What
 
@@ -79,4 +79,4 @@ That is not a productivity hack. That is removing an artificial bottleneck that 
 
 Here is what Monday morning looks like after the change: the designer ships three visual fixes before standup. The PM updates the landing page CTA without filing a ticket. The developer's PR queue has zero pixel-adjustment requests. Everyone is working on what they are actually good at. Nobody is blocked on anyone else for a one-character diff.
 
-[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started), works with your existing project. Read about [how Frontman keeps every change safe and reviewable](/blog/security).
+[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started/), works with your existing project. Read about [how Frontman keeps every change safe and reviewable](/blog/security/).

--- a/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
+++ b/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
@@ -38,21 +38,21 @@ Here's a card grid component with a subtle problem:
 ```tsx
 // src/components/CardGrid.tsx
 export function CardGrid({ items }: { items: Item[] }) {
-  return (
-    <div className="grid grid-cols-3 gap-6 p-8">
-      {items.map((item) => (
-        <div key={item.id} className="rounded-lg bg-white p-6 shadow-sm">
-          <h3 className="text-lg font-semibold">{item.title}</h3>
-          {item.featured && (
-            <span className="mt-2 inline-block rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800">
-              Featured
-            </span>
-          )}
-          <p className="mt-4 text-gray-600">{item.description}</p>
-        </div>
-      ))}
-    </div>
-  );
+	return (
+		<div className="grid grid-cols-3 gap-6 p-8">
+			{items.map((item) => (
+				<div key={item.id} className="rounded-lg bg-white p-6 shadow-sm">
+					<h3 className="text-lg font-semibold">{item.title}</h3>
+					{item.featured && (
+						<span className="mt-2 inline-block rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800">
+							Featured
+						</span>
+					)}
+					<p className="mt-4 text-gray-600">{item.description}</p>
+				</div>
+			))}
+		</div>
+	)
 }
 ```
 
@@ -74,7 +74,7 @@ Now describe the fix:
 
 > "Make all cards the same height and align the description text at the bottom, regardless of whether the Featured badge is present."
 
-Frontman sends the AI your description, the source code, the computed layout showing actual height differences, and the component tree context. The AI generates a targeted edit — adding `flex flex-col` to the card wrapper and `mt-auto` to the description paragraph. It knows this is the right fix because it can see the *actual* height difference.
+Frontman sends the AI your description, the source code, the computed layout showing actual height differences, and the component tree context. The AI generates a targeted edit — adding `flex flex-col` to the card wrapper and `mt-auto` to the description paragraph. It knows this is the right fix because it can see the _actual_ height difference.
 
 The edit is applied to your source file. Hot reload shows the result immediately. Cards align.
 
@@ -98,7 +98,7 @@ The edit is applied to your source file. Hot reload shows the result immediately
 9. The browser updated — you see the fix immediately
 ```
 
-The AI didn't guess what the layout looks like. It *knew* — because Frontman gave it the computed layout data from the browser.
+The AI didn't guess what the layout looks like. It _knew_ — because Frontman gave it the computed layout data from the browser.
 
 ### Beyond CSS
 
@@ -120,4 +120,4 @@ Runtime-aware AI coding is not a silver bullet:
 
 The runtime context gap is real, and closing it saves time on a specific class of problems. It doesn't replace engineering judgment. It just means the AI guesses less.
 
-[Get started with Frontman](https://frontman.sh) — works with Next.js, Astro, and Vite. Or [see how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code). For a detailed feature-by-feature breakdown, see [Frontman vs Cursor](/vs/cursor).
+[Get started with Frontman](https://frontman.sh) — works with Next.js, Astro, and Vite. Or [see how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/). For a detailed feature-by-feature breakdown, see [Frontman vs Cursor](/vs/cursor/).

--- a/apps/marketing/src/pages/pricing.astro
+++ b/apps/marketing/src/pages/pricing.astro
@@ -1,51 +1,31 @@
 ---
-// Components
-// - Layout
-// import Layout from '../layouts/Layout.astro'
-// // - UI
-// import Hero from '../components/blocks/hero/PageHeader.astro'
-// import Price from '../components/blocks/pricing/PricingColumns.astro'
-// import SocialProof from '../components/blocks/socialproof/Basic.astro'
-// import FAQ from '../components/blocks/FAQ/Basic.astro'
-// import Testimonial from '../components/blocks/testimonials/BasicDark.astro'
-// import Feature from '../components/blocks/features/FeatureList.astro'
-// import CTA from '../components/blocks/CTA/BasicDark.astro'
+import Layout from '../layouts/Layout.astro'
 
-// // Content
-// // - SEO
-// const SEO = {
-// 	title: 'Frontman | Pricing made simple',
-// 	description:
-// 		'Discover the perfect SaaS pricing plan for your business. From startups to enterprises, our scalable solutions offer unparalleled features and 24/7 support.'
-// }
-// // - Page Header
-// const header = {
-// 	title: 'Choose the plan that works for <strong>your</strong> needs',
-// 	text: 'All plans come with a 30-day money-back guarantee.'
-// }
-// // - Testimonial data
-// import testimonialBackground from '../assets/testimonial-bg-02.webp'
-// const testimonialData = {
-// 	blockquote:
-// 		"Frontman isn't just an app—it's like having a mischievous yet brilliant sidekick for your business. It streamlines tasks and also cracks jokes to keep spirits high",
-// 	figcaption: 'Max Widgetson',
-// 	cite: ' CEO, Widgetify Ltd'
-// }
+const SEO = {
+	title: 'Frontman | Pricing',
+	description:
+		'Frontman pricing plans. Currently free and open source during early access.'
+}
 ---
 
-<!-- Pricing page commented out - no pricing yet -->
-<!-- <Layout title={SEO.title} description={SEO.description}>
-	<Hero title={header.title} text={header.text} />
-	<Price />
-	<SocialProof />
-	<Feature />
-	<Testimonial
-		bg={testimonialBackground}
-		bgPosition="left"
-		blockquote={testimonialData.blockquote}
-		figcaption={testimonialData.figcaption}
-		cite={testimonialData.cite}
-	/>
-	<FAQ classes="bg-slate-50 dark:bg-neutral-900/40" />
-	<CTA />
-</Layout> -->
+<Layout title={SEO.title} description={SEO.description} noindex={true}>
+	<section class="py-24 sm:py-32">
+		<div class="mx-auto max-w-2xl text-center">
+			<h1 class="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white sm:text-4xl">
+				Pricing coming soon
+			</h1>
+			<p class="mt-6 text-lg leading-8 text-neutral-600 dark:text-neutral-400">
+				Frontman is free and open source during early access. We're working on pricing plans
+				and will share them here when they're ready.
+			</p>
+			<div class="mt-10">
+				<a
+					href="/"
+					class="rounded-md bg-teal-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+				>
+					Back to home
+				</a>
+			</div>
+		</div>
+	</section>
+</Layout>

--- a/apps/marketing/src/pages/terms.astro
+++ b/apps/marketing/src/pages/terms.astro
@@ -31,7 +31,7 @@ const SEO = {
 					<h2>Acceptance of Terms</h2>
 					<p>
 						By accessing or using Frontman, you agree to comply with and be bound by these Terms of
-						Service and our <a href="/privacy">Privacy Policy</a>. If you do not agree with these
+						Service and our <a href="/privacy/">Privacy Policy</a>. If you do not agree with these
 						terms, you should not use our services.
 					</p>
 				</section>

--- a/apps/marketing/src/pages/vs/cursor.astro
+++ b/apps/marketing/src/pages/vs/cursor.astro
@@ -266,7 +266,7 @@ const faqJsonLd = {
 					<li><strong>Visual editing workflows</strong> where seeing the live result matters more than typing speed</li>
 				</ul>
 				<p>Many developers use both. Cursor for backend, refactoring, and general-purpose coding. Frontman for visual frontend changes where the AI needs to see what's actually rendered in the browser.</p>
-				<p>For a deeper technical comparison including Claude Code, read our <a href="/blog/frontman-vs-cursor-vs-claude-code" class="text-link">full comparison of Frontman, Cursor, and Claude Code</a>. Also see: <a href="/vs/stagewise" class="text-link">Frontman vs Stagewise</a> for a comparison with another browser-based tool.</p>
+				<p>For a deeper technical comparison including Claude Code, read our <a href="/blog/frontman-vs-cursor-vs-claude-code/" class="text-link">full comparison of Frontman, Cursor, and Claude Code</a>. Also see: <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a> for a comparison with another browser-based tool.</p>
 			</div>
 		</div>
 	</section>

--- a/apps/marketing/src/pages/vs/stagewise.astro
+++ b/apps/marketing/src/pages/vs/stagewise.astro
@@ -268,7 +268,7 @@ const faqJsonLd = {
 					<li><strong>Server-side context matters</strong> — you need the AI to understand routes, server logs, and server-side state alongside the visual UI</li>
 				</ul>
 				<p>Many developers who start with Stagewise's zero-install experience migrate to Frontman when they hit prompt limits or need deeper framework context.</p>
-				<p>Also see: <a href="/vs/cursor" class="text-link">Frontman vs Cursor</a> for a comparison with a full AI-powered IDE.</p>
+				<p>Also see: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a> for a comparison with a full AI-powered IDE.</p>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
## Summary

Fixes 25 "not indexed" pages flagged in Google Search Console for `frontman.sh`.

### Changes

- **Add `trailingSlash: "always"` to Astro config** — eliminates 308 redirects that caused "Page with redirect" errors (e.g. `/blog/lighthouse-audits-without-leaving-the-browser` → `/blog/lighthouse-audits-without-leaving-the-browser/`)
- **Fix pricing page soft 404** — the page was an empty HTML shell (all code commented out). Now has `noindex` meta tag and minimal "coming soon" content so Google doesn't flag it
- **Normalize 36 internal links to use trailing slashes** — across navigation config (navbar + footer), `.astro` pages, and 11 blog `.md` files. Prevents duplicate URL indexing (`/terms` vs `/terms/`) and unnecessary redirects

### Search Console issues addressed

| Issue | Pages | Fix |
|---|---|---|
| Page with redirect (Failed) | 2 | `trailingSlash: "always"` + link normalization |
| Soft 404 | 1 (`/pricing/`) | noindex + real content |
| Crawled - currently not indexed | 7 | Trailing slash deduplication helps `/terms` vs `/terms/` |
| Alternate page with proper canonical | 3 | Already working correctly (no change needed) |
| Discovered - currently not indexed | 12 | Google-side, no code change needed |

### Verification

- Build passes with 0 errors, 0 warnings
- All sitemap URLs use trailing slashes
- Canonical URLs use trailing slashes
- Pricing page excluded from sitemap + has noindex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
