### PR TITLE
fix: add wordpress framework to unblock production deploy

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/execution/framework.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/framework.ex
@@ -25,7 +25,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
 
   use TypedStruct
 
-  @type id :: :nextjs | :vite | :astro
+  @type id :: :nextjs | :vite | :astro | :wordpress
 
   typedstruct enforce: true do
     @typedoc "Framework identity with display metadata"
@@ -38,6 +38,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   defp build(:nextjs), do: %__MODULE__{id: :nextjs, display_name: "Next.js"}
   defp build(:vite), do: %__MODULE__{id: :vite, display_name: "Vite"}
   defp build(:astro), do: %__MODULE__{id: :astro, display_name: "Astro"}
+  defp build(:wordpress), do: %__MODULE__{id: :wordpress, display_name: "WordPress"}
 
   # ── Public API ────────────────────────────────────────────────────────
 
@@ -45,7 +46,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   All known framework ids.
   """
   @spec known_ids() :: [id()]
-  def known_ids, do: [:nextjs, :vite, :astro]
+  def known_ids, do: [:nextjs, :vite, :astro, :wordpress]
 
   @doc """
   Normalize a raw client string into a framework struct.
@@ -87,6 +88,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   def from_string("nextjs"), do: build(:nextjs)
   def from_string("vite"), do: build(:vite)
   def from_string("astro"), do: build(:astro)
+  def from_string("wordpress"), do: build(:wordpress)
 
   @doc """
   Serialize a framework struct to the string stored in the database.
@@ -99,6 +101,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   def to_string(%__MODULE__{id: :nextjs}), do: "nextjs"
   def to_string(%__MODULE__{id: :vite}), do: "vite"
   def to_string(%__MODULE__{id: :astro}), do: "astro"
+  def to_string(%__MODULE__{id: :wordpress}), do: "wordpress"
 
   # ── Feature flags ─────────────────────────────────────────────────────
 
@@ -125,6 +128,7 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   defp display_label_to_id("Next.js"), do: :nextjs
   defp display_label_to_id("Vite"), do: :vite
   defp display_label_to_id("Astro"), do: :astro
+  defp display_label_to_id("WordPress"), do: :wordpress
   defp display_label_to_id(_), do: nil
 
   # Defensive normalization: lowercase, strip non-alpha, then match.
@@ -138,4 +142,5 @@ defmodule FrontmanServer.Tasks.Execution.Framework do
   defp slug_to_id("nextjs"), do: :nextjs
   defp slug_to_id("vite"), do: :vite
   defp slug_to_id("astro"), do: :astro
+  defp slug_to_id("wordpress"), do: :wordpress
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
@@ -138,6 +138,7 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
 
   defp append_framework_guidance(prompt, %Framework{id: :vite}), do: prompt
   defp append_framework_guidance(prompt, %Framework{id: :astro}), do: prompt
+  defp append_framework_guidance(prompt, %Framework{id: :wordpress}), do: prompt
   defp append_framework_guidance(prompt, nil), do: prompt
 
   defp append_project_structure(prompt, nil), do: prompt

--- a/apps/frontman_server/priv/repo/migrations/20260302000000_normalize_frameworks.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260302000000_normalize_frameworks.exs
@@ -11,9 +11,10 @@ defmodule FrontmanServer.Repo.Migrations.NormalizeFrameworks do
 
   def up do
     # Normalize known display labels to IDs
-    execute("UPDATE tasks SET framework = 'nextjs'  WHERE framework = 'Next.js'")
-    execute("UPDATE tasks SET framework = 'vite'    WHERE framework = 'Vite'")
-    execute("UPDATE tasks SET framework = 'astro'   WHERE framework = 'Astro'")
+    execute("UPDATE tasks SET framework = 'nextjs'    WHERE framework = 'Next.js'")
+    execute("UPDATE tasks SET framework = 'vite'      WHERE framework = 'Vite'")
+    execute("UPDATE tasks SET framework = 'astro'     WHERE framework = 'Astro'")
+    execute("UPDATE tasks SET framework = 'wordpress' WHERE framework = 'wordpress'")
 
     # Verify no unknown frameworks remain — crash the migration if so.
     # If this fails, investigate what unexpected values exist before proceeding.
@@ -22,11 +23,11 @@ defmodule FrontmanServer.Repo.Migrations.NormalizeFrameworks do
     BEGIN
       IF EXISTS (
         SELECT 1 FROM tasks
-        WHERE framework NOT IN ('nextjs', 'vite', 'astro')
+        WHERE framework NOT IN ('nextjs', 'vite', 'astro', 'wordpress')
            OR framework IS NULL
       ) THEN
         RAISE EXCEPTION 'Found tasks with unrecognized framework values. '
-          'Run: SELECT DISTINCT framework FROM tasks WHERE framework NOT IN (''nextjs'', ''vite'', ''astro'') '
+          'Run: SELECT DISTINCT framework FROM tasks WHERE framework NOT IN (''nextjs'', ''vite'', ''astro'', ''wordpress'') '
           'to investigate before migrating.';
       END IF;
     END $$;


### PR DESCRIPTION
## Summary

- **Fixes production deploy failure** — the `NormalizeFrameworks` migration crashes because production has `tasks.framework = 'wordpress'` which isn't in the migration's allowlist
- Adds `:wordpress` as a recognized framework across the full stack: type spec, constructors, `from_string`/`to_string`, client label parsing, `known_ids`, and prompt guidance (no-op, same as Vite/Astro)
- `has_typescript_react?` returns `false` for WordPress

## Files changed

| File | Change |
|------|--------|
| `framework.ex` | Add `:wordpress` to type, build, from_string, to_string, display_label_to_id, slug_to_id, known_ids |
| `prompts.ex` | Add no-op `append_framework_guidance` clause for `:wordpress` |
| `20260302000000_normalize_frameworks.exs` | Add `'wordpress'` to migration allowlist |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
