### PR TITLE
fix(marketing): add VideoObject structured data for blog video indexing

### DIFF
--- a/apps/marketing/src/content.config.ts
+++ b/apps/marketing/src/content.config.ts
@@ -11,15 +11,24 @@ const blog = defineCollection({
 			image: z.string(),
 			author: z.string(),
 			tags: z.array(z.string()),
-			faq: z
-				.array(
-					z.object({
-						question: z.string(),
-						answer: z.string()
-					})
-				)
-				.optional()
-		})
+		faq: z
+			.array(
+				z.object({
+					question: z.string(),
+					answer: z.string()
+				})
+			)
+			.optional(),
+		video: z
+			.object({
+				name: z.string(),
+				description: z.string(),
+				youtubeId: z.string(),
+				thumbnailUrl: z.string().optional(),
+				uploadDate: z.string().optional()
+			})
+			.optional()
+	})
 })
 
 const glossary = defineCollection({

--- a/apps/marketing/src/content/blog/multi-select.md
+++ b/apps/marketing/src/content/blog/multi-select.md
@@ -5,6 +5,11 @@ description: 'Select multiple elements in your running app, give each one instru
 author: 'Frontman Team'
 image: '/blog/multi-select-cover.png'
 tags: ['announcement', 'developer-tools', 'ai']
+video:
+  name: 'Frontman Multi-Select Demo'
+  description: 'See how Frontman multi-select lets you Shift-click multiple UI elements in your running app, add instructions to each, and fix them all in one shot with real source code edits and hot reload.'
+  youtubeId: 'J3_OQzzEJPY'
+  thumbnailUrl: '/blog/multi-select-cover.png'
 faq:
   - question: 'What is multi-select in Frontman?'
     answer: 'Multi-select lets you hold Shift and click multiple UI elements in your running app, add separate instructions to each one, and have Frontman generate real source code edits for all of them in a single pass with hot-reload. Instead of fixing elements one at a time with separate round trips, you batch all your visual fixes into one operation.'

--- a/apps/marketing/src/layouts/PostLayout.astro
+++ b/apps/marketing/src/layouts/PostLayout.astro
@@ -56,6 +56,23 @@ const faqJsonLd = frontmatter.faq?.length
 			}))
 		}
 	: null
+
+// VideoObject JSON-LD (optional, driven by frontmatter.video)
+const videoJsonLd = frontmatter.video
+	? {
+			"@context": "https://schema.org",
+			"@type": "VideoObject",
+			"name": frontmatter.video.name,
+			"description": frontmatter.video.description,
+			"thumbnailUrl": frontmatter.video.thumbnailUrl
+				? `https://frontman.sh${frontmatter.video.thumbnailUrl}`
+				: `https://img.youtube.com/vi/${frontmatter.video.youtubeId}/maxresdefault.jpg`,
+			"uploadDate": frontmatter.video.uploadDate
+				?? (frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate),
+			"contentUrl": `https://www.youtube.com/watch?v=${frontmatter.video.youtubeId}`,
+			"embedUrl": `https://www.youtube-nocookie.com/embed/${frontmatter.video.youtubeId}`
+		}
+	: null
 ---
 
 <Layout
@@ -69,6 +86,7 @@ const faqJsonLd = frontmatter.faq?.length
 >
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(blogPostJsonLd)} />
 	{faqJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
+	{videoJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} />}
 	<BlogPostHero
 		tags={frontmatter.tags}
 		title={frontmatter.title}


### PR DESCRIPTION
## Summary

- Google Search Console reports the multi-select blog post video (`/blog/multi-select/`) as **"Video isn't on a watch page"** — 0 videos indexed, 1 not indexed
- Adds `schema.org/VideoObject` JSON-LD structured data to help Google understand and index embedded YouTube videos
- The structured data is opt-in per blog post via a `video` frontmatter field, following the same pattern as the existing FAQ JSON-LD

## Changes

- **`content.config.ts`** — Added optional `video` schema field (`name`, `description`, `youtubeId`, optional `thumbnailUrl` and `uploadDate`)
- **`PostLayout.astro`** — Generates `VideoObject` JSON-LD when `frontmatter.video` is present, with sensible defaults (YouTube thumbnail fallback, pubDate fallback for uploadDate)
- **`multi-select.md`** — Added video frontmatter for the Multi-Select Demo YouTube embed

## Next steps after deploy

Go to GSC → Video indexing → "Video isn't on a watch page" → click **VALIDATE FIX** to trigger re-crawl.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
