### PR TITLE
chore: rename publishable packages to @frontman-ai/ scope

### DIFF
--- a/.changeset/annotation-system.md
+++ b/.changeset/annotation-system.md
@@ -1,5 +1,5 @@
 ---
-"@frontman/client": minor
+"@frontman-ai/client": minor
 ---
 
 Replace element picker with annotation system. Users can now pin multiple elements on the page as numbered annotations, add/remove them freely, and reference them in chat. The server interaction schema and prompts are updated to handle annotation-based context instead of single element selections.

--- a/.changeset/containerized-worktrees-infra.md
+++ b/.changeset/containerized-worktrees-infra.md
@@ -1,6 +1,6 @@
 ---
 "@frontman-ai/astro": patch
-"@frontman/client": patch
+"@frontman-ai/client": patch
 ---
 
 Fix trailing-slash 404 on Frontman API routes behind reverse proxy and mixed-content URL scheme mismatch when running behind TLS-terminating proxy (Caddy). Add containerized worktree infrastructure with Podman pods for parallel isolated development.

--- a/.changeset/filter-third-party-sentry.md
+++ b/.changeset/filter-third-party-sentry.md
@@ -1,6 +1,6 @@
 ---
 "@frontman-ai/nextjs": patch
-"@frontman/frontman-client": patch
+"@frontman-ai/frontman-client": patch
 ---
 
-Filter third-party errors from Frontman's internal Sentry reporting. Extracts shared Sentry types, config (DSN, internal-dev detection), and a `beforeSend` filter into `@frontman/bindings` so all framework integrations share a single source of truth. The filter inspects stacktrace frames and drops events that don't originate from Frontman code, preventing noise from framework internals (e.g. Next.js/Turbopack source-map WASM fetch failures). Both `@frontman-ai/nextjs` and `@frontman/frontman-client` now use this shared filter.
+Filter third-party errors from Frontman's internal Sentry reporting. Extracts shared Sentry types, config (DSN, internal-dev detection), and a `beforeSend` filter into `@frontman/bindings` so all framework integrations share a single source of truth. The filter inspects stacktrace frames and drops events that don't originate from Frontman code, preventing noise from framework internals (e.g. Next.js/Turbopack source-map WASM fetch failures). Both `@frontman-ai/nextjs` and `@frontman-ai/frontman-client` now use this shared filter.

--- a/.changeset/fix-selection-cursor-crosshair.md
+++ b/.changeset/fix-selection-cursor-crosshair.md
@@ -1,5 +1,5 @@
 ---
-"@frontman/client": patch
+"@frontman-ai/client": patch
 ---
 
 Fix selection mode cursor reverting to pointer/hand on interactive elements inside iframe. Replaced body-level inline cursor style with an injected `<style>` tag using `* { cursor: crosshair !important; }` so that buttons, links, and inputs can't override the crosshair during selection mode.

--- a/.changeset/migrate-console-to-logs.md
+++ b/.changeset/migrate-console-to-logs.md
@@ -1,5 +1,5 @@
 ---
-"@frontman/client": patch
+"@frontman-ai/client": patch
 "@frontman/react-statestore": patch
 "@frontman/logs": patch
 ---

--- a/.changeset/pure-bindings-refactor.md
+++ b/.changeset/pure-bindings-refactor.md
@@ -1,10 +1,10 @@
 ---
 "@frontman/bindings": patch
-"@frontman/frontman-core": patch
+"@frontman-ai/frontman-core": patch
 "@frontman-ai/nextjs": patch
-"@frontman/frontman-client": patch
+"@frontman-ai/frontman-client": patch
 "@frontman-ai/astro": patch
-"@frontman/frontman-protocol": patch
+"@frontman-ai/frontman-protocol": patch
 ---
 
 Enforce pure bindings architecture: extract all business logic from `@frontman/bindings` to domain packages, delete dead code, rename Sentry modules, and fix circular dependency in frontman-protocol.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,7 @@ jobs:
       # write .res.mjs output to src/, not lib/.  Restoring stale lib/
       # metadata without the corresponding src/*.res.mjs files causes
       # ReScript to skip recompilation, leaving tsup unable to resolve
-      # imports like @frontman/frontman-core/src/FrontmanCore__Hosts.res.mjs.
+      # imports like @frontman-ai/frontman-core/src/FrontmanCore__Hosts.res.mjs.
       - name: Cache JS build artifacts
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         id: js-build-cache

--- a/apps/dogfooding/README.md
+++ b/apps/dogfooding/README.md
@@ -1,3 +1,3 @@
 # Dogfooding
 
-A vite app that hosts @frontman/client together with a plugin that hosts frontman-agent
+A vite app that hosts @frontman-ai/client together with a plugin that hosts frontman-agent

--- a/apps/dogfooding/bootstrap.js
+++ b/apps/dogfooding/bootstrap.js
@@ -1,2 +1,2 @@
-import "http://localhost:6123/node_modules/@frontman/client/dist/index.css"
-import "http://localhost:6123/node_modules/@frontman/client/dist/index.js"
+import "http://localhost:6123/node_modules/@frontman-ai/client/dist/index.css"
+import "http://localhost:6123/node_modules/@frontman-ai/client/dist/index.js"

--- a/apps/dogfooding/package.json
+++ b/apps/dogfooding/package.json
@@ -20,7 +20,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@frontman/client": "0.1.6",
+		"@frontman-ai/client": "0.1.6",
 		"@frontman-ai/vite": "workspace:*",
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0"

--- a/apps/dogfooding/vite.config.ts
+++ b/apps/dogfooding/vite.config.ts
@@ -8,7 +8,7 @@ const fixReactImports = (): vite.Plugin => {
 		enforce: "pre",
 		transform(code, id) {
 			// Only transform the client library files
-			if (id.includes("@frontman/client") || id.includes("node_modules/@frontman/client")) {
+			if (id.includes("@frontman-ai/client") || id.includes("node_modules/@frontman-ai/client")) {
 				// React 19 should export jsxs and Fragment from jsx-runtime, but if there are issues,
 				// we can log them for debugging
 				return code;
@@ -24,7 +24,7 @@ export default vite.defineConfig({
 	},
 	optimizeDeps: {
 		include: ["react", "react-dom", "react/jsx-runtime"],
-		exclude: ["@frontman/client"],
+		exclude: ["@frontman-ai/client"],
 	},
 	resolve: {
 		dedupe: ["react", "react-dom"],

--- a/apps/frontman_server/assets/js/browser-test.js
+++ b/apps/frontman_server/assets/js/browser-test.js
@@ -1,7 +1,7 @@
 // Re-export frontman-client modules for browser-test page
-export * as ACP from '@frontman/frontman-client/src/FrontmanClient__ACP.res.mjs';
-export * as MCP from '@frontman/frontman-client/src/FrontmanClient__MCP.res.mjs';
-export * as MCPServer from '@frontman/frontman-client/src/FrontmanClient__MCP__Server.res.mjs';
-export * as Relay from '@frontman/frontman-client/src/FrontmanClient__Relay.res.mjs';
-export * as Socket from '@frontman/frontman-client/src/FrontmanClient__Phoenix__Socket.res.mjs';
-export * as Channel from '@frontman/frontman-client/src/FrontmanClient__Phoenix__Channel.res.mjs';
+export * as ACP from '@frontman-ai/frontman-client/src/FrontmanClient__ACP.res.mjs';
+export * as MCP from '@frontman-ai/frontman-client/src/FrontmanClient__MCP.res.mjs';
+export * as MCPServer from '@frontman-ai/frontman-client/src/FrontmanClient__MCP__Server.res.mjs';
+export * as Relay from '@frontman-ai/frontman-client/src/FrontmanClient__Relay.res.mjs';
+export * as Socket from '@frontman-ai/frontman-client/src/FrontmanClient__Phoenix__Socket.res.mjs';
+export * as Channel from '@frontman-ai/frontman-client/src/FrontmanClient__Phoenix__Channel.res.mjs';

--- a/apps/frontman_server/assets/package.json
+++ b/apps/frontman_server/assets/package.json
@@ -4,6 +4,6 @@
 	"license": "AGPL-3.0-only",
 	"private": true,
 	"dependencies": {
-		"@frontman/frontman-client": "workspace:*"
+		"@frontman-ai/frontman-client": "workspace:*"
 	}
 }

--- a/libs/client/CHANGELOG.md
+++ b/libs/client/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @frontman/client
+# @frontman-ai/client
 
 ## 0.5.1
 

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,5 +1,8 @@
 {
-	"name": "@frontman/client",
+	"name": "@frontman-ai/client",
+	"publishConfig": {
+		"access": "public"
+	},
 	"version": "0.5.1",
 	"description": "React UI component library for Frontman",
 	"license": "Apache-2.0",
@@ -41,10 +44,10 @@
 		"@ai-sdk/react": "^2.0.92",
 		"@babel/core": "^7.29.0",
 		"@biomejs/biome": "^2.3.5",
+		"@frontman-ai/frontman-client": "workspace:*",
+		"@frontman-ai/frontman-protocol": "workspace:*",
 		"@frontman-ai/nextjs": "workspace:*",
 		"@frontman/bindings": "workspace:*",
-		"@frontman/frontman-client": "workspace:*",
-		"@frontman/frontman-protocol": "workspace:*",
 		"@frontman/logs": "workspace:*",
 		"@frontman/react-statestore": "workspace:*",
 		"@medv/finder": "^4.0.2",

--- a/libs/client/rescript.json
+++ b/libs/client/rescript.json
@@ -1,5 +1,5 @@
 {
-	"name": "@frontman/client",
+	"name": "@frontman-ai/client",
 	"namespace": true,
 	"sources": [
 		{
@@ -31,9 +31,9 @@
 		"@frontman/logs",
 		"@rescript/react",
 		"@rescript/webapi",
-		"@frontman/frontman-client",
+		"@frontman-ai/frontman-client",
 		"@frontman-ai/nextjs",
-		"@frontman/frontman-protocol",
+		"@frontman-ai/frontman-protocol",
 		"@frontman/react-statestore",
 		"sury"
 	],

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -8,10 +8,10 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #ConnectionReducer
 })
 
-module ACP = FrontmanFrontmanClient.FrontmanClient__ACP
-module Relay = FrontmanFrontmanClient.FrontmanClient__Relay
-module MCPServer = FrontmanFrontmanClient.FrontmanClient__MCP__Server
-module Channel = FrontmanFrontmanClient.FrontmanClient__Phoenix__Channel
+module ACP = FrontmanAiFrontmanClient.FrontmanClient__ACP
+module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
+module MCPServer = FrontmanAiFrontmanClient.FrontmanClient__MCP__Server
+module Channel = FrontmanAiFrontmanClient.FrontmanClient__Phoenix__Channel
 
 // Configuration for initialization
 type initConfig = {
@@ -83,14 +83,14 @@ type action =
   | SessionCreateSuccess(ACP.session)
   | SessionCreateError(string)
   | CreateSession({
-      onUpdate: (string, FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
-      onMcpMessage: (FrontmanFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
+      onUpdate: (string, FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
+      onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
       onComplete: result<string, string> => unit,
     })
   | SendPrompt({
       text: string,
-      additionalBlocks: array<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
-      onComplete: result<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
+      additionalBlocks: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
+      onComplete: result<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
       metadata: option<JSON.t>,
     })
   | PromptSent
@@ -98,8 +98,8 @@ type action =
   | LoadTask({
       taskId: string,
       needsHistory: bool,
-      onUpdate: (string, FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
-      onMcpMessage: (FrontmanFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
+      onUpdate: (string, FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
+      onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
       onComplete: result<unit, string> => unit,
     })
   | DeleteSession({taskId: string, onComplete: result<unit, string> => unit})
@@ -118,15 +118,15 @@ type effect =
   | CreateSessionEffect({
       connection: ACP.connection,
       mcpServer: MCPServer.t,
-      onUpdate: (string, FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
-      onMcpMessage: (FrontmanFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
+      onUpdate: (string, FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
+      onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
       onComplete: result<string, string> => unit,
     })
   | SendPromptEffect({
       session: ACP.session,
       text: string,
-      additionalBlocks: array<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
-      onComplete: result<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
+      additionalBlocks: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
+      onComplete: result<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
       metadata: option<JSON.t>,
     })
   | CancelPromptEffect({session: ACP.session})
@@ -136,8 +136,8 @@ type effect =
       mcpServer: MCPServer.t,
       taskId: string,
       needsHistory: bool,
-      onUpdate: (string, FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
-      onMcpMessage: (FrontmanFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
+      onUpdate: (string, FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionUpdate) => unit,
+      onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
       onComplete: result<unit, string> => unit,
     })
   | DeleteSessionEffect({connection: ACP.connection, taskId: string, onComplete: result<unit, string> => unit})

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -5,10 +5,10 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #FrontmanProvider
 })
 
-module ACP = FrontmanFrontmanClient.FrontmanClient__ACP
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
-module Relay = FrontmanFrontmanClient.FrontmanClient__Relay
-module MCPServer = FrontmanFrontmanClient.FrontmanClient__MCP__Server
+module ACP = FrontmanAiFrontmanClient.FrontmanClient__ACP
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
+module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
+module MCPServer = FrontmanAiFrontmanClient.FrontmanClient__MCP__Server
 module Reducer = Client__ConnectionReducer
 module StateReducer = FrontmanReactStatestore.StateReducer
 module RuntimeConfig = Client__RuntimeConfig
@@ -90,7 +90,7 @@ module Provider = {
     })
 
     let logMCPMessage = React.useCallback0((direction, payload) => {
-      let arrow = direction == FrontmanFrontmanClient.FrontmanClient__MCP.Send ? `→` : `←`
+      let arrow = direction == FrontmanAiFrontmanClient.FrontmanClient__MCP.Send ? `→` : `←`
       Log.debug(~ctx={"payload": payload}, `MCP ${arrow}`)
     })
 

--- a/libs/client/src/Client__PlanDisplay.res
+++ b/libs/client/src/Client__PlanDisplay.res
@@ -5,7 +5,7 @@
  */
 
 module PlanList = Client__PlanList
-module ACPTypes = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module ACPTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 @react.component
 let make = (~entries: array<ACPTypes.planEntry>) => {

--- a/libs/client/src/Client__ToolRegistry.res
+++ b/libs/client/src/Client__ToolRegistry.res
@@ -1,7 +1,7 @@
 // Client-side Tool Registry - composable browser tool collection
 // Mirrors the server-side FrontmanCore__ToolRegistry pattern
 
-module FrontmanClient = FrontmanFrontmanClient
+module FrontmanClient = FrontmanAiFrontmanClient
 module MCPServer = FrontmanClient.FrontmanClient__MCP__Server
 module Tool = FrontmanClient.FrontmanClient__MCP__Tool
 

--- a/libs/client/src/components/frontman/Client__PlanList.res
+++ b/libs/client/src/components/frontman/Client__PlanList.res
@@ -6,7 +6,7 @@
  */
 
 module Icons = Client__ToolIcons
-module ACPTypes = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module ACPTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 // Status helpers
 let statusToCompleted = (status: ACPTypes.planEntryStatus): bool => {

--- a/libs/client/src/state/Client__StateSnapshot.res
+++ b/libs/client/src/state/Client__StateSnapshot.res
@@ -9,7 +9,7 @@ S.enableJson()
  */
 
 // Re-export plan entry types from frontman-client (they already have Sury schemas)
-module ACPTypes = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module ACPTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 // ============================================================================
 // Schema Helpers

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -83,7 +83,7 @@ type action =
   // Session loading actions
   | SessionsLoadStarted
   | SessionsLoadSuccess({
-      sessions: array<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary>,
+      sessions: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary>,
     })
   | SessionsLoadError({error: string})
 

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -78,7 +78,7 @@ module Todo = {
 }
 
 // Re-export ACP types for convenience
-module ACPTypes = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module ACPTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 module Task = {
   // ============================================================================

--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -4,7 +4,7 @@
 // start narrow, drill down, never dump the full page.
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.getDom

--- a/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
+++ b/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
@@ -3,7 +3,7 @@
 // accessible names, and CSS selectors for use by interact_with_element.
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.getInteractiveElements

--- a/libs/client/src/tools/Client__Tool__InteractWithElement.res
+++ b/libs/client/src/tools/Client__Tool__InteractWithElement.res
@@ -3,7 +3,7 @@
 // Elements can be targeted by CSS selector, role+name, or text content.
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.interactWithElement

--- a/libs/client/src/tools/Client__Tool__Navigate.res
+++ b/libs/client/src/tools/Client__Tool__Navigate.res
@@ -2,7 +2,7 @@
 // Supports: goto URL, back, forward, refresh
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.navigate

--- a/libs/client/src/tools/Client__Tool__SearchText.res
+++ b/libs/client/src/tools/Client__Tool__SearchText.res
@@ -3,7 +3,7 @@
 // and returns matches with surrounding context and CSS selectors.
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.searchText

--- a/libs/client/src/tools/Client__Tool__SetDeviceMode.res
+++ b/libs/client/src/tools/Client__Tool__SetDeviceMode.res
@@ -2,7 +2,7 @@
 // Allows the agent to simulate mobile/tablet/desktop viewports
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.setDeviceMode

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -2,7 +2,7 @@
 // Captures the document body from the previewFrame
 
 S.enableJson()
-module Tool = FrontmanFrontmanClient.FrontmanClient__MCP__Tool
+module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.takeScreenshot

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -1,9 +1,9 @@
 open Vitest
 
 module Reducer = Client__ConnectionReducer
-module ACP = FrontmanFrontmanClient.FrontmanClient__ACP
-module Relay = FrontmanFrontmanClient.FrontmanClient__Relay
-module MCPServer = FrontmanFrontmanClient.FrontmanClient__MCP__Server
+module ACP = FrontmanAiFrontmanClient.FrontmanClient__ACP
+module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
+module MCPServer = FrontmanAiFrontmanClient.FrontmanClient__MCP__Server
 
 // Helper to check if effect list contains a specific effect type
 let hasEffect = (effects, predicate) => effects->Array.some(predicate)

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -881,7 +881,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
   test("SessionsLoadSuccess adds sessions to tasks dict", t => {
     let state = Reducer.defaultState
 
-    let sessions: array<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary> = [
+    let sessions: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary> = [
       {
         sessionId: "session-1",
         title: "First Session",
@@ -955,7 +955,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
     }
 
     // Load sessions including one with the same ID as existing task
-    let sessions: array<FrontmanFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary> = [
+    let sessions: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionSummary> = [
       {
         sessionId: "session-1",
         title: "Should Not Overwrite",

--- a/libs/frontman-astro/package.json
+++ b/libs/frontman-astro/package.json
@@ -63,9 +63,9 @@
 		"access": "public"
 	},
 	"devDependencies": {
+		"@frontman-ai/frontman-core": "*",
+		"@frontman-ai/frontman-protocol": "*",
 		"@frontman/bindings": "*",
-		"@frontman/frontman-core": "*",
-		"@frontman/frontman-protocol": "*",
 		"@rescript/runtime": "12.0.0-beta.14",
 		"@rescript/webapi": "*",
 		"@vitest/ui": "catalog:",

--- a/libs/frontman-astro/rescript.json
+++ b/libs/frontman-astro/rescript.json
@@ -18,8 +18,8 @@
 	"dependencies": [
 		"@rescript/webapi",
 		"sury",
-		"@frontman/frontman-protocol",
-		"@frontman/frontman-core",
+		"@frontman-ai/frontman-protocol",
+		"@frontman-ai/frontman-core",
 		"@frontman/bindings"
 	],
 	"jsx": {

--- a/libs/frontman-astro/src/FrontmanAstro.res
+++ b/libs/frontman-astro/src/FrontmanAstro.res
@@ -14,7 +14,7 @@ module Integration = FrontmanAstro__Integration
 module ViteAdapter = FrontmanAstro__ViteAdapter
 
 // Re-export core SSE for convenience
-module SSE = FrontmanFrontmanCore.FrontmanCore__SSE
+module SSE = FrontmanAiFrontmanCore.FrontmanCore__SSE
 
 // The main integration factory - accepts optional config
 // This is also exported as default for `astro add` compatibility

--- a/libs/frontman-astro/src/FrontmanAstro__Config.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Config.res
@@ -1,7 +1,7 @@
 // Astro configuration for Frontman
 
 module Bindings = FrontmanBindings
-module Hosts = FrontmanFrontmanCore.FrontmanCore__Hosts
+module Hosts = FrontmanAiFrontmanCore.FrontmanCore__Hosts
 
 // Default host can be overridden via FRONTMAN_HOST env var for remote development
 let defaultHost = switch Bindings.Process.env->Dict.get("FRONTMAN_HOST") {

--- a/libs/frontman-astro/src/FrontmanAstro__Integration.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Integration.res
@@ -114,7 +114,7 @@ let make = (configInput: Config.jsConfigInput): Bindings.astroIntegration => {
         ({server, toolbar}) => {
           // Initialize core LogCapture to intercept console/stdout for the
           // get_logs tool and post-edit error checking in edit_file
-          FrontmanFrontmanCore.FrontmanCore__LogCapture.initialize()
+          FrontmanAiFrontmanCore.FrontmanCore__LogCapture.initialize()
 
           // Rewrite Frontman routes so Astro's trailingSlash: "always" doesn't
           // 404 them. Astro's trailing-slash check runs inside its Connect

--- a/libs/frontman-astro/src/FrontmanAstro__Middleware.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Middleware.res
@@ -7,7 +7,7 @@
 
 module Config = FrontmanAstro__Config
 module ToolRegistry = FrontmanAstro__ToolRegistry
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreMiddleware = Core.FrontmanCore__Middleware
 module CoreMiddlewareConfig = Core.FrontmanCore__MiddlewareConfig
 

--- a/libs/frontman-astro/src/FrontmanAstro__Server.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Server.res
@@ -1,7 +1,7 @@
 // Request handlers for Frontman Astro endpoints
 // Thin wrapper around shared core request handlers
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRequestHandlers = Core.FrontmanCore__RequestHandlers
 module CoreCORS = Core.FrontmanCore__CORS
 module ToolRegistry = FrontmanAstro__ToolRegistry

--- a/libs/frontman-astro/src/FrontmanAstro__ToolRegistry.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ToolRegistry.res
@@ -1,6 +1,6 @@
 // Tool registry for Astro - composes core tools with Astro specific tools
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRegistry = Core.FrontmanCore__ToolRegistry
 
 // Re-export types from core

--- a/libs/frontman-astro/src/FrontmanAstro__ViteAdapter.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ViteAdapter.res
@@ -6,7 +6,7 @@
 
 module NodeHttp = FrontmanBindings.NodeHttp
 module WebStreams = FrontmanBindings.WebStreams
-module CoreMiddleware = FrontmanFrontmanCore.FrontmanCore__Middleware
+module CoreMiddleware = FrontmanAiFrontmanCore.FrontmanCore__Middleware
 
 // Collect the full request body by async-iterating over the IncomingMessage stream
 let collectRequestBody: NodeHttp.incomingMessage => promise<NodeHttp.Buffer.t> = %raw(`

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__EditFile.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__EditFile.res
@@ -4,8 +4,8 @@
 // errors 800ms after the edit. This gives Astro/Vite's HMR time to process
 // the change and report any issues.
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module Core = FrontmanFrontmanCore
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Core = FrontmanAiFrontmanCore
 module CoreEditFile = Core.FrontmanCore__Tool__EditFile
 module LogCapture = Core.FrontmanCore__LogCapture
 

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetLogs.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetLogs.res
@@ -1,7 +1,7 @@
 // Astro GetLogs tool - retrieves dev server logs from the core LogCapture buffer
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module Core = FrontmanFrontmanCore
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Core = FrontmanAiFrontmanCore
 module LogCapture = Core.FrontmanCore__LogCapture
 module CircularBuffer = Core.FrontmanCore__CircularBuffer
 

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
@@ -3,8 +3,8 @@
 
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module PathContext = FrontmanFrontmanCore.FrontmanCore__PathContext
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module PathContext = FrontmanAiFrontmanCore.FrontmanCore__PathContext
 
 let name = "get_client_pages"
 let visibleToAgent = true

--- a/libs/frontman-astro/tsup.config.ts
+++ b/libs/frontman-astro/tsup.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'tsup';
 
 const sharedNoExternal = [
-  '@frontman/frontman-core',
-  '@frontman/frontman-protocol',
+  '@frontman-ai/frontman-core',
+  '@frontman-ai/frontman-protocol',
   '@frontman/bindings',
   '@rescript/runtime',
   'sury',

--- a/libs/frontman-client/CHANGELOG.md
+++ b/libs/frontman-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-client
+# @frontman-ai/frontman-client
 
 ## 0.3.1
 

--- a/libs/frontman-client/README.md
+++ b/libs/frontman-client/README.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-client
+# @frontman-ai/frontman-client
 
 Browser-based client library implementing MCP (Model Context Protocol) server for AI agent tool execution, with support for multiple transport mechanisms.
 
@@ -63,7 +63,7 @@ let channel = Phoenix__Channel.create(socket, "agent:lobby")
 ## Dependencies
 
 - `phoenix` ^1.7.0 - WebSocket transport
-- `@frontman/frontman-protocol` - Type definitions
+- `@frontman-ai/frontman-protocol` - Type definitions
 
 ## Commands
 

--- a/libs/frontman-client/package.json
+++ b/libs/frontman-client/package.json
@@ -1,5 +1,8 @@
 {
-	"name": "@frontman/frontman-client",
+	"name": "@frontman-ai/frontman-client",
+	"publishConfig": {
+		"access": "public"
+	},
 	"version": "0.3.1",
 	"description": "Browser-side client for Frontman",
 	"license": "Apache-2.0",

--- a/libs/frontman-client/rescript.json
+++ b/libs/frontman-client/rescript.json
@@ -1,5 +1,5 @@
 {
-	"name": "@frontman/frontman-client",
+	"name": "@frontman-ai/frontman-client",
 	"namespace": true,
 	"sources": [
 		{
@@ -20,7 +20,7 @@
 		}
 	],
 	"ppx-flags": ["sury-ppx/bin"],
-	"dependencies": ["@rescript/webapi", "sury", "@frontman/bindings", "@frontman/frontman-protocol", "@frontman/logs"],
+	"dependencies": ["@rescript/webapi", "sury", "@frontman/bindings", "@frontman-ai/frontman-protocol", "@frontman/logs"],
 	"dev-dependencies": ["rescript-vitest"],
 	"jsx": {
 		"version": 4

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -1,7 +1,7 @@
 // Main ACP Client entry point
 // Thin orchestrator - delegates to Protocol for messaging, uses Constants for topics
 
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 module Client = FrontmanClient__ACP__Client
 module Protocol = FrontmanClient__ACP__Protocol
 module Channel = FrontmanClient__Phoenix__Channel

--- a/libs/frontman-client/src/FrontmanClient__ACP__Client.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Client.res
@@ -1,8 +1,8 @@
 // ACP Client - handles Agent Client Protocol communication
 // Uses pure state reducer pattern
 
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
-module JsonRpc = FrontmanFrontmanProtocol.FrontmanProtocol__JsonRpc
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
+module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 module Channel = FrontmanClient__Phoenix__Channel
 module Decoders = FrontmanClient__Decoders
 module Log = FrontmanLogs.Logs.Make({

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -1,10 +1,10 @@
 // ACP Protocol helpers
 // Centralizes JSON-RPC request/response pattern and message handling
 
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 module Client = FrontmanClient__ACP__Client
 module Channel = FrontmanClient__Phoenix__Channel
-module JsonRpc = FrontmanFrontmanProtocol.FrontmanProtocol__JsonRpc
+module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 module Constants = FrontmanClient__Transport__Constants
 
 type messageDirection = Send | Receive

--- a/libs/frontman-client/src/FrontmanClient__MCP.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP.res
@@ -4,7 +4,7 @@
 
 module Types = FrontmanClient__MCP__Types
 module Channel = FrontmanClient__Phoenix__Channel
-module JsonRpc = FrontmanFrontmanProtocol.FrontmanProtocol__JsonRpc
+module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 module Decoders = FrontmanClient__Decoders
 module Log = FrontmanLogs.Logs.Make({
   let component = #MCP

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -3,7 +3,7 @@
 
 module Types = FrontmanClient__MCP__Types
 module Tool = FrontmanClient__MCP__Tool
-module ToolNames = FrontmanFrontmanProtocol.FrontmanProtocol__Tool.ToolNames
+module ToolNames = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ToolNames
 module Relay = FrontmanClient__Relay
 module Log = FrontmanLogs.Logs.Make({
   let component = #MCPServer

--- a/libs/frontman-client/src/FrontmanClient__MCP__Tool.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Tool.res
@@ -1,4 +1,4 @@
 // Re-export from protocol package
-type toolResult<'a> = FrontmanFrontmanProtocol.FrontmanProtocol__Tool.toolResult<'a>
-module type Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool.BrowserTool
-module ToolNames = FrontmanFrontmanProtocol.FrontmanProtocol__Tool.ToolNames
+type toolResult<'a> = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.toolResult<'a>
+module type Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.BrowserTool
+module ToolNames = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ToolNames

--- a/libs/frontman-client/src/FrontmanClient__MCP__Types.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Types.res
@@ -1,2 +1,2 @@
 // Re-export from protocol package
-include FrontmanFrontmanProtocol.FrontmanProtocol__MCP
+include FrontmanAiFrontmanProtocol.FrontmanProtocol__MCP

--- a/libs/frontman-client/src/FrontmanClient__Relay__Types.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay__Types.res
@@ -1,2 +1,2 @@
 // Re-export from protocol package
-include FrontmanFrontmanProtocol.FrontmanProtocol__Relay
+include FrontmanAiFrontmanProtocol.FrontmanProtocol__Relay

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -1,8 +1,8 @@
 open Vitest
 
 module Client = FrontmanClient__ACP__Client
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
-module JsonRpc = FrontmanFrontmanProtocol.FrontmanProtocol__JsonRpc
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
+module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 
 describe("ACP Client State Reducer", _t => {
   test("initialState has correct defaults", t => {

--- a/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
@@ -1,6 +1,6 @@
 open Vitest
 
-module Types = FrontmanFrontmanProtocol.FrontmanProtocol__ACP
+module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 describe("ACP Types encoding/decoding", _t => {
   test("initializeParams should encode without throwing", _t => {

--- a/libs/frontman-client/test/FrontmanClient__JsonRpc.test.res
+++ b/libs/frontman-client/test/FrontmanClient__JsonRpc.test.res
@@ -1,6 +1,6 @@
 open Vitest
 
-module JsonRpc = FrontmanFrontmanProtocol.FrontmanProtocol__JsonRpc
+module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 
 describe("JsonRpc Request", _t => {
   test("make creates request with correct fields", t => {

--- a/libs/frontman-core/CHANGELOG.md
+++ b/libs/frontman-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-core
+# @frontman-ai/frontman-core
 
 ## 0.5.1
 

--- a/libs/frontman-core/README.md
+++ b/libs/frontman-core/README.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-core
+# @frontman-ai/frontman-core
 
 Core server functionality shared across framework adapters, providing a composable tool registry and HTTP server implementation with built-in file system and code search tools.
 
@@ -60,7 +60,7 @@ let result = await Server.executeTool(registry, "ReadFile", {
 ## Dependencies
 
 - `@frontman/bindings` - File I/O and process execution
-- `@frontman/frontman-protocol` - Tool type definitions
+- `@frontman-ai/frontman-protocol` - Tool type definitions
 - `vscode-ripgrep` - Fast content search
 
 ## Commands

--- a/libs/frontman-core/package.json
+++ b/libs/frontman-core/package.json
@@ -1,5 +1,8 @@
 {
-	"name": "@frontman/frontman-core",
+	"name": "@frontman-ai/frontman-core",
+	"publishConfig": {
+		"access": "public"
+	},
 	"version": "0.5.1",
 	"description": "Core server-side tools for Frontman",
 	"license": "Apache-2.0",
@@ -33,8 +36,8 @@
 		"prepublishOnly": "yarn build"
 	},
 	"dependencies": {
+		"@frontman-ai/frontman-protocol": "0.4.0",
 		"@frontman/bindings": "0.3.0",
-		"@frontman/frontman-protocol": "0.4.0",
 		"@rescript/runtime": "12.0.0-beta.14",
 		"chrome-launcher": "^1.1.2",
 		"lighthouse": "^12.5.1",

--- a/libs/frontman-core/rescript.json
+++ b/libs/frontman-core/rescript.json
@@ -1,5 +1,5 @@
 {
-	"name": "@frontman/frontman-core",
+	"name": "@frontman-ai/frontman-core",
 	"namespace": true,
 	"sources": [
 		{
@@ -20,7 +20,7 @@
 		}
 	],
 	"ppx-flags": ["sury-ppx/bin"],
-	"dependencies": ["@rescript/webapi", "sury", "@frontman/frontman-protocol", "@frontman/bindings"],
+	"dependencies": ["@rescript/webapi", "sury", "@frontman-ai/frontman-protocol", "@frontman/bindings"],
 	"dev-dependencies": ["rescript-vitest"],
 	"jsx": {
 		"version": 4

--- a/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
+++ b/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
@@ -5,7 +5,7 @@
 // - POST /tools/call - execute a tool with SSE streaming
 // - POST /resolve-source-location - resolve source maps
 
-module Protocol = FrontmanFrontmanProtocol
+module Protocol = FrontmanAiFrontmanProtocol
 module MCP = Protocol.FrontmanProtocol__MCP
 module Relay = Protocol.FrontmanProtocol__Relay
 module CoreServer = FrontmanCore__Server

--- a/libs/frontman-core/src/FrontmanCore__SSE.res
+++ b/libs/frontman-core/src/FrontmanCore__SSE.res
@@ -1,6 +1,6 @@
 // SSE (Server-Sent Events) response helpers
 
-module Protocol = FrontmanFrontmanProtocol
+module Protocol = FrontmanAiFrontmanProtocol
 module MCP = Protocol.FrontmanProtocol__MCP
 
 // Format SSE event

--- a/libs/frontman-core/src/FrontmanCore__Server.res
+++ b/libs/frontman-core/src/FrontmanCore__Server.res
@@ -1,6 +1,6 @@
 // Core server execution logic - framework agnostic
 
-module Protocol = FrontmanFrontmanProtocol
+module Protocol = FrontmanAiFrontmanProtocol
 module MCP = Protocol.FrontmanProtocol__MCP
 module Relay = Protocol.FrontmanProtocol__Relay
 module Tool = Protocol.FrontmanProtocol__Tool

--- a/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
@@ -1,6 +1,6 @@
 // Composable Tool Registry - holds and manages tools
 
-module Protocol = FrontmanFrontmanProtocol
+module Protocol = FrontmanAiFrontmanProtocol
 module Tool = Protocol.FrontmanProtocol__Tool
 module Relay = Protocol.FrontmanProtocol__Relay
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
@@ -5,7 +5,7 @@
 // Requires the file to have been read first via read_file.
 
 module Fs = FrontmanBindings.Fs
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 module FileTracker = FrontmanCore__FileTracker
 module Matcher = FrontmanCore__Tool__EditFile__Matcher

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
@@ -1,6 +1,6 @@
 // File exists tool - checks if a file or directory exists
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module SafePath = FrontmanCore__SafePath
 module FsUtils = FrontmanCore__FsUtils
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
@@ -2,7 +2,7 @@
 
 module Path = FrontmanBindings.Path
 module ChildProcess = FrontmanCore__ChildProcess
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.grep

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Lighthouse.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Lighthouse.res
@@ -5,7 +5,7 @@ module ChromeLauncher = FrontmanCore__ChromeLauncher
 module ExnUtils = FrontmanCore__ExnUtils
 module Lighthouse = FrontmanBindings.Lighthouse
 module LighthouseRunner = FrontmanCore__Lighthouse
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let name = Tool.ToolNames.lighthouse
 let visibleToAgent = true

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
@@ -3,7 +3,7 @@
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module ChildProcess = FrontmanCore__ChildProcess
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.listFiles

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
@@ -6,7 +6,7 @@
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module ChildProcess = FrontmanCore__ChildProcess
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 module FsUtils = FrontmanCore__FsUtils
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__LoadAgentInstructions.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__LoadAgentInstructions.res
@@ -2,7 +2,7 @@
 
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module SafePath = FrontmanCore__SafePath
 
 let name = Tool.ToolNames.loadAgentInstructions

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
@@ -1,7 +1,7 @@
 // Read file tool - reads file content with optional offset/limit
 
 module Fs = FrontmanBindings.Fs
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.readFile

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -2,7 +2,7 @@
 
 module Path = FrontmanBindings.Path
 module ChildProcess = FrontmanCore__ChildProcess
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.searchFiles

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
@@ -2,7 +2,7 @@
 
 module Fs = FrontmanBindings.Fs
 module NodeBuffer = FrontmanBindings.NodeBuffer
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.writeFile

--- a/libs/frontman-core/test/FrontmanCore__Middleware.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Middleware.test.res
@@ -3,7 +3,7 @@ open Vitest
 module Middleware = FrontmanCore__Middleware
 module MiddlewareConfig = FrontmanCore__MiddlewareConfig
 module ToolRegistry = FrontmanCore__ToolRegistry
-module Relay = FrontmanFrontmanProtocol.FrontmanProtocol__Relay
+module Relay = FrontmanAiFrontmanProtocol.FrontmanProtocol__Relay
 
 module Helpers = {
   let config: MiddlewareConfig.t = {

--- a/libs/frontman-core/test/FrontmanCore__RequestHandlers.test.res
+++ b/libs/frontman-core/test/FrontmanCore__RequestHandlers.test.res
@@ -2,7 +2,7 @@ open Vitest
 
 module RequestHandlers = FrontmanCore__RequestHandlers
 module ToolRegistry = FrontmanCore__ToolRegistry
-module Relay = FrontmanFrontmanProtocol.FrontmanProtocol__Relay
+module Relay = FrontmanAiFrontmanProtocol.FrontmanProtocol__Relay
 
 module Helpers = {
   let handlerConfig: RequestHandlers.handlerConfig = {

--- a/libs/frontman-core/test/FrontmanCore__SSE.test.res
+++ b/libs/frontman-core/test/FrontmanCore__SSE.test.res
@@ -1,7 +1,7 @@
 open Vitest
 
 module SSE = FrontmanCore__SSE
-module MCP = FrontmanFrontmanProtocol.FrontmanProtocol__MCP
+module MCP = FrontmanAiFrontmanProtocol.FrontmanProtocol__MCP
 
 describe("SSE", _t => {
   test("formats progress event correctly", t => {

--- a/libs/frontman-core/test/FrontmanCore__Tool__Grep.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__Grep.test.res
@@ -3,7 +3,7 @@
 open Vitest
 
 module Grep = FrontmanCore__Tool__Grep
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module Os = FrontmanBindings.Os

--- a/libs/frontman-core/test/FrontmanCore__Tool__Lighthouse.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__Lighthouse.test.res
@@ -4,7 +4,7 @@ open Vitest
 
 module Lighthouse = FrontmanCore__Tool__Lighthouse
 module LighthouseBindings = FrontmanBindings.Lighthouse
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 // Create a mock execution context
 let mockCtx: Tool.serverExecutionContext = {

--- a/libs/frontman-core/test/FrontmanCore__Tool__ListFiles.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__ListFiles.test.res
@@ -3,7 +3,7 @@
 open Vitest
 
 module ListFiles = FrontmanCore__Tool__ListFiles
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module Path = FrontmanBindings.Path
 module ChildProcess = FrontmanCore__ChildProcess
 module Process = FrontmanBindings.Process

--- a/libs/frontman-core/test/FrontmanCore__Tool__ListTree.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__ListTree.test.res
@@ -3,7 +3,7 @@
 open Vitest
 
 module ListTree = FrontmanCore__Tool__ListTree
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module ChildProcess = FrontmanCore__ChildProcess

--- a/libs/frontman-core/test/FrontmanCore__Tool__LoadAgentInstructions.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__LoadAgentInstructions.test.res
@@ -2,7 +2,7 @@ open Vitest
 
 module Tool = FrontmanCore__Tool__LoadAgentInstructions
 module Bindings = FrontmanBindings
-module Protocol = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Protocol = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let fixturesPath = Bindings.Path.join([
   Bindings.Process.cwd(),

--- a/libs/frontman-core/test/FrontmanCore__Tool__SearchFiles.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__SearchFiles.test.res
@@ -3,7 +3,7 @@
 open Vitest
 
 module SearchFiles = FrontmanCore__Tool__SearchFiles
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module Os = FrontmanBindings.Os

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -74,8 +74,8 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@frontman/frontman-core": "*",
-		"@frontman/frontman-protocol": "*",
+		"@frontman-ai/frontman-core": "*",
+		"@frontman-ai/frontman-protocol": "*",
 		"@rescript/runtime": "12.0.0-beta.14",
 		"@rescript/webapi": "*",
 		"@vitest/ui": "catalog:",

--- a/libs/frontman-nextjs/rescript.json
+++ b/libs/frontman-nextjs/rescript.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"ppx-flags": ["sury-ppx/bin"],
-	"dependencies": ["@rescript/webapi", "sury", "@frontman/frontman-protocol", "@frontman/frontman-core", "@frontman/bindings"],
+	"dependencies": ["@rescript/webapi", "sury", "@frontman-ai/frontman-protocol", "@frontman-ai/frontman-core", "@frontman/bindings"],
 	"dev-dependencies": ["rescript-vitest"],
 	"jsx": {
 		"version": 4

--- a/libs/frontman-nextjs/src/FrontmanNextjs.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs.res
@@ -6,7 +6,7 @@ module Middleware = FrontmanNextjs__Middleware
 module Server = FrontmanNextjs__Server
 module ToolRegistry = FrontmanNextjs__ToolRegistry
 
-module SSE = FrontmanFrontmanCore.FrontmanCore__SSE
+module SSE = FrontmanAiFrontmanCore.FrontmanCore__SSE
 
 module OpenTelemetry = FrontmanNextjs__OpenTelemetry
 

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Config.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Config.res
@@ -1,5 +1,5 @@
 module Bindings = FrontmanBindings
-module Hosts = FrontmanFrontmanCore.FrontmanCore__Hosts
+module Hosts = FrontmanAiFrontmanCore.FrontmanCore__Hosts
 
 // Default host can be overridden via env vars for development.
 // Priority:

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Middleware.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Middleware.res
@@ -1,7 +1,7 @@
 // Middleware factory for Next.js
 // Thin wrapper around shared core middleware
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreMiddleware = Core.FrontmanCore__Middleware
 module CoreMiddlewareConfig = Core.FrontmanCore__MiddlewareConfig
 module Server = FrontmanNextjs__Server

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Server.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Server.res
@@ -1,7 +1,7 @@
 // Request handlers for Frontman Next.js endpoints
 // Thin wrapper around shared core request handlers
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRequestHandlers = Core.FrontmanCore__RequestHandlers
 module ToolRegistry = FrontmanNextjs__ToolRegistry
 

--- a/libs/frontman-nextjs/src/FrontmanNextjs__ToolRegistry.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__ToolRegistry.res
@@ -1,6 +1,6 @@
 // Tool registry for Next.js - composes core tools with Next.js specific tools
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRegistry = Core.FrontmanCore__ToolRegistry
 
 // Re-export types from core

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli.res
@@ -2,7 +2,7 @@
 // Usage: npx @frontman-ai/nextjs install --server <host>
 
 module Process = FrontmanBindings.Process
-module Hosts = FrontmanFrontmanCore.FrontmanCore__Hosts
+module Hosts = FrontmanAiFrontmanCore.FrontmanCore__Hosts
 module Install = FrontmanNextjs__Cli__Install
 
 // Parse command line arguments (simple implementation without external deps)

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Detect.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Detect.res
@@ -3,7 +3,7 @@ module Bindings = FrontmanBindings
 module Fs = Bindings.Fs
 module Path = Bindings.Path
 module Process = Bindings.Process
-module FsUtils = FrontmanFrontmanCore.FrontmanCore__FsUtils
+module FsUtils = FrontmanAiFrontmanCore.FrontmanCore__FsUtils
 
 type nextVersion = {
   major: int,

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Install.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Install.res
@@ -1,6 +1,6 @@
 // Install command implementation
 module Bindings = FrontmanBindings
-module ChildProcess = FrontmanFrontmanCore.FrontmanCore__ChildProcess
+module ChildProcess = FrontmanAiFrontmanCore.FrontmanCore__ChildProcess
 module Path = Bindings.Path
 module Process = Bindings.Process
 

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__EditFile.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__EditFile.res
@@ -5,8 +5,8 @@
 // LogCapture (which captures webpack/turbopack output) rather than the
 // core version.
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module Core = FrontmanFrontmanCore
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Core = FrontmanAiFrontmanCore
 module CoreEditFile = Core.FrontmanCore__Tool__EditFile
 module LogCapture = FrontmanNextjs__LogCapture
 

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetLogs.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetLogs.res
@@ -1,4 +1,4 @@
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module LogCapture = FrontmanNextjs__LogCapture
 
 let name = "get_logs"

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
@@ -2,7 +2,7 @@
 
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let name = "get_routes"
 let visibleToAgent = true

--- a/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__AutoEdit.test.res
+++ b/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__AutoEdit.test.res
@@ -15,7 +15,7 @@ module Fs = Bindings.Fs
 module Path = Bindings.Path
 module Process = Bindings.Process
 module Os = Bindings.Os
-module ChildProcess = FrontmanFrontmanCore.FrontmanCore__ChildProcess
+module ChildProcess = FrontmanAiFrontmanCore.FrontmanCore__ChildProcess
 
 module AutoEdit = FrontmanNextjs__Cli__AutoEdit
 

--- a/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
+++ b/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
@@ -5,7 +5,7 @@ module Fs = Bindings.Fs
 module Path = Bindings.Path
 module Process = Bindings.Process
 module Os = Bindings.Os
-module ChildProcess = FrontmanFrontmanCore.FrontmanCore__ChildProcess
+module ChildProcess = FrontmanAiFrontmanCore.FrontmanCore__ChildProcess
 
 module AutoEdit = FrontmanNextjs__Cli__AutoEdit
 module Detect = FrontmanNextjs__Cli__Detect

--- a/libs/frontman-nextjs/tsup.config.ts
+++ b/libs/frontman-nextjs/tsup.config.ts
@@ -9,8 +9,8 @@ export default defineConfig([
     clean: true,
     // Bundle internal workspace dependencies
     noExternal: [
-      '@frontman/frontman-core',
-      '@frontman/frontman-protocol',
+      '@frontman-ai/frontman-core',
+      '@frontman-ai/frontman-protocol',
       '@frontman/bindings',
       '@rescript/runtime',
       'sury',
@@ -61,8 +61,8 @@ export default defineConfig([
     outDir: 'dist',
     clean: false, // Don't clean, we already did in first build
     noExternal: [
-      '@frontman/frontman-core',
-      '@frontman/frontman-protocol',
+      '@frontman-ai/frontman-core',
+      '@frontman-ai/frontman-protocol',
       '@frontman/bindings',
       '@rescript/runtime',
       'sury',
@@ -112,8 +112,8 @@ export default defineConfig([
     outDir: 'dist',
     clean: false,
     noExternal: [
-      '@frontman/frontman-core',
-      '@frontman/frontman-protocol',
+      '@frontman-ai/frontman-core',
+      '@frontman-ai/frontman-protocol',
       '@frontman/bindings',
       '@rescript/runtime',
       'sury',

--- a/libs/frontman-protocol/CHANGELOG.md
+++ b/libs/frontman-protocol/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-protocol
+# @frontman-ai/frontman-protocol
 
 ## 0.4.0
 

--- a/libs/frontman-protocol/README.md
+++ b/libs/frontman-protocol/README.md
@@ -1,4 +1,4 @@
-# @frontman/frontman-protocol
+# @frontman-ai/frontman-protocol
 
 Shared protocol definitions and type schemas for communication between clients and servers, defining the contract for tool-based systems.
 

--- a/libs/frontman-protocol/package.json
+++ b/libs/frontman-protocol/package.json
@@ -1,5 +1,8 @@
 {
-	"name": "@frontman/frontman-protocol",
+	"name": "@frontman-ai/frontman-protocol",
+	"publishConfig": {
+		"access": "public"
+	},
 	"version": "0.4.0",
 	"description": "Protocol definitions for Frontman",
 	"license": "Apache-2.0",

--- a/libs/frontman-protocol/rescript.json
+++ b/libs/frontman-protocol/rescript.json
@@ -1,5 +1,5 @@
 {
-	"name": "@frontman/frontman-protocol",
+	"name": "@frontman-ai/frontman-protocol",
 	"namespace": true,
 	"sources": [
 		{

--- a/libs/frontman-vite/package.json
+++ b/libs/frontman-vite/package.json
@@ -62,8 +62,8 @@
 		"vite": ">=5.0.0"
 	},
 	"devDependencies": {
-		"@frontman/frontman-core": "*",
-		"@frontman/frontman-protocol": "*",
+		"@frontman-ai/frontman-core": "*",
+		"@frontman-ai/frontman-protocol": "*",
 		"@rescript/runtime": "12.0.0-beta.14",
 		"@rescript/webapi": "*",
 		"@vitest/ui": "catalog:",

--- a/libs/frontman-vite/rescript.json
+++ b/libs/frontman-vite/rescript.json
@@ -18,8 +18,8 @@
 	"dependencies": [
 		"@rescript/webapi",
 		"sury",
-		"@frontman/frontman-protocol",
-		"@frontman/frontman-core",
+		"@frontman-ai/frontman-protocol",
+		"@frontman-ai/frontman-core",
 		"@frontman/bindings"
 	],
 	"dev-dependencies": ["rescript-vitest"],

--- a/libs/frontman-vite/src/FrontmanVite.res
+++ b/libs/frontman-vite/src/FrontmanVite.res
@@ -8,7 +8,7 @@ module ToolRegistry = FrontmanVite__ToolRegistry
 module Plugin = FrontmanVite__Plugin
 
 // Re-export core SSE for convenience
-module SSE = FrontmanFrontmanCore.FrontmanCore__SSE
+module SSE = FrontmanAiFrontmanCore.FrontmanCore__SSE
 
 // Re-export for convenience
 let createMiddleware = Middleware.createMiddleware

--- a/libs/frontman-vite/src/FrontmanVite__Config.res
+++ b/libs/frontman-vite/src/FrontmanVite__Config.res
@@ -1,7 +1,7 @@
 // Vite configuration for Frontman
 
 module Bindings = FrontmanBindings
-module Hosts = FrontmanFrontmanCore.FrontmanCore__Hosts
+module Hosts = FrontmanAiFrontmanCore.FrontmanCore__Hosts
 
 // Default host can be overridden via FRONTMAN_HOST env var for development
 let defaultHost = switch Bindings.Process.env->Dict.get("FRONTMAN_HOST") {

--- a/libs/frontman-vite/src/FrontmanVite__Middleware.res
+++ b/libs/frontman-vite/src/FrontmanVite__Middleware.res
@@ -1,7 +1,7 @@
 // Middleware factory for Vite
 // Thin wrapper around shared core middleware
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreMiddleware = Core.FrontmanCore__Middleware
 module CoreMiddlewareConfig = Core.FrontmanCore__MiddlewareConfig
 module Config = FrontmanVite__Config

--- a/libs/frontman-vite/src/FrontmanVite__Plugin.res
+++ b/libs/frontman-vite/src/FrontmanVite__Plugin.res
@@ -3,7 +3,7 @@
 
 module Config = FrontmanVite__Config
 module Middleware = FrontmanVite__Middleware
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 open FrontmanVite__Bindings
 
 // Helper: convert WebAPI Headers to a Dict<string>
@@ -143,7 +143,7 @@ let frontmanPlugin = (~options: option<pluginOptions>=?): array<plugin> => {
     configureServer: server => {
       // Initialize core LogCapture to intercept console/stdout for the
       // get_logs tool and post-edit error checking in edit_file
-      FrontmanFrontmanCore.FrontmanCore__LogCapture.initialize()
+      FrontmanAiFrontmanCore.FrontmanCore__LogCapture.initialize()
 
       // Create config from options - pass through optional fields directly
       let isDev = opts.isDev

--- a/libs/frontman-vite/src/FrontmanVite__Server.res
+++ b/libs/frontman-vite/src/FrontmanVite__Server.res
@@ -1,7 +1,7 @@
 // Request handlers for Frontman Vite endpoints
 // Thin wrapper around shared core request handlers
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRequestHandlers = Core.FrontmanCore__RequestHandlers
 module ToolRegistry = FrontmanVite__ToolRegistry
 module Config = FrontmanVite__Config

--- a/libs/frontman-vite/src/FrontmanVite__ToolRegistry.res
+++ b/libs/frontman-vite/src/FrontmanVite__ToolRegistry.res
@@ -1,6 +1,6 @@
 // Tool registry for Vite - composes core tools with Vite-specific tools
 
-module Core = FrontmanFrontmanCore
+module Core = FrontmanAiFrontmanCore
 module CoreRegistry = Core.FrontmanCore__ToolRegistry
 
 // Re-export types from core

--- a/libs/frontman-vite/src/cli/FrontmanVite__Cli.res
+++ b/libs/frontman-vite/src/cli/FrontmanVite__Cli.res
@@ -2,7 +2,7 @@
 // Usage: npx @frontman-ai/vite install --server <host>
 
 module Process = FrontmanBindings.Process
-module Hosts = FrontmanFrontmanCore.FrontmanCore__Hosts
+module Hosts = FrontmanAiFrontmanCore.FrontmanCore__Hosts
 module Install = FrontmanVite__Cli__Install
 
 // Parse command line arguments

--- a/libs/frontman-vite/src/cli/FrontmanVite__Cli__Detect.res
+++ b/libs/frontman-vite/src/cli/FrontmanVite__Cli__Detect.res
@@ -2,7 +2,7 @@
 module Bindings = FrontmanBindings
 module Fs = Bindings.Fs
 module Path = Bindings.Path
-module FsUtils = FrontmanFrontmanCore.FrontmanCore__FsUtils
+module FsUtils = FrontmanAiFrontmanCore.FrontmanCore__FsUtils
 
 type packageManager =
   | Npm

--- a/libs/frontman-vite/src/cli/FrontmanVite__Cli__Install.res
+++ b/libs/frontman-vite/src/cli/FrontmanVite__Cli__Install.res
@@ -1,6 +1,6 @@
 // Install command implementation for Vite
 module Bindings = FrontmanBindings
-module ChildProcess = FrontmanFrontmanCore.FrontmanCore__ChildProcess
+module ChildProcess = FrontmanAiFrontmanCore.FrontmanCore__ChildProcess
 module Fs = Bindings.Fs
 module Path = Bindings.Path
 module Process = Bindings.Process

--- a/libs/frontman-vite/src/tools/FrontmanVite__Tool__EditFile.res
+++ b/libs/frontman-vite/src/tools/FrontmanVite__Tool__EditFile.res
@@ -4,8 +4,8 @@
 // errors 800ms after the edit. This gives Vite's HMR time to process the
 // change and report any issues.
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module Core = FrontmanFrontmanCore
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Core = FrontmanAiFrontmanCore
 module CoreEditFile = Core.FrontmanCore__Tool__EditFile
 module LogCapture = Core.FrontmanCore__LogCapture
 

--- a/libs/frontman-vite/src/tools/FrontmanVite__Tool__GetLogs.res
+++ b/libs/frontman-vite/src/tools/FrontmanVite__Tool__GetLogs.res
@@ -1,7 +1,7 @@
 // Vite GetLogs tool - retrieves dev server logs from the core LogCapture buffer
 
-module Tool = FrontmanFrontmanProtocol.FrontmanProtocol__Tool
-module Core = FrontmanFrontmanCore
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Core = FrontmanAiFrontmanCore
 module LogCapture = Core.FrontmanCore__LogCapture
 module CircularBuffer = Core.FrontmanCore__CircularBuffer
 

--- a/libs/frontman-vite/tsup.config.ts
+++ b/libs/frontman-vite/tsup.config.ts
@@ -36,8 +36,8 @@ const nodeBuiltins = [
 ];
 
 const internalDeps = [
-  '@frontman/frontman-core',
-  '@frontman/frontman-protocol',
+  '@frontman-ai/frontman-core',
+  '@frontman-ai/frontman-protocol',
   '@frontman/bindings',
   '@rescript/runtime',
   'sury',

--- a/rescript.json
+++ b/rescript.json
@@ -4,11 +4,11 @@
 	"dependencies": [
 		"@frontman/chrome-extension",
 		"@frontman/bindings",
-		"@frontman/client",
+		"@frontman-ai/client",
 		"@frontman-ai/astro",
-		"@frontman/frontman-client",
+		"@frontman-ai/frontman-client",
 		"@frontman-ai/nextjs",
-		"@frontman/frontman-protocol",
+		"@frontman-ai/frontman-protocol",
 		"@frontman/react-statestore",
 		"@rescript/webapi"
 	],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,9 +2454,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontman-ai/astro@workspace:libs/frontman-astro"
   dependencies:
+    "@frontman-ai/frontman-core": "npm:*"
+    "@frontman-ai/frontman-protocol": "npm:*"
     "@frontman/bindings": "npm:*"
-    "@frontman/frontman-core": "npm:*"
-    "@frontman/frontman-protocol": "npm:*"
     "@rescript/runtime": "npm:12.0.0-beta.14"
     "@rescript/webapi": "npm:*"
     "@vitest/ui": "catalog:"
@@ -2474,115 +2474,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@frontman-ai/nextjs@workspace:*, @frontman-ai/nextjs@workspace:libs/frontman-nextjs":
+"@frontman-ai/client@workspace:libs/client":
   version: 0.0.0-use.local
-  resolution: "@frontman-ai/nextjs@workspace:libs/frontman-nextjs"
-  dependencies:
-    "@frontman/frontman-core": "npm:*"
-    "@frontman/frontman-protocol": "npm:*"
-    "@rescript/runtime": "npm:12.0.0-beta.14"
-    "@rescript/webapi": "npm:*"
-    "@sentry/nextjs": "npm:^9.0.0"
-    "@vitest/ui": "catalog:"
-    chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "npm:0.5.0"
-    lighthouse: "npm:^12.5.1"
-    next: "npm:^15.0.0"
-    rescript: "catalog:"
-    rescript-vitest: "catalog:"
-    sentry-testkit: "npm:^6.0.0"
-    sury: "npm:11.0.0-alpha.4"
-    tsup: "npm:^8.0.0"
-    vite: "catalog:"
-    vitest: "catalog:"
-  peerDependencies:
-    "@opentelemetry/api": ^1.9.0
-    "@opentelemetry/sdk-logs": ^0.52.0
-    "@opentelemetry/sdk-trace-base": ^1.25.0
-    next: ^13.2.0 || ^14.0 || ^15.0 || ^16.0
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    "@opentelemetry/sdk-logs":
-      optional: true
-    "@opentelemetry/sdk-trace-base":
-      optional: true
-  bin:
-    frontman-nextjs: dist/cli.js
-    nextjs: dist/cli.js
-  languageName: unknown
-  linkType: soft
-
-"@frontman-ai/vite@workspace:*, @frontman-ai/vite@workspace:libs/frontman-vite":
-  version: 0.0.0-use.local
-  resolution: "@frontman-ai/vite@workspace:libs/frontman-vite"
-  dependencies:
-    "@frontman/frontman-core": "npm:*"
-    "@frontman/frontman-protocol": "npm:*"
-    "@rescript/runtime": "npm:12.0.0-beta.14"
-    "@rescript/webapi": "npm:*"
-    "@vitest/ui": "catalog:"
-    chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "npm:0.5.0"
-    lighthouse: "npm:^12.5.1"
-    rescript: "catalog:"
-    rescript-vitest: "catalog:"
-    sury: "npm:11.0.0-alpha.4"
-    tsup: "npm:^8.0.0"
-    vite: "catalog:"
-    vitest: "catalog:"
-  peerDependencies:
-    vite: ">=5.0.0"
-  bin:
-    frontman-vite: ./dist/cli.js
-  languageName: unknown
-  linkType: soft
-
-"@frontman/bindings@npm:*, @frontman/bindings@npm:0.3.0, @frontman/bindings@workspace:*, @frontman/bindings@workspace:libs/bindings":
-  version: 0.0.0-use.local
-  resolution: "@frontman/bindings@workspace:libs/bindings"
-  dependencies:
-    "@rescript/runtime": "npm:12.0.0-beta.14"
-    dom-element-to-component-source: "npm:^0.5.0"
-    rescript: "catalog:"
-    sentry-testkit: "npm:^6.0.0"
-    sury: "npm:11.0.0-alpha.4"
-    sury-ppx: "npm:^11.0.0-alpha.2"
-  languageName: unknown
-  linkType: soft
-
-"@frontman/chrome-extension@workspace:apps/chrome-extension":
-  version: 0.0.0-use.local
-  resolution: "@frontman/chrome-extension@workspace:apps/chrome-extension"
-  dependencies:
-    "@frontman/bindings": "npm:*"
-    "@rescript/react": "npm:^0.14.0"
-    "@rescript/webapi": "npm:*"
-    "@toon-format/toon": "npm:^1.0.0"
-    "@types/react": "npm:^19.1.12"
-    "@types/react-dom": "npm:^19.1.9"
-    "@wxt-dev/module-react": "npm:^1.1.3"
-    react: "npm:^19.1.1"
-    react-dom: "npm:^19.1.1"
-    rescript: "catalog:"
-    rescript-vitest: "catalog:"
-    typescript: "npm:^5.9.2"
-    vite: "catalog:"
-    wxt: "npm:^0.20.6"
-  languageName: unknown
-  linkType: soft
-
-"@frontman/client@workspace:libs/client":
-  version: 0.0.0-use.local
-  resolution: "@frontman/client@workspace:libs/client"
+  resolution: "@frontman-ai/client@workspace:libs/client"
   dependencies:
     "@ai-sdk/react": "npm:^2.0.92"
     "@babel/core": "npm:^7.29.0"
     "@biomejs/biome": "npm:^2.3.5"
+    "@frontman-ai/frontman-client": "workspace:*"
+    "@frontman-ai/frontman-protocol": "workspace:*"
     "@frontman-ai/nextjs": "workspace:*"
     "@frontman/bindings": "workspace:*"
-    "@frontman/frontman-client": "workspace:*"
-    "@frontman/frontman-protocol": "workspace:*"
     "@frontman/logs": "workspace:*"
     "@frontman/react-statestore": "workspace:*"
     "@medv/finder": "npm:^4.0.2"
@@ -2647,6 +2549,156 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@frontman-ai/frontman-client@workspace:*, @frontman-ai/frontman-client@workspace:libs/frontman-client":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/frontman-client@workspace:libs/frontman-client"
+  dependencies:
+    "@frontman/logs": "workspace:*"
+    "@rescript/webapi": "npm:*"
+    "@sentry/browser": "npm:^9.0.0"
+    "@vitest/ui": "catalog:"
+    phoenix: "npm:^1.7.0"
+    rescript: "catalog:"
+    rescript-vitest: "catalog:"
+    sentry-testkit: "npm:^6.0.0"
+    sury: "catalog:"
+    sury-ppx: "npm:^11.0.0-alpha.2"
+    vite: "catalog:"
+    vitest: "catalog:"
+  languageName: unknown
+  linkType: soft
+
+"@frontman-ai/frontman-core@npm:*, @frontman-ai/frontman-core@workspace:libs/frontman-core":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/frontman-core@workspace:libs/frontman-core"
+  dependencies:
+    "@frontman-ai/frontman-protocol": "npm:0.4.0"
+    "@frontman/bindings": "npm:0.3.0"
+    "@rescript/runtime": "npm:12.0.0-beta.14"
+    "@rescript/webapi": "npm:*"
+    "@vitest/ui": "catalog:"
+    "@vscode/ripgrep": "npm:^1.15.0"
+    chrome-launcher: "npm:^1.1.2"
+    lighthouse: "npm:^12.5.1"
+    rescript: "catalog:"
+    rescript-vitest: "catalog:"
+    sury: "npm:11.0.0-alpha.4"
+    vite: "catalog:"
+    vitest: "catalog:"
+  dependenciesMeta:
+    "@vscode/ripgrep":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@frontman-ai/frontman-protocol@npm:*, @frontman-ai/frontman-protocol@npm:0.4.0, @frontman-ai/frontman-protocol@workspace:*, @frontman-ai/frontman-protocol@workspace:libs/frontman-protocol":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/frontman-protocol@workspace:libs/frontman-protocol"
+  dependencies:
+    "@rescript/webapi": "npm:*"
+    rescript: "catalog:"
+    sury: "npm:11.0.0-alpha.4"
+  languageName: unknown
+  linkType: soft
+
+"@frontman-ai/nextjs@workspace:*, @frontman-ai/nextjs@workspace:libs/frontman-nextjs":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/nextjs@workspace:libs/frontman-nextjs"
+  dependencies:
+    "@frontman-ai/frontman-core": "npm:*"
+    "@frontman-ai/frontman-protocol": "npm:*"
+    "@rescript/runtime": "npm:12.0.0-beta.14"
+    "@rescript/webapi": "npm:*"
+    "@sentry/nextjs": "npm:^9.0.0"
+    "@vitest/ui": "catalog:"
+    chrome-launcher: "npm:^1.1.2"
+    dom-element-to-component-source: "npm:0.5.0"
+    lighthouse: "npm:^12.5.1"
+    next: "npm:^15.0.0"
+    rescript: "catalog:"
+    rescript-vitest: "catalog:"
+    sentry-testkit: "npm:^6.0.0"
+    sury: "npm:11.0.0-alpha.4"
+    tsup: "npm:^8.0.0"
+    vite: "catalog:"
+    vitest: "catalog:"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/sdk-logs": ^0.52.0
+    "@opentelemetry/sdk-trace-base": ^1.25.0
+    next: ^13.2.0 || ^14.0 || ^15.0 || ^16.0
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@opentelemetry/sdk-logs":
+      optional: true
+    "@opentelemetry/sdk-trace-base":
+      optional: true
+  bin:
+    frontman-nextjs: dist/cli.js
+    nextjs: dist/cli.js
+  languageName: unknown
+  linkType: soft
+
+"@frontman-ai/vite@workspace:*, @frontman-ai/vite@workspace:libs/frontman-vite":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/vite@workspace:libs/frontman-vite"
+  dependencies:
+    "@frontman-ai/frontman-core": "npm:*"
+    "@frontman-ai/frontman-protocol": "npm:*"
+    "@rescript/runtime": "npm:12.0.0-beta.14"
+    "@rescript/webapi": "npm:*"
+    "@vitest/ui": "catalog:"
+    chrome-launcher: "npm:^1.1.2"
+    dom-element-to-component-source: "npm:0.5.0"
+    lighthouse: "npm:^12.5.1"
+    rescript: "catalog:"
+    rescript-vitest: "catalog:"
+    sury: "npm:11.0.0-alpha.4"
+    tsup: "npm:^8.0.0"
+    vite: "catalog:"
+    vitest: "catalog:"
+  peerDependencies:
+    vite: ">=5.0.0"
+  bin:
+    frontman-vite: ./dist/cli.js
+  languageName: unknown
+  linkType: soft
+
+"@frontman/bindings@npm:*, @frontman/bindings@npm:0.3.0, @frontman/bindings@workspace:*, @frontman/bindings@workspace:libs/bindings":
+  version: 0.0.0-use.local
+  resolution: "@frontman/bindings@workspace:libs/bindings"
+  dependencies:
+    "@rescript/runtime": "npm:12.0.0-beta.14"
+    dom-element-to-component-source: "npm:^0.5.0"
+    rescript: "catalog:"
+    sentry-testkit: "npm:^6.0.0"
+    sury: "npm:11.0.0-alpha.4"
+    sury-ppx: "npm:^11.0.0-alpha.2"
+  languageName: unknown
+  linkType: soft
+
+"@frontman/chrome-extension@workspace:apps/chrome-extension":
+  version: 0.0.0-use.local
+  resolution: "@frontman/chrome-extension@workspace:apps/chrome-extension"
+  dependencies:
+    "@frontman/bindings": "npm:*"
+    "@rescript/react": "npm:^0.14.0"
+    "@rescript/webapi": "npm:*"
+    "@toon-format/toon": "npm:^1.0.0"
+    "@types/react": "npm:^19.1.12"
+    "@types/react-dom": "npm:^19.1.9"
+    "@wxt-dev/module-react": "npm:^1.1.3"
+    react: "npm:^19.1.1"
+    react-dom: "npm:^19.1.1"
+    rescript: "catalog:"
+    rescript-vitest: "catalog:"
+    typescript: "npm:^5.9.2"
+    vite: "catalog:"
+    wxt: "npm:^0.20.6"
+  languageName: unknown
+  linkType: soft
+
 "@frontman/e2e-astro@workspace:test/e2e/fixtures/astro":
   version: 0.0.0-use.local
   resolution: "@frontman/e2e-astro@workspace:test/e2e/fixtures/astro"
@@ -2700,63 +2752,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@frontman/frontman-client@workspace:*, @frontman/frontman-client@workspace:libs/frontman-client":
-  version: 0.0.0-use.local
-  resolution: "@frontman/frontman-client@workspace:libs/frontman-client"
-  dependencies:
-    "@frontman/logs": "workspace:*"
-    "@rescript/webapi": "npm:*"
-    "@sentry/browser": "npm:^9.0.0"
-    "@vitest/ui": "catalog:"
-    phoenix: "npm:^1.7.0"
-    rescript: "catalog:"
-    rescript-vitest: "catalog:"
-    sentry-testkit: "npm:^6.0.0"
-    sury: "catalog:"
-    sury-ppx: "npm:^11.0.0-alpha.2"
-    vite: "catalog:"
-    vitest: "catalog:"
-  languageName: unknown
-  linkType: soft
-
-"@frontman/frontman-core@npm:*, @frontman/frontman-core@workspace:libs/frontman-core":
-  version: 0.0.0-use.local
-  resolution: "@frontman/frontman-core@workspace:libs/frontman-core"
-  dependencies:
-    "@frontman/bindings": "npm:0.3.0"
-    "@frontman/frontman-protocol": "npm:0.4.0"
-    "@rescript/runtime": "npm:12.0.0-beta.14"
-    "@rescript/webapi": "npm:*"
-    "@vitest/ui": "catalog:"
-    "@vscode/ripgrep": "npm:^1.15.0"
-    chrome-launcher: "npm:^1.1.2"
-    lighthouse: "npm:^12.5.1"
-    rescript: "catalog:"
-    rescript-vitest: "catalog:"
-    sury: "npm:11.0.0-alpha.4"
-    vite: "catalog:"
-    vitest: "catalog:"
-  dependenciesMeta:
-    "@vscode/ripgrep":
-      optional: true
-  languageName: unknown
-  linkType: soft
-
-"@frontman/frontman-protocol@npm:*, @frontman/frontman-protocol@npm:0.4.0, @frontman/frontman-protocol@workspace:*, @frontman/frontman-protocol@workspace:libs/frontman-protocol":
-  version: 0.0.0-use.local
-  resolution: "@frontman/frontman-protocol@workspace:libs/frontman-protocol"
-  dependencies:
-    "@rescript/webapi": "npm:*"
-    rescript: "catalog:"
-    sury: "npm:11.0.0-alpha.4"
-  languageName: unknown
-  linkType: soft
-
 "@frontman/frontman-server-assets@workspace:apps/frontman_server/assets":
   version: 0.0.0-use.local
   resolution: "@frontman/frontman-server-assets@workspace:apps/frontman_server/assets"
   dependencies:
-    "@frontman/frontman-client": "workspace:*"
+    "@frontman-ai/frontman-client": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Renames 4 publishable packages from `@frontman/` to `@frontman-ai/` npm scope: `client`, `frontman-core`, `frontman-client`, `frontman-protocol`
- Fixes `make release` failure where `yarn changeset version` errored on `@frontman-ai/client` not being in the workspace
- Adds `publishConfig.access: public` to each renamed package
- Updates all cross-references across 39 files (package.json, rescript.json, tsup.config.ts, changesets, CI, docs)

## Notes

- `.res.mjs` files (ReScript compiler output) still contain old import paths — they will be correct after the next `rescript build`
- Historical CHANGELOG entries are intentionally left with old names (they were accurate at time of release)
- `@frontman/bindings`, `@frontman/logs`, `@frontman/react-statestore` remain under `@frontman/` as they are `private: true`

## Testing

- `yarn install` resolves cleanly with new names
- `yarn changeset version` passes workspace validation (only fails on missing `GITHUB_TOKEN` which CI provides)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
