### PR TITLE
feat: attach annotations to messages instead of task state

### DIFF
--- a/.changeset/annotations-on-messages.md
+++ b/.changeset/annotations-on-messages.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": minor
+---
+
+Attach annotations to messages instead of task state. Annotations are now stored as serializable snapshots on each `Message.User` record, rendered as compact chips in the conversation history. This fixes empty purple chat bubbles when sending annotation-only messages and preserves annotation context in the message timeline.

--- a/bin/wt-dashboard
+++ b/bin/wt-dashboard
@@ -30,6 +30,10 @@ else
   LINE="--------------------------------------------------------------"
 fi
 
+# ── Resolve main repo root (works from any worktree) ────
+MAIN_REPO=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+WORKTREES_DIR="${MAIN_REPO}/.worktrees"
+
 # ── Portable MD5 (same logic as Makefile) ───────────────
 md5_short() {
   if command -v md5sum >/dev/null 2>&1; then
@@ -101,12 +105,12 @@ collect_pods() {
 # ── Collect all worktree branches ───────────────────────
 collect_worktrees() {
   local -n _branches=$1  # nameref to caller's array
-  if [[ ! -d ".worktrees" ]]; then
+  if [[ ! -d "$WORKTREES_DIR" ]]; then
     return
   fi
 
   # Single-level: .worktrees/my-branch
-  for wt in .worktrees/*; do
+  for wt in "$WORKTREES_DIR"/*; do
     [[ -d "$wt" ]] || continue
     local name
     name=$(basename "$wt")
@@ -117,11 +121,11 @@ collect_worktrees() {
   done
 
   # Nested: .worktrees/feature/my-branch
-  for wt in .worktrees/*/*; do
+  for wt in "$WORKTREES_DIR"/*/*; do
     [[ -d "$wt" ]] || continue
     if [[ -f "$wt/.git" ]] || [[ -d "$wt/.git" ]]; then
       local name
-      name=$(echo "$wt" | sed 's|^\.worktrees/||')
+      name=$(echo "$wt" | sed "s|^${WORKTREES_DIR}/||")
       _branches+=("$name")
     fi
   done
@@ -190,7 +194,7 @@ print_worktree() {
     printf "  ${DIM}%-12s${RESET} Plain worktree (no container)\n" "Status:"
 
     # Show git status summary
-    local wt_dir=".worktrees/$branch"
+    local wt_dir="${WORKTREES_DIR}/$branch"
     local git_status
     git_status=$(git -C "$wt_dir" status -s 2>/dev/null | wc -l | tr -d ' ')
     local current_branch
@@ -211,11 +215,11 @@ print_orphan_pods() {
   for hash in "${!POD_STATUS[@]}"; do
     # Check if any worktree maps to this hash
     local matched=false
-    if [[ -d ".worktrees" ]]; then
-      for wt in .worktrees/* .worktrees/*/*; do
+    if [[ -d "$WORKTREES_DIR" ]]; then
+      for wt in "$WORKTREES_DIR"/* "$WORKTREES_DIR"/*/*; do
         [[ -d "$wt" ]] || continue
         local name
-        name=$(echo "$wt" | sed 's|^\.worktrees/||')
+        name=$(echo "$wt" | sed "s|^${WORKTREES_DIR}/||")
         local wt_hash
         wt_hash=$(md5_short "$name")
         if [[ "$wt_hash" == "$hash" ]]; then

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -141,17 +141,19 @@ let make = (
     ~sessionInitialized,
   )
 
-  let hasAnnotatedComments = annotations->Array.some(a => a.comment->Option.isSome)
+  let hasAnnotations = Array.length(annotations) > 0
 
   let handleSubmit = (~text: string, ~inputItems: array<Client__PromptInput.inputItem>) => {
+    // Snapshot live annotations into serializable MessageAnnotation records
+    let messageAnnotations = annotations->Array.map(Client__Message.MessageAnnotation.fromAnnotation)
+
     let sendWithContent = (content) => {
-      // Allow send if there's content OR annotations with comments (annotations are
-      // attached by the reducer as additional content blocks during addUserMessage)
-      switch Array.length(content) > 0 || hasAnnotatedComments {
+      // Allow send if there's content OR annotations (annotations are first-class message content)
+      switch Array.length(content) > 0 || Array.length(messageAnnotations) > 0 {
       | false => ()
       | true =>
         let sendMessage = (sessionId: string) => {
-          Client__State.Actions.addUserMessage(~sessionId, ~content)
+          Client__State.Actions.addUserMessage(~sessionId, ~content, ~annotations=messageAnnotations)
         }
         switch session {
         | Some(sess) => sendMessage(sess.sessionId)
@@ -262,12 +264,12 @@ let make = (
     let isLastToolGroup = itemIndex == lastToolGroupIndex
 
     switch item {
-    | UserMsg(Message.User({id, content, _}), _) =>
+    | UserMsg(Message.User({id, content, annotations, _}), _) =>
       // Use stable message ID for key
       // frontman-content-auto: browser skips layout/paint for off-screen messages
       let messageId = `user-${id}`
       <div key={messageId} className="frontman-content-auto">
-        <UserMessage content messageId isNew={isLastItem} />
+        <UserMessage content annotations messageId isNew={isLastItem} />
       </div>
 
     | AssistantMsg(Message.Assistant(Streaming({id, textBuffer, _})), _) =>
@@ -421,7 +423,7 @@ let make = (
       disabledPlaceholder="Free requests exhausted. Add your API key in Settings to continue."
       onSelectElement={Client__State.Actions.toggleWebPreviewSelection}
       isSelecting={webPreviewIsSelecting}
-      hasAnnotatedComments
+      hasAnnotations
     />
   </div>
 }

--- a/libs/client/src/Client__TaskTabs.story.res
+++ b/libs/client/src/Client__TaskTabs.story.res
@@ -27,6 +27,7 @@ module Fixtures = {
       let msg = StateReducer.Message.User({
         id: `msg-${id}`,
         content: [StateReducer.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
         createdAt,
       })
       [msg]

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -503,7 +503,7 @@ let make = (
   ~disabledPlaceholder: option<string>=?,
   ~onSelectElement: option<unit => unit>=?,
   ~isSelecting: bool=false,
-  ~hasAnnotatedComments: bool=false,
+  ~hasAnnotations: bool=false,
 ) => {
   let (hasContent, setHasContent) = React.useState(() => false)
   let (inputItems, setInputItems) = React.useState((): array<inputItem> => [])
@@ -792,7 +792,7 @@ let make = (
       )
       // Walk the DOM in order, expanding pasted-text chips inline at their position
       let text = getExpandedTextFromEditable(el, pastedTextMap)
-      if String.trim(text) != "" || Array.length(items) > 0 || hasAnnotatedComments {
+      if String.trim(text) != "" || Array.length(items) > 0 || hasAnnotations {
         onSubmit(~text=String.trim(text), ~inputItems=items)
         clearEditable(el)
         setInputItems(_ => [])
@@ -812,7 +812,7 @@ let make = (
   }
 
   let isInputDisabled = !hasActiveACPSession || isAgentRunning || disabled
-  let isSubmitDisabled = isInputDisabled || (!hasContent && !hasAnnotatedComments)
+  let isSubmitDisabled = isInputDisabled || (!hasContent && !hasAnnotations)
 
   // Determine placeholder text based on state
   let currentPlaceholder = if disabled {

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -1,15 +1,33 @@
 /**
- * UserMessage - Renders user messages (text, images, files)
+ * UserMessage - Renders user messages (text, images, files, annotations)
  * 
  * Displays user messages in a purple/violet bubble style.
  * Sticky at top when scrolling for context.
  * Images render as thumbnails with lightbox preview.
+ * Annotations render as compact chips with numbered badges.
  */
 
 module UserContentPart = Client__State__Types.UserContentPart
+module MessageAnnotation = Client__Message.MessageAnnotation
+
+// Circled number characters for annotation badges (1-20)
+let _circledNumbers = [
+  "\u{2460}", "\u{2461}", "\u{2462}", "\u{2463}", "\u{2464}",
+  "\u{2465}", "\u{2466}", "\u{2467}", "\u{2468}", "\u{2469}",
+  "\u{246A}", "\u{246B}", "\u{246C}", "\u{246D}", "\u{246E}",
+  "\u{246F}", "\u{2470}", "\u{2471}", "\u{2472}", "\u{2473}",
+]
+
+let _getBadge = (index: int): string =>
+  _circledNumbers->Array.get(index)->Option.getOr(Int.toString(index + 1))
 
 @react.component
-let make = (~content: array<UserContentPart.t>, ~messageId: string, ~isNew: bool=false) => {
+let make = (
+  ~content: array<UserContentPart.t>,
+  ~annotations: array<MessageAnnotation.t>=[],
+  ~messageId: string,
+  ~isNew: bool=false,
+) => {
   let animationClass = isNew ? "animate-in fade-in duration-100" : ""
   let (previewSrc, setPreviewSrc) = React.useState((): option<string> => None)
 
@@ -33,9 +51,47 @@ let make = (~content: array<UserContentPart.t>, ~messageId: string, ~isNew: bool
     }
   )
 
+  let hasAnnotations = Array.length(annotations) > 0
+
   // Sticky container with dark background for proper stacking
   <div className={`sticky top-0 z-10 bg-[#180C2D] py-2 px-3 ${animationClass}`}>
     <div className="inline-block max-w-[85%] bg-violet-600/80 rounded-2xl px-4 py-3">
+      // Annotation chips (above images/text)
+      {hasAnnotations
+        ? <div className="flex flex-wrap gap-1.5 mb-2">
+            {annotations->Array.mapWithIndex((annotation, i) => {
+              let key = `${messageId}-ann-${Int.toString(i)}`
+              let badge = _getBadge(i)
+              let label = switch annotation.cssClasses {
+              | Some(classes) =>
+                let firstClass = classes->String.split(" ")->Array.get(0)->Option.getOr("")
+                firstClass->String.length > 0
+                  ? `<${annotation.tagName}.${firstClass}>`
+                  : `<${annotation.tagName}>`
+              | None => `<${annotation.tagName}>`
+              }
+              <div key className="flex flex-col gap-0.5">
+                <div
+                  className="flex items-center gap-1 px-2 py-0.5 rounded-md
+                             bg-violet-500/60 text-violet-100 text-xs font-mono"
+                >
+                  <span className="text-violet-200">{React.string(badge)}</span>
+                  <span className="truncate max-w-[160px]">{React.string(label)}</span>
+                </div>
+                {switch annotation.comment {
+                | Some(comment) =>
+                  <div
+                    className="text-[11px] text-violet-200/80 italic pl-1 max-w-[200px] truncate"
+                  >
+                    {React.string(comment)}
+                  </div>
+                | None => React.null
+                }}
+              </div>
+            })->React.array}
+          </div>
+        : React.null}
+
       // Image thumbnails row (above text)
       {Array.length(imageParts) > 0
         ? <div className="flex flex-wrap gap-2 mb-2">

--- a/libs/client/src/components/frontman/Client__UserMessage.story.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.story.res
@@ -1,0 +1,134 @@
+open Bindings__Storybook
+
+type args = {text: string}
+
+module Samples = {
+  open Client__Message.MessageAnnotation
+
+  let buttonAnnotation: Client__Message.MessageAnnotation.t = {
+    id: "ann-1",
+    selector: Some(".btn-submit"),
+    tagName: "button",
+    cssClasses: Some("btn-submit primary"),
+    comment: Some("This button should be blue"),
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: Some("Submit"),
+  }
+
+  let headerAnnotation: t = {
+    id: "ann-2",
+    selector: Some("h1.page-title"),
+    tagName: "h1",
+    cssClasses: Some("page-title text-lg"),
+    comment: None,
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: Some("Welcome to the App"),
+  }
+
+  let inputAnnotation: t = {
+    id: "ann-3",
+    selector: Some("input#email"),
+    tagName: "input",
+    cssClasses: Some("form-input"),
+    comment: Some("Email field needs validation"),
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: Some("Enter your email"),
+  }
+
+  let divAnnotation: t = {
+    id: "ann-4",
+    selector: None,
+    tagName: "div",
+    cssClasses: None,
+    comment: None,
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: None,
+  }
+}
+
+let default: Meta.t<args> = {
+  title: "Components/Frontman/UserMessage",
+  tags: ["autodocs"],
+  decorators: [Decorators.darkBackground],
+  render: args =>
+    <Client__UserMessage
+      content={switch args.text {
+      | "" => []
+      | text => [Client__State__Types.UserContentPart.Text({text: text})]
+      }}
+      messageId="story-msg-1"
+    />,
+}
+
+let textOnly: Story.t<args> = {
+  name: "Text Only",
+  args: {text: "Make the header font size larger"},
+}
+
+let textWithAnnotations: Story.t<args> = {
+  name: "Text + Annotations",
+  args: {text: "Fix these elements please"},
+  render: args =>
+    <Client__UserMessage
+      content=[Client__State__Types.UserContentPart.Text({text: args.text})]
+      annotations=[Samples.buttonAnnotation, Samples.headerAnnotation]
+      messageId="story-msg-2"
+    />,
+}
+
+let annotationsOnly: Story.t<args> = {
+  name: "Annotations Only (No Text)",
+  args: {text: ""},
+  render: _args =>
+    <Client__UserMessage
+      content=[]
+      annotations=[Samples.buttonAnnotation, Samples.headerAnnotation, Samples.inputAnnotation]
+      messageId="story-msg-3"
+    />,
+}
+
+let singleAnnotationWithComment: Story.t<args> = {
+  name: "Single Annotation with Comment",
+  args: {text: ""},
+  render: _args =>
+    <Client__UserMessage
+      content=[]
+      annotations=[Samples.buttonAnnotation]
+      messageId="story-msg-4"
+    />,
+}
+
+let annotationWithoutCssClass: Story.t<args> = {
+  name: "Annotation Without CSS Class",
+  args: {text: "Check this div"},
+  render: args =>
+    <Client__UserMessage
+      content=[Client__State__Types.UserContentPart.Text({text: args.text})]
+      annotations=[Samples.divAnnotation]
+      messageId="story-msg-5"
+    />,
+}
+
+let manyAnnotations: Story.t<args> = {
+  name: "Many Annotations",
+  args: {text: ""},
+  render: _args =>
+    <Client__UserMessage
+      content=[]
+      annotations=[
+        Samples.buttonAnnotation,
+        Samples.headerAnnotation,
+        Samples.inputAnnotation,
+        Samples.divAnnotation,
+      ]
+      messageId="story-msg-6"
+    />,
+}

--- a/libs/client/src/state/Client__Message.res
+++ b/libs/client/src/state/Client__Message.res
@@ -23,6 +23,69 @@ let resolveAttachmentImage = (att: fileAttachmentData): resolvedImageData => {
   {base64, mediaType: att.mediaType}
 }
 
+// Serializable annotation snapshot — stored on user messages.
+// Captures all annotation metadata at send time, dropping the live DOM element ref.
+module MessageAnnotation = {
+  type boundingBox = {
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+  }
+
+  type rec sourceLocation = {
+    componentName: option<string>,
+    tagName: string,
+    file: string,
+    line: int,
+    column: int,
+    parent: option<sourceLocation>,
+    componentProps: option<Dict.t<JSON.t>>,
+  }
+
+  type t = {
+    id: string,
+    selector: option<string>,
+    tagName: string,
+    cssClasses: option<string>,
+    comment: option<string>,
+    screenshot: option<string>,
+    sourceLocation: option<sourceLocation>,
+    boundingBox: option<boundingBox>,
+    nearbyText: option<string>,
+  }
+
+  // Convert a SourceLocation.t to the local sourceLocation type (same shape, just decoupled)
+  let rec sourceLocationFromClientTypes = (loc: Client__Types.SourceLocation.t): sourceLocation => {
+    componentName: loc.componentName,
+    tagName: loc.tagName,
+    file: loc.file,
+    line: loc.line,
+    column: loc.column,
+    parent: loc.parent->Option.map(sourceLocationFromClientTypes),
+    componentProps: loc.componentProps,
+  }
+
+  // Snapshot a live Annotation.t into a serializable MessageAnnotation.t
+  // Drops the live DOM element reference.
+  let fromAnnotation = (annotation: Client__Annotation__Types.t): t => {
+    id: annotation.id,
+    selector: annotation.selector,
+    tagName: annotation.tagName,
+    cssClasses: annotation.cssClasses,
+    comment: annotation.comment,
+    screenshot: annotation.screenshot,
+    sourceLocation: annotation.sourceLocation->Option.map(sourceLocationFromClientTypes),
+    boundingBox: annotation.boundingBox->Option.map(bb => {
+      x: bb.x,
+      y: bb.y,
+      width: bb.width,
+      height: bb.height,
+    }),
+    nearbyText: annotation.nearbyText,
+  }
+}
+
 // Content part types for messages (simplified from Vercel AI SDK)
 module UserContentPart = {
   type t =
@@ -65,7 +128,7 @@ type toolCall = {
 }
 
 type t =
-  | User({id: string, content: array<UserContentPart.t>, createdAt: float})
+  | User({id: string, content: array<UserContentPart.t>, annotations: array<MessageAnnotation.t>, createdAt: float})
   | Assistant(assistantMessage)
   | ToolCall(toolCall)
 

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -11,9 +11,9 @@ module AssistantContentPart = Client__State__Types.AssistantContentPart
 
 // Action creators
 module Actions = {
-  let addUserMessage = (~sessionId, ~content) => {
+  let addUserMessage = (~sessionId, ~content, ~annotations=[]) => {
     let id = `user-${Date.now()->Float.toString}`
-    Client__State__Store.dispatch(AddUserMessage({id, sessionId, content}))
+    Client__State__Store.dispatch(AddUserMessage({id, sessionId, content, annotations}))
   }
 
   // ForTask(taskId) actions - streaming/tool events from ACP

--- a/libs/client/src/state/Client__StateSnapshot.res
+++ b/libs/client/src/state/Client__StateSnapshot.res
@@ -241,9 +241,37 @@ module AssistantMessage = {
   ])
 }
 
+// Serializable annotation snapshot for state snapshots
+module SnapshotAnnotation = {
+  type boundingBox = {
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+  }
+
+  type t = {
+    id: string,
+    selector: option<string>,
+    tagName: string,
+    cssClasses: option<string>,
+    comment: option<string>,
+    nearbyText: option<string>,
+  }
+
+  let schema = S.object(s => {
+    id: s.field("id", S.string),
+    selector: s.field("selector", nullableToOption(S.string)),
+    tagName: s.field("tagName", S.string),
+    cssClasses: s.field("cssClasses", nullableToOption(S.string)),
+    comment: s.field("comment", nullableToOption(S.string)),
+    nearbyText: s.field("nearbyText", nullableToOption(S.string)),
+  })
+}
+
 module Message = {
   type t =
-    | User({id: string, content: array<UserContentPart.t>, createdAt: float})
+    | User({id: string, content: array<UserContentPart.t>, annotations: array<SnapshotAnnotation.t>, createdAt: float})
     | Assistant(AssistantMessage.t)
     | ToolCall(ToolCall.t)
 
@@ -253,6 +281,7 @@ module Message = {
       User({
         id: s.field("id", S.string),
         content: s.field("content", S.array(UserContentPart.schema)),
+        annotations: s.fieldOr("annotations", S.array(SnapshotAnnotation.schema), []),
         createdAt: s.field("createdAt", S.float),
       })
     }),
@@ -438,12 +467,22 @@ let convertAssistantMessage = (
   }
 }
 
+let convertMessageAnnotation = (ann: Client__Message.MessageAnnotation.t): SnapshotAnnotation.t => {
+  id: ann.id,
+  selector: ann.selector,
+  tagName: ann.tagName,
+  cssClasses: ann.cssClasses,
+  comment: ann.comment,
+  nearbyText: ann.nearbyText,
+}
+
 let convertMessage = (msg: Client__State__Types.Message.t): Message.t => {
   switch msg {
-  | User({id, content, createdAt}) =>
+  | User({id, content, annotations, createdAt}) =>
     User({
       id,
       content: content->Array.map(convertUserContentPart),
+      annotations: annotations->Array.map(convertMessageAnnotation),
       createdAt,
     })
   | Assistant(assistantMsg) => Assistant(convertAssistantMessage(assistantMsg))
@@ -593,13 +632,25 @@ let assistantMessageToJson = (msg: AssistantMessage.t): JSON.t => {
   }
 }
 
+let snapshotAnnotationToJson = (ann: SnapshotAnnotation.t): JSON.t => {
+  obj([
+    ("id", JSON.Encode.string(ann.id)),
+    ("selector", ann.selector->Option.mapOr(JSON.Encode.null, JSON.Encode.string)),
+    ("tagName", JSON.Encode.string(ann.tagName)),
+    ("cssClasses", ann.cssClasses->Option.mapOr(JSON.Encode.null, JSON.Encode.string)),
+    ("comment", ann.comment->Option.mapOr(JSON.Encode.null, JSON.Encode.string)),
+    ("nearbyText", ann.nearbyText->Option.mapOr(JSON.Encode.null, JSON.Encode.string)),
+  ])
+}
+
 let messageToJson = (msg: Message.t): JSON.t => {
   switch msg {
-  | User({id, content, createdAt}) =>
+  | User({id, content, annotations, createdAt}) =>
     obj([
       ("type", JSON.Encode.string("user")),
       ("id", JSON.Encode.string(id)),
       ("content", JSON.Encode.array(content->Array.map(userContentPartToJson))),
+      ("annotations", JSON.Encode.array(annotations->Array.map(snapshotAnnotationToJson))),
       ("createdAt", JSON.Encode.float(createdAt)),
     ])
   | Assistant(assistantMsg) =>

--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -92,12 +92,27 @@ let convertAssistantMessage = (
   }
 }
 
+let convertSnapshotAnnotation = (
+  ann: Snapshot.SnapshotAnnotation.t,
+): Client__Message.MessageAnnotation.t => {
+  id: ann.id,
+  selector: ann.selector,
+  tagName: ann.tagName,
+  cssClasses: ann.cssClasses,
+  comment: ann.comment,
+  screenshot: None, // Screenshots not stored in snapshots
+  sourceLocation: None, // Source locations not stored in snapshot annotations
+  boundingBox: None, // Bounding boxes not stored in snapshot annotations
+  nearbyText: ann.nearbyText,
+}
+
 let convertMessage = (msg: Snapshot.Message.t): StateTypes.Message.t => {
   switch msg {
-  | User({id, content, createdAt}) =>
+  | User({id, content, annotations, createdAt}) =>
     User({
       id,
       content: content->Array.map(convertUserContentPart),
+      annotations: annotations->Array.map(convertSnapshotAnnotation),
       createdAt,
     })
   | Assistant(assistantMsg) => Assistant(convertAssistantMessage(assistantMsg))

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -25,7 +25,7 @@ type action =
   // Task-scoped actions (routed to task sub-reducer)
   | TaskAction({target: taskTarget, action: TaskReducer.action})
   // User actions
-  | AddUserMessage({id: string, sessionId: string, content: array<UserContentPart.t>})
+  | AddUserMessage({id: string, sessionId: string, content: array<UserContentPart.t>, annotations: array<Message.MessageAnnotation.t>})
   // Cancel current turn
   | CancelTurn
   // Task management actions
@@ -509,18 +509,23 @@ let sendMessageToAPIImpl = (
   dispatch,
   ~message,
   ~attachments: array<Client__Message.fileAttachmentData>=[],
+  ~annotations: array<Client__Message.MessageAnnotation.t>=[],
   ~taskId,
 ) => {
   switch state.acpSession {
   | AcpSessionActive({sendPrompt}) =>
-    let contextBlocks =
+    // Page context from task (always included)
+    let pageContextBlocks =
       state.tasks
       ->Dict.get(taskId)
-      ->Option.mapOr([], Client__State__Types.taskToContentBlocks)
+      ->Option.mapOr([], Client__State__Types.taskToPageContextBlocks)
+
+    // Annotation content blocks from the message (not task state)
+    let annotationBlocks = Client__State__Types.messageAnnotationsToContentBlocks(annotations)
 
     // Build attachment content blocks
     let attachmentBlocks = buildAttachmentContentBlocks(attachments)
-    let additionalBlocks = Array.concat(contextBlocks, attachmentBlocks)
+    let additionalBlocks = Array.concat(pageContextBlocks, annotationBlocks)->Array.concat(attachmentBlocks)
 
     // Include runtime config metadata (e.g., framework, openrouterKeyValue) with each prompt
     let runtimeConfig = Client__RuntimeConfig.read()
@@ -613,7 +618,7 @@ let handleEffect = (effect, state: state, dispatch) => {
       // Handle delegation from task effects
       let delegate = (delegated: TaskReducer.delegated) => {
         switch delegated {
-        | NeedSendMessage({text, attachments}) =>
+        | NeedSendMessage({text, attachments, annotations}) =>
           // Resolve the taskId from target
           let taskId = switch target {
           | ForTask(id) => id
@@ -624,7 +629,7 @@ let handleEffect = (effect, state: state, dispatch) => {
               failwith("[TaskEffect] NeedSendMessage from CurrentTask but currentTask is New")
             }
           }
-          sendMessageToAPIImpl(state, dispatch, ~message=text, ~attachments, ~taskId)
+          sendMessageToAPIImpl(state, dispatch, ~message=text, ~attachments, ~annotations, ~taskId)
         | NeedUsageRefresh =>
           switch state.acpSession {
           | AcpSessionActive({apiBaseUrl}) => fetchUsageInfoImpl(dispatch, ~apiBaseUrl)
@@ -1090,7 +1095,7 @@ let next = (state: state, action) => {
   // ============================================================================
   // AddUserMessage - cross-cutting (creates tasks, manages dict)
   // ============================================================================
-  | AddUserMessage({id, sessionId, content}) => {
+  | AddUserMessage({id, sessionId, content, annotations}) => {
       let textContent = TaskReducer.extractTextFromUserContent(content)
 
       switch state.currentTask {
@@ -1107,10 +1112,10 @@ let next = (state: state, action) => {
         // Delegate AddUserMessage to the (now Loaded) task reducer
         promotedState->Lens.delegateToTask(
           Task.Selected(sessionId),
-          TaskReducer.AddUserMessage({id, content}),
+          TaskReducer.AddUserMessage({id, content, annotations}),
         )
       | Task.Selected(taskId) =>
-        state->Lens.delegateToTask(Task.Selected(taskId), TaskReducer.AddUserMessage({id, content}))
+        state->Lens.delegateToTask(Task.Selected(taskId), TaskReducer.AddUserMessage({id, content, annotations}))
       }
     }
 

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -14,6 +14,8 @@ let stripFileUriPrefix = Client__Task__Types.stripFileUriPrefix
 let makeAnnotationMeta = Client__Task__Types.makeAnnotationMeta
 let annotationToContentBlocks = Client__Task__Types.annotationToContentBlocks
 let taskToContentBlocks = Client__Task__Types.taskToContentBlocks
+let taskToPageContextBlocks = Client__Task__Types.taskToPageContextBlocks
+let messageAnnotationsToContentBlocks = Client__Task__Types.messageAnnotationsToContentBlocks
 
 type sendPromptFn = (
   string,

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -350,7 +350,7 @@ type action =
   | ToolErrorReceived({id: string, error: string})
   | ToolCallReceived({toolCall: Message.toolCall})
   // Content actions
-  | AddUserMessage({id: string, content: array<UserContentPart.t>})
+  | AddUserMessage({id: string, content: array<UserContentPart.t>, annotations: array<Message.MessageAnnotation.t>})
   // Annotation actions — unified selection mode
   | SetAnnotationMode({mode: Annotation.annotationMode})
   | ToggleAnnotationMode
@@ -407,6 +407,7 @@ type effect =
   | SendMessage({
       text: string,
       attachments: array<Message.fileAttachmentData>,
+      annotations: array<Message.MessageAnnotation.t>,
     })
   | NotifyTurnCompleted
   | CancelPrompt
@@ -416,6 +417,7 @@ type delegated =
   | NeedSendMessage({
       text: string,
       attachments: array<Message.fileAttachmentData>,
+      annotations: array<Message.MessageAnnotation.t>,
     })
   | NeedUsageRefresh
   | NeedCancelPrompt
@@ -818,16 +820,16 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
   // Per ACP spec: a new user message signals the end of the previous agent message
   | (Task.Loading(_), UserMessageReceived({id, text, timestamp})) =>
     let createdAt = Date.fromString(timestamp)->Date.getTime
-    let userMessage = Message.User({id, content: [UserContentPart.text(text)], createdAt})
+    let userMessage = Message.User({id, content: [UserContentPart.text(text)], annotations: [], createdAt})
     (task->Lens.completeStreamingMessage->Lens.insertMessage(userMessage), [])
 
   // ============================================================================
   // Loaded-only Actions - require isAgentRunning or planEntries
   // ============================================================================
-  | (Task.Loaded(data), AddUserMessage({id, content})) =>
+  | (Task.Loaded(data), AddUserMessage({id, content, annotations})) =>
     let text = extractTextFromUserContent(content)
     let attachments = extractAttachmentsFromUserContent(content)
-    let message = Message.User({id, content, createdAt: Date.now()})
+    let message = Message.User({id, content, annotations, createdAt: Date.now()})
 
     // Accumulate image attachments keyed by URI for write_file image_ref resolution
     let updatedImageAttachments = data.imageAttachments->Dict.copy
@@ -843,8 +845,12 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
         isAgentRunning: true,
         turnError: None, // Clear any previous error when sending a new message
         imageAttachments: updatedImageAttachments,
+        // Clear annotations from task state — they now live on the message
+        annotations: [],
+        annotationMode: Annotation.Off,
+        activePopupAnnotationId: None,
       }),
-      [SendMessage({text, attachments})],
+      [SendMessage({text, attachments, annotations})],
     )
 
   | (Task.Loaded(data), PlanReceived({entries})) => (
@@ -1123,7 +1129,7 @@ let handleEffect = (effect: effect, ~dispatch: action => unit, ~delegate: delega
           Promise.resolve()
         })
     }
-  | SendMessage({text, attachments}) => delegate(NeedSendMessage({text, attachments}))
+  | SendMessage({text, attachments, annotations}) => delegate(NeedSendMessage({text, attachments, annotations}))
   | NotifyTurnCompleted => delegate(NeedUsageRefresh)
   | CancelPrompt => delegate(NeedCancelPrompt)
   }

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -946,3 +946,154 @@ let taskToContentBlocks = (task: Task.t): array<ACPTypes.contentBlock> => {
     }
   }
 }
+
+// ============================================================================
+// Page-context-only content blocks (annotations now live on messages)
+// ============================================================================
+
+// Build page context blocks from Task (no annotations — those come from the message)
+let taskToPageContextBlocks = (task: Task.t): array<ACPTypes.contentBlock> => {
+  switch task {
+  | Task.Unloaded(_) => []
+  | Task.New({previewFrame})
+  | Task.Loading({previewFrame})
+  | Task.Loaded({previewFrame}) =>
+    [currentPageToContentBlock(previewFrame)]
+  }
+}
+
+// ============================================================================
+// MessageAnnotation -> ContentBlock conversion
+// ============================================================================
+
+// Convert a MessageAnnotation.sourceLocation back to Client__Types.SourceLocation.t
+// for reuse with makeAnnotationMeta
+let rec messageAnnotationSourceLocationToClientTypes = (
+  loc: Message.MessageAnnotation.sourceLocation,
+): Client__Types.SourceLocation.t => {
+  componentName: loc.componentName,
+  tagName: loc.tagName,
+  file: loc.file,
+  line: loc.line,
+  column: loc.column,
+  parent: loc.parent->Option.map(messageAnnotationSourceLocationToClientTypes),
+  componentProps: loc.componentProps,
+}
+
+// Build _meta JSON for a MessageAnnotation (reuses makeAnnotationMeta logic)
+let makeMessageAnnotationMeta = (
+  annotation: Message.MessageAnnotation.t,
+  ~index: int,
+): JSON.t => {
+  let sourceLocation = annotation.sourceLocation->Option.map(
+    messageAnnotationSourceLocationToClientTypes,
+  )
+  // Build a minimal Annotation.t-compatible record for makeAnnotationMeta
+  let obj = Dict.make()
+  obj->Dict.set("annotation", JSON.Encode.bool(true))
+  obj->Dict.set("annotation_index", JSON.Encode.int(index))
+  obj->Dict.set("annotation_id", JSON.Encode.string(annotation.id))
+  obj->Dict.set("tag_name", JSON.Encode.string(annotation.tagName))
+
+  let (file, line, column, componentName, componentProps, parent) = switch sourceLocation {
+  | Some(loc) => {
+      let cleanFile = stripFileUriPrefix(loc.file)
+      (Some(cleanFile), Some(loc.line), Some(loc.column), loc.componentName, loc.componentProps, loc.parent)
+    }
+  | None => (None, None, None, None, None, None)
+  }
+
+  obj->setOpt("comment", JSON.Encode.string, annotation.comment)
+  obj->setOpt("file", JSON.Encode.string, file)
+  obj->setOpt("line", JSON.Encode.int, line)
+  obj->setOpt("column", JSON.Encode.int, column)
+  obj->setOpt("component_name", JSON.Encode.string, componentName)
+  obj->setOpt("component_props", JSON.Encode.object, componentProps)
+  obj->setOpt("parent", x => x, serializeParentToJson(parent))
+  obj->setOpt("css_classes", JSON.Encode.string, annotation.cssClasses)
+  obj->setOpt("nearby_text", JSON.Encode.string, annotation.nearbyText)
+  obj->setOpt("bounding_box", boundingBoxToJson, annotation.boundingBox->Option.map(bb => {
+    Annotation.x: bb.x,
+    y: bb.y,
+    width: bb.width,
+    height: bb.height,
+  }))
+
+  JSON.Encode.object(obj)
+}
+
+// Build content blocks for a single MessageAnnotation
+// Returns 1-2 blocks: resource block with annotation _meta, optional screenshot blob
+let messageAnnotationToContentBlocks = (
+  annotation: Message.MessageAnnotation.t,
+  ~index: int,
+): array<ACPTypes.contentBlock> => {
+  let _meta = makeMessageAnnotationMeta(annotation, ~index)
+
+  // Build text description and URI from source location, falling back to selector
+  let (uri, text) = switch annotation.sourceLocation {
+  | Some(loc) => {
+      let f = stripFileUriPrefix(loc.file)
+      let l = loc.line->Int.toString
+      let c = loc.column->Int.toString
+      (`file://${f}:${l}:${c}`, `Annotated element: <${annotation.tagName}> at ${f}:${l}:${c}`)
+    }
+  | None =>
+    switch annotation.selector {
+    | Some(sel) => (`selector://${sel}`, `Annotated element: <${annotation.tagName}> matching ${sel}`)
+    | None => (`element://${annotation.tagName}`, `Annotated element: <${annotation.tagName}>`)
+    }
+  }
+
+  let resourceBlock: ACPTypes.contentBlock = {
+    type_: "resource",
+    text: None,
+    uri: None,
+    resource: Some({
+      _meta: Some(_meta),
+      annotations: None,
+      resource: ACPTypes.TextResourceContents({uri, mimeType: Some("text/plain"), text}),
+    }),
+    content: None,
+  }
+
+  let screenshotBlock = annotation.screenshot->Option.map(screenshotDataUrl => {
+    let (mimeType, base64Data) = parseDataUrl(screenshotDataUrl)
+
+    let screenshotMeta: JSON.t = {
+      let obj = Dict.make()
+      obj->Dict.set("annotation_screenshot", JSON.Encode.bool(true))
+      obj->Dict.set("annotation_index", JSON.Encode.int(index))
+      obj->Dict.set("annotation_id", JSON.Encode.string(annotation.id))
+      JSON.Encode.object(obj)
+    }
+
+    let block: ACPTypes.contentBlock = {
+      type_: "resource",
+      text: None,
+      uri: None,
+      resource: Some({
+        _meta: Some(screenshotMeta),
+        annotations: None,
+        resource: ACPTypes.BlobResourceContents({
+          uri: `annotation://${annotation.id}/screenshot`,
+          mimeType: Some(mimeType),
+          blob: base64Data,
+        }),
+      }),
+      content: None,
+    }
+    block
+  })
+
+  [Some(resourceBlock), screenshotBlock]->Array.filterMap(x => x)
+}
+
+// Build content blocks from an array of MessageAnnotations
+let messageAnnotationsToContentBlocks = (
+  annotations: array<Message.MessageAnnotation.t>,
+): array<ACPTypes.contentBlock> => {
+  annotations->Array.flatMapWithIndex((annotation, index) =>
+    messageAnnotationToContentBlocks(annotation, ~index)
+  )
+}

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -65,6 +65,7 @@ describe("Client State Reducer", () => {
       id: "user-1",
       sessionId: "session-1",
       content: [UserContentPart.text("Hello")],
+      annotations: [],
     })
 
     let (nextState, _effects) = Reducer.next(state, action)
@@ -147,6 +148,7 @@ describe("Client State Reducer", () => {
         id: "user-1",
         sessionId: "session-1",
         content: [UserContentPart.text("Hi")],
+        annotations: [],
       }),
     )
 
@@ -351,6 +353,7 @@ describe("Client State Reducer - Streaming Flow", () => {
         id: "user-1",
         sessionId: "session-id",
         content: [UserContentPart.text("Hello")],
+        annotations: [],
       }),
     )
 
@@ -394,6 +397,7 @@ describe("Client State Reducer - Selectors", () => {
     let userMsg = Reducer.Message.User({
       id: "user-1",
       content: [],
+      annotations: [],
       createdAt: 0.0,
     })
 
@@ -575,6 +579,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
         id: "user-1",
         sessionId: "sessionId",
         content: [UserContentPart.text("First message")],
+        annotations: [],
       }),
     )
 
@@ -586,6 +591,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
         id: "user-2",
         sessionId: "sessionId",
         content: [UserContentPart.text("Second message")],
+        annotations: [],
       }),
     )
 
@@ -605,6 +611,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
         id: "user-1",
         sessionId: "sessionId",
         content: [UserContentPart.text("First message")],
+        annotations: [],
       }),
     )
 
@@ -629,6 +636,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         Reducer.Message.User({
           id: "user-1",
           content: [UserContentPart.Text({text: "Hello from task 1"})],
+          annotations: [],
           createdAt: 1000.0,
         }),
       ],
@@ -643,6 +651,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         Reducer.Message.User({
           id: "user-2",
           content: [UserContentPart.Text({text: "Hello from task 2"})],
+          annotations: [],
           createdAt: 2000.0,
         }),
       ],
@@ -741,6 +750,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         Reducer.Message.User({
           id: "user-1",
           content: [UserContentPart.Text({text: "Old message"})],
+          annotations: [],
           createdAt: 1000.0,
         }),
       ],
@@ -783,6 +793,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         id: "user-2",
         sessionId: "session-new",
         content: [UserContentPart.text("Hello after delete")],
+        annotations: [],
       }),
     )
 
@@ -844,6 +855,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         id: "user-1",
         sessionId: "session",
         content: [UserContentPart.Text({text: "Message in task 1"})],
+        annotations: [],
       }),
     )
 
@@ -853,6 +865,7 @@ describe("Client State Reducer - Task Management Actions", () => {
         id: "user-2",
         sessionId: "session",
         content: [UserContentPart.Text({text: "Second message"})],
+        annotations: [],
       }),
     )
 
@@ -927,6 +940,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
         Reducer.Message.User({
           id: "user-1",
           content: [UserContentPart.Text({text: "Existing message"})],
+          annotations: [],
           createdAt: 1000.0,
         }),
       ],
@@ -1115,5 +1129,131 @@ describe("Client State Reducer - UpdateTaskTitle safety", () => {
     t->expect(TestHelpers.getTaskCount(nextState))->Expect.toBe(1)
     let task = nextState.tasks->Dict.get("task-1")->Option.getOrThrow
     t->expect(Task.getTitle(task))->Expect.toEqual(Some("Test Task"))
+  })
+})
+
+// ============================================================================
+// Annotation-to-Message Tests (Issue #466)
+// ============================================================================
+
+module MessageAnnotation = Client__Message.MessageAnnotation
+
+describe("Client State Reducer - Annotations on Messages", () => {
+  let _sampleAnnotations: array<MessageAnnotation.t> = [
+    {
+      id: "ann-1",
+      selector: Some(".btn-submit"),
+      tagName: "button",
+      cssClasses: Some("btn-submit primary"),
+      comment: Some("This button is broken"),
+      screenshot: None,
+      sourceLocation: None,
+      boundingBox: None,
+      nearbyText: Some("Submit"),
+    },
+    {
+      id: "ann-2",
+      selector: Some("div.header"),
+      tagName: "div",
+      cssClasses: Some("header"),
+      comment: None,
+      screenshot: None,
+      sourceLocation: None,
+      boundingBox: None,
+      nearbyText: Some("Welcome"),
+    },
+  ]
+
+  test("AddUserMessage with annotations stores them on the message", t => {
+    let state = Reducer.defaultState
+    let action = Reducer.AddUserMessage({
+      id: "user-1",
+      sessionId: "session-1",
+      content: [UserContentPart.text("Fix this")],
+      annotations: _sampleAnnotations,
+    })
+
+    let (nextState, _effects) = Reducer.next(state, action)
+
+    let messages = Reducer.Selectors.messages(nextState)
+    t->expect(messages->Array.length)->Expect.toBe(1)
+
+    switch messages->Array.get(0)->Option.getOrThrow {
+    | Reducer.Message.User({annotations, _}) =>
+      t->expect(annotations->Array.length)->Expect.toBe(2)
+      t->expect((annotations->Array.getUnsafe(0)).id)->Expect.toBe("ann-1")
+      t->expect((annotations->Array.getUnsafe(0)).tagName)->Expect.toBe("button")
+      t->expect((annotations->Array.getUnsafe(0)).comment)->Expect.toEqual(Some("This button is broken"))
+      t->expect((annotations->Array.getUnsafe(1)).id)->Expect.toBe("ann-2")
+    | _ => JsExn.throw("Expected User message")
+    }
+  })
+
+  test("AddUserMessage with only annotations (no text) creates valid message", t => {
+    let state = Reducer.defaultState
+    let action = Reducer.AddUserMessage({
+      id: "user-1",
+      sessionId: "session-1",
+      content: [],
+      annotations: _sampleAnnotations,
+    })
+
+    let (nextState, _effects) = Reducer.next(state, action)
+
+    let messages = Reducer.Selectors.messages(nextState)
+    t->expect(messages->Array.length)->Expect.toBe(1)
+
+    switch messages->Array.get(0)->Option.getOrThrow {
+    | Reducer.Message.User({content, annotations, _}) =>
+      t->expect(content->Array.length)->Expect.toBe(0)
+      t->expect(annotations->Array.length)->Expect.toBe(2)
+    | _ => JsExn.throw("Expected User message")
+    }
+  })
+
+  test("AddUserMessage without annotations stores empty array", t => {
+    let state = Reducer.defaultState
+    let action = Reducer.AddUserMessage({
+      id: "user-1",
+      sessionId: "session-1",
+      content: [UserContentPart.text("Hello")],
+      annotations: [],
+    })
+
+    let (nextState, _effects) = Reducer.next(state, action)
+
+    let messages = Reducer.Selectors.messages(nextState)
+    switch messages->Array.get(0)->Option.getOrThrow {
+    | Reducer.Message.User({annotations, _}) =>
+      t->expect(annotations->Array.length)->Expect.toBe(0)
+    | _ => JsExn.throw("Expected User message")
+    }
+  })
+
+  test("SendMessage effect carries annotations from AddUserMessage", t => {
+    let state = Reducer.defaultState
+    let action = Reducer.AddUserMessage({
+      id: "user-1",
+      sessionId: "session-1",
+      content: [UserContentPart.text("Fix this")],
+      annotations: _sampleAnnotations,
+    })
+
+    let (_nextState, effects) = Reducer.next(state, action)
+
+    // Find the TaskEffect wrapping SendMessage
+    let sendEffect = effects->Array.find(eff =>
+      switch eff {
+      | Reducer.TaskEffect({effect: SendMessage(_)}) => true
+      | _ => false
+      }
+    )
+
+    switch sendEffect {
+    | Some(Reducer.TaskEffect({effect: SendMessage({annotations})})) =>
+      t->expect(annotations->Array.length)->Expect.toBe(2)
+      t->expect((annotations->Array.getUnsafe(0)).id)->Expect.toBe("ann-1")
+    | _ => JsExn.throw("Expected TaskEffect(SendMessage) with annotations")
+    }
   })
 })

--- a/libs/client/test/Client__State__Types.test.res
+++ b/libs/client/test/Client__State__Types.test.res
@@ -358,3 +358,170 @@ describe("Client__State__Types", () => {
     })
   })
 })
+
+// ============================================================================
+// MessageAnnotation Tests (Issue #466)
+// ============================================================================
+
+module MessageAnnotation = Client__Message.MessageAnnotation
+
+describe("MessageAnnotation.fromAnnotation", () => {
+  test("snapshots all annotation fields", t => {
+    let annotation = makeTestAnnotation(
+      ~file="file:///home/user/src/Button.tsx",
+      ~line=42,
+      ~column=5,
+      ~componentName="Button",
+      ~tagName="button",
+      ~selector=".btn-submit",
+      ~cssClasses="btn-submit primary",
+      ~nearbyText="Submit",
+      ~boundingBox={x: 10.0, y: 20.0, width: 100.0, height: 50.0},
+    )
+    // Add a comment and screenshot to the annotation
+    let annotation = {...annotation, comment: Some("This is broken"), screenshot: Some("data:image/jpeg;base64,abc123")}
+
+    let snapshot = MessageAnnotation.fromAnnotation(annotation)
+
+    t->expect(snapshot.id)->Expect.toBe("test-annotation-id")
+    t->expect(snapshot.selector)->Expect.toEqual(Some(".btn-submit"))
+    t->expect(snapshot.tagName)->Expect.toBe("button")
+    t->expect(snapshot.cssClasses)->Expect.toEqual(Some("btn-submit primary"))
+    t->expect(snapshot.comment)->Expect.toEqual(Some("This is broken"))
+    t->expect(snapshot.screenshot)->Expect.toEqual(Some("data:image/jpeg;base64,abc123"))
+    t->expect(snapshot.nearbyText)->Expect.toEqual(Some("Submit"))
+  })
+
+  test("converts source location correctly", t => {
+    let annotation = makeTestAnnotation(
+      ~file="file:///home/user/src/Header.tsx",
+      ~line=10,
+      ~column=3,
+      ~componentName="Header",
+      ~tagName="div",
+    )
+
+    let snapshot = MessageAnnotation.fromAnnotation(annotation)
+
+    switch snapshot.sourceLocation {
+    | Some(loc) =>
+      t->expect(loc.file)->Expect.toBe("file:///home/user/src/Header.tsx")
+      t->expect(loc.line)->Expect.toBe(10)
+      t->expect(loc.column)->Expect.toBe(3)
+      t->expect(loc.componentName)->Expect.toEqual(Some("Header"))
+    | None => t->expect("sourceLocation")->Expect.toBe("should be Some")
+    }
+  })
+
+  test("converts bounding box correctly", t => {
+    let annotation = makeTestAnnotation(
+      ~file="src/App.tsx",
+      ~line=1,
+      ~column=1,
+      ~boundingBox={x: 5.5, y: 10.5, width: 200.0, height: 100.0},
+    )
+
+    let snapshot = MessageAnnotation.fromAnnotation(annotation)
+
+    switch snapshot.boundingBox {
+    | Some(bb) =>
+      t->expect(bb.x)->Expect.toBe(5.5)
+      t->expect(bb.y)->Expect.toBe(10.5)
+      t->expect(bb.width)->Expect.toBe(200.0)
+      t->expect(bb.height)->Expect.toBe(100.0)
+    | None => t->expect("boundingBox")->Expect.toBe("should be Some")
+    }
+  })
+
+  test("handles None fields gracefully", t => {
+    let annotation: Annotation.t = {
+      id: "test-minimal",
+      element: makeMockElement(),
+      comment: None,
+      selector: None,
+      screenshot: None,
+      sourceLocation: None,
+      tagName: "span",
+      cssClasses: None,
+      boundingBox: None,
+      nearbyText: None,
+      position: {xPercent: 0.0, yAbsolute: 0.0},
+      timestamp: 0.0,
+    }
+
+    let snapshot = MessageAnnotation.fromAnnotation(annotation)
+
+    t->expect(snapshot.id)->Expect.toBe("test-minimal")
+    t->expect(snapshot.tagName)->Expect.toBe("span")
+    t->expect(snapshot.selector)->Expect.toEqual(None)
+    t->expect(snapshot.comment)->Expect.toEqual(None)
+    t->expect(snapshot.screenshot)->Expect.toEqual(None)
+    t->expect(snapshot.sourceLocation)->Expect.toEqual(None)
+    t->expect(snapshot.boundingBox)->Expect.toEqual(None)
+    t->expect(snapshot.nearbyText)->Expect.toEqual(None)
+  })
+})
+
+describe("messageAnnotationsToContentBlocks", () => {
+  test("produces resource blocks from MessageAnnotation array", t => {
+    let annotations: array<MessageAnnotation.t> = [
+      {
+        id: "ann-1",
+        selector: Some(".submit"),
+        tagName: "button",
+        cssClasses: Some("submit"),
+        comment: Some("Fix this"),
+        screenshot: None,
+        sourceLocation: Some({
+          componentName: Some("Form"),
+          tagName: "button",
+          file: "/src/Form.tsx",
+          line: 42,
+          column: 5,
+          parent: None,
+          componentProps: None,
+        }),
+        boundingBox: None,
+        nearbyText: Some("Submit"),
+      },
+    ]
+
+    let blocks = Types.messageAnnotationsToContentBlocks(annotations)
+
+    // 1 annotation without screenshot = 1 block
+    t->expect(blocks->Array.length)->Expect.toBe(1)
+
+    let meta = getMeta(blocks->Array.getUnsafe(0))
+    t->expect(getMetaBool(meta, "annotation"))->Expect.toBe(true)
+    t->expect(getMetaFloat(meta, "annotation_index"))->Expect.toBe(0.0)
+    t->expect(getMetaString(meta, "annotation_id"))->Expect.toBe("ann-1")
+    t->expect(getMetaString(meta, "tag_name"))->Expect.toBe("button")
+    t->expect(getMetaString(meta, "comment"))->Expect.toBe("Fix this")
+  })
+
+  test("produces screenshot blocks when screenshot is present", t => {
+    let annotations: array<MessageAnnotation.t> = [
+      {
+        id: "ann-1",
+        selector: None,
+        tagName: "div",
+        cssClasses: None,
+        comment: None,
+        screenshot: Some("data:image/jpeg;base64,abc123"),
+        sourceLocation: None,
+        boundingBox: None,
+        nearbyText: None,
+      },
+    ]
+
+    let blocks = Types.messageAnnotationsToContentBlocks(annotations)
+
+    // 1 annotation with screenshot = 2 blocks
+    t->expect(blocks->Array.length)->Expect.toBe(2)
+  })
+
+  test("empty annotations array produces no blocks", t => {
+    let blocks = Types.messageAnnotationsToContentBlocks([])
+    t->expect(blocks->Array.length)->Expect.toBe(0)
+  })
+})

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -35,6 +35,7 @@ describe("Task - Single Streaming Message Invariant", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     task1
@@ -103,6 +104,7 @@ describe("Task - Tool Call Lifecycle", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     task1
@@ -213,6 +215,7 @@ describe("Task - Agent Running State", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
 
@@ -226,6 +229,7 @@ describe("Task - Agent Running State", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     t->expect(TaskReducer.Selectors.isAgentRunning(task2))->Expect.toEqual(Some(true))
@@ -303,6 +307,7 @@ describe("Task - Error Handling", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     t->expect(TaskReducer.Selectors.isAgentRunning(task2))->Expect.toEqual(Some(true))
@@ -320,6 +325,7 @@ describe("Task - Error Handling", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     let (task1, _) = TaskReducer.next(task0, StreamingStarted)
@@ -384,6 +390,7 @@ describe("Task - Error Handling", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "New message"})],
+        annotations: [],
       }),
     )
     t->expect(TaskReducer.Selectors.turnError(task3))->Expect.toEqual(None)
@@ -403,6 +410,7 @@ describe("Task - CancelTurn", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     // Agent is now running
@@ -467,6 +475,7 @@ describe("Task - CancelTurn", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
 
@@ -511,6 +520,7 @@ describe("Task - CancelTurn", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "retry"})],
+        annotations: [],
       }),
     )
     let (cancelled, _) = TaskReducer.next(task2, CancelTurn)
@@ -527,6 +537,7 @@ describe("Task - CancelTurn", () => {
       AddUserMessage({
         id: "user-2",
         content: [Client__Task__Types.UserContentPart.Text({text: "New question"})],
+        annotations: [],
       }),
     )
 
@@ -560,6 +571,7 @@ describe("Task - Stale Event Guard", () => {
       AddUserMessage({
         id: "user-1",
         content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
       }),
     )
     let (task2, _) = TaskReducer.next(task1, CancelTurn)
@@ -647,6 +659,169 @@ describe("Task - Stale Event Guard", () => {
     | Some(Message.Streaming({textBuffer})) =>
       t->expect(textBuffer)->Expect.toBe("loading text")
     | _ => t->expect("Streaming message")->Expect.toBe("not found during loading")
+    }
+  })
+})
+
+// ============================================================================
+// Annotation-to-Message Tests (Issue #466)
+// ============================================================================
+
+module Annotation = Client__Annotation__Types
+module MessageAnnotation = Client__Message.MessageAnnotation
+
+// Helper to create a mock DOM element for testing
+let _makeMockElement: unit => WebAPI.DOMAPI.element = %raw(`
+  function() { return { tagName: "DIV" }; }
+`)
+
+let _sampleMessageAnnotations: array<MessageAnnotation.t> = [
+  {
+    id: "ann-1",
+    selector: Some(".btn-submit"),
+    tagName: "button",
+    cssClasses: Some("btn-submit primary"),
+    comment: Some("This button is broken"),
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: Some("Submit"),
+  },
+  {
+    id: "ann-2",
+    selector: Some("div.header"),
+    tagName: "div",
+    cssClasses: Some("header"),
+    comment: None,
+    screenshot: None,
+    sourceLocation: None,
+    boundingBox: None,
+    nearbyText: Some("Welcome"),
+  },
+]
+
+describe("Task - Annotations Cleared on Send (Issue #466)", () => {
+  // Helper: create a loaded task with annotations in task state
+  let _taskWithAnnotations = () => {
+    let task = TestHelpers.makeLoadedTask()
+    // Enter selecting mode and add annotations
+    let (task1, _) = TaskReducer.next(task, SetAnnotationMode({mode: Selecting}))
+    // Manually set annotations via ToggleAnnotation
+    let el1 = _makeMockElement()
+    let el2 = _makeMockElement()
+    let (task2, _) = TaskReducer.next(
+      task1,
+      ToggleAnnotation({element: el1, position: {xPercent: 50.0, yAbsolute: 100.0}, tagName: "button"}),
+    )
+    let (task3, _) = TaskReducer.next(
+      task2,
+      ToggleAnnotation({element: el2, position: {xPercent: 30.0, yAbsolute: 200.0}, tagName: "div"}),
+    )
+    task3
+  }
+
+  test("AddUserMessage with annotations clears task-level annotations", t => {
+    let task = _taskWithAnnotations()
+
+    // Verify annotations exist on task before send
+    t->expect(TaskReducer.Selectors.annotations(task)->Option.getOr([])->Array.length)->Expect.toBe(2)
+
+    // Send message with annotations
+    let (task2, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: "user-1",
+        content: [Client__Task__Types.UserContentPart.Text({text: "Fix this"})],
+        annotations: _sampleMessageAnnotations,
+      }),
+    )
+
+    // Task-level annotations should be cleared
+    t->expect(TaskReducer.Selectors.annotations(task2)->Option.getOr([])->Array.length)->Expect.toBe(0)
+  })
+
+  test("AddUserMessage resets annotationMode to Off", t => {
+    let task = _taskWithAnnotations()
+
+    // Verify we're in Selecting mode before send
+    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task))->Expect.toEqual(Some(true))
+
+    // Send message
+    let (task2, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: "user-1",
+        content: [Client__Task__Types.UserContentPart.Text({text: "Fix this"})],
+        annotations: _sampleMessageAnnotations,
+      }),
+    )
+
+    // Annotation mode should be Off
+    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task2))->Expect.toEqual(Some(false))
+  })
+
+  test("AddUserMessage clears activePopupAnnotationId", t => {
+    let task = _taskWithAnnotations()
+
+    // Verify popup is open (from ToggleAnnotation which opens popup for last added)
+    t->expect(TaskReducer.Selectors.activePopupAnnotationId(task)->Option.getOr(None)->Option.isSome)->Expect.toBe(true)
+
+    // Send message
+    let (task2, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: "user-1",
+        content: [],
+        annotations: _sampleMessageAnnotations,
+      }),
+    )
+
+    // Active popup should be cleared
+    t->expect(TaskReducer.Selectors.activePopupAnnotationId(task2)->Option.getOr(None)->Option.isNone)->Expect.toBe(true)
+  })
+
+  test("Annotations are stored on the message itself", t => {
+    let task = TestHelpers.makeLoadedTask()
+
+    let (task2, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: "user-1",
+        content: [Client__Task__Types.UserContentPart.Text({text: "Check these"})],
+        annotations: _sampleMessageAnnotations,
+      }),
+    )
+
+    let messages = TestHelpers.getMessages(task2)
+    t->expect(messages->Array.length)->Expect.toBe(1)
+
+    switch messages->Array.get(0) {
+    | Some(Message.User({annotations, _})) =>
+      t->expect(annotations->Array.length)->Expect.toBe(2)
+      t->expect((annotations->Array.getUnsafe(0)).id)->Expect.toBe("ann-1")
+      t->expect((annotations->Array.getUnsafe(0)).comment)->Expect.toEqual(Some("This button is broken"))
+      t->expect((annotations->Array.getUnsafe(1)).id)->Expect.toBe("ann-2")
+      t->expect((annotations->Array.getUnsafe(1)).comment)->Expect.toEqual(None)
+    | _ => t->expect("User message")->Expect.toBe("not found")
+    }
+  })
+
+  test("SendMessage effect carries annotations", t => {
+    let task = TestHelpers.makeLoadedTask()
+
+    let (_task2, effects) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: "user-1",
+        content: [Client__Task__Types.UserContentPart.Text({text: "Fix"})],
+        annotations: _sampleMessageAnnotations,
+      }),
+    )
+
+    switch effects->Array.get(0) {
+    | Some(SendMessage({annotations})) =>
+      t->expect(annotations->Array.length)->Expect.toBe(2)
+    | _ => t->expect("SendMessage effect")->Expect.toBe("not found")
     }
   })
 })


### PR DESCRIPTION
## Summary

Closes #466

Moves annotations from task-level state to being first-class content on `Message.User` records. This fixes two issues:

1. **Empty bubble fixed**: When sending only annotations (no text), the chat now renders annotation chips instead of an empty purple bubble
2. **Visual history**: Annotated elements are now visible in the chat history as compact chips with numbered badges, tag names, and optional comments

## What Changed

### New Type: `MessageAnnotation.t`
Serializable snapshot of an annotation — captures all metadata (selector, tagName, cssClasses, comment, screenshot, sourceLocation, boundingBox, nearbyText) while dropping the live DOM `element` reference.

### Send Flow
- **Chatbox** snapshots live annotations into `MessageAnnotation` records at submit time
- **`AddUserMessage`** action carries annotations through the entire chain
- **Task reducer** attaches annotations to the `Message.User` record, then clears task-level annotations, annotation mode, and popup
- **`sendMessageToAPIImpl`** reads annotations from the effect payload (not task state), via new `messageAnnotationsToContentBlocks` function

### API Send Path Split
- `taskToPageContextBlocks(task)` — page context only (URL, viewport, device)
- `messageAnnotationsToContentBlocks(annotations)` — annotation content blocks from the message

### Rendering
`Client__UserMessage` renders annotations as compact chips: circled number badge + `<tagName.firstClass>` label, with optional comment text below. When a message has only annotations and no text, the chips *are* the message content.

### Send Gate
Changed from `hasAnnotatedComments` (only annotations with comments enabled send) to `hasAnnotations` (any annotation enables the send button).

## Files Changed (16)

| File | Change |
|------|--------|
| `Client__Message.res` | `MessageAnnotation` module + `annotations` on `User` |
| `Client__Task__Reducer.res` | Carry annotations, clear task state on send |
| `Client__Task__Types.res` | `taskToPageContextBlocks`, `messageAnnotationsToContentBlocks` |
| `Client__State__StateReducer.res` | Updated action type + send path |
| `Client__State__Types.res` | Re-exports for new functions |
| `Client__State.res` | Updated `addUserMessage` signature |
| `Client__Chatbox.res` | Snapshot annotations on send |
| `Client__PromptInput.res` | `hasAnnotatedComments` → `hasAnnotations` |
| `Client__UserMessage.res` | Annotation chip rendering |
| `Client__StateSnapshot.res` | `SnapshotAnnotation` + serialization |
| `Client__StateSnapshot__Storybook.res` | Snapshot → live conversion |
| `Client__TaskTabs.story.res` | Updated `Message.User` construction |
| `Client__UserMessage.story.res` | **New** — 6 story variants |
| 3 test files | **16 new tests** (231 total) |

## Tests

- **StateReducer**: annotations on message, annotation-only message, empty annotations, SendMessage effect carries annotations
- **TaskReducer**: annotations cleared on send, annotationMode reset to Off, popup cleared, annotations stored on message, SendMessage effect carries them
- **Types**: `fromAnnotation` snapshots all fields, source location conversion, bounding box, None fields, `messageAnnotationsToContentBlocks` output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
