### PR TITLE
fix(sentry): filter third-party errors and extract shared Sentry infrastructure

### DIFF
--- a/.changeset/filter-third-party-sentry.md
+++ b/.changeset/filter-third-party-sentry.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/nextjs": patch
+"@frontman/frontman-client": patch
+---
+
+Filter third-party errors from Frontman's internal Sentry reporting. Extracts shared Sentry types, config (DSN, internal-dev detection), and a `beforeSend` filter into `@frontman/bindings` so all framework integrations share a single source of truth. The filter inspects stacktrace frames and drops events that don't originate from Frontman code, preventing noise from framework internals (e.g. Next.js/Turbopack source-map WASM fetch failures). Both `@frontman-ai/nextjs` and `@frontman/frontman-client` now use this shared filter.

--- a/libs/bindings/src/Bindings__Sentry__Config.res
+++ b/libs/bindings/src/Bindings__Sentry__Config.res
@@ -1,0 +1,9 @@
+// Shared Sentry configuration for all Frontman libraries
+// Single source of truth for DSN and environment detection
+
+// Frontman's Sentry DSN - public (client-side DSNs are always public)
+let dsn = "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296"
+
+// Detect Frontman team internal development (set via mprocs.yml / .dev.env)
+let isInternalDev = () =>
+  %raw(`typeof process !== 'undefined' && process.env?.FRONTMAN_INTERNAL_DEV === 'true'`)

--- a/libs/bindings/src/Bindings__Sentry__Filter.res
+++ b/libs/bindings/src/Bindings__Sentry__Filter.res
@@ -1,0 +1,47 @@
+// Shared Sentry event filter for all Frontman libraries
+// Drops error events that don't originate from Frontman code, preventing
+// third-party errors (e.g. Next.js/Turbopack internals) from polluting our Sentry project.
+
+// Patterns that identify Frontman frames in stacktraces
+let frontmanFramePatterns = ["frontman", "@frontman-ai"]
+
+// Check if a filename belongs to Frontman code
+let isFrontmanFrame = (filename: string): bool =>
+  frontmanFramePatterns->Array.some(pattern =>
+    filename->String.toLowerCase->String.includes(pattern)
+  )
+
+// Check if an event has at least one Frontman frame in any exception stacktrace.
+// Events without exception data (e.g. captureMessage) are always kept.
+let hasFrontmanFrames = (event: Bindings__Sentry__Types.sentryEvent): bool =>
+  switch event.exception_ {
+  | None => true
+  | Some({values: None}) | Some({values: Some([])}) => true
+  | Some({values: Some(values)}) =>
+    values->Array.some(exceptionValue =>
+      switch exceptionValue.stacktrace {
+      | None => true
+      | Some({frames: None}) | Some({frames: Some([])}) => true
+      | Some({frames: Some(frames)}) =>
+        frames->Array.some(frame =>
+          switch frame.filename {
+          | None => false
+          | Some(filename) => isFrontmanFrame(filename)
+          }
+        )
+      }
+    )
+  }
+
+// beforeSend filter: drop events that don't originate from Frontman code.
+// This prevents third-party errors caught by Sentry's global handlers from
+// polluting our project.
+let beforeSend = (
+  event: Bindings__Sentry__Types.sentryEvent,
+  _hint: Bindings__Sentry__Types.eventHint,
+): Nullable.t<Bindings__Sentry__Types.sentryEvent> =>
+  if hasFrontmanFrames(event) {
+    Nullable.make(event)
+  } else {
+    Nullable.null
+  }

--- a/libs/bindings/src/Bindings__Sentry__Types.res
+++ b/libs/bindings/src/Bindings__Sentry__Types.res
@@ -1,0 +1,31 @@
+// Shared Sentry types used by all framework integrations
+// These are SDK-agnostic — they describe the Sentry data model, not a specific @sentry/* package
+
+type severity = [#fatal | #error | #warning | #log | #info | #debug]
+
+type breadcrumb = {
+  category?: string,
+  message?: string,
+  level?: severity,
+  data?: Dict.t<JSON.t>,
+}
+
+type eventHint = {originalException?: exn}
+
+// Stacktrace frame shape (subset of Sentry's StackFrame)
+type stacktraceFrame = {filename: option<string>}
+type stacktrace = {frames: option<array<stacktraceFrame>>}
+type exceptionValue = {stacktrace: option<stacktrace>}
+type exceptionValues = {values: option<array<exceptionValue>>}
+
+// Sentry event shape (subset of Sentry Event interface)
+type sentryEvent = {@as("exception") exception_: option<exceptionValues>}
+
+type scopeContext = {
+  tags?: Dict.t<string>,
+  extra?: Dict.t<JSON.t>,
+  user?: {id?: string, email?: string, username?: string},
+}
+
+// Re-export transport type for convenience
+type transport = Bindings__Sentry__Transport.t

--- a/libs/frontman-client/src/FrontmanClient__Sentry.res
+++ b/libs/frontman-client/src/FrontmanClient__Sentry.res
@@ -2,27 +2,23 @@
 // Reports errors to Frontman's own Sentry project
 
 module Bindings = FrontmanClient__Sentry__Bindings
-
-// Frontman's Sentry DSN - public (client-side DSNs are always public)
-let dsn = "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296"
+module SentryConfig = FrontmanBindings.Bindings__Sentry__Config
+module SentryFilter = FrontmanBindings.Bindings__Sentry__Filter
 
 let initialized = ref(false)
 
-// Detect Frontman team internal development (set via mprocs.yml / .dev.env)
-let isInternalDev = () =>
-  %raw(`typeof process !== 'undefined' && process.env?.FRONTMAN_INTERNAL_DEV === 'true'`)
-
 let initialize = (~transport: option<Bindings.transport>=?) => {
   // Skip Sentry in Frontman internal dev; custom transport (tests) always initializes
-  if !initialized.contents && (Option.isSome(transport) || !isInternalDev()) {
+  if !initialized.contents && (Option.isSome(transport) || !SentryConfig.isInternalDev()) {
     Bindings.init({
-      dsn,
+      dsn: SentryConfig.dsn,
       environment: %raw(`typeof window !== 'undefined' && window.location?.hostname === 'localhost' ? 'development' : 'production'`),
       sampleRate: 1.0,
       ?transport,
       initialScope: {
         tags: Dict.fromArray([("frontman.library", "frontman-client")]),
       },
+      beforeSend: SentryFilter.beforeSend,
     })
     initialized.contents = true
   }

--- a/libs/frontman-client/src/FrontmanClient__Sentry__Bindings.res
+++ b/libs/frontman-client/src/FrontmanClient__Sentry__Bindings.res
@@ -1,25 +1,16 @@
 // Sentry SDK bindings for ReScript
 // Using @sentry/browser for browser client
+// Types are shared via FrontmanBindings.Bindings__Sentry__Types
 
-type severity = [#fatal | #error | #warning | #log | #info | #debug]
+module Types = FrontmanBindings.Bindings__Sentry__Types
 
-type breadcrumb = {
-  category?: string,
-  message?: string,
-  level?: severity,
-  data?: Dict.t<JSON.t>,
-}
-
-type eventHint = {originalException?: exn}
-
-type scopeContext = {
-  tags?: Dict.t<string>,
-  extra?: Dict.t<JSON.t>,
-  user?: {id?: string, email?: string, username?: string},
-}
-
-// Transport type for custom transports (e.g., sentry-testkit)
-type transport = FrontmanBindings.Bindings__Sentry__Transport.t
+// Re-export shared types for convenience
+type severity = Types.severity
+type breadcrumb = Types.breadcrumb
+type eventHint = Types.eventHint
+type sentryEvent = Types.sentryEvent
+type scopeContext = Types.scopeContext
+type transport = Types.transport
 
 type initOptions = {
   dsn: string,
@@ -30,6 +21,7 @@ type initOptions = {
   enabled?: bool,
   initialScope?: scopeContext,
   transport?: transport,
+  beforeSend?: (sentryEvent, eventHint) => Nullable.t<sentryEvent>,
 }
 
 // Main Sentry functions from @sentry/browser

--- a/libs/frontman-client/test/FrontmanClient__Sentry.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Sentry.test.res
@@ -1,6 +1,8 @@
 open Vitest
 
 module Sentry = FrontmanClient__Sentry
+module SentryTypes = FrontmanBindings.Bindings__Sentry__Types
+module SentryFilter = FrontmanBindings.Bindings__Sentry__Filter
 module SentryTestkit = FrontmanBindings.Bindings__Test__SentryTestkit
 
 describe("FrontmanClient Sentry", () => {
@@ -283,6 +285,97 @@ describe("FrontmanClient Sentry", () => {
           }
         | None => t->expect(false)->Expect.toBe(true)
         }
+      },
+    )
+  })
+
+  describe("beforeSend filtering", () => {
+    test(
+      "keeps events with Frontman frames",
+      t => {
+        let event: SentryTypes.sentryEvent = {
+          exception_: Some({
+            values: Some([
+              {
+                stacktrace: Some({
+                  frames: Some([
+                    {
+                      filename: Some(
+                        "/node_modules/@frontman-ai/nextjs/dist/instrumentation.js",
+                      ),
+                    },
+                  ]),
+                }),
+              },
+            ]),
+          }),
+        }
+        let hint: SentryTypes.eventHint = {}
+        let result = SentryFilter.beforeSend(event, hint)
+        t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
+      },
+    )
+
+    test(
+      "drops events with only third-party frames",
+      t => {
+        let event: SentryTypes.sentryEvent = {
+          exception_: Some({
+            values: Some([
+              {
+                stacktrace: Some({
+                  frames: Some([
+                    {filename: Some("/next/dist/server/chunks/ssr/dedupeFetch.js")},
+                    {filename: Some("node:internal/deps/undici/undici")},
+                  ]),
+                }),
+              },
+            ]),
+          }),
+        }
+        let hint: SentryTypes.eventHint = {}
+        let result = SentryFilter.beforeSend(event, hint)
+        t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(false)
+      },
+    )
+
+    test(
+      "keeps captureMessage events (no exception)",
+      t => {
+        let event: SentryTypes.sentryEvent = {exception_: None}
+        let hint: SentryTypes.eventHint = {}
+        let result = SentryFilter.beforeSend(event, hint)
+        t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
+      },
+    )
+
+    test(
+      "keeps events with empty values array",
+      t => {
+        let event: SentryTypes.sentryEvent = {
+          exception_: Some({values: Some([])}),
+        }
+        let hint: SentryTypes.eventHint = {}
+        let result = SentryFilter.beforeSend(event, hint)
+        t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
+      },
+    )
+
+    test(
+      "keeps events with empty frames array",
+      t => {
+        let event: SentryTypes.sentryEvent = {
+          exception_: Some({
+            values: Some([
+              {
+                stacktrace: Some({frames: Some([])}),
+              },
+            ]),
+          }),
+        }
+        let hint: SentryTypes.eventHint = {}
+        let result = SentryFilter.beforeSend(event, hint)
+        t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
       },
     )
   })

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Sentry.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Sentry.res
@@ -2,39 +2,36 @@
 // Reports errors to Frontman's own Sentry project
 
 module Bindings = FrontmanNextjs__Sentry__Bindings
-
-// Frontman's Sentry DSN - public (client-side DSNs are always public)
-let dsn = "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296"
+module SentryConfig = FrontmanBindings.Bindings__Sentry__Config
+module SentryFilter = FrontmanBindings.Bindings__Sentry__Filter
 
 let initialized = ref(false)
 
-// Detect Frontman team internal development (set via mprocs.yml / .dev.env)
-let isInternalDev = () =>
-  %raw(`typeof process !== 'undefined' && process.env?.FRONTMAN_INTERNAL_DEV === 'true'`)
-
 let initialize = (~transport: option<Bindings.transport>=?) => {
   // Skip Sentry in Frontman internal dev; custom transport (tests) always initializes
-  if !initialized.contents && (Option.isSome(transport) || !isInternalDev()) {
-    let scope = {
-      Bindings.tags: Dict.fromArray([("frontman.library", "frontman-nextjs")]),
+  if !initialized.contents && (Option.isSome(transport) || !SentryConfig.isInternalDev()) {
+    let scope: Bindings.scopeContext = {
+      tags: Dict.fromArray([("frontman.library", "frontman-nextjs")]),
     }
     switch transport {
     | Some(t) =>
       Bindings.initWithTransport({
-        dsn,
+        dsn: SentryConfig.dsn,
         environment: %raw(`process.env.NODE_ENV || "development"`),
         release: %raw(`process.env.npm_package_version || "unknown"`),
         sampleRate: 1.0,
         transport: t,
         initialScope: scope,
+        beforeSend: SentryFilter.beforeSend,
       })
     | None =>
       Bindings.init({
-        dsn,
+        dsn: SentryConfig.dsn,
         environment: %raw(`process.env.NODE_ENV || "development"`),
         release: %raw(`process.env.npm_package_version || "unknown"`),
         sampleRate: 1.0,
         initialScope: scope,
+        beforeSend: SentryFilter.beforeSend,
       })
     }
     initialized.contents = true

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Sentry__Bindings.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Sentry__Bindings.res
@@ -1,27 +1,16 @@
 // Sentry SDK bindings for ReScript
 // Using @sentry/nextjs for Next.js integration
+// Types are shared via FrontmanBindings.Bindings__Sentry__Types
 
-type severity = [#fatal | #error | #warning | #log | #info | #debug]
+module Types = FrontmanBindings.Bindings__Sentry__Types
 
-type breadcrumb = {
-  category?: string,
-  message?: string,
-  level?: severity,
-  data?: Dict.t<JSON.t>,
-}
-
-type eventHint = {originalException?: exn}
-
-type sentryEvent
-
-type scopeContext = {
-  tags?: Dict.t<string>,
-  extra?: Dict.t<JSON.t>,
-  user?: {id?: string, email?: string, username?: string},
-}
-
-// Transport type for custom transports (e.g., sentry-testkit)
-type transport = FrontmanBindings.Bindings__Sentry__Transport.t
+// Re-export shared types for convenience
+type severity = Types.severity
+type breadcrumb = Types.breadcrumb
+type eventHint = Types.eventHint
+type sentryEvent = Types.sentryEvent
+type scopeContext = Types.scopeContext
+type transport = Types.transport
 
 // Standard Sentry init options
 type initOptions = {
@@ -33,6 +22,7 @@ type initOptions = {
   debug?: bool,
   enabled?: bool,
   initialScope?: scopeContext,
+  beforeSend?: (sentryEvent, eventHint) => Nullable.t<sentryEvent>,
 }
 
 type initOptionsWithTransport = {
@@ -45,6 +35,7 @@ type initOptionsWithTransport = {
   enabled?: bool,
   initialScope?: scopeContext,
   transport: transport,
+  beforeSend?: (sentryEvent, eventHint) => Nullable.t<sentryEvent>,
 }
 
 // Main Sentry functions from @sentry/nextjs

--- a/libs/frontman-nextjs/test/FrontmanNextjs__Sentry.test.res
+++ b/libs/frontman-nextjs/test/FrontmanNextjs__Sentry.test.res
@@ -1,6 +1,8 @@
 open Vitest
 
 module Sentry = FrontmanNextjs__Sentry
+module SentryTypes = FrontmanBindings.Bindings__Sentry__Types
+module SentryFilter = FrontmanBindings.Bindings__Sentry__Filter
 module SentryTestkit = FrontmanBindings.Bindings__Test__SentryTestkit
 
 describe("FrontmanNextjs Sentry", () => {
@@ -294,5 +296,244 @@ describe("FrontmanNextjs Sentry", () => {
         }
       },
     )
+  })
+
+  describe("beforeSend filtering", () => {
+    describe("hasFrontmanFrames", () => {
+      test(
+        "returns true for events with no exception (e.g. captureMessage)",
+        t => {
+          let event: SentryTypes.sentryEvent = {exception_: None}
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true for exception with no values",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({values: None}),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true for exception with empty values array",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({values: Some([])}),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true for exception with no stacktrace",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([{stacktrace: None}]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true for exception with empty frames array",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({frames: Some([])}),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true when a frame contains frontman in filename",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {filename: Some("/node_modules/.pnpm/next/dist/server.js")},
+                      {
+                        filename: Some(
+                          "/node_modules/.pnpm/@frontman-ai+nextjs/dist/instrumentation.js",
+                        ),
+                      },
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns true when a frame contains FrontmanNextjs in filename",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {
+                        filename: Some(
+                          "/libs/frontman-nextjs/src/FrontmanNextjs__Middleware.res.mjs",
+                        ),
+                      },
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "returns false when all frames are third-party (Next.js/Turbopack)",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {
+                        filename: Some(
+                          "/my-website/.next/dev/server/chunks/ssr/b142f_next_dist.js",
+                        ),
+                      },
+                      {
+                        filename: Some(
+                          "/my-website/.next/dev/server/chunks/5fae1__pnpm_164ddc1c._.js",
+                        ),
+                      },
+                      {filename: Some("node:internal/deps/undici/undici")},
+                      {filename: Some("node:internal/process/task_queues")},
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(false)
+        },
+      )
+
+      test(
+        "returns false when all frames have no filename",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([{filename: None}, {filename: None}]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(false)
+        },
+      )
+
+      test(
+        "is case-insensitive for filename matching",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {filename: Some("/path/to/FRONTMAN-NEXTJS/dist/index.js")},
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          t->expect(SentryFilter.hasFrontmanFrames(event))->Expect.toBe(true)
+        },
+      )
+    })
+
+    describe("beforeSend", () => {
+      test(
+        "keeps events with Frontman frames",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {
+                        filename: Some(
+                          "/node_modules/@frontman-ai/nextjs/dist/instrumentation.js",
+                        ),
+                      },
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          let hint: SentryTypes.eventHint = {}
+          let result = SentryFilter.beforeSend(event, hint)
+          t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
+        },
+      )
+
+      test(
+        "drops events with only third-party frames",
+        t => {
+          let event: SentryTypes.sentryEvent = {
+            exception_: Some({
+              values: Some([
+                {
+                  stacktrace: Some({
+                    frames: Some([
+                      {filename: Some("/next/dist/server/chunks/ssr/dedupeFetch.js")},
+                      {filename: Some("node:internal/deps/undici/undici")},
+                    ]),
+                  }),
+                },
+              ]),
+            }),
+          }
+          let hint: SentryTypes.eventHint = {}
+          let result = SentryFilter.beforeSend(event, hint)
+          t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(false)
+        },
+      )
+
+      test(
+        "keeps captureMessage events (no exception)",
+        t => {
+          let event: SentryTypes.sentryEvent = {exception_: None}
+          let hint: SentryTypes.eventHint = {}
+          let result = SentryFilter.beforeSend(event, hint)
+          t->expect(result->Nullable.toOption->Option.isSome)->Expect.toBe(true)
+        },
+      )
+    })
   })
 })


### PR DESCRIPTION
# User description
## Summary

- Extract shared Sentry types, config (DSN, `isInternalDev`), and `beforeSend` filter into `@frontman/bindings` so all framework integrations share a single source of truth
- Add `beforeSend` hook that inspects stacktrace frames and drops events not originating from Frontman code, preventing noise from Next.js/Turbopack internals (e.g. source-map WASM fetch failures)
- Wire the filter into both `@frontman-ai/nextjs` and `@frontman/frontman-client` (previously only nextjs had it)
- Add tests for the shared filter in both consumer libs

## New shared modules in `libs/bindings/`

| File | Purpose |
|---|---|
| `Bindings__Sentry__Types.res` | Shared types: severity, breadcrumb, eventHint, sentryEvent, scopeContext, etc. |
| `Bindings__Sentry__Config.res` | Single source of truth for DSN + `isInternalDev()` |
| `Bindings__Sentry__Filter.res` | `beforeSend` filter that drops non-Frontman error events |

## Test results

- **frontman-nextjs**: 161 tests passed
- **frontman-client**: 57 tests passed

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extracts shared Sentry types, configuration, and filtering logic into a centralized bindings library to ensure a single source of truth across all framework integrations. Implements a <code>beforeSend</code> hook that filters out error events not originating from Frontman code by inspecting stacktrace frames.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/frontman-ai/frontman/455?tool=ast&topic=Shared+Sentry+Core>Shared Sentry Core</a>
        </td><td>Establish a centralized Sentry infrastructure in <code>libs/bindings</code> including shared types, DSN configuration, and a <code>beforeSend</code> filter logic.<details><summary>Modified files (3)</summary><ul><li>libs/bindings/src/Bindings__Sentry__Config.res</li>
<li>libs/bindings/src/Bindings__Sentry__Filter.res</li>
<li>libs/bindings/src/Bindings__Sentry__Types.res</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/frontman-ai/frontman/455?tool=ast&topic=Library+Integration>Library Integration</a>
        </td><td>Integrate the shared Sentry filter and configuration into <code>@frontman/frontman-client</code> and <code>@frontman-ai/nextjs</code>, supported by comprehensive unit tests.<details><summary>Modified files (7)</summary><ul><li>.changeset/filter-third-party-sentry.md</li>
<li>libs/frontman-client/src/FrontmanClient__Sentry.res</li>
<li>libs/frontman-client/src/FrontmanClient__Sentry__Bindings.res</li>
<li>libs/frontman-client/test/FrontmanClient__Sentry.test.res</li>
<li>libs/frontman-nextjs/src/FrontmanNextjs__Sentry.res</li>
<li>libs/frontman-nextjs/src/FrontmanNextjs__Sentry__Bindings.res</li>
<li>libs/frontman-nextjs/test/FrontmanNextjs__Sentry.test.res</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>BlueHotDog@users.norep...</td><td>fix-suppress-Sentry-er...</td><td>February 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/frontman-ai/frontman/455?tool=ast>(Baz)</a>.