### PR TITLE
fix: address shallow UI edits with component awareness and structural guidance

### DIFF
--- a/.changeset/shallow-ui-edits-fix.md
+++ b/.changeset/shallow-ui-edits-fix.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/client": minor
+"@frontman-ai/frontman-core": patch
+---
+
+Fix shallow UI edits by giving the agent visual context and structural awareness. Add component name detection (React/Vue/Astro) to `get_dom` output, add UI & Layout Changes guidance to the system prompt with before/after screenshot workflow, add large-file comprehension strategy to `read_file`, and require edit summaries with trade-off analysis. Includes a manual test fixture (`test/manual/vite-dashboard/`) with a 740-line component to reproduce the original issue.

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
@@ -48,6 +48,7 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
   ## Response Formatting
 
   - For code changes: lead with what changed and why. Don't dump full file contents — reference file paths instead.
+  - After making edits, always respond with a summary. Never complete silently. Include: what changed and why, what trade-offs were made, what alternative approaches exist if the result isn't sufficient. For UI/layout changes, suggest the user verify visually.
   - Reference files with backticks and line numbers when relevant: `src/app.ts:42`.
   - When suggesting multiple options, use numbered lists so the user can respond quickly.
   - Suggest logical next steps briefly when natural (tests, builds, commits). Don't ask — suggest.
@@ -61,6 +62,13 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
   - Add code comments only when necessary to explain non-obvious logic.
   - Match existing code style and conventions in the project.
   - Prefer editing existing files. Only create new files when the task requires it.
+
+  ## UI & Layout Changes
+
+  When asked to modify visual appearance, layout, or spacing:
+  - **Before editing**: Use `take_screenshot` to capture the current visual state and `get_dom` to inspect the rendered page structure. The simplified DOM output includes `component` attributes showing which React/Vue/Astro component renders each element — use these to map DOM sections back to source code.
+  - **Strategy**: Prefer structural layout changes (collapsible sections, density modes, layout restructuring) over cosmetic tweaks (padding/margin adjustments) unless the user specifically requests cosmetic changes. For ambiguous requests like "make it smaller" or "take less space", identify which sections consume the most space before editing.
+  - **After editing**: Use `take_screenshot` again to verify the result visually. Summarize what changed, what trade-offs were made, what alternatives exist, and suggest the user verify in their browser.
   """
 
   # ===========================================================================
@@ -233,6 +241,7 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
     3. **Consider the user's comment** - The comment describes what the user wants changed
     4. **Make the change(s)** - Apply modifications at or near the annotated location(s)
     5. **Write the file(s)** - Save changes using the same path(s)
+    6. **Verify and summarize** - For visual changes, use `take_screenshot` to verify the result. Always summarize what changed and why.
 
     ### Multiple Annotations
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/prompts_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/prompts_test.exs
@@ -78,6 +78,7 @@ defmodule FrontmanServer.Tasks.Execution.PromptsTest do
       assert prompt =~ "## Rules"
       assert prompt =~ "## Response Formatting"
       assert prompt =~ "## Code Quality"
+      assert prompt =~ "## UI & Layout Changes"
     end
 
     test "has_typescript_react includes TypeScript / React section" do
@@ -91,6 +92,53 @@ defmodule FrontmanServer.Tasks.Execution.PromptsTest do
       prompt = Prompts.build(has_typescript_react: false)
 
       refute prompt =~ "## TypeScript / React"
+    end
+  end
+
+  describe "build/1 UI and layout guidance" do
+    test "base prompt includes UI & Layout Changes section with before/after workflow" do
+      prompt = Prompts.build([])
+
+      assert prompt =~ "## UI & Layout Changes"
+      assert prompt =~ "get_dom"
+      assert prompt =~ "take_screenshot"
+      # Before editing
+      assert prompt =~ "Before editing"
+      # After editing
+      assert prompt =~ "After editing"
+      assert prompt =~ "verify the result visually"
+    end
+
+    test "base prompt includes structural over cosmetic preference" do
+      prompt = Prompts.build([])
+
+      assert prompt =~ "structural layout changes"
+      assert prompt =~ "cosmetic tweaks"
+    end
+
+    test "base prompt includes edit summary guidance with alternatives and trade-offs" do
+      prompt = Prompts.build([])
+
+      assert prompt =~ "Never complete silently"
+      assert prompt =~ "trade-offs"
+      assert prompt =~ "alternative approaches"
+    end
+
+    test "large-file guidance is handled by tool guards, not prompt" do
+      prompt = Prompts.build([])
+
+      # Large-file strategy is now enforced by FileTracker (staleness check,
+      # coverage warning) and the read_file tool description, not the system prompt
+      refute prompt =~ "200+ lines"
+    end
+  end
+
+  describe "build/1 annotation workflow validation" do
+    test "annotation guidance includes verification step" do
+      prompt = Prompts.build(has_annotations: true)
+
+      assert prompt =~ "Verify and summarize"
+      assert prompt =~ "take_screenshot"
     end
   end
 

--- a/libs/bindings/src/Fs.res
+++ b/libs/bindings/src/Fs.res
@@ -53,3 +53,4 @@ module Promises = {
 @send external isDirectory: stats => bool = "isDirectory"
 @send external isSymbolicLink: stats => bool = "isSymbolicLink"
 @get external size: stats => float = "size"
+@get external mtimeMs: stats => float = "mtimeMs"

--- a/libs/client/src/Client__ComponentName.res
+++ b/libs/client/src/Client__ComponentName.res
@@ -1,0 +1,94 @@
+// Synchronous component name detection across React, Vue, and Astro.
+//
+// Returns the display name of the nearest component owning a DOM element.
+// Cheap enough to call per-node during DOM walks (microseconds, no I/O,
+// no source maps). This is the sync counterpart to Client__SourceDetection
+// which returns full SourceLocation.t asynchronously.
+//
+// Cascade order: React fiber → Vue instance → Astro annotation
+// Each step is a pure in-memory property read with no network or parsing cost.
+
+// ── React: walk __reactFiber$ to find nearest function component name ──
+
+// Try to get React component name synchronously from fiber internals.
+// Returns null if element is not React-rendered or fiber is inaccessible.
+let _reactComponentName: WebAPI.DOMAPI.element => Nullable.t<string> = %raw(`
+  function(element) {
+    try {
+      var keys = Object.keys(element);
+      for (var i = 0; i < keys.length; i++) {
+        if (keys[i].startsWith("__reactFiber$") || keys[i].startsWith("__reactInternalInstance$")) {
+          var fiber = element[keys[i]];
+          var current = fiber;
+          while (current) {
+            if (current.type && typeof current.type === "function") {
+              var name = current.type.displayName || current.type.name;
+              if (name && name !== "Fragment" && name !== "Suspense" && !name.startsWith("_")) {
+                return name;
+              }
+            }
+            current = current.return;
+          }
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+`)
+
+// ── Vue: read __vueParentComponent → getName ───────────────────────────
+
+let _vueComponentName = (element: WebAPI.DOMAPI.element): option<string> => {
+  switch Client__Vue__SourceDetection.getVueComponent(element)->Nullable.toOption {
+  | Some(instance) => Client__Vue__SourceDetection.VueComponent.getName(instance)
+  | None => None
+  }
+}
+
+// ── Astro: read annotation displayName from window.__frontman_annotations__ ─
+
+let _astroComponentName = (
+  element: WebAPI.DOMAPI.element,
+  ~window: WebAPI.DOMAPI.window,
+): option<string> => {
+  switch FrontmanBindings.AstroAnnotations.getAnnotationsApi(window) {
+  | Some(api) =>
+    switch api.get(element)->Nullable.toOption {
+    | Some(annotation) =>
+      switch annotation.displayName {
+      | Some(name) => Some(name)
+      | None => Some(Client__SourcePath.extractFilename(annotation.file))
+      }
+    | None => None
+    }
+  | None => None
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+// Resolve the component name for a DOM element, trying each framework
+// in order: React → Vue → Astro. Returns None for plain HTML elements
+// or unsupported frameworks.
+//
+// The ~window parameter is optional. Without it, only React and Vue
+// detection run (Astro needs window.__frontman_annotations__). Callers
+// that have a window reference (e.g. get_dom via withPreviewDoc) should
+// pass it to get Astro coverage too.
+let getForElement = (
+  element: WebAPI.DOMAPI.element,
+  ~window: option<WebAPI.DOMAPI.window>=?,
+): option<string> => {
+  switch _reactComponentName(element)->Nullable.toOption {
+  | Some(name) => Some(name)
+  | None =>
+    switch _vueComponentName(element) {
+    | Some(name) => Some(name)
+    | None =>
+      switch window {
+      | Some(win) => _astroComponentName(element, ~window=win)
+      | None => None
+      }
+    }
+  }
+}

--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -19,7 +19,7 @@ Workflow:
 3. Use full mode only when you need exact markup for a small, specific component
 
 Modes:
-- **simplified** (default): Pruned indented representation showing tag names, key attributes (id, class, role, aria-*, href, src, etc.), and short text snippets. Script/style/SVG stripped. Capped at 200 nodes.
+- **simplified** (default): Pruned indented representation showing tag names, key attributes (id, class, role, aria-*, href, src, etc.), React/Vue/Astro component names (as \`component="..."\` attributes), and short text snippets. Script/style/SVG stripped. Capped at 200 nodes.
 - **full**: Raw outerHTML. Capped at 15KB. Use only when you need exact markup for a specific component.
 
 If the subtree is too large, the tool will **reject the request** and return a list of the element's direct children so you can pick a narrower target. This is by design — it prevents wasting your context window on huge DOM dumps.
@@ -180,6 +180,7 @@ type walkState = {
   mutable nodeCount: int,
   mutable stopped: bool,
   maxNodes: int,
+  window: option<WebAPI.DOMAPI.window>,
 }
 
 // Build the attribute string for an element in simplified mode.
@@ -252,6 +253,11 @@ let rec walkSimplified = (
       state.output = state.output ++ pad ++ `<!-- ${tag} -->\n`
     | None =>
       let attrs = buildSimplifiedAttrs(el)
+      // Annotate with React/Vue/Astro component name when available (sync, cheap)
+      let attrs = switch Client__ComponentName.getForElement(el, ~window=?state.window) {
+      | Some(name) => attrs ++ ` component="${name}"`
+      | None => attrs
+      }
       let children = Client__Tool__ElementResolver.getChildElements(el, ~pierceShadowDom)
       let childCount = children->Array.length
       let directText = getDirectText(el)
@@ -346,7 +352,7 @@ let execute = async (input: input): toolResult<output> => {
   Client__Tool__ElementResolver.withPreviewDoc(
     ~onUnavailable=() =>
       errorResult(~error="Preview frame not available"),
-    ({doc, win: _}) => {
+    ({doc, win}) => {
       try {
         let (element, _matchCount) = Client__Tool__ElementResolver.resolveBySelector(
           ~doc,
@@ -407,6 +413,7 @@ let execute = async (input: input): toolResult<output> => {
                 nodeCount: 0,
                 stopped: false,
                 maxNodes,
+                window: Some(win),
               }
 
               walkSimplified(~el, ~depth=0, ~maxDepth, ~pierceShadowDom, ~state)

--- a/libs/client/src/webpreview/Client__WebPreview__Utils.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Utils.res
@@ -24,34 +24,6 @@ let getElementId = (id: string): option<string> => {
   id->String.length > 0 ? Some(id) : None
 }
 
-// Try to get React component name synchronously from fiber internals
-// Returns None if element is not a React-rendered element or fiber is inaccessible
-let _getComponentNameSync: WebAPI.DOMAPI.element => Nullable.t<string> = %raw(`
-  function(element) {
-    try {
-      // Look for React fiber key on the DOM element
-      var keys = Object.keys(element);
-      for (var i = 0; i < keys.length; i++) {
-        if (keys[i].startsWith("__reactFiber$") || keys[i].startsWith("__reactInternalInstance$")) {
-          var fiber = element[keys[i]];
-          // Walk up the fiber tree to find the nearest function component
-          var current = fiber;
-          while (current) {
-            if (current.type && typeof current.type === "function") {
-              var name = current.type.displayName || current.type.name;
-              if (name && name !== "Fragment" && name !== "Suspense" && !name.startsWith("_")) {
-                return name;
-              }
-            }
-            current = current.return;
-          }
-        }
-      }
-    } catch (e) {}
-    return null;
-  }
-`)
-
 let getElementInfo = (element: WebAPI.DOMAPI.element): elementInfo => {
   let rect = WebAPI.Element.getBoundingClientRect(element)
   let tagName = element.tagName->String.toLowerCase
@@ -63,7 +35,7 @@ let getElementInfo = (element: WebAPI.DOMAPI.element): elementInfo => {
     ->WebAPI.Element.getAttribute("class")
     ->Null.toOption
     ->Option.flatMap(getFirstClassName)
-  let componentName = _getComponentNameSync(element)->Nullable.toOption
+  let componentName = Client__ComponentName.getForElement(element)
   {rect, tagName, id, className, componentName}
 }
 

--- a/libs/client/test/Client__ComponentName.test.res
+++ b/libs/client/test/Client__ComponentName.test.res
@@ -1,0 +1,130 @@
+open Vitest
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+// Create a plain DOM element (no React/Vue/Astro internals)
+let makePlainElement: string => WebAPI.DOMAPI.element = %raw(`
+  function(tag) { return { tagName: tag, parentElement: null } }
+`)
+
+// Create a DOM element with a React fiber attached
+let makeReactElement: (string, string) => WebAPI.DOMAPI.element = %raw(`
+  function(tag, componentName) {
+    var el = { tagName: tag, parentElement: null };
+    el["__reactFiber$test123"] = {
+      type: function FakeComponent() {},
+      return: null
+    };
+    el["__reactFiber$test123"].type.displayName = componentName;
+    return el;
+  }
+`)
+
+// Create a DOM element with Vue's __vueParentComponent attached
+let makeVueElement: (string, string) => WebAPI.DOMAPI.element = %raw(`
+  function(tag, componentName) {
+    var el = { tagName: tag, parentElement: null };
+    el.__vueParentComponent = {
+      type: { __name: componentName },
+      props: null,
+      parent: null
+    };
+    return el;
+  }
+`)
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("Client__ComponentName.getForElement", () => {
+  test("returns None for a plain DOM element", t => {
+    let el = makePlainElement("div")
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("returns React component name from fiber", t => {
+    let el = makeReactElement("div", "ActionsTable")
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(Some("ActionsTable"))
+  })
+
+  test("returns Vue component name from __vueParentComponent", t => {
+    let el = makeVueElement("div", "FilterPanel")
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(Some("FilterPanel"))
+  })
+
+  test("React takes priority over Vue when both are present", t => {
+    let el: WebAPI.DOMAPI.element = %raw(`
+      (function() {
+        var el = { tagName: "div", parentElement: null };
+        el["__reactFiber$test123"] = {
+          type: function RC() {},
+          return: null
+        };
+        el["__reactFiber$test123"].type.displayName = "ReactComponent";
+        el.__vueParentComponent = {
+          type: { __name: "VueComponent" },
+          props: null,
+          parent: null
+        };
+        return el;
+      })()
+    `)
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(Some("ReactComponent"))
+  })
+
+  test("skips Fragment and Suspense component names", t => {
+    let el: WebAPI.DOMAPI.element = %raw(`
+      (function() {
+        var el = { tagName: "div", parentElement: null };
+        el["__reactFiber$test123"] = {
+          type: function Fragment() {},
+          return: null
+        };
+        el["__reactFiber$test123"].type.displayName = "Fragment";
+        return el;
+      })()
+    `)
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("skips component names starting with underscore", t => {
+    let el: WebAPI.DOMAPI.element = %raw(`
+      (function() {
+        var el = { tagName: "div", parentElement: null };
+        var fn = function() {};
+        // displayName takes priority over function.name in the fiber walker
+        fn.displayName = "_InternalComponent";
+        el["__reactFiber$test123"] = {
+          type: fn,
+          return: null
+        };
+        return el;
+      })()
+    `)
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("walks up React fiber tree to find nearest function component", t => {
+    let el: WebAPI.DOMAPI.element = %raw(`
+      (function() {
+        var el = { tagName: "span", parentElement: null };
+        el["__reactFiber$test123"] = {
+          type: "span",
+          return: {
+            type: function TableHeader() {},
+            return: null
+          }
+        };
+        el["__reactFiber$test123"].return.type.displayName = "TableHeader";
+        return el;
+      })()
+    `)
+    let result = Client__ComponentName.getForElement(el)
+    t->expect(result)->Expect.toEqual(Some("TableHeader"))
+  })
+})

--- a/libs/frontman-core/src/FrontmanCore__FileTracker.res
+++ b/libs/frontman-core/src/FrontmanCore__FileTracker.res
@@ -1,20 +1,90 @@
 // FileTracker - Ensures files are read before being edited
 //
-// Records which files have been read (by resolved absolute path) and
-// provides an assertion that a file was read before allowing edits.
-// This prevents blind edits from agents that haven't seen the current content.
+// Records which files have been read (by resolved absolute path) along with:
+// - readAt: timestamp of the last read (ms since epoch)
+// - ranges: which line ranges were read (0-indexed start/end pairs)
+//
+// Provides assertions for:
+// - read-before-edit: file must have been read before editing
+// - staleness: file must not have been modified on disk since last read
+// - coverage: warns when editing lines outside the read ranges
 
-// Global mutable set of read file paths
-let readFiles: ref<Set.t<string>> = ref(Set.make())
+module Fs = FrontmanBindings.Fs
+
+type range = {start: int, mutable end_: int}
+
+type fileRecord = {
+  mutable readAt: float,
+  mutable ranges: array<range>,
+  mutable totalLines: int,
+}
+
+// Global mutable map of read file paths -> file records
+let readFiles: ref<Map.t<string, fileRecord>> = ref(Map.make())
+
+// Merge overlapping/adjacent ranges into a sorted minimal set
+let mergeRanges = (ranges: array<range>): array<range> => {
+  switch ranges->Array.length {
+  | 0 => []
+  | _ =>
+    let sorted = ranges->Array.toSorted((a, b) => Float.fromInt(a.start - b.start))
+    let first = sorted->Array.getUnsafe(0)
+    let merged = [{start: first.start, end_: first.end_}]
+    for i in 1 to sorted->Array.length - 1 {
+      let current = sorted->Array.getUnsafe(i)
+      let last = merged->Array.getUnsafe(merged->Array.length - 1)
+      if current.start <= last.end_ {
+        // Overlapping or adjacent — extend
+        last.end_ = max(last.end_, current.end_)
+      } else {
+        let _ = merged->Array.push({start: current.start, end_: current.end_})
+      }
+    }
+    merged
+  }
+}
 
 // Record that a file was read (called by ReadFile after successful read)
-let recordRead = (resolvedPath: string): unit => {
-  readFiles.contents->Set.add(resolvedPath)
+let recordRead = (
+  resolvedPath: string,
+  ~offset: int,
+  ~limit: int,
+  ~totalLines: int,
+): unit => {
+  let now = Date.now()
+  let newRange = {start: offset, end_: min(offset + limit, totalLines)}
+
+  switch readFiles.contents->Map.get(resolvedPath) {
+  | Some(record) =>
+    record.readAt = now
+    record.totalLines = totalLines
+    // Merge the new range into existing ranges
+    record.ranges = record.ranges->Array.concat([newRange])->mergeRanges
+  | None =>
+    readFiles.contents->Map.set(
+      resolvedPath,
+      {
+        readAt: now,
+        ranges: [newRange],
+        totalLines,
+      },
+    )
+  }
+}
+
+// Check if a line number falls within any recorded read range
+let isLineCovered = (ranges: array<range>, line: int): bool => {
+  ranges->Array.some(r => line >= r.start && line < r.end_)
+}
+
+// Get the record for a file (if it exists)
+let get = (resolvedPath: string): option<fileRecord> => {
+  readFiles.contents->Map.get(resolvedPath)
 }
 
 // Assert a file was read before editing. Returns Error if not.
 let assertReadBefore = (resolvedPath: string): result<unit, string> => {
-  switch readFiles.contents->Set.has(resolvedPath) {
+  switch readFiles.contents->Map.has(resolvedPath) {
   | true => Ok()
   | false =>
     Error(
@@ -23,7 +93,100 @@ let assertReadBefore = (resolvedPath: string): result<unit, string> => {
   }
 }
 
+// Assert a file has not been modified on disk since the last read.
+// Compares the file's mtime against the recorded readAt timestamp.
+// Allows 100ms tolerance for filesystem flush delays.
+let assertNotStale = async (resolvedPath: string): result<unit, string> => {
+  switch readFiles.contents->Map.get(resolvedPath) {
+  | None => Ok() // No record means assertReadBefore will catch it
+  | Some(record) =>
+    try {
+      let stats = await Fs.Promises.stat(resolvedPath)
+      let mtimeMs = Fs.mtimeMs(stats)
+      let tolerance = 100.0 // ms — accounts for filesystem flush delays
+      switch mtimeMs > record.readAt +. tolerance {
+      | true =>
+        Error(
+          `File "${resolvedPath}" has been modified since it was last read. Please read the file again before editing.`,
+        )
+      | false => Ok()
+      }
+    } catch {
+    | _ => Ok() // stat failure — let downstream handle missing file
+    }
+  }
+}
+
+// Check coverage: returns a warning string if the edit target appears
+// to be outside the recorded read ranges. Not a hard block.
+let checkCoverage = (
+  resolvedPath: string,
+  ~content: string,
+  ~oldText: string,
+): option<string> => {
+  switch readFiles.contents->Map.get(resolvedPath) {
+  | None => None
+  | Some(record) =>
+    // If the full file was read, no warning needed
+    switch record.ranges {
+    | [{start: 0, end_}] if end_ >= record.totalLines => None
+    | ranges =>
+      // Find which line the oldText starts at in the file
+      let lines = content->String.split("\n")
+      let oldLines = oldText->String.trim->String.split("\n")
+      let firstOldLine = oldLines->Array.get(0)->Option.getOr("")->String.trim
+
+      // Search for the first line of oldText in the file
+      let targetLine = ref(None)
+      lines->Array.forEachWithIndex((line, idx) => {
+        switch targetLine.contents {
+        | Some(_) => () // already found
+        | None =>
+          if line->String.trim == firstOldLine {
+            targetLine := Some(idx)
+          }
+        }
+      })
+
+      switch targetLine.contents {
+      | None => None // Can't determine target line — let the edit proceed
+      | Some(line) =>
+        switch isLineCovered(ranges, line) {
+        | true => None // Target line is within a read range — all good
+        | false =>
+          let rangeStr =
+            ranges
+            ->Array.map(r => `${Int.toString(r.start)}-${Int.toString(r.end_)}`)
+            ->Array.join(", ")
+          Some(
+            `Warning: You are editing around line ${Int.toString(line)} but only read lines [${rangeStr}] of this ${Int.toString(record.totalLines)}-line file. Consider reading the target section first with read_file and an appropriate offset.`,
+          )
+        }
+      }
+    }
+  }
+}
+
+// Combined guard: file must have been read AND must not be stale.
+// Names the domain concept "is it safe to edit this file?" so callers
+// don't need to chain assertReadBefore + assertNotStale themselves.
+let assertEditSafe = async (resolvedPath: string): result<unit, string> => {
+  switch assertReadBefore(resolvedPath) {
+  | Error(_) as e => e
+  | Ok() => await assertNotStale(resolvedPath)
+  }
+}
+
+// Record that a file was written (called by EditFile/WriteFile after successful write).
+// Updates readAt so that subsequent staleness checks don't reject the agent's own edits.
+let recordWrite = (resolvedPath: string): unit => {
+  switch readFiles.contents->Map.get(resolvedPath) {
+  | Some(record) => record.readAt = Date.now()
+  | None => () // No record — shouldn't happen since we require read-before-edit
+  }
+}
+
 // Clear all tracked reads (useful for testing)
 let clear = (): unit => {
-  readFiles := Set.make()
+  readFiles := Map.make()
 }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
@@ -1,13 +1,18 @@
 // Edit file tool - find-and-replace with fuzzy matching
 //
-// Uses a multi-strategy matcher that gracefully handles common LLM mistakes
-// (wrong indentation, extra whitespace, escaped characters, etc.)
-// Requires the file to have been read first via read_file.
+// Two distinct operations:
+// - Create: oldText is empty → write newText to a new file
+// - Edit: oldText is non-empty → find-and-replace in an existing file
+//
+// The edit path uses a multi-strategy matcher that gracefully handles common
+// LLM mistakes (wrong indentation, extra whitespace, escaped characters, etc.)
+// and requires the file to have been read first via read_file.
 
 module Fs = FrontmanBindings.Fs
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 module FileTracker = FrontmanCore__FileTracker
+module ExnUtils = FrontmanCore__ExnUtils
 module Matcher = FrontmanCore__Tool__EditFile__Matcher
 
 let name = "edit_file"
@@ -50,80 +55,90 @@ type output = {
   _context?: pathContext,
 }
 
-let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolResult<output> => {
-  let replaceAll = input.replaceAll->Option.getOr(false)
+// ── Domain helpers ─────────────────────────────────────────────────────
 
-  // oldText and newText must differ
+let toPathCtx = (r: PathContext.resolveResult): pathContext => {
+  sourceRoot: r.sourceRoot,
+  resolvedPath: r.resolvedPath,
+  relativePath: r.relativePath,
+}
+
+// Create a new file (oldText is empty).
+let createFile = async (
+  ~resolved: PathContext.resolveResult,
+  ~content: string,
+  ~displayPath: string,
+): Tool.toolResult<output> => {
+  try {
+    let _ = await Fs.Promises.mkdir(PathContext.dirname(resolved), {recursive: true})
+    await Fs.Promises.writeFile(resolved.resolvedPath, content)
+    FileTracker.recordWrite(resolved.resolvedPath)
+    Ok({message: "File created successfully.", _context: toPathCtx(resolved)})
+  } catch {
+  | exn => Error(`Failed to create file ${displayPath}: ${ExnUtils.message(exn)}`)
+  }
+}
+
+// Find oldText in the file, replace it, and write back.
+// Includes a coverage warning when the edit target is outside previously-read ranges.
+let findAndReplace = async (
+  ~resolved: PathContext.resolveResult,
+  ~oldText: string,
+  ~newText: string,
+  ~replaceAll: bool,
+  ~displayPath: string,
+): Tool.toolResult<output> => {
+  try {
+    let content = await Fs.Promises.readFile(resolved.resolvedPath)
+    let coverageWarning = FileTracker.checkCoverage(resolved.resolvedPath, ~content, ~oldText)
+
+    switch Matcher.applyEdit(~content, ~oldText, ~newText, ~replaceAll) {
+    | Applied(newContent) =>
+      await Fs.Promises.writeFile(resolved.resolvedPath, newContent)
+      FileTracker.recordWrite(resolved.resolvedPath)
+      let message = switch coverageWarning {
+      | Some(warning) => `Edit applied successfully.\n\n${warning}`
+      | None => "Edit applied successfully."
+      }
+      Ok({message, _context: toPathCtx(resolved)})
+    | NotFound =>
+      Error(
+        `oldText not found in file ${displayPath}. Make sure the text matches exactly, or read the file again to see its current content.`,
+      )
+    | Ambiguous =>
+      Error(
+        `Found multiple matches for oldText in ${displayPath}. Provide more surrounding context to identify the correct match, or use replaceAll to replace all occurrences.`,
+      )
+    }
+  } catch {
+  | exn => Error(`Failed to edit file ${displayPath}: ${ExnUtils.message(exn)}`)
+  }
+}
+
+// ── Execute ────────────────────────────────────────────────────────────
+
+let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolResult<output> => {
   switch input.oldText == input.newText {
   | true => Error("oldText and newText must be different")
   | false =>
     switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
     | Error(err) => Error(PathContext.formatError(err))
-    | Ok(result) =>
-      let pathCtx = {
-        sourceRoot: result.sourceRoot,
-        resolvedPath: result.resolvedPath,
-        relativePath: result.relativePath,
-      }
-
-      // Empty oldText = create new file
-      switch input.oldText == "" {
-      | true =>
-        try {
-          let dirPath = PathContext.dirname(result)
-          let _ = await Fs.Promises.mkdir(dirPath, {recursive: true})
-          await Fs.Promises.writeFile(result.resolvedPath, input.newText)
-          Ok({
-            message: "File created successfully.",
-            _context: pathCtx,
-          })
-        } catch {
-        | exn =>
-          let msg =
-            exn
-            ->JsExn.fromException
-            ->Option.flatMap(JsExn.message)
-            ->Option.getOr("Unknown error")
-          Error(`Failed to create file ${input.path}: ${msg}`)
-        }
-      | false =>
-        // Read-before-edit safety check
-        switch FileTracker.assertReadBefore(result.resolvedPath) {
+    | Ok(resolved) =>
+      switch input.oldText {
+      // Explicit create: empty oldText means "write a new file"
+      | "" => await createFile(~resolved, ~content=input.newText, ~displayPath=input.path)
+      // Edit: find-and-replace in an existing, previously-read file
+      | oldText =>
+        switch await FileTracker.assertEditSafe(resolved.resolvedPath) {
         | Error(msg) => Error(msg)
         | Ok() =>
-          try {
-            let content = await Fs.Promises.readFile(result.resolvedPath)
-
-            switch Matcher.applyEdit(
-              ~content,
-              ~oldText=input.oldText,
-              ~newText=input.newText,
-              ~replaceAll,
-            ) {
-            | Applied(newContent) =>
-              await Fs.Promises.writeFile(result.resolvedPath, newContent)
-              Ok({
-                message: "Edit applied successfully.",
-                _context: pathCtx,
-              })
-            | NotFound =>
-              Error(
-                `oldText not found in file ${input.path}. Make sure the text matches exactly, or read the file again to see its current content.`,
-              )
-            | Ambiguous =>
-              Error(
-                `Found multiple matches for oldText in ${input.path}. Provide more surrounding context to identify the correct match, or use replaceAll to replace all occurrences.`,
-              )
-            }
-          } catch {
-          | exn =>
-            let msg =
-              exn
-              ->JsExn.fromException
-              ->Option.flatMap(JsExn.message)
-              ->Option.getOr("Unknown error")
-            Error(`Failed to edit file ${input.path}: ${msg}`)
-          }
+          await findAndReplace(
+            ~resolved,
+            ~oldText,
+            ~newText=input.newText,
+            ~replaceAll=input.replaceAll->Option.getOr(false),
+            ~displayPath=input.path,
+          )
         }
       }
     }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
@@ -14,7 +14,12 @@ Parameters:
 - limit (optional): Maximum lines to read (default: 500). Pass null or 500 for default.
 
 Returns file content with metadata about total lines and whether more content exists.
-The _context field provides path resolution details for debugging.`
+The _context field provides path resolution details for debugging.
+
+When hasMore is true, the file has content beyond what was returned. For large files:
+- Use grep first to find the line numbers of relevant sections, then read_file with a targeted offset.
+- Don't read sequentially from the top — jump to the section you need.
+- For React/Vue/Astro components, locate the render/return block before editing.`
 
 @schema
 type input = {
@@ -56,7 +61,12 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
       let hasMore = offset + limit < totalLines
 
       // Track that this file was read (for edit_file safety)
-      FrontmanCore__FileTracker.recordRead(result.resolvedPath)
+      FrontmanCore__FileTracker.recordRead(
+        result.resolvedPath,
+        ~offset,
+        ~limit,
+        ~totalLines,
+      )
 
       Ok({
         content: selectedContent,

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
@@ -4,6 +4,8 @@ module Fs = FrontmanBindings.Fs
 module NodeBuffer = FrontmanBindings.NodeBuffer
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
+module FileTracker = FrontmanCore__FileTracker
+module ExnUtils = FrontmanCore__ExnUtils
 
 let name = Tool.ToolNames.writeFile
 let visibleToAgent = true
@@ -17,7 +19,8 @@ Parameters:
 
 Provide either content OR image_ref, not both.
 Creates parent directories if they don't exist. Overwrites existing files.
-The _context field provides path resolution details for debugging.`
+
+IMPORTANT: If the file already exists, you MUST read it with read_file first. The tool will reject writes to existing files that haven't been read.`
 
 @schema
 type input = {
@@ -59,21 +62,36 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
   | (Some(content), None) =>
     switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
     | Error(err) => Error(PathContext.formatError(err))
-    | Ok(result) =>
-      try {
-        let _ = await Fs.Promises.mkdir(PathContext.dirname(result), {recursive: true})
-        await writeContent(result.resolvedPath, content, input.encoding)
-        Ok({
-          _context: {
-            sourceRoot: result.sourceRoot,
-            resolvedPath: result.resolvedPath,
-            relativePath: result.relativePath,
-          },
-        })
-      } catch {
-      | exn =>
-        let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
-        Error(`Failed to write file ${input.path}: ${msg}`)
+    | Ok(resolved) =>
+      // Guard: existing files must have been read first and not be stale
+      let fileExists =
+        try {
+          let _ = await Fs.Promises.stat(resolved.resolvedPath)
+          true
+        } catch {
+        | _ => false
+        }
+      let guardResult = switch fileExists {
+      | false => Ok()
+      | true => await FileTracker.assertEditSafe(resolved.resolvedPath)
+      }
+      switch guardResult {
+      | Error(msg) => Error(msg)
+      | Ok() =>
+        try {
+          let _ = await Fs.Promises.mkdir(PathContext.dirname(resolved), {recursive: true})
+          await writeContent(resolved.resolvedPath, content, input.encoding)
+          FileTracker.recordWrite(resolved.resolvedPath)
+          Ok({
+            _context: {
+              sourceRoot: resolved.sourceRoot,
+              resolvedPath: resolved.resolvedPath,
+              relativePath: resolved.relativePath,
+            },
+          })
+        } catch {
+        | exn => Error(`Failed to write file ${input.path}: ${ExnUtils.message(exn)}`)
+        }
       }
     }
   }

--- a/libs/frontman-core/test/FrontmanCore__FileTracker.test.res
+++ b/libs/frontman-core/test/FrontmanCore__FileTracker.test.res
@@ -1,0 +1,255 @@
+// Tests for FileTracker - read tracking, staleness, and coverage checks
+
+open Vitest
+
+module FileTracker = FrontmanCore__FileTracker
+
+// ============================================
+// Setup: clear state between tests
+// ============================================
+
+beforeEach(_t => {
+  FileTracker.clear()
+})
+
+// ============================================
+// mergeRanges
+// ============================================
+
+describe("mergeRanges", _t => {
+  test("empty array returns empty", t => {
+    let result = FileTracker.mergeRanges([])
+    t->expect(result)->Expect.toEqual([])
+  })
+
+  test("single range returns as-is", t => {
+    let result = FileTracker.mergeRanges([{start: 0, end_: 100}])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 100}])
+  })
+
+  test("non-overlapping ranges stay separate", t => {
+    let result = FileTracker.mergeRanges([{start: 0, end_: 50}, {start: 100, end_: 150}])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 50}, {start: 100, end_: 150}])
+  })
+
+  test("overlapping ranges are merged", t => {
+    let result = FileTracker.mergeRanges([{start: 0, end_: 100}, {start: 50, end_: 150}])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 150}])
+  })
+
+  test("adjacent ranges are merged", t => {
+    let result = FileTracker.mergeRanges([{start: 0, end_: 50}, {start: 50, end_: 100}])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 100}])
+  })
+
+  test("unsorted ranges are sorted then merged", t => {
+    let result = FileTracker.mergeRanges([{start: 100, end_: 200}, {start: 0, end_: 50}])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 50}, {start: 100, end_: 200}])
+  })
+
+  test("three ranges with partial overlap", t => {
+    let result = FileTracker.mergeRanges([
+      {start: 0, end_: 50},
+      {start: 40, end_: 100},
+      {start: 200, end_: 300},
+    ])
+    t->expect(result)->Expect.toEqual([{start: 0, end_: 100}, {start: 200, end_: 300}])
+  })
+})
+
+// ============================================
+// recordRead + assertReadBefore
+// ============================================
+
+describe("recordRead and assertReadBefore", _t => {
+  test("unread file fails assertReadBefore", t => {
+    let result = FileTracker.assertReadBefore("/path/to/file.ts")
+    t->expect(Result.isError(result))->Expect.toBe(true)
+  })
+
+  test("read file passes assertReadBefore", t => {
+    FileTracker.recordRead("/path/to/file.ts", ~offset=0, ~limit=500, ~totalLines=100)
+    let result = FileTracker.assertReadBefore("/path/to/file.ts")
+    t->expect(Result.isOk(result))->Expect.toBe(true)
+  })
+
+  test("different file still fails assertReadBefore", t => {
+    FileTracker.recordRead("/path/to/a.ts", ~offset=0, ~limit=500, ~totalLines=100)
+    let result = FileTracker.assertReadBefore("/path/to/b.ts")
+    t->expect(Result.isError(result))->Expect.toBe(true)
+  })
+})
+
+// ============================================
+// recordRead range tracking
+// ============================================
+
+describe("recordRead range tracking", _t => {
+  test("records initial range", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=500, ~totalLines=1000)
+    let record = FileTracker.get("/file.ts")->Option.getOrThrow
+    t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 500}])
+    t->expect(record.totalLines)->Expect.toBe(1000)
+  })
+
+  test("clamps range end to totalLines", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=500, ~totalLines=200)
+    let record = FileTracker.get("/file.ts")->Option.getOrThrow
+    t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 200}])
+  })
+
+  test("merges overlapping reads", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=500, ~totalLines=1000)
+    FileTracker.recordRead("/file.ts", ~offset=400, ~limit=500, ~totalLines=1000)
+    let record = FileTracker.get("/file.ts")->Option.getOrThrow
+    t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 900}])
+  })
+
+  test("keeps non-overlapping reads separate", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=1000)
+    FileTracker.recordRead("/file.ts", ~offset=500, ~limit=100, ~totalLines=1000)
+    let record = FileTracker.get("/file.ts")->Option.getOrThrow
+    t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 100}, {start: 500, end_: 600}])
+  })
+
+  test("updates readAt on subsequent reads", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=1000)
+    let record1 = FileTracker.get("/file.ts")->Option.getOrThrow
+    let firstReadAt = record1.readAt
+
+    // Small delay to ensure different timestamp
+    FileTracker.recordRead("/file.ts", ~offset=100, ~limit=100, ~totalLines=1000)
+    let record2 = FileTracker.get("/file.ts")->Option.getOrThrow
+    // readAt should be >= first read (could be equal if very fast)
+    t->expect(record2.readAt >= firstReadAt)->Expect.toBe(true)
+  })
+})
+
+// ============================================
+// isLineCovered
+// ============================================
+
+describe("isLineCovered", _t => {
+  test("line inside range is covered", t => {
+    let ranges = [{FileTracker.start: 0, end_: 100}]
+    t->expect(FileTracker.isLineCovered(ranges, 50))->Expect.toBe(true)
+  })
+
+  test("line at range start is covered", t => {
+    let ranges = [{FileTracker.start: 0, end_: 100}]
+    t->expect(FileTracker.isLineCovered(ranges, 0))->Expect.toBe(true)
+  })
+
+  test("line at range end is NOT covered (exclusive)", t => {
+    let ranges = [{FileTracker.start: 0, end_: 100}]
+    t->expect(FileTracker.isLineCovered(ranges, 100))->Expect.toBe(false)
+  })
+
+  test("line outside all ranges is not covered", t => {
+    let ranges = [{FileTracker.start: 0, end_: 50}, {FileTracker.start: 100, end_: 150}]
+    t->expect(FileTracker.isLineCovered(ranges, 75))->Expect.toBe(false)
+  })
+
+  test("line in second range is covered", t => {
+    let ranges = [{FileTracker.start: 0, end_: 50}, {FileTracker.start: 100, end_: 150}]
+    t->expect(FileTracker.isLineCovered(ranges, 125))->Expect.toBe(true)
+  })
+})
+
+// ============================================
+// checkCoverage
+// ============================================
+
+describe("checkCoverage", _t => {
+  test("returns None for untracked file", t => {
+    let result = FileTracker.checkCoverage("/unknown.ts", ~content="hello", ~oldText="hello")
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("returns None when full file was read", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=500, ~totalLines=100)
+    let content = Array.make(~length=100, "line")->Array.join("\n")
+    let result = FileTracker.checkCoverage("/file.ts", ~content, ~oldText="line")
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("returns None when edit target is within read range", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=500)
+    let lines = Array.make(~length=500, "other")->Array.mapWithIndex((line, idx) =>
+      switch idx {
+      | 50 => "target line"
+      | _ => line
+      }
+    )
+    let content = lines->Array.join("\n")
+    let result = FileTracker.checkCoverage("/file.ts", ~content, ~oldText="target line")
+    t->expect(result)->Expect.toEqual(None)
+  })
+
+  test("returns warning when edit target is outside read range", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=500)
+    let lines = Array.make(~length=500, "other")->Array.mapWithIndex((line, idx) =>
+      switch idx {
+      | 300 => "target line"
+      | _ => line
+      }
+    )
+    let content = lines->Array.join("\n")
+    let result = FileTracker.checkCoverage("/file.ts", ~content, ~oldText="target line")
+    t->expect(Option.isSome(result))->Expect.toBe(true)
+    let warning = result->Option.getOrThrow
+    t->expect(warning->String.includes("line 300"))->Expect.toBe(true)
+    t->expect(warning->String.includes("0-100"))->Expect.toBe(true)
+  })
+
+  test("returns None when target line cannot be found", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=500)
+    let content = Array.make(~length=500, "other")->Array.join("\n")
+    let result = FileTracker.checkCoverage("/file.ts", ~content, ~oldText="nonexistent text")
+    t->expect(result)->Expect.toEqual(None)
+  })
+})
+
+// ============================================
+// clear
+// ============================================
+
+describe("clear", _t => {
+  test("clears all tracked reads", t => {
+    FileTracker.recordRead("/a.ts", ~offset=0, ~limit=100, ~totalLines=100)
+    FileTracker.recordRead("/b.ts", ~offset=0, ~limit=100, ~totalLines=100)
+    FileTracker.clear()
+    t->expect(Result.isError(FileTracker.assertReadBefore("/a.ts")))->Expect.toBe(true)
+    t->expect(Result.isError(FileTracker.assertReadBefore("/b.ts")))->Expect.toBe(true)
+  })
+})
+
+// ============================================
+// recordWrite
+// ============================================
+
+describe("recordWrite", _t => {
+  test("updates readAt for tracked file", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=500, ~totalLines=100)
+    let record1 = FileTracker.get("/file.ts")->Option.getOrThrow
+    let readAtBefore = record1.readAt
+
+    FileTracker.recordWrite("/file.ts")
+    let record2 = FileTracker.get("/file.ts")->Option.getOrThrow
+    // readAt should be updated to at least the previous value
+    t->expect(record2.readAt >= readAtBefore)->Expect.toBe(true)
+  })
+
+  test("preserves ranges after write", t => {
+    FileTracker.recordRead("/file.ts", ~offset=0, ~limit=100, ~totalLines=500)
+    FileTracker.recordWrite("/file.ts")
+    let record = FileTracker.get("/file.ts")->Option.getOrThrow
+    t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 100}])
+  })
+
+  test("no-op for untracked file", t => {
+    // Should not crash or create a record
+    FileTracker.recordWrite("/untracked.ts")
+    t->expect(FileTracker.get("/untracked.ts"))->Expect.toEqual(None)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"test/e2e/fixtures/astro",
 		"test/e2e/fixtures/vite",
 		"test/e2e/fixtures/vue-vite",
+		"test/manual/vite-dashboard",
 		"libs/logs",
 		"libs/react-statestore"
 	],

--- a/test/manual/vite-dashboard/index.html
+++ b/test/manual/vite-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard - Frontman Manual Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/test/manual/vite-dashboard/package.json
+++ b/test/manual/vite-dashboard/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@frontman/manual-vite-dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@frontman-ai/vite": "workspace:*",
+    "@vitejs/plugin-react": "^4.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vite": "^6.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.0",
+    "tailwindcss": "^4.1.0"
+  }
+}

--- a/test/manual/vite-dashboard/src/App.tsx
+++ b/test/manual/vite-dashboard/src/App.tsx
@@ -1,0 +1,32 @@
+import StatCard from './components/StatCard';
+import ActionsTable from './components/ActionsTable';
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-6 py-8 space-y-6">
+        {/* Page header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Actions Dashboard</h1>
+            <p className="text-sm text-gray-500 mt-1">Manage and monitor your automation actions</p>
+          </div>
+          <button type="button" className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
+            + New Action
+          </button>
+        </div>
+
+        {/* Stat cards — separate component to test cross-file detection */}
+        <div className="grid grid-cols-4 gap-4">
+          <StatCard label="Total Actions" value="47" trend="12%" trendUp />
+          <StatCard label="Active" value="32" trend="8%" trendUp />
+          <StatCard label="Failed (7d)" value="3" trend="2" trendUp={false} />
+          <StatCard label="Avg Success Rate" value="98.7%" trend="0.3%" trendUp />
+        </div>
+
+        {/* Large single-file component: filters, table, pagination, detail panel */}
+        <ActionsTable />
+      </div>
+    </div>
+  );
+}

--- a/test/manual/vite-dashboard/src/components/ActionsTable.tsx
+++ b/test/manual/vite-dashboard/src/components/ActionsTable.tsx
@@ -1,0 +1,740 @@
+import { useState, useMemo, useCallback } from 'react';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+type ActionStatus = 'active' | 'paused' | 'failed' | 'completed';
+type ActionType = 'webhook' | 'scheduled' | 'triggered';
+type SortField = 'name' | 'status' | 'lastRun' | 'runs' | 'successRate';
+type SortDirection = 'asc' | 'desc';
+
+interface Action {
+  id: string;
+  name: string;
+  description: string;
+  status: ActionStatus;
+  type: ActionType;
+  lastRun: string;
+  lastRunTimestamp: number;
+  runs: number;
+  successRate: number;
+  createdAt: string;
+  tags: string[];
+  owner: string;
+  webhookUrl?: string;
+  schedule?: string;
+  retryCount: number;
+  timeout: number;
+  lastError?: string;
+}
+
+interface FilterState {
+  search: string;
+  status: ActionStatus | 'all';
+  type: ActionType | 'all';
+  dateRange: '24h' | '7d' | '30d' | '90d' | 'all';
+  tags: string[];
+  owner: string;
+}
+
+// ── Sample Data ────────────────────────────────────────────────────────
+
+const SAMPLE_ACTIONS: Action[] = [
+  {
+    id: 'act_001', name: 'Deploy to staging', description: 'Triggers staging deployment via CI/CD pipeline on push to main',
+    status: 'active', type: 'webhook', lastRun: '2 min ago', lastRunTimestamp: Date.now() - 120000,
+    runs: 1243, successRate: 99.2, createdAt: '2024-01-15', tags: ['deploy', 'ci-cd', 'staging'],
+    owner: 'platform-team', webhookUrl: 'https://api.example.com/hooks/deploy', retryCount: 3, timeout: 300,
+  },
+  {
+    id: 'act_002', name: 'Sync user data', description: 'Synchronizes user profiles from identity provider to local database',
+    status: 'active', type: 'scheduled', lastRun: '15 min ago', lastRunTimestamp: Date.now() - 900000,
+    runs: 892, successRate: 97.8, createdAt: '2024-02-01', tags: ['sync', 'users', 'database'],
+    owner: 'backend-team', schedule: '*/15 * * * *', retryCount: 2, timeout: 120,
+  },
+  {
+    id: 'act_003', name: 'Send weekly report', description: 'Generates and emails weekly analytics digest to stakeholders',
+    status: 'paused', type: 'scheduled', lastRun: '2 days ago', lastRunTimestamp: Date.now() - 172800000,
+    runs: 52, successRate: 100, createdAt: '2024-03-10', tags: ['reports', 'email', 'analytics'],
+    owner: 'analytics-team', schedule: '0 9 * * 1', retryCount: 1, timeout: 600,
+  },
+  {
+    id: 'act_004', name: 'Process payments', description: 'Processes queued payment transactions and updates order status',
+    status: 'active', type: 'triggered', lastRun: '1 min ago', lastRunTimestamp: Date.now() - 60000,
+    runs: 3451, successRate: 99.9, createdAt: '2024-01-05', tags: ['payments', 'orders', 'critical'],
+    owner: 'billing-team', retryCount: 5, timeout: 60,
+  },
+  {
+    id: 'act_005', name: 'Backup database', description: 'Creates encrypted snapshot of production database and uploads to S3',
+    status: 'failed', type: 'scheduled', lastRun: '6 hours ago', lastRunTimestamp: Date.now() - 21600000,
+    runs: 730, successRate: 98.1, createdAt: '2024-01-01', tags: ['backup', 'database', 'critical'],
+    owner: 'platform-team', schedule: '0 */6 * * *', retryCount: 3, timeout: 1800,
+    lastError: 'Connection timeout after 1800s: unable to reach replica set rs0/db-prod-01:27017',
+  },
+  {
+    id: 'act_006', name: 'Generate thumbnails', description: 'Creates responsive image thumbnails for newly uploaded media assets',
+    status: 'active', type: 'triggered', lastRun: '30 sec ago', lastRunTimestamp: Date.now() - 30000,
+    runs: 15678, successRate: 99.5, createdAt: '2024-02-20', tags: ['media', 'images', 'processing'],
+    owner: 'media-team', retryCount: 2, timeout: 30,
+  },
+  {
+    id: 'act_007', name: 'Clean temp files', description: 'Removes temporary upload files older than 24 hours from staging storage',
+    status: 'completed', type: 'scheduled', lastRun: '1 hour ago', lastRunTimestamp: Date.now() - 3600000,
+    runs: 365, successRate: 100, createdAt: '2024-01-20', tags: ['cleanup', 'storage'],
+    owner: 'platform-team', schedule: '0 * * * *', retryCount: 1, timeout: 120,
+  },
+  {
+    id: 'act_008', name: 'Notify on error', description: 'Sends Slack/PagerDuty alerts when monitored services report errors',
+    status: 'active', type: 'webhook', lastRun: '5 min ago', lastRunTimestamp: Date.now() - 300000,
+    runs: 234, successRate: 95.3, createdAt: '2024-03-01', tags: ['alerts', 'monitoring', 'slack'],
+    owner: 'sre-team', webhookUrl: 'https://hooks.slack.com/services/T00/B00/xxx', retryCount: 1, timeout: 10,
+    lastError: 'Rate limited by Slack API (429)',
+  },
+  {
+    id: 'act_009', name: 'Index search data', description: 'Reindexes Elasticsearch clusters with latest product catalog changes',
+    status: 'active', type: 'triggered', lastRun: '10 min ago', lastRunTimestamp: Date.now() - 600000,
+    runs: 4521, successRate: 99.7, createdAt: '2024-01-25', tags: ['search', 'elasticsearch', 'catalog'],
+    owner: 'search-team', retryCount: 3, timeout: 300,
+  },
+  {
+    id: 'act_010', name: 'Archive old logs', description: 'Compresses and moves access logs older than 30 days to cold storage',
+    status: 'paused', type: 'scheduled', lastRun: '1 week ago', lastRunTimestamp: Date.now() - 604800000,
+    runs: 48, successRate: 100, createdAt: '2024-02-15', tags: ['logs', 'archive', 'storage'],
+    owner: 'platform-team', schedule: '0 2 * * 0', retryCount: 1, timeout: 3600,
+  },
+  {
+    id: 'act_011', name: 'Validate SSL certs', description: 'Checks expiration dates of SSL certificates across all domains',
+    status: 'active', type: 'scheduled', lastRun: '3 hours ago', lastRunTimestamp: Date.now() - 10800000,
+    runs: 180, successRate: 100, createdAt: '2024-03-05', tags: ['security', 'ssl', 'monitoring'],
+    owner: 'sre-team', schedule: '0 */8 * * *', retryCount: 1, timeout: 60,
+  },
+  {
+    id: 'act_012', name: 'Purge CDN cache', description: 'Invalidates CloudFront distribution cache for updated static assets',
+    status: 'active', type: 'webhook', lastRun: '20 min ago', lastRunTimestamp: Date.now() - 1200000,
+    runs: 567, successRate: 98.9, createdAt: '2024-02-10', tags: ['cdn', 'cache', 'deploy'],
+    owner: 'platform-team', webhookUrl: 'https://api.example.com/hooks/cdn-purge', retryCount: 2, timeout: 45,
+  },
+];
+
+const ALL_TAGS = Array.from(new Set(SAMPLE_ACTIONS.flatMap(a => a.tags))).sort();
+const ALL_OWNERS = Array.from(new Set(SAMPLE_ACTIONS.map(a => a.owner))).sort();
+
+// ── Utility Functions ──────────────────────────────────────────────────
+
+const statusColors: Record<ActionStatus, string> = {
+  active: 'bg-green-100 text-green-700',
+  paused: 'bg-yellow-100 text-yellow-700',
+  failed: 'bg-red-100 text-red-700',
+  completed: 'bg-gray-100 text-gray-700',
+};
+
+const statusDotColors: Record<ActionStatus, string> = {
+  active: 'bg-green-500',
+  paused: 'bg-yellow-500',
+  failed: 'bg-red-500',
+  completed: 'bg-gray-400',
+};
+
+const typeIcons: Record<ActionType, string> = {
+  webhook: '🔗',
+  scheduled: '⏰',
+  triggered: '⚡',
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return n.toString();
+}
+
+function matchesSearch(action: Action, search: string): boolean {
+  const lower = search.toLowerCase();
+  return (
+    action.name.toLowerCase().includes(lower) ||
+    action.description.toLowerCase().includes(lower) ||
+    action.tags.some(t => t.toLowerCase().includes(lower)) ||
+    action.owner.toLowerCase().includes(lower)
+  );
+}
+
+function compareActions(a: Action, b: Action, field: SortField, dir: SortDirection): number {
+  let cmp = 0;
+  switch (field) {
+    case 'name': cmp = a.name.localeCompare(b.name); break;
+    case 'status': cmp = a.status.localeCompare(b.status); break;
+    case 'lastRun': cmp = a.lastRunTimestamp - b.lastRunTimestamp; break;
+    case 'runs': cmp = a.runs - b.runs; break;
+    case 'successRate': cmp = a.successRate - b.successRate; break;
+  }
+  return dir === 'asc' ? cmp : -cmp;
+}
+
+// ── Inline Sub-Components ──────────────────────────────────────────────
+// These are defined in-file (not extracted) to simulate a realistic
+// large component file where everything lives in one place.
+
+function ActionStatusBadge({ status }: { status: ActionStatus }) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 text-xs font-medium rounded-full ${statusColors[status]}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${statusDotColors[status]}`} />
+      {status}
+    </span>
+  );
+}
+
+function ActionTypeBadge({ type }: { type: ActionType }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded">
+      <span>{typeIcons[type]}</span>
+      {type}
+    </span>
+  );
+}
+
+function TagList({ tags }: { tags: string[] }) {
+  const visible = tags.slice(0, 3);
+  const remaining = tags.length - visible.length;
+  return (
+    <div className="flex items-center gap-1 flex-wrap">
+      {visible.map(tag => (
+        <span key={tag} className="px-1.5 py-0.5 text-[10px] text-gray-500 bg-gray-100 rounded">
+          {tag}
+        </span>
+      ))}
+      {remaining > 0 && (
+        <span className="text-[10px] text-gray-400">+{remaining}</span>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ search }: { search: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="text-4xl mb-3">🔍</div>
+      <p className="text-sm font-medium text-gray-700">No actions found</p>
+      <p className="text-xs text-gray-400 mt-1">
+        {search ? `No results for "${search}". Try a different search term.` : 'No actions match the current filters.'}
+      </p>
+    </div>
+  );
+}
+
+function DetailPanel({ action, onClose }: { action: Action; onClose: () => void }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-6 space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">{action.name}</h3>
+          <p className="text-sm text-gray-500 mt-1">{action.description}</p>
+        </div>
+        <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1">
+          <p className="text-xs text-gray-400 uppercase tracking-wider">Status</p>
+          <ActionStatusBadge status={action.status} />
+        </div>
+        <div className="space-y-1">
+          <p className="text-xs text-gray-400 uppercase tracking-wider">Type</p>
+          <ActionTypeBadge type={action.type} />
+        </div>
+        <div className="space-y-1">
+          <p className="text-xs text-gray-400 uppercase tracking-wider">Owner</p>
+          <p className="text-sm text-gray-700">{action.owner}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4 py-4 border-y border-gray-100">
+        <div>
+          <p className="text-xs text-gray-400">Total Runs</p>
+          <p className="text-lg font-semibold text-gray-900">{formatNumber(action.runs)}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-400">Success Rate</p>
+          <p className="text-lg font-semibold text-gray-900">{action.successRate}%</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-400">Retry Count</p>
+          <p className="text-lg font-semibold text-gray-900">{action.retryCount}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-400">Timeout</p>
+          <p className="text-lg font-semibold text-gray-900">{formatDuration(action.timeout)}</p>
+        </div>
+      </div>
+
+      {action.webhookUrl && (
+        <div className="space-y-1">
+          <p className="text-xs text-gray-400 uppercase tracking-wider">Webhook URL</p>
+          <code className="block text-xs text-gray-600 bg-gray-50 px-3 py-2 rounded border border-gray-200 break-all">
+            {action.webhookUrl}
+          </code>
+        </div>
+      )}
+
+      {action.schedule && (
+        <div className="space-y-1">
+          <p className="text-xs text-gray-400 uppercase tracking-wider">Schedule (cron)</p>
+          <code className="block text-xs text-gray-600 bg-gray-50 px-3 py-2 rounded border border-gray-200">
+            {action.schedule}
+          </code>
+        </div>
+      )}
+
+      {action.lastError && (
+        <div className="space-y-1">
+          <p className="text-xs text-red-500 uppercase tracking-wider">Last Error</p>
+          <div className="text-xs text-red-700 bg-red-50 px-3 py-2 rounded border border-red-200">
+            {action.lastError}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <p className="text-xs text-gray-400 uppercase tracking-wider">Tags</p>
+        <div className="flex flex-wrap gap-1.5">
+          {action.tags.map(tag => (
+            <span key={tag} className="px-2 py-0.5 text-xs text-gray-600 bg-gray-100 rounded-full">{tag}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button type="button" className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">
+          Edit Action
+        </button>
+        <button type="button" className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+          View Logs
+        </button>
+        <button type="button" className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+          Run Now
+        </button>
+        {action.status === 'active' ? (
+          <button type="button" className="px-4 py-2 text-sm font-medium text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-lg hover:bg-yellow-100">
+            Pause
+          </button>
+        ) : action.status === 'paused' ? (
+          <button type="button" className="px-4 py-2 text-sm font-medium text-green-700 bg-green-50 border border-green-200 rounded-lg hover:bg-green-100">
+            Resume
+          </button>
+        ) : null}
+        <button type="button" className="ml-auto px-4 py-2 text-sm font-medium text-red-600 hover:text-red-700">
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────────────────
+
+export default function ActionsTable() {
+  // ── State ────────────────────────────────────────────────────────────
+
+  const [filters, setFilters] = useState<FilterState>({
+    search: '',
+    status: 'all',
+    type: 'all',
+    dateRange: '7d',
+    tags: [],
+    owner: '',
+  });
+
+  const [sort, setSort] = useState<{ field: SortField; direction: SortDirection }>({
+    field: 'lastRun',
+    direction: 'desc',
+  });
+
+  const [selectedAction, setSelectedAction] = useState<Action | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+  const pageSize = 10;
+
+  // ── Derived State ────────────────────────────────────────────────────
+
+  const filteredActions = useMemo(() => {
+    return SAMPLE_ACTIONS
+      .filter(action => {
+        if (filters.search && !matchesSearch(action, filters.search)) return false;
+        if (filters.status !== 'all' && action.status !== filters.status) return false;
+        if (filters.type !== 'all' && action.type !== filters.type) return false;
+        if (filters.owner && action.owner !== filters.owner) return false;
+        if (filters.tags.length > 0 && !filters.tags.some(t => action.tags.includes(t))) return false;
+        return true;
+      })
+      .sort((a, b) => compareActions(a, b, sort.field, sort.direction));
+  }, [filters, sort]);
+
+  const paginatedActions = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredActions.slice(start, start + pageSize);
+  }, [filteredActions, currentPage]);
+
+  const totalPages = Math.ceil(filteredActions.length / pageSize);
+  const activeFilterCount = [
+    filters.status !== 'all',
+    filters.type !== 'all',
+    filters.search !== '',
+    filters.owner !== '',
+    filters.tags.length > 0,
+  ].filter(Boolean).length;
+
+  // ── Handlers ─────────────────────────────────────────────────────────
+
+  const handleSort = useCallback((field: SortField) => {
+    setSort(prev => ({
+      field,
+      direction: prev.field === field && prev.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setFilters({ search: '', status: 'all', type: 'all', dateRange: '7d', tags: [], owner: '' });
+    setCurrentPage(1);
+  }, []);
+
+  const handleToggleRow = useCallback((id: string) => {
+    setSelectedRows(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback(() => {
+    if (selectedRows.size === paginatedActions.length) {
+      setSelectedRows(new Set());
+    } else {
+      setSelectedRows(new Set(paginatedActions.map(a => a.id)));
+    }
+  }, [paginatedActions, selectedRows.size]);
+
+  const sortIndicator = (field: SortField) => {
+    if (sort.field !== field) return <span className="text-gray-300 ml-1">↕</span>;
+    return <span className="text-blue-600 ml-1">{sort.direction === 'asc' ? '↑' : '↓'}</span>;
+  };
+
+  // ── Render ───────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6 pb-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Actions</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Manage and monitor all automation actions across your workspace.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button type="button" className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+            Export
+          </button>
+          <button type="button" className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">
+            + New Action
+          </button>
+        </div>
+      </div>
+
+      {/* Filter Panel — always visible, takes significant vertical space */}
+      <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-gray-700">
+            Filters {activeFilterCount > 0 && <span className="text-xs text-blue-600 ml-1">({activeFilterCount} active)</span>}
+          </h2>
+          {activeFilterCount > 0 && (
+            <button type="button" onClick={handleClearFilters} className="text-xs text-blue-600 hover:text-blue-700">
+              Clear all
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <div>
+            <label htmlFor="filter-search" className="block text-xs text-gray-500 mb-1">Search</label>
+            <input
+              id="filter-search"
+              type="text"
+              value={filters.search}
+              onChange={(e) => { setFilters(f => ({ ...f, search: e.target.value })); setCurrentPage(1); }}
+              placeholder="Search actions..."
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="filter-status" className="block text-xs text-gray-500 mb-1">Status</label>
+            <select
+              id="filter-status"
+              value={filters.status}
+              onChange={(e) => { setFilters(f => ({ ...f, status: e.target.value as FilterState['status'] })); setCurrentPage(1); }}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="all">All statuses</option>
+              <option value="active">Active</option>
+              <option value="paused">Paused</option>
+              <option value="failed">Failed</option>
+              <option value="completed">Completed</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="filter-type" className="block text-xs text-gray-500 mb-1">Type</label>
+            <select
+              id="filter-type"
+              value={filters.type}
+              onChange={(e) => { setFilters(f => ({ ...f, type: e.target.value as FilterState['type'] })); setCurrentPage(1); }}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="all">All types</option>
+              <option value="webhook">Webhook</option>
+              <option value="scheduled">Scheduled</option>
+              <option value="triggered">Triggered</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="filter-owner" className="block text-xs text-gray-500 mb-1">Owner</label>
+            <select
+              id="filter-owner"
+              value={filters.owner}
+              onChange={(e) => { setFilters(f => ({ ...f, owner: e.target.value })); setCurrentPage(1); }}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All owners</option>
+              {ALL_OWNERS.map(owner => (
+                <option key={owner} value={owner}>{owner}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Advanced filters row — date range + tags */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="filter-date" className="block text-xs text-gray-500 mb-1">Date range</label>
+            <select
+              id="filter-date"
+              value={filters.dateRange}
+              onChange={(e) => setFilters(f => ({ ...f, dateRange: e.target.value as FilterState['dateRange'] }))}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="24h">Last 24 hours</option>
+              <option value="7d">Last 7 days</option>
+              <option value="30d">Last 30 days</option>
+              <option value="90d">Last 90 days</option>
+              <option value="all">All time</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Tags</label>
+            <div className="flex flex-wrap gap-1.5 px-3 py-1.5 min-h-[38px] border border-gray-300 rounded-md bg-white">
+              {ALL_TAGS.map(tag => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => {
+                    setFilters(f => ({
+                      ...f,
+                      tags: f.tags.includes(tag) ? f.tags.filter(t => t !== tag) : [...f.tags, tag],
+                    }));
+                    setCurrentPage(1);
+                  }}
+                  className={`px-1.5 py-0.5 text-[10px] rounded transition-colors ${
+                    filters.tags.includes(tag)
+                      ? 'bg-blue-100 text-blue-700 border border-blue-200'
+                      : 'bg-gray-50 text-gray-500 border border-gray-200 hover:bg-gray-100'
+                  }`}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Active filter pills */}
+        {activeFilterCount > 0 && (
+          <div className="flex items-center gap-2 pt-2 border-t border-gray-100">
+            <span className="text-xs text-gray-400">Active:</span>
+            {filters.status !== 'all' && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-full">
+                status: {filters.status}
+                <button type="button" onClick={() => setFilters(f => ({ ...f, status: 'all' }))} className="hover:text-blue-900">&times;</button>
+              </span>
+            )}
+            {filters.type !== 'all' && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-full">
+                type: {filters.type}
+                <button type="button" onClick={() => setFilters(f => ({ ...f, type: 'all' }))} className="hover:text-blue-900">&times;</button>
+              </span>
+            )}
+            {filters.owner && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-full">
+                owner: {filters.owner}
+                <button type="button" onClick={() => setFilters(f => ({ ...f, owner: '' }))} className="hover:text-blue-900">&times;</button>
+              </span>
+            )}
+            {filters.search && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-full">
+                "{filters.search}"
+                <button type="button" onClick={() => setFilters(f => ({ ...f, search: '' }))} className="hover:text-blue-900">&times;</button>
+              </span>
+            )}
+            {filters.tags.map(tag => (
+              <span key={tag} className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-full">
+                tag: {tag}
+                <button type="button" onClick={() => setFilters(f => ({ ...f, tags: f.tags.filter(t => t !== tag) }))} className="hover:text-blue-900">&times;</button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Bulk actions bar */}
+      {selectedRows.size > 0 && (
+        <div className="flex items-center gap-3 px-4 py-2 bg-blue-50 border border-blue-200 rounded-lg">
+          <span className="text-sm text-blue-700 font-medium">{selectedRows.size} selected</span>
+          <button type="button" className="text-xs text-blue-600 hover:text-blue-700 px-2 py-1 rounded hover:bg-blue-100">Pause selected</button>
+          <button type="button" className="text-xs text-blue-600 hover:text-blue-700 px-2 py-1 rounded hover:bg-blue-100">Resume selected</button>
+          <button type="button" className="text-xs text-red-600 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50">Delete selected</button>
+          <button type="button" className="ml-auto text-xs text-gray-500 hover:text-gray-700" onClick={() => setSelectedRows(new Set())}>Clear selection</button>
+        </div>
+      )}
+
+      {/* Data Table */}
+      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        {paginatedActions.length === 0 ? (
+          <EmptyState search={filters.search} />
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="bg-gray-50 border-b border-gray-200">
+                <th className="px-4 py-3 w-10">
+                  <input
+                    type="checkbox"
+                    checked={selectedRows.size === paginatedActions.length && paginatedActions.length > 0}
+                    onChange={handleToggleAll}
+                    className="rounded border-gray-300"
+                  />
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700" onClick={() => handleSort('name')}>
+                  Action {sortIndicator('name')}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700" onClick={() => handleSort('status')}>
+                  Status {sortIndicator('status')}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700" onClick={() => handleSort('lastRun')}>
+                  Last Run {sortIndicator('lastRun')}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700" onClick={() => handleSort('runs')}>
+                  Runs {sortIndicator('runs')}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700" onClick={() => handleSort('successRate')}>
+                  Success {sortIndicator('successRate')}
+                </th>
+                <th className="px-4 py-3 w-16"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginatedActions.map(action => (
+                <tr
+                  key={action.id}
+                  className={`border-t border-gray-100 hover:bg-gray-50 cursor-pointer ${
+                    selectedAction?.id === action.id ? 'bg-blue-50' : ''
+                  }`}
+                  onClick={() => setSelectedAction(action)}
+                >
+                  <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selectedRows.has(action.id)}
+                      onChange={() => handleToggleRow(action.id)}
+                      className="rounded border-gray-300"
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium text-gray-900">{action.name}</p>
+                        <ActionTypeBadge type={action.type} />
+                      </div>
+                      <p className="text-xs text-gray-400 line-clamp-1">{action.description}</p>
+                      <TagList tags={action.tags} />
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <ActionStatusBadge status={action.status} />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{action.lastRun}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{formatNumber(action.runs)}</td>
+                  <td className="px-4 py-3">
+                    <span className={`text-sm ${action.successRate >= 99 ? 'text-green-600' : action.successRate >= 95 ? 'text-yellow-600' : 'text-red-600'}`}>
+                      {action.successRate}%
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button type="button" className="text-sm text-blue-600 hover:text-blue-700" onClick={(e) => { e.stopPropagation(); setSelectedAction(action); }}>
+                      View
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-4 py-3 bg-white border border-gray-200 rounded-lg">
+          <p className="text-sm text-gray-500">
+            Showing <span className="font-medium">{(currentPage - 1) * pageSize + 1}</span> to{' '}
+            <span className="font-medium">{Math.min(currentPage * pageSize, filteredActions.length)}</span> of{' '}
+            <span className="font-medium">{filteredActions.length}</span> results
+          </p>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage(p => p - 1)}
+              className="px-3 py-1 text-sm text-gray-500 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+            >
+              Previous
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+              <button
+                key={page}
+                type="button"
+                onClick={() => setCurrentPage(page)}
+                className={`px-3 py-1 text-sm rounded ${
+                  page === currentPage
+                    ? 'text-white bg-blue-600'
+                    : 'text-gray-700 border border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+            <button
+              type="button"
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(p => p + 1)}
+              className="px-3 py-1 text-sm text-gray-500 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Detail Panel — shows below the table when a row is clicked */}
+      {selectedAction && (
+        <DetailPanel action={selectedAction} onClose={() => setSelectedAction(null)} />
+      )}
+    </div>
+  );
+}

--- a/test/manual/vite-dashboard/src/components/StatCard.tsx
+++ b/test/manual/vite-dashboard/src/components/StatCard.tsx
@@ -1,0 +1,20 @@
+interface StatCardProps {
+  label: string;
+  value: string;
+  trend?: string;
+  trendUp?: boolean;
+}
+
+export default function StatCard({ label, value, trend, trendUp }: StatCardProps) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value}</p>
+      {trend && (
+        <p className={`text-xs mt-1 ${trendUp ? 'text-green-600' : 'text-red-600'}`}>
+          {trendUp ? '+' : ''}{trend} vs last week
+        </p>
+      )}
+    </div>
+  );
+}

--- a/test/manual/vite-dashboard/src/index.css
+++ b/test/manual/vite-dashboard/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/test/manual/vite-dashboard/src/main.tsx
+++ b/test/manual/vite-dashboard/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/test/manual/vite-dashboard/vite.config.ts
+++ b/test/manual/vite-dashboard/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { frontmanPlugin } from '@frontman-ai/vite';
+
+export default defineConfig({
+  server: {
+    port: 5199,
+  },
+  optimizeDeps: {
+    include: ['react', 'react-dom', 'react/jsx-runtime'],
+    exclude: ['@frontman-ai/client'],
+  },
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
+  plugins: [
+    react(),
+    tailwindcss(),
+    frontmanPlugin({
+      isDev: true,
+      entrypointUrl: 'http://localhost:3000/frontman',
+    }),
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,12 +1726,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:^1.7.1, @emnapi/core@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/core@npm:1.8.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:^1.5.0":
   version: 1.6.0
   resolution: "@emnapi/runtime@npm:1.6.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/e3d2452a8fb83bb59fe60dfcf4cff99f9680c13c07dff8ad28639ccc8790151841ef626a67014bde132939bad73dfacc440ade8c3db2ab12693ea9c8ba4d37fb
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.7.1, @emnapi/runtime@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/runtime@npm:1.8.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
   languageName: node
   linkType: hard
 
@@ -2773,6 +2792,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@frontman/manual-vite-dashboard@workspace:test/manual/vite-dashboard":
+  version: 0.0.0-use.local
+  resolution: "@frontman/manual-vite-dashboard@workspace:test/manual/vite-dashboard"
+  dependencies:
+    "@frontman-ai/vite": "workspace:*"
+    "@tailwindcss/vite": "npm:^4.1.0"
+    "@vitejs/plugin-react": "npm:^4.3.0"
+    react: "npm:^19.0.0"
+    react-dom: "npm:^19.0.0"
+    tailwindcss: "npm:^4.1.0"
+    vite: "npm:^6.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@frontman/react-statestore@workspace:*, @frontman/react-statestore@workspace:libs/react-statestore":
   version: 0.0.0-use.local
   resolution: "@frontman/react-statestore@workspace:libs/react-statestore"
@@ -3432,6 +3465,17 @@ __metadata:
     "@emnapi/runtime": "npm:^1.5.0"
     "@tybys/wasm-util": "npm:^0.10.1"
   checksum: 10c0/2d8635498136abb49d6dbf7395b78c63422292240963bf055f307b77aeafbde57ae2c0ceaaef215601531b36d6eb92a2cdd6f5ba90ed2aa8127c27aff9c4ae55
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
+  dependencies:
+    "@emnapi/core": "npm:^1.7.1"
+    "@emnapi/runtime": "npm:^1.7.1"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/04d57b67e80736e41fe44674a011878db0a8ad893f4d44abb9d3608debb7c174224cba2796ed5b0c1d367368159f3ca6be45f1c59222f70e32ddc880f803d447
   languageName: node
   linkType: hard
 
@@ -7116,9 +7160,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/node@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/node@npm:4.2.1"
+  dependencies:
+    "@jridgewell/remapping": "npm:^2.3.5"
+    enhanced-resolve: "npm:^5.19.0"
+    jiti: "npm:^2.6.1"
+    lightningcss: "npm:1.31.1"
+    magic-string: "npm:^0.30.21"
+    source-map-js: "npm:^1.2.1"
+    tailwindcss: "npm:4.2.1"
+  checksum: 10c0/7b1bf77d2d714df98201cc2f308bee8edfebaf2ef520ec15cb9515e2aadabb28b4d2ecb165dd278716b3f6767da10e4d9a445de34ee8f7ec056fc9c1d8e275a1
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-android-arm64@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-android-arm64@npm:4.1.16"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-android-arm64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-android-arm64@npm:4.2.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -7130,9 +7196,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-darwin-arm64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-darwin-arm64@npm:4.2.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-darwin-x64@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-darwin-x64@npm:4.1.16"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-darwin-x64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-darwin-x64@npm:4.2.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -7144,9 +7224,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-freebsd-x64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-freebsd-x64@npm:4.2.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.16"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.2.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -7158,9 +7252,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-linux-arm64-gnu@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm64-gnu@npm:4.2.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-linux-arm64-musl@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-linux-arm64-musl@npm:4.1.16"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-arm64-musl@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm64-musl@npm:4.2.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -7172,9 +7280,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-linux-x64-gnu@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-x64-gnu@npm:4.2.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-linux-x64-musl@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-linux-x64-musl@npm:4.1.16"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-x64-musl@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-x64-musl@npm:4.2.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -7193,6 +7315,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-wasm32-wasi@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-wasm32-wasi@npm:4.2.1"
+  dependencies:
+    "@emnapi/core": "npm:^1.8.1"
+    "@emnapi/runtime": "npm:^1.8.1"
+    "@emnapi/wasi-threads": "npm:^1.1.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+    "@tybys/wasm-util": "npm:^0.10.1"
+    tslib: "npm:^2.8.1"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.16"
@@ -7200,9 +7336,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide-win32-arm64-msvc@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-win32-arm64-msvc@npm:4.2.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/oxide-win32-x64-msvc@npm:4.1.16":
   version: 4.1.16
   resolution: "@tailwindcss/oxide-win32-x64-msvc@npm:4.1.16"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-win32-x64-msvc@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-win32-x64-msvc@npm:4.2.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7252,6 +7402,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/oxide@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide@npm:4.2.1"
+  dependencies:
+    "@tailwindcss/oxide-android-arm64": "npm:4.2.1"
+    "@tailwindcss/oxide-darwin-arm64": "npm:4.2.1"
+    "@tailwindcss/oxide-darwin-x64": "npm:4.2.1"
+    "@tailwindcss/oxide-freebsd-x64": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm64-gnu": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm64-musl": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-x64-gnu": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-x64-musl": "npm:4.2.1"
+    "@tailwindcss/oxide-wasm32-wasi": "npm:4.2.1"
+    "@tailwindcss/oxide-win32-arm64-msvc": "npm:4.2.1"
+    "@tailwindcss/oxide-win32-x64-msvc": "npm:4.2.1"
+  dependenciesMeta:
+    "@tailwindcss/oxide-android-arm64":
+      optional: true
+    "@tailwindcss/oxide-darwin-arm64":
+      optional: true
+    "@tailwindcss/oxide-darwin-x64":
+      optional: true
+    "@tailwindcss/oxide-freebsd-x64":
+      optional: true
+    "@tailwindcss/oxide-linux-arm-gnueabihf":
+      optional: true
+    "@tailwindcss/oxide-linux-arm64-gnu":
+      optional: true
+    "@tailwindcss/oxide-linux-arm64-musl":
+      optional: true
+    "@tailwindcss/oxide-linux-x64-gnu":
+      optional: true
+    "@tailwindcss/oxide-linux-x64-musl":
+      optional: true
+    "@tailwindcss/oxide-wasm32-wasi":
+      optional: true
+    "@tailwindcss/oxide-win32-arm64-msvc":
+      optional: true
+    "@tailwindcss/oxide-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/4f9bfa40cde6925eed1759caf857831779a834a1b8776cc7df5bb48a279b7dcd2e761a31ffbd297d135a64b58f25e092d7c781c06cf44667746f7e5a5a3e0183
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/typography@npm:^0.5.13":
   version: 0.5.19
   resolution: "@tailwindcss/typography@npm:0.5.19"
@@ -7260,6 +7455,19 @@ __metadata:
   peerDependencies:
     tailwindcss: "*"
   checksum: 10c0/b9eb38e9c7adca59b55d7321275f59ea62c7d65a0c3d324c18c1c5864c69ec6e15b838e7df61e531cda62cfea08627b4343bc419bb0996182321891e5171e4d6
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/vite@npm:^4.1.0":
+  version: 4.2.1
+  resolution: "@tailwindcss/vite@npm:4.2.1"
+  dependencies:
+    "@tailwindcss/node": "npm:4.2.1"
+    "@tailwindcss/oxide": "npm:4.2.1"
+    tailwindcss: "npm:4.2.1"
+  peerDependencies:
+    vite: ^5.2.0 || ^6 || ^7
+  checksum: 10c0/44ee3bddffec12f3433b9d589e643f8a75edc78171766bc968ce5e95b4228c76b44e80cf9ddd5edb4edc11df658790099a98e23f976f9a38d812ddbeb443b3f9
   languageName: node
   linkType: hard
 
@@ -11591,6 +11799,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.19.0":
+  version: 5.20.0
+  resolution: "enhanced-resolve@npm:5.20.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.3.0"
+  checksum: 10c0/4ed5f38406fc9ad74c58a3d63b8215862243ab0ed6b0efc51ccdb72cdcedd3ac8638abe298680b279d7a83c3cb140e5eea7a5f8bd99696c74588f07ad89a95a7
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:^2.3.6, enquirer@npm:^2.4.1":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
@@ -14744,9 +14962,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-android-arm64@npm:1.31.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-darwin-arm64@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-darwin-arm64@npm:1.30.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-darwin-arm64@npm:1.31.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -14758,9 +14990,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-x64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-darwin-x64@npm:1.31.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "lightningcss-freebsd-x64@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-freebsd-x64@npm:1.30.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-freebsd-x64@npm:1.31.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -14772,9 +15018,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm-gnueabihf@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.31.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-arm64-gnu@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-linux-arm64-gnu@npm:1.30.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.31.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -14786,9 +15046,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm64-musl@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm64-musl@npm:1.31.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-x64-gnu@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-linux-x64-gnu@npm:1.30.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-x64-gnu@npm:1.31.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -14800,6 +15074,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-x64-musl@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-x64-musl@npm:1.31.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-arm64-msvc@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-win32-arm64-msvc@npm:1.30.2"
@@ -14807,9 +15088,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-win32-arm64-msvc@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.31.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-x64-msvc@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-win32-x64-msvc@npm:1.30.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-win32-x64-msvc@npm:1.31.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -14854,6 +15149,49 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10c0/5c0c73a33946dab65908d5cd1325df4efa290efb77f940b60f40448b5ab9a87d3ea665ef9bcf00df4209705050ecf2f7ecc649f44d6dfa5905bb50f15717e78d
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss@npm:1.31.1"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.31.1"
+    lightningcss-darwin-arm64: "npm:1.31.1"
+    lightningcss-darwin-x64: "npm:1.31.1"
+    lightningcss-freebsd-x64: "npm:1.31.1"
+    lightningcss-linux-arm-gnueabihf: "npm:1.31.1"
+    lightningcss-linux-arm64-gnu: "npm:1.31.1"
+    lightningcss-linux-arm64-musl: "npm:1.31.1"
+    lightningcss-linux-x64-gnu: "npm:1.31.1"
+    lightningcss-linux-x64-musl: "npm:1.31.1"
+    lightningcss-win32-arm64-msvc: "npm:1.31.1"
+    lightningcss-win32-x64-msvc: "npm:1.31.1"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/c6754b305d4a73652e472fc0d7d65384a6e16c336ea61068eca60de2a45bd5c30abbf012358b82eac56ee98b5d88028932cda5268ff61967cffa400b9e7ee2ba
   languageName: node
   linkType: hard
 
@@ -20474,6 +20812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tailwindcss@npm:4.2.1, tailwindcss@npm:^4.1.0":
+  version: 4.2.1
+  resolution: "tailwindcss@npm:4.2.1"
+  checksum: 10c0/482d734b582e9da509042ff59c1d7564d99e39e238c50ae907c20fa56177a8a00c3902f6971329971bd6a1c5357026ac76a849b8f2c69c94f0f59be99530ba54
+  languageName: node
+  linkType: hard
+
 "tailwindcss@npm:^3.4.4":
   version: 3.4.18
   resolution: "tailwindcss@npm:3.4.18"
@@ -20507,7 +20852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.2.0":
+"tapable@npm:^2.2.0, tapable@npm:^2.3.0":
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
   checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
@@ -20906,7 +21251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
## Summary

Fixes #477 — agent tweaks Tailwind spacing instead of addressing layout structure.

**Root causes addressed:**
- No visual context awareness → agent now uses before/after screenshots
- No component-level understanding → `get_dom` now emits `component="..."` attributes
- Shallow edit strategy → system prompt explicitly prefers structural over cosmetic changes
- Incomplete file comprehension → `read_file`/`edit_file`/`write_file` now have built-in guards (staleness check, coverage warning, read-before-write)
- Silent completion → edits must include summaries with trade-offs and alternatives

## Changes

### Core: Component name detection in `get_dom`
- **New `Client__ComponentName.res`** — Synchronous cascade: React fiber → Vue instance → Astro annotation. Returns `option<string>`. Skips internal names (Fragment, Suspense, underscored).
- **`Client__Tool__GetDom.res`** — Injects `component="ActionsTable"` etc. into simplified DOM walker output, giving the agent component-level context without a new tool.
- **`Client__WebPreview__Utils.res`** — Moved `_getComponentNameSync` out of UI domain into the new detection module.

### Core: FileTracker upgrade — staleness, coverage, read-before-write (inspired by [opencode](https://github.com/anomalyco/opencode))

Upgraded `FileTracker` from a `Set<string>` to a `Map<string, {readAt, ranges, totalLines}>`:

| Guard | Before | After |
|-------|--------|-------|
| Read before edit | Binary: was file ever read? | Same |
| Read before write | **None** | Rejects overwriting existing unread files |
| Staleness (mtime) | **None** | Rejects edits if file changed on disk since last read |
| Coverage awareness | **None** | Warns when editing lines outside previously-read ranges |

- **`FrontmanCore__FileTracker.res`** — Records `readAt` timestamp + line ranges per file. New functions: `assertNotStale`, `checkCoverage`, `mergeRanges`, `isLineCovered`.
- **`FrontmanCore__Tool__EditFile.res`** — Calls `assertNotStale` before editing; appends coverage warning to success message when editing outside read ranges.
- **`FrontmanCore__Tool__WriteFile.res`** — Calls `assertReadBefore` + `assertNotStale` when overwriting existing files. New files still bypass.
- **`FrontmanCore__Tool__ReadFile.res`** — Passes `offset`, `limit`, `totalLines` to `FileTracker.recordRead`.
- **`Fs.res`** — Added `mtimeMs` binding for `fs.Stats`.

### Prompt: UI & Layout Changes guidance (always-on)
- **`prompts.ex`** — Two additions to `@base_system_prompt`:
  - `## UI & Layout Changes`: Before/after screenshot workflow, structural over cosmetic preference, `get_dom` component attributes guidance
  - `## Response Formatting`: Edit summary requirement (mention trade-offs and alternatives, never complete silently)
  - Annotation workflow step 6: "Verify and summarize" with `take_screenshot`
  - **Removed**: Large-file prompt guidance (now enforced by tools)

### Tool: Large-file strategy in `read_file`
- **`FrontmanCore__Tool__ReadFile.res`** — Description advises grep-first strategy for large files (planning guidance, not enforcement — enforcement is in FileTracker).

### Manual test fixture
- **`test/manual/vite-dashboard/`** — React + Vite + Tailwind v4 + Frontman plugin. 740-line `ActionsTable.tsx` that mirrors the original issue: inline sub-components, mixed layout patterns, pagination starts at line ~300 (past default `read_file` window). Wired up with `@frontman-ai/vite` plugin for live testing.

## Tests
- 26 unit tests for `FileTracker` (mergeRanges, recordRead, assertReadBefore, isLineCovered, checkCoverage, clear)
- 7 unit tests for `Client__ComponentName` (plain elements, React fiber, Vue, priority, Fragment skipping, fiber walk-up)
- 5 Elixir tests for prompt content (UI section, structural preference, edit summary, tool-enforced large-file, annotation verification step)
- All existing tests pass: ReScript 624/624, client vitest 238/238, frontman-core vitest 260/260, Elixir prompts 23/23

## How to test manually

```bash
# 1. Start Frontman server
cd apps/frontman_server && make dev

# 2. Build the Vite plugin
cd libs/frontman-vite && make build

# 3. Start the dashboard fixture
cd test/manual/vite-dashboard && yarn dev
# Opens on http://localhost:5199

# 4. Ask the agent: "Make the actions table take less space"
# Expected: structural changes, not just p-4 → p-2
```