### PR TITLE
feat(swarm_ai): add tool suspension primitives

### DIFF
--- a/.changeset/swarm-ai-suspension-primitives.md
+++ b/.changeset/swarm-ai-suspension-primitives.md
@@ -1,0 +1,11 @@
+---
+"swarm_ai": minor
+---
+
+Add tool suspension primitives to SwarmAi
+
+- New `ToolResult.suspended/1` constructor for creating suspended tool results
+- `ToolCall.completed?/1` returns false for suspended results; new `ToolCall.suspended?/1` predicate
+- `Step.has_suspended_tools?/1` checks if any tool calls in a step are suspended
+- `run_streaming/3` and `run_blocking/3` return `{:suspended, loop_id}` when a tool executor returns `:suspended`
+- `Runtime.run/5` supports `on_suspended` lifecycle callback

--- a/apps/swarm_ai/lib/swarm_ai.ex
+++ b/apps/swarm_ai/lib/swarm_ai.ex
@@ -82,10 +82,14 @@ defmodule SwarmAi do
   - `{:ok, content}` - Tool executed successfully
   - `{:error, reason}` - Tool failed
   - `{:spawn, request}` - Delegate to a child agent
+  - `:suspended` - Tool is waiting for external input (e.g., user interaction)
   """
   @type tool_executor ::
           (SwarmAi.ToolCall.t() ->
-             {:ok, String.t()} | {:error, String.t()} | {:spawn, SwarmAi.SpawnChildAgent.t()})
+             {:ok, String.t()}
+             | {:error, String.t()}
+             | {:spawn, SwarmAi.SpawnChildAgent.t()}
+             | :suspended)
 
   @typedoc """
   Callback options for run_streaming/3.
@@ -144,7 +148,9 @@ defmodule SwarmAi do
       {:ok, result, _loop_id} = SwarmAi.run_streaming(agent, "Hello", tool_executor: fn _ -> {:ok, "done"} end)
   """
   @spec run_streaming(SwarmAi.Agent.t(), message_input(), streaming_opts()) ::
-          {:ok, String.t(), SwarmAi.Id.t()} | {:error, term(), SwarmAi.Id.t()}
+          {:ok, String.t(), SwarmAi.Id.t()}
+          | {:error, term(), SwarmAi.Id.t()}
+          | {:suspended, SwarmAi.Id.t()}
   def run_streaming(agent, message, opts) when is_list(opts) do
     tool_executor = Keyword.fetch!(opts, :tool_executor)
     callbacks = build_callbacks(opts)
@@ -167,9 +173,23 @@ defmodule SwarmAi do
 
         result =
           case final_loop.status do
-            :completed -> {:ok, final_loop.result, loop.id}
-            :failed -> {:error, final_loop.error, loop.id}
-            other -> {:error, {:unexpected_status, other}, loop.id}
+            :completed ->
+              {:ok, final_loop.result, loop.id}
+
+            :failed ->
+              {:error, final_loop.error, loop.id}
+
+            :waiting_for_tools ->
+              step = Loop.current_step(final_loop)
+
+              if step && SwarmAi.Loop.Step.has_suspended_tools?(step) do
+                {:suspended, loop.id}
+              else
+                {:error, {:unexpected_status, :waiting_for_tools}, loop.id}
+              end
+
+            other ->
+              {:error, {:unexpected_status, other}, loop.id}
           end
 
         # Include loop_id, metadata, and output in stop metadata
@@ -200,7 +220,9 @@ defmodule SwarmAi do
       end)
   """
   @spec run_blocking(SwarmAi.Agent.t(), message_input(), tool_executor()) ::
-          {:ok, String.t(), SwarmAi.Id.t()} | {:error, term(), SwarmAi.Id.t()}
+          {:ok, String.t(), SwarmAi.Id.t()}
+          | {:error, term(), SwarmAi.Id.t()}
+          | {:suspended, SwarmAi.Id.t()}
   def run_blocking(agent, message, tool_executor) when is_function(tool_executor, 1) do
     run_streaming(agent, message, tool_executor: tool_executor)
   end
@@ -534,6 +556,9 @@ defmodule SwarmAi do
               child_result = run_child(loop, tc.id, request, tool_executor)
               content = child_result.result || "Child failed: #{inspect(child_result.error)}"
               ToolResult.make(tc.id, content, child_result.status == :failed)
+
+            :suspended ->
+              ToolResult.suspended(tc.id)
           end
 
         stop_meta = %{

--- a/apps/swarm_ai/lib/swarm_ai/loop/step.ex
+++ b/apps/swarm_ai/lib/swarm_ai/loop/step.ex
@@ -73,6 +73,12 @@ defmodule SwarmAi.Loop.Step do
     Enum.any?(calls, &(not SwarmAi.ToolCall.completed?(&1)))
   end
 
+  @doc "Returns true if any tool calls have a suspended result."
+  @spec has_suspended_tools?(t()) :: boolean()
+  def has_suspended_tools?(%__MODULE__{tool_calls: calls}) do
+    Enum.any?(calls, &SwarmAi.ToolCall.suspended?/1)
+  end
+
   @doc "Returns true if there are tool calls and all have results."
   @spec all_tools_complete?(t()) :: boolean()
   def all_tools_complete?(%__MODULE__{tool_calls: []}), do: true

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -32,6 +32,7 @@ defmodule SwarmAi.Runtime do
 
   - `on_complete` - Called with `{:ok, result, loop_id}` after successful execution
   - `on_error` - Called with `{:error, reason, loop_id}` after failed execution
+  - `on_suspended` - Called with `{:suspended, loop_id}` when a tool returns `:suspended`
   - `on_crash` - Called with `{reason, stacktrace}` if the execution process crashes
   - `on_cancelled` - Called with no args if the execution is cancelled
 
@@ -76,6 +77,7 @@ defmodule SwarmAi.Runtime do
   All options from `SwarmAi.run_streaming/3`, plus:
   - `:on_complete` - Called with `{:ok, result, loop_id}` after successful execution
   - `:on_error` - Called with `{:error, reason, loop_id}` after failed execution
+  - `:on_suspended` - Called with `{:suspended, loop_id}` when a tool returns `:suspended`
   - `:on_crash` - Called with `{reason, stacktrace}` if the execution process crashes
   - `:on_cancelled` - Called with no args if the execution is cancelled
   - `:metadata` - Map of metadata passed to `SwarmAi.run_streaming/3`
@@ -170,10 +172,11 @@ defmodule SwarmAi.Runtime do
        ) do
     on_complete = Keyword.get(opts, :on_complete, fn _ -> :ok end)
     on_error = Keyword.get(opts, :on_error, fn _ -> :ok end)
+    on_suspended = Keyword.get(opts, :on_suspended, fn _ -> :ok end)
 
     streaming_opts =
       opts
-      |> Keyword.drop([:on_complete, :on_error, :on_crash, :on_cancelled])
+      |> Keyword.drop([:on_complete, :on_error, :on_suspended, :on_crash, :on_cancelled])
 
     caller = self()
     ack_ref = make_ref()
@@ -203,7 +206,8 @@ defmodule SwarmAi.Runtime do
                registry,
                registry_key,
                on_complete,
-               on_error
+               on_error,
+               on_suspended
              )
            after
              # Safety net — idempotent if already unregistered in execute
@@ -244,7 +248,7 @@ defmodule SwarmAi.Runtime do
     end
   end
 
-  defp execute(agent, messages, opts, registry, registry_key, on_complete, on_error) do
+  defp execute(agent, messages, opts, registry, registry_key, on_complete, on_error, on_suspended) do
     result = SwarmAi.run_streaming(agent, messages, opts)
 
     # Unregister BEFORE callback so running?/2 returns false before
@@ -257,6 +261,9 @@ defmodule SwarmAi.Runtime do
 
       {:error, _reason, _loop_id} = err ->
         on_error.(err)
+
+      {:suspended, _loop_id} = suspended ->
+        on_suspended.(suspended)
     end
 
     result

--- a/apps/swarm_ai/lib/swarm_ai/tool_call.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_call.ex
@@ -16,9 +16,16 @@ defmodule SwarmAi.ToolCall do
     field(:result, ToolResult.t())
   end
 
-  @doc "Returns true if the tool call has a result."
+  @doc "Returns true if the tool call has a non-suspended result."
   @spec completed?(t()) :: boolean()
-  def completed?(%__MODULE__{result: result}), do: result != nil
+  def completed?(%__MODULE__{result: nil}), do: false
+  def completed?(%__MODULE__{result: %ToolResult{suspended: true}}), do: false
+  def completed?(%__MODULE__{result: %ToolResult{}}), do: true
+
+  @doc "Returns true if the tool call has a suspended result."
+  @spec suspended?(t()) :: boolean()
+  def suspended?(%__MODULE__{result: %ToolResult{suspended: true}}), do: true
+  def suspended?(%__MODULE__{result: _}), do: false
 
   @doc "Adds a result to the tool call."
   @spec with_result(t(), ToolResult.t()) :: t()

--- a/apps/swarm_ai/lib/swarm_ai/tool_result.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_result.ex
@@ -10,6 +10,19 @@ defmodule SwarmAi.ToolResult do
     field(:id, String.t())
     field(:content, [ContentPart.t()])
     field(:is_error, boolean(), default: false)
+    field(:suspended, boolean(), default: false, enforce: false)
+  end
+
+  @doc """
+  Creates a suspended ToolResult.
+
+  A suspended result indicates the tool is waiting for external input (e.g., user
+  interaction) before it can complete. The tool call is not considered completed
+  and the agent loop will pause.
+  """
+  @spec suspended(String.t()) :: t()
+  def suspended(id) do
+    %__MODULE__{id: id, content: [ContentPart.text("")], is_error: false, suspended: true}
   end
 
   @doc """

--- a/apps/swarm_ai/test/swarm_ai/runtime_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime_test.exs
@@ -259,6 +259,62 @@ defmodule SwarmAi.RuntimeTest do
     end
   end
 
+  describe "on_suspended callback" do
+    test "on_suspended fires when tool returns :suspended" do
+      runtime = start_runtime!()
+      test_pid = self()
+
+      llm =
+        tool_then_complete_llm(
+          [%SwarmAi.ToolCall{id: "tc_1", name: "question", arguments: ~s({"prompt":"yes?"})}],
+          "Done"
+        )
+
+      agent = test_agent(llm)
+
+      {:ok, pid} =
+        SwarmAi.Runtime.run(runtime, "task-suspend", agent, "Ask user",
+          tool_executor: fn _tc -> :suspended end,
+          on_suspended: fn result ->
+            send(test_pid, {:suspended, result})
+          end
+        )
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      assert_receive {:suspended, {:suspended, _loop_id}}, 1000
+    end
+
+    test "on_suspended does not fire when tool completes normally" do
+      runtime = start_runtime!()
+      test_pid = self()
+
+      llm =
+        tool_then_complete_llm(
+          [%SwarmAi.ToolCall{id: "tc_1", name: "search", arguments: ~s({"q":"test"})}],
+          "Done"
+        )
+
+      agent = test_agent(llm)
+
+      {:ok, pid} =
+        SwarmAi.Runtime.run(runtime, "task-no-suspend", agent, "Search",
+          tool_executor: fn _tc -> {:ok, "results"} end,
+          on_suspended: fn result ->
+            send(test_pid, {:suspended, result})
+          end,
+          on_complete: fn result ->
+            send(test_pid, {:completed, result})
+          end
+        )
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      assert_receive {:completed, {:ok, "Done", _loop_id}}, 1000
+      refute_receive {:suspended, _}, 200
+    end
+  end
+
   describe "cancel vs crash distinction" do
     test "cancel invokes on_cancelled, not on_crash" do
       runtime = start_runtime!()

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -415,6 +415,108 @@ defmodule SwarmTest do
     end
   end
 
+  describe "suspended tool results and suspension" do
+    test "run_streaming suspends when tool executor returns :suspended" do
+      llm =
+        tool_then_complete_llm(
+          [%SwarmAi.ToolCall{id: "tc_1", name: "question", arguments: ~s({"prompt":"yes?"})}],
+          "Done"
+        )
+
+      agent = test_agent(llm)
+
+      result =
+        SwarmAi.run_streaming(agent, "Ask user", tool_executor: fn _tc -> :suspended end)
+
+      assert {:suspended, loop_id} = result
+      assert is_binary(loop_id)
+    end
+
+    test "non-suspended tools execute normally alongside suspended ones" do
+      # When a batch has both suspended and non-suspended tools,
+      # the non-suspended ones should execute and the loop suspends
+      # because not all tools are complete.
+      table = :ets.new(:tool_tracker, [:set, :public])
+
+      llm =
+        tool_then_complete_llm(
+          [
+            %SwarmAi.ToolCall{id: "tc_sync", name: "search", arguments: ~s({"q":"test"})},
+            %SwarmAi.ToolCall{id: "tc_suspend", name: "question", arguments: ~s({"prompt":"?"})}
+          ],
+          "Done"
+        )
+
+      agent = test_agent(llm)
+
+      result =
+        SwarmAi.run_streaming(agent, "Search and ask",
+          tool_executor: fn tc ->
+            case tc.name do
+              "search" ->
+                :ets.insert(table, {:search_executed, true})
+                {:ok, "search results"}
+
+              "question" ->
+                :suspended
+            end
+          end
+        )
+
+      assert {:suspended, _loop_id} = result
+      # The sync tool was actually executed
+      assert [{:search_executed, true}] = :ets.lookup(table, :search_executed)
+      :ets.delete(table)
+    end
+
+    test "run_blocking suspends when tool executor returns :suspended" do
+      llm =
+        tool_then_complete_llm(
+          [%SwarmAi.ToolCall{id: "tc_1", name: "question", arguments: ~s({"prompt":"yes?"})}],
+          "Done"
+        )
+
+      agent = test_agent(llm)
+
+      result = SwarmAi.run_blocking(agent, "Ask user", fn _tc -> :suspended end)
+      assert {:suspended, _loop_id} = result
+    end
+
+    test "ToolCall.suspended? returns true for suspended result" do
+      tc = %SwarmAi.ToolCall{
+        id: "tc_1",
+        name: "question",
+        arguments: "{}",
+        result: ToolResult.suspended("tc_1")
+      }
+
+      assert SwarmAi.ToolCall.suspended?(tc)
+    end
+
+    test "ToolCall.suspended? returns false for completed result" do
+      tc = %SwarmAi.ToolCall{
+        id: "tc_1",
+        name: "test",
+        arguments: "{}",
+        result: ToolResult.make("tc_1", "done", false)
+      }
+
+      refute SwarmAi.ToolCall.suspended?(tc)
+    end
+
+    test "ToolCall.suspended? returns false for nil result" do
+      tc = %SwarmAi.ToolCall{id: "tc_1", name: "test", arguments: "{}"}
+      refute SwarmAi.ToolCall.suspended?(tc)
+    end
+
+    test "ToolResult.suspended creates a suspended result" do
+      result = ToolResult.suspended("tc_1")
+      assert result.id == "tc_1"
+      assert result.suspended == true
+      assert result.is_error == false
+    end
+  end
+
   describe "tool call utilities" do
     test "tool call arguments can be parsed as JSON" do
       llm =


### PR DESCRIPTION
## Summary

Add suspension primitives to the SwarmAi framework, allowing tools to pause execution for external input (e.g., user interaction) instead of returning immediately.

**Part of #553 — PR 6 in the [split plan](docs/issue-553-pr-split-plan.md)**

## Changes

- **`ToolResult.suspended/1`** — new constructor that creates a suspended result placeholder
- **`ToolCall.completed?/1`** — returns `false` for suspended results (was just `result != nil`)
- **`ToolCall.suspended?/1`** — new predicate to check if a tool call is suspended
- **`Step.has_suspended_tools?/1`** — checks if any tool calls in a step have suspended results
- **`SwarmAi.run_streaming/3` & `run_blocking/3`** — return `{:suspended, loop_id}` when the tool executor returns `:suspended`
- **`Runtime.run/5`** — new `on_suspended` lifecycle callback

## How it works

When a tool executor returns `:suspended`, the framework:
1. Creates a `ToolResult.suspended(tc.id)` — a placeholder result with `suspended: true`
2. Since `ToolCall.completed?` returns `false` for suspended results, the runner's convergence gate (`all_tools_complete?`) prevents the loop from continuing
3. The loop exits with `status: :waiting_for_tools`
4. `run_streaming` detects suspended tools via `has_suspended_tools?` and returns `{:suspended, loop_id}`

Non-suspended tools in the same batch execute normally — only the loop continuation is blocked.

## Tests

- 7 new tests in `swarm_ai_test.exs` covering `run_streaming`, `run_blocking`, mixed batches, and unit tests for predicates
- 2 new tests in `runtime_test.exs` covering `on_suspended` callback (fires / does not fire)
- All 132 tests pass

## Dependencies

None — this PR is independent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
