### PR TITLE
fix: make Plan.entries required per ACP spec (#541)

### DIFF
--- a/.changeset/fix-plan-entries-required.md
+++ b/.changeset/fix-plan-entries-required.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-protocol": patch
+"@frontman-ai/client": patch
+---
+
+Fix ACP spec deviation: make Plan.entries a required field instead of optional. The ACP spec defines entries as required, so the Option wrapper was incorrect.

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -188,7 +188,7 @@ module Provider = {
         | None => ()
         }
       | Plan({entries}) =>
-        entries->Option.forEach(e => Client__State.Actions.planReceived(~taskId, ~entries=e))
+        Client__State.Actions.planReceived(~taskId, ~entries)
       | Error({message}) =>
         Client__State.Actions.agentErrorReceived(~taskId, ~error=message)
       | Unknown(_) => ()

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -388,7 +388,8 @@
               },
               "additionalProperties": true,
               "required": [
-                "sessionUpdate"
+                "sessionUpdate",
+                "entries"
               ]
             },
             {

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -292,7 +292,7 @@ type sessionUpdate =
       status: option<string>,
       content: option<array<toolCallContentItem>>,
     })
-  | Plan({entries: option<array<planEntry>>})
+  | Plan({entries: array<planEntry>})
   | Error({message: string})
   | Unknown({sessionUpdate: string})
 
@@ -333,7 +333,7 @@ let sessionUpdateSchema = S.union([
   S.object(s => {
     s.tag("sessionUpdate", "plan")
     Plan({
-      entries: s.field("entries", S.option(S.array(planEntrySchema))),
+      entries: s.field("entries", S.array(planEntrySchema)),
     })
   }),
   S.object(s => {


### PR DESCRIPTION
## Summary

Closes #541

- **`FrontmanProtocol__ACP.res`**: Changed `Plan` variant `entries` field from `option<array<planEntry>>` to `array<planEntry>`, and removed `S.option()` wrapper from the schema
- **`Client__FrontmanProvider.res`**: Removed the `Option.forEach` bridge that was only needed because of the unnecessary optionality

### Why

The ACP spec defines `Plan.entries` as `"required": ["entries"]` — a required `PlanEntry[]`. Our implementation incorrectly declared it as optional. All downstream consumers (`PlanReceived` action, task state, UI components) already used non-optional arrays, so this change is fully contained in 2 files / 3 lines.