### PR TITLE
fix: enable tools and reasoning capabilities for gpt-5.3-codex on OpenRouter (#441)

### DIFF
--- a/.changeset/fix-openrouter-codex-capabilities.md
+++ b/.changeset/fix-openrouter-codex-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@frontman/frontman-server-assets": patch
+---
+
+Fix gpt-5.3-codex custom LLMDB capabilities for OpenRouter and OpenAI providers. Tools, streaming tool_calls, and reasoning were incorrectly disabled, causing silent failures when the agent framework attempted tool calling with this model.

--- a/apps/frontman_server/config/config.exs
+++ b/apps/frontman_server/config/config.exs
@@ -125,9 +125,9 @@ config :llm_db,
           name: "GPT-5.3 Codex",
           capabilities: %{
             chat: true,
-            reasoning: %{enabled: false},
-            streaming: %{text: true, tool_calls: false},
-            tools: %{enabled: false}
+            reasoning: %{enabled: true},
+            streaming: %{text: true, tool_calls: true},
+            tools: %{enabled: true}
           },
           limits: %{context: 400_000, output: 128_000},
           modalities: %{input: [:text, :image], output: [:text]}
@@ -176,9 +176,9 @@ config :llm_db,
           name: "GPT-5.3 Codex",
           capabilities: %{
             chat: true,
-            reasoning: %{enabled: false},
-            streaming: %{text: true, tool_calls: false},
-            tools: %{enabled: false}
+            reasoning: %{enabled: true},
+            streaming: %{text: true, tool_calls: true},
+            tools: %{enabled: true}
           },
           limits: %{context: 400_000, output: 128_000},
           modalities: %{input: [:text, :image], output: [:text]}


### PR DESCRIPTION
## Summary

- Fix custom LLMDB capabilities for `openai/gpt-5.3-codex` on both OpenRouter and OpenAI providers — reasoning, streaming tool_calls, and tools were all set to `false` when they should be `true`
- Capabilities now match the existing `gpt-5.2-codex` entry and what OpenRouter's live API reports in `supported_parameters`

## Root cause

The custom LLMDB config entries for `gpt-5.3-codex` were added with tools and reasoning disabled. When the agent framework attempted tool calling with this model, it failed silently because the model metadata said tools weren't supported.

## Why not just update llm_db?

`openai/gpt-5.3-codex` is on OpenRouter's live API (since Feb 24) but missing from llm_db's packaged data — even the latest release `2026.2.9`. This is because `LLMDB.Sources.OpenRouter` (which pulls directly from OpenRouter's API) isn't wired into the `mix llm_db.pull` task. OpenRouter data only comes through `models.dev`, which lags behind.

Upstream issue filed: https://github.com/agentjido/llm_db/issues/138

Closes #441