### PR TITLE
feat: model ContentBlock as discriminated union per ACP spec

### DIFF
--- a/.changeset/contentblock-discriminated-union.md
+++ b/.changeset/contentblock-discriminated-union.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/frontman-protocol": minor
+"@frontman-ai/client": minor
+"@frontman-ai/frontman-client": minor
+---
+
+Model ContentBlock as a discriminated union per ACP spec instead of a flat record with optional fields. Adds TextContent, ImageContent, AudioContent, ResourceLink, and EmbeddedResource variants with compile-time type safety. Wire format unchanged.

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -19,6 +19,13 @@ let textDeltaBuffer = Client__TextDeltaBuffer.make(~onFlush=(~taskId, ~text) => 
 })
 let () = Client__TextDeltaBuffer.active := Some(textDeltaBuffer)
 
+// Extract text from a contentBlock (returns Some for TextContent, None for other variants)
+let getContentBlockText = (block: Types.contentBlock): option<string> =>
+  switch block {
+  | TextContent({text}) => Some(text)
+  | ImageContent(_) | AudioContent(_) | ResourceLink(_) | EmbeddedResource(_) => None
+  }
+
 // Re-export status types for consumers
 type connectionState = Reducer.Selectors.connectionStatus
 type mcpState = Reducer.Selectors.mcpStatus
@@ -147,11 +154,11 @@ module Provider = {
         // Message end is signaled by session/prompt response with stopReason.
         // Buffer text deltas and flush once per animation frame to avoid
         // dozens of full state rebuilds per second during fast streaming.
-        content->Option.flatMap(c => c.text)->Option.forEach(text => {
+        content->Option.flatMap(getContentBlockText)->Option.forEach(text => {
           textDeltaBuffer.add(~taskId, ~text)
         })
       | UserMessageChunk({content, timestamp}) =>
-        content.text->Option.forEach(text => {
+        getContentBlockText(content)->Option.forEach(text => {
           let id = `user-hydrated-${WebAPI.Global.crypto->WebAPI.Crypto.randomUUID}`
           Client__State.Actions.userMessageReceived(~taskId, ~id, ~text, ~timestamp)
         })
@@ -169,7 +176,7 @@ module Provider = {
           spawningToolName,
         })
       | ToolCallUpdate({toolCallId, status, content}) =>
-        let text = content->Option.flatMap(c => c->Array.get(0))->Option.flatMap(i => i.content)->Option.flatMap(c => c.text)
+        let text = content->Option.flatMap(c => c->Array.get(0))->Option.flatMap(i => i.content)->Option.flatMap(getContentBlockText)
         switch status {
         | Some("pending") =>
           text->Option.flatMap(t => try { Some(JSON.parseOrThrow(t)) } catch { | _ => None })->Option.forEach(input => {

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -513,11 +513,8 @@ let buildAttachmentContentBlocks = (attachments: array<Client__Message.fileAttac
       return { "user_image": true, "filename": filename };
     })`)(att.filename)
 
-    {
-      Client__State__Types.ACPTypes.type_: "resource",
-      text: None,
-      uri: None,
-      resource: Some({
+    Client__State__Types.ACPTypes.EmbeddedResource({
+      resource: {
         _meta: Some(meta),
         annotations: None,
         resource: Client__State__Types.ACPTypes.BlobResourceContents({
@@ -525,9 +522,10 @@ let buildAttachmentContentBlocks = (attachments: array<Client__Message.fileAttac
           mimeType: Some(att.mediaType),
           blob: base64Data,
         }),
-      }),
-      content: None,
-    }
+      },
+      _meta: None,
+      annotations: None,
+    })
   })
 }
 

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -732,17 +732,15 @@ let annotationToContentBlocks = (annotation: Annotation.t, ~index: int): array<A
     }
   }
 
-  let resourceBlock: ACPTypes.contentBlock = {
-    type_: "resource",
-    text: None,
-    uri: None,
-    resource: Some({
+  let resourceBlock: ACPTypes.contentBlock = ACPTypes.EmbeddedResource({
+    resource: {
       _meta: Some(_meta),
       annotations: None,
       resource: ACPTypes.TextResourceContents({uri, mimeType: Some("text/plain"), text}),
-    }),
-    content: None,
-  }
+    },
+    _meta: None,
+    annotations: None,
+  })
 
   let screenshotBlock = annotation.screenshot->Option.map(screenshotDataUrl => {
     let (mimeType, base64Data) = parseDataUrl(screenshotDataUrl)
@@ -756,11 +754,8 @@ let annotationToContentBlocks = (annotation: Annotation.t, ~index: int): array<A
       screenshotMetaSchema,
     )
 
-    let block: ACPTypes.contentBlock = {
-      type_: "resource",
-      text: None,
-      uri: None,
-      resource: Some({
+    let block: ACPTypes.contentBlock = ACPTypes.EmbeddedResource({
+      resource: {
         _meta: Some(screenshotMeta),
         annotations: None,
         resource: ACPTypes.BlobResourceContents({
@@ -768,9 +763,10 @@ let annotationToContentBlocks = (annotation: Annotation.t, ~index: int): array<A
           mimeType: Some(mimeType),
           blob: base64Data,
         }),
-      }),
-      content: None,
-    }
+      },
+      _meta: None,
+      annotations: None,
+    })
     block
   })
 
@@ -809,13 +805,11 @@ let figmaNodeToContentBlock = (
     resource: ACPTypes.TextResourceContents(textResource),
   }
 
-  {
-    ACPTypes.type_: "resource",
-    text: None,
-    uri: None,
-    resource: Some(embeddedResource),
-    content: None,
-  }
+  ACPTypes.EmbeddedResource({
+    resource: embeddedResource,
+    _meta: None,
+    annotations: None,
+  })
 }
 
 // Build an Image ContentBlock from FigmaNode image data
@@ -838,13 +832,11 @@ let figmaImageToContentBlock = (imageDataUrl: string): ACPTypes.contentBlock => 
     resource: ACPTypes.BlobResourceContents(blobResource),
   }
 
-  {
-    ACPTypes.type_: "resource",
-    text: None,
-    uri: None,
-    resource: Some(embeddedResource),
-    content: None,
-  }
+  ACPTypes.EmbeddedResource({
+    resource: embeddedResource,
+    _meta: None,
+    annotations: None,
+  })
 }
 
 // Helper: read document.title from a document reference
@@ -1012,13 +1004,11 @@ let currentPageToContentBlock = (previewFrame: Task.previewFrame): ACPTypes.cont
     resource: ACPTypes.TextResourceContents(textResource),
   }
 
-  {
-    ACPTypes.type_: "resource",
-    text: None,
-    uri: None,
-    resource: Some(embeddedResource),
-    content: None,
-  }
+  ACPTypes.EmbeddedResource({
+    resource: embeddedResource,
+    _meta: None,
+    annotations: None,
+  })
 }
 
 // Build ContentBlocks array from Task
@@ -1146,17 +1136,15 @@ let messageAnnotationToContentBlocks = (
     }
   }
 
-  let resourceBlock: ACPTypes.contentBlock = {
-    type_: "resource",
-    text: None,
-    uri: None,
-    resource: Some({
+  let resourceBlock: ACPTypes.contentBlock = ACPTypes.EmbeddedResource({
+    resource: {
       _meta: Some(_meta),
       annotations: None,
       resource: ACPTypes.TextResourceContents({uri, mimeType: Some("text/plain"), text}),
-    }),
-    content: None,
-  }
+    },
+    _meta: None,
+    annotations: None,
+  })
 
   let screenshotBlock = annotation.screenshot->Option.map(screenshotDataUrl => {
     let (mimeType, base64Data) = parseDataUrl(screenshotDataUrl)
@@ -1170,11 +1158,8 @@ let messageAnnotationToContentBlocks = (
       screenshotMetaSchema,
     )
 
-    let block: ACPTypes.contentBlock = {
-      type_: "resource",
-      text: None,
-      uri: None,
-      resource: Some({
+    let block: ACPTypes.contentBlock = ACPTypes.EmbeddedResource({
+      resource: {
         _meta: Some(screenshotMeta),
         annotations: None,
         resource: ACPTypes.BlobResourceContents({
@@ -1182,9 +1167,10 @@ let messageAnnotationToContentBlocks = (
           mimeType: Some(mimeType),
           blob: base64Data,
         }),
-      }),
-      content: None,
-    }
+      },
+      _meta: None,
+      annotations: None,
+    })
     block
   })
 

--- a/libs/client/test/Client__State__Types.test.res
+++ b/libs/client/test/Client__State__Types.test.res
@@ -48,10 +48,22 @@ let makeTestAnnotation = (
   timestamp: 0.0,
 }
 
-// Helper to extract _meta from a content block
+// Helper to extract _meta from an EmbeddedResource content block
 let getMeta = (block: ACPTypes.contentBlock): JSON.t => {
-  let resource: ACPTypes.embeddedResource = block.resource->Option.getOrThrow
-  resource._meta->Option.getOrThrow
+  switch block {
+  | EmbeddedResource({resource}) => resource._meta->Option.getOrThrow
+  | TextContent(_) | ImageContent(_) | AudioContent(_) | ResourceLink(_) =>
+    failwith("getMeta: expected EmbeddedResource content block")
+  }
+}
+
+// Helper to extract the embeddedResource from an EmbeddedResource content block
+let getEmbeddedResource = (block: ACPTypes.contentBlock): ACPTypes.embeddedResource => {
+  switch block {
+  | EmbeddedResource({resource}) => resource
+  | TextContent(_) | ImageContent(_) | AudioContent(_) | ResourceLink(_) =>
+    failwith("getEmbeddedResource: expected EmbeddedResource content block")
+  }
 }
 
 // Helper to get a string field from _meta JSON
@@ -164,7 +176,7 @@ describe("Client__State__Types", () => {
 
       let blocks = Types.annotationToContentBlocks(annotation, ~index=0)
       let block = blocks->Array.getUnsafe(0)
-      let embeddedResource = block.resource->Option.getOrThrow
+      let embeddedResource = getEmbeddedResource(block)
 
       switch embeddedResource.resource {
       | TextResourceContents(textResource) =>
@@ -191,7 +203,7 @@ describe("Client__State__Types", () => {
 
       // Second block should be screenshot blob
       let screenshotBlock = blocks->Array.getUnsafe(1)
-      let screenshotResource = screenshotBlock.resource->Option.getOrThrow
+      let screenshotResource = getEmbeddedResource(screenshotBlock)
       let screenshotMeta = screenshotResource._meta->Option.getOrThrow
 
       t->expect(getMetaBool(screenshotMeta, "annotation_screenshot"))->Expect.toBe(true)
@@ -234,7 +246,7 @@ describe("Client__State__Types", () => {
 
       let blocks = Types.annotationToContentBlocks(annotation, ~index=0)
       let block = blocks->Array.getUnsafe(0)
-      let embeddedResource = block.resource->Option.getOrThrow
+      let embeddedResource = getEmbeddedResource(block)
 
       switch embeddedResource.resource {
       | TextResourceContents(textResource) =>

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -367,19 +367,10 @@ let sendPrompt = async (
   ~metadata: option<JSON.t>=None,
 ): result<Types.promptResult, string> => {
   // Build prompt array starting with the text block
-  let textBlock = JSON.Encode.object(
-    Dict.fromArray([("type", JSON.Encode.string("text")), ("text", JSON.Encode.string(text))]),
+  let textBlock: Types.contentBlock = TextContent({text, _meta: None, annotations: None})
+  let allBlocks = Array.concat([textBlock], additionalBlocks)->Array.map(block =>
+    block->S.reverseConvertToJsonOrThrow(Types.contentBlockSchema)
   )
-
-  let allBlocks = if Array.length(additionalBlocks) > 0 {
-    let additionalBlocksJson =
-      additionalBlocks->Array.map(block =>
-        block->S.reverseConvertToJsonOrThrow(Types.contentBlockSchema)
-      )
-    Array.concat([textBlock], additionalBlocksJson)
-  } else {
-    [textBlock]
-  }
 
   await Protocol.sendPrompt(
     ~channel=session.channel,

--- a/libs/frontman-protocol/schemas/acp/contentBlock.json
+++ b/libs/frontman-protocol/schemas/acp/contentBlock.json
@@ -1,18 +1,15 @@
 {
-  "type": "object",
-  "properties": {
-    "type": {
-      "type": "string"
-    },
-    "text": {
-      "type": "string"
-    },
-    "uri": {
-      "type": "string"
-    },
-    "resource": {
+  "anyOf": [
+    {
       "type": "object",
       "properties": {
+        "type": {
+          "type": "string",
+          "const": "text"
+        },
+        "text": {
+          "type": "string"
+        },
         "_meta": {},
         "annotations": {
           "type": "object",
@@ -20,59 +17,181 @@
             "_meta": {}
           },
           "additionalProperties": true
-        },
-        "resource": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "uri": {
-                  "type": "string"
-                },
-                "mimeType": {
-                  "type": "string"
-                },
-                "text": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": true,
-              "required": [
-                "uri",
-                "text"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "uri": {
-                  "type": "string"
-                },
-                "mimeType": {
-                  "type": "string"
-                },
-                "blob": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": true,
-              "required": [
-                "uri",
-                "blob"
-              ]
-            }
-          ]
         }
       },
       "additionalProperties": true,
       "required": [
-        "resource"
+        "type",
+        "text"
       ]
     },
-    "content": {}
-  },
-  "additionalProperties": true,
-  "required": [
-    "type"
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "image"
+        },
+        "data": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "_meta": {},
+        "annotations": {
+          "type": "object",
+          "properties": {
+            "_meta": {}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "data",
+        "mimeType"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "audio"
+        },
+        "data": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "_meta": {},
+        "annotations": {
+          "type": "object",
+          "properties": {
+            "_meta": {}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "data",
+        "mimeType"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "resource_link"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "_meta": {},
+        "annotations": {
+          "type": "object",
+          "properties": {
+            "_meta": {}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "name",
+        "uri"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "resource"
+        },
+        "resource": {
+          "type": "object",
+          "properties": {
+            "_meta": {},
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "_meta": {}
+              },
+              "additionalProperties": true
+            },
+            "resource": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "uri": {
+                      "type": "string"
+                    },
+                    "mimeType": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "uri",
+                    "text"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "uri": {
+                      "type": "string"
+                    },
+                    "mimeType": {
+                      "type": "string"
+                    },
+                    "blob": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "uri",
+                    "blob"
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "resource"
+          ]
+        },
+        "_meta": {},
+        "annotations": {
+          "type": "object",
+          "properties": {
+            "_meta": {}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "resource"
+      ]
+    }
   ]
 }

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -23,20 +23,17 @@
                   "const": "agent_message_chunk"
                 },
                 "content": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    },
-                    "uri": {
-                      "type": "string"
-                    },
-                    "resource": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "text"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
                         "_meta": {},
                         "annotations": {
                           "type": "object",
@@ -44,60 +41,182 @@
                             "_meta": {}
                           },
                           "additionalProperties": true
-                        },
-                        "resource": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "uri": {
-                                  "type": "string"
-                                },
-                                "mimeType": {
-                                  "type": "string"
-                                },
-                                "text": {
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": true,
-                              "required": [
-                                "uri",
-                                "text"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "uri": {
-                                  "type": "string"
-                                },
-                                "mimeType": {
-                                  "type": "string"
-                                },
-                                "blob": {
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": true,
-                              "required": [
-                                "uri",
-                                "blob"
-                              ]
-                            }
-                          ]
                         }
                       },
                       "additionalProperties": true,
                       "required": [
-                        "resource"
+                        "type",
+                        "text"
                       ]
                     },
-                    "content": {}
-                  },
-                  "additionalProperties": true,
-                  "required": [
-                    "type"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "image"
+                        },
+                        "data": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "data",
+                        "mimeType"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "audio"
+                        },
+                        "data": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "data",
+                        "mimeType"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "resource_link"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "name",
+                        "uri"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "resource"
+                        },
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {},
+                            "annotations": {
+                              "type": "object",
+                              "properties": {
+                                "_meta": {}
+                              },
+                              "additionalProperties": true
+                            },
+                            "resource": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "uri": {
+                                      "type": "string"
+                                    },
+                                    "mimeType": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": true,
+                                  "required": [
+                                    "uri",
+                                    "text"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "uri": {
+                                      "type": "string"
+                                    },
+                                    "mimeType": {
+                                      "type": "string"
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": true,
+                                  "required": [
+                                    "uri",
+                                    "blob"
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": true,
+                          "required": [
+                            "resource"
+                          ]
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "resource"
+                      ]
+                    }
                   ]
                 }
               },
@@ -114,20 +233,17 @@
                   "const": "user_message_chunk"
                 },
                 "content": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    },
-                    "uri": {
-                      "type": "string"
-                    },
-                    "resource": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "text"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
                         "_meta": {},
                         "annotations": {
                           "type": "object",
@@ -135,60 +251,182 @@
                             "_meta": {}
                           },
                           "additionalProperties": true
-                        },
-                        "resource": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "uri": {
-                                  "type": "string"
-                                },
-                                "mimeType": {
-                                  "type": "string"
-                                },
-                                "text": {
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": true,
-                              "required": [
-                                "uri",
-                                "text"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "uri": {
-                                  "type": "string"
-                                },
-                                "mimeType": {
-                                  "type": "string"
-                                },
-                                "blob": {
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": true,
-                              "required": [
-                                "uri",
-                                "blob"
-                              ]
-                            }
-                          ]
                         }
                       },
                       "additionalProperties": true,
                       "required": [
-                        "resource"
+                        "type",
+                        "text"
                       ]
                     },
-                    "content": {}
-                  },
-                  "additionalProperties": true,
-                  "required": [
-                    "type"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "image"
+                        },
+                        "data": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "data",
+                        "mimeType"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "audio"
+                        },
+                        "data": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "data",
+                        "mimeType"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "resource_link"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "name",
+                        "uri"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "resource"
+                        },
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {},
+                            "annotations": {
+                              "type": "object",
+                              "properties": {
+                                "_meta": {}
+                              },
+                              "additionalProperties": true
+                            },
+                            "resource": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "uri": {
+                                      "type": "string"
+                                    },
+                                    "mimeType": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": true,
+                                  "required": [
+                                    "uri",
+                                    "text"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "uri": {
+                                      "type": "string"
+                                    },
+                                    "mimeType": {
+                                      "type": "string"
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": true,
+                                  "required": [
+                                    "uri",
+                                    "blob"
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": true,
+                          "required": [
+                            "resource"
+                          ]
+                        },
+                        "_meta": {},
+                        "annotations": {
+                          "type": "object",
+                          "properties": {
+                            "_meta": {}
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "type",
+                        "resource"
+                      ]
+                    }
                   ]
                 },
                 "timestamp": {
@@ -255,20 +493,17 @@
                         "type": "string"
                       },
                       "content": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string"
-                          },
-                          "text": {
-                            "type": "string"
-                          },
-                          "uri": {
-                            "type": "string"
-                          },
-                          "resource": {
+                        "anyOf": [
+                          {
                             "type": "object",
                             "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "text"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
                               "_meta": {},
                               "annotations": {
                                 "type": "object",
@@ -276,60 +511,182 @@
                                   "_meta": {}
                                 },
                                 "additionalProperties": true
-                              },
-                              "resource": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "uri": {
-                                        "type": "string"
-                                      },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "text": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": true,
-                                    "required": [
-                                      "uri",
-                                      "text"
-                                    ]
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "uri": {
-                                        "type": "string"
-                                      },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "blob": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": true,
-                                    "required": [
-                                      "uri",
-                                      "blob"
-                                    ]
-                                  }
-                                ]
                               }
                             },
                             "additionalProperties": true,
                             "required": [
-                              "resource"
+                              "type",
+                              "text"
                             ]
                           },
-                          "content": {}
-                        },
-                        "additionalProperties": true,
-                        "required": [
-                          "type"
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "image"
+                              },
+                              "data": {
+                                "type": "string"
+                              },
+                              "mimeType": {
+                                "type": "string"
+                              },
+                              "_meta": {},
+                              "annotations": {
+                                "type": "object",
+                                "properties": {
+                                  "_meta": {}
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "additionalProperties": true,
+                            "required": [
+                              "type",
+                              "data",
+                              "mimeType"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "audio"
+                              },
+                              "data": {
+                                "type": "string"
+                              },
+                              "mimeType": {
+                                "type": "string"
+                              },
+                              "_meta": {},
+                              "annotations": {
+                                "type": "object",
+                                "properties": {
+                                  "_meta": {}
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "additionalProperties": true,
+                            "required": [
+                              "type",
+                              "data",
+                              "mimeType"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "resource_link"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uri": {
+                                "type": "string"
+                              },
+                              "_meta": {},
+                              "annotations": {
+                                "type": "object",
+                                "properties": {
+                                  "_meta": {}
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "additionalProperties": true,
+                            "required": [
+                              "type",
+                              "name",
+                              "uri"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "resource"
+                              },
+                              "resource": {
+                                "type": "object",
+                                "properties": {
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    },
+                                    "additionalProperties": true
+                                  },
+                                  "resource": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": true,
+                                        "required": [
+                                          "uri",
+                                          "text"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": true,
+                                        "required": [
+                                          "uri",
+                                          "blob"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": true,
+                                "required": [
+                                  "resource"
+                                ]
+                              },
+                              "_meta": {},
+                              "annotations": {
+                                "type": "object",
+                                "properties": {
+                                  "_meta": {}
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "additionalProperties": true,
+                            "required": [
+                              "type",
+                              "resource"
+                            ]
+                          }
                         ]
                       }
                     },

--- a/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
+++ b/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
@@ -5,20 +5,17 @@
       "type": "string"
     },
     "content": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "text": {
-          "type": "string"
-        },
-        "uri": {
-          "type": "string"
-        },
-        "resource": {
+      "anyOf": [
+        {
           "type": "object",
           "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            },
+            "text": {
+              "type": "string"
+            },
             "_meta": {},
             "annotations": {
               "type": "object",
@@ -26,60 +23,182 @@
                 "_meta": {}
               },
               "additionalProperties": true
-            },
-            "resource": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "uri": {
-                      "type": "string"
-                    },
-                    "mimeType": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": true,
-                  "required": [
-                    "uri",
-                    "text"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "uri": {
-                      "type": "string"
-                    },
-                    "mimeType": {
-                      "type": "string"
-                    },
-                    "blob": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": true,
-                  "required": [
-                    "uri",
-                    "blob"
-                  ]
-                }
-              ]
             }
           },
           "additionalProperties": true,
           "required": [
-            "resource"
+            "type",
+            "text"
           ]
         },
-        "content": {}
-      },
-      "additionalProperties": true,
-      "required": [
-        "type"
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "image"
+            },
+            "data": {
+              "type": "string"
+            },
+            "mimeType": {
+              "type": "string"
+            },
+            "_meta": {},
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "_meta": {}
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "data",
+            "mimeType"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "audio"
+            },
+            "data": {
+              "type": "string"
+            },
+            "mimeType": {
+              "type": "string"
+            },
+            "_meta": {},
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "_meta": {}
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "data",
+            "mimeType"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "resource_link"
+            },
+            "name": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            },
+            "_meta": {},
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "_meta": {}
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name",
+            "uri"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "resource"
+            },
+            "resource": {
+              "type": "object",
+              "properties": {
+                "_meta": {},
+                "annotations": {
+                  "type": "object",
+                  "properties": {
+                    "_meta": {}
+                  },
+                  "additionalProperties": true
+                },
+                "resource": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "uri": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "uri",
+                        "text"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "uri": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "blob": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true,
+                      "required": [
+                        "uri",
+                        "blob"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "resource"
+              ]
+            },
+            "_meta": {},
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "_meta": {}
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "resource"
+          ]
+        }
       ]
     }
   },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -182,27 +182,83 @@ type embeddedResource = {
 }
 
 // Content block for prompts and responses
-// Supports text, resource_link, resource types per ACP spec, and structured JSON content
-type contentBlock = {
-  @as("type")
-  type_: string,
-  // For type="text"
-  text: option<string>,
-  // For type="resource_link"
-  uri: option<string>,
-  // For type="resource" - contains EmbeddedResource wrapper
-  resource: option<embeddedResource>,
-  // For structured JSON content from backend tools
-  content: option<JSON.t>,
-}
+// Discriminated union on "type" field per ACP spec:
+// - TextContent (type="text"): text string
+// - ImageContent (type="image"): base64 data + mimeType
+// - AudioContent (type="audio"): base64 data + mimeType
+// - ResourceLink (type="resource_link"): name + uri
+// - EmbeddedResource (type="resource"): embedded resource wrapper
+type contentBlock =
+  | TextContent({text: string, _meta: option<JSON.t>, annotations: option<annotations>})
+  | ImageContent({
+      data: string,
+      mimeType: string,
+      _meta: option<JSON.t>,
+      annotations: option<annotations>,
+    })
+  | AudioContent({
+      data: string,
+      mimeType: string,
+      _meta: option<JSON.t>,
+      annotations: option<annotations>,
+    })
+  | ResourceLink({
+      name: string,
+      uri: string,
+      _meta: option<JSON.t>,
+      annotations: option<annotations>,
+    })
+  | EmbeddedResource({
+      resource: embeddedResource,
+      _meta: option<JSON.t>,
+      annotations: option<annotations>,
+    })
 
-let contentBlockSchema = S.object(s => {
-  type_: s.field("type", S.string),
-  text: s.field("text", S.option(S.string)),
-  uri: s.field("uri", S.option(S.string)),
-  resource: s.field("resource", S.option(embeddedResourceSchema)),
-  content: s.field("content", S.option(S.json)),
-})
+let contentBlockSchema = S.union([
+  S.object(s => {
+    s.tag("type", "text")
+    TextContent({
+      text: s.field("text", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+      annotations: s.field("annotations", S.option(annotationsSchema)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "image")
+    ImageContent({
+      data: s.field("data", S.string),
+      mimeType: s.field("mimeType", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+      annotations: s.field("annotations", S.option(annotationsSchema)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "audio")
+    AudioContent({
+      data: s.field("data", S.string),
+      mimeType: s.field("mimeType", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+      annotations: s.field("annotations", S.option(annotationsSchema)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "resource_link")
+    ResourceLink({
+      name: s.field("name", S.string),
+      uri: s.field("uri", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+      annotations: s.field("annotations", S.option(annotationsSchema)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "resource")
+    EmbeddedResource({
+      resource: s.field("resource", embeddedResourceSchema),
+      _meta: s.field("_meta", S.option(S.json)),
+      annotations: s.field("annotations", S.option(annotationsSchema)),
+    })
+  }),
+])
 
 let embeddedResourceSchema = S.object(s => {
   _meta: s.field("_meta", S.option(S.json)),


### PR DESCRIPTION
## Summary

Closes #523

- Replaces flat `contentBlock` record (bag of optionals) with a proper discriminated union tagged on `"type"`: `TextContent`, `ImageContent`, `AudioContent`, `ResourceLink`, `EmbeddedResource`
- Adds `ImageContent` and `AudioContent` variants that were missing from the protocol layer
- Updates all construction sites, reading sites, serialization, and tests to use pattern matching

## Changes

| File | What changed |
|------|-------------|
| `FrontmanProtocol__ACP.res` | Type + Sury schema: flat record → `S.union` with `s.tag("type", ...)` |
| `Client__Task__Types.res` | 7 construction sites → `EmbeddedResource(...)` variant |
| `Client__State__StateReducer.res` | `buildAttachmentContentBlocks` → `EmbeddedResource(...)` |
| `Client__FrontmanProvider.res` | `.text` field access → `getContentBlockText` pattern match helper |
| `FrontmanClient__ACP.res` | Raw JSON text block → `TextContent(...)` variant via schema |
| `Client__State__Types.test.res` | Test helpers → pattern match with `getEmbeddedResource` |

## Wire format

JSON on the wire is **unchanged** — `S.union` with `s.tag` produces identical JSON (e.g. `{"type":"text","text":"hello"}`). No server changes needed.

## Testing

- ReScript build: clean (0 errors)
- All 257 client tests pass