### PR TITLE
fix(marketing): add trailing slashes to internal links to eliminate 308 redirects

### DIFF
--- a/apps/marketing/src/components/blocks/contact/ContactCards.astro
+++ b/apps/marketing/src/components/blocks/contact/ContactCards.astro
@@ -38,7 +38,7 @@ const { classes } = Astro.props
 				subtitle="Need help with Frontman? Our support team is available 24/7 to assist you with any issues or questions you might have."
 				icon="rocket"
 				classes="text-center dark:!bg-neutral-800/50"
-				link="/contact"
+				link="/contact/"
 			/>
 		</Col>
 		<Col span="3">
@@ -47,7 +47,7 @@ const { classes } = Astro.props
 				subtitle="Interested in our plans or want a custom solution? Get in touch with our sales team to find the perfect fit. "
 				icon="document-text"
 				classes="text-center dark:!bg-neutral-800/50"
-				link="/contact"
+				link="/contact/"
 			/>
 		</Col>
 		<Col span="3">
@@ -56,7 +56,7 @@ const { classes } = Astro.props
 				subtitle="Have an idea to make Frontman even better? We’d love to hear from you! Share your feature requests and help us improve "
 				icon="bolt"
 				classes="text-center dark:!bg-neutral-800/50"
-				link="/contact"
+				link="/contact/"
 			/>
 		</Col>
 		<Col span="3" classes="flex flex-col gap-6">
@@ -65,7 +65,7 @@ const { classes } = Astro.props
 				subtitle="Your feedback is invaluable to us. Let us know how we’re doing and how we can improve. "
 				icon="chat-bubble-left-ellipsis"
 				classes="text-center dark:!bg-neutral-800/50"
-				link="/contact"
+				link="/contact/"
 			/>
 		</Col>
 	</Row>

--- a/apps/marketing/src/components/blocks/features/FeatureCards.astro
+++ b/apps/marketing/src/components/blocks/features/FeatureCards.astro
@@ -37,7 +37,7 @@ import feature05 from '../../../assets/cards/feature-05.svg'
 				title="All your data in one place"
 				subtitle="Stay on top of your tasks and deadlines with our intuitive project management tool. Visualize progress, assign tasks, and collaborate seamlessly."
 				image={feature01}
-				link="/features"
+				link="/features/"
 			/>
 		</Col>
 		<Col span="4" classes="flex flex-col gap-6">
@@ -45,13 +45,13 @@ import feature05 from '../../../assets/cards/feature-05.svg'
 				title="Organize & manage your projects "
 				subtitle="Stay on top of your tasks and deadlines with our intuitive project management tool. "
 				image={feature02}
-				link="/features"
+				link="/features/"
 			/>
 			<Card
 				title="Keep your team connected"
 				subtitle="With our integrated chat platform share updates, files, and messages in a secure and user-friendly environment."
 				image={feature03}
-				link="/features"
+				link="/features/"
 			/>
 		</Col>
 		<Col span="4" classes="flex flex-col gap-6">
@@ -59,13 +59,13 @@ import feature05 from '../../../assets/cards/feature-05.svg'
 				title="Manage your customers"
 				subtitle="Build and nurture customer relationships with our powerful CRM system. "
 				image={feature04}
-				link="/features"
+				link="/features/"
 			/>
 			<Card
 				title="Simplify your financial operations"
 				subtitle="Streamline your billing process with our easy-to-use invoicing tool. Create, send, and track invoices effortlessly."
 				image={feature05}
-				link="/features"
+				link="/features/"
 			/>
 		</Col>
 	</Row>

--- a/apps/marketing/src/components/ui/Breadcrumbs.astro
+++ b/apps/marketing/src/components/ui/Breadcrumbs.astro
@@ -29,7 +29,7 @@ const { classes } = Astro.props
 		{
 			breadcrumbs.map((segment, index) => (
 				<li class="breadcrumbs__list-item">
-					<a href={`/${segments.slice(0, index).join('/')}`} class="breadcrumbs__item-link">
+					<a href={index === 0 ? '/' : `/${segments.slice(0, index).join('/')}/`} class="breadcrumbs__item-link">
 						{index === 0 ? segment : segment.replace(/-/g, ' ')}
 					</a>
 					{index < breadcrumbs.length - 1 && (

--- a/apps/marketing/src/content/blog/multi-select.md
+++ b/apps/marketing/src/content/blog/multi-select.md
@@ -56,7 +56,7 @@ Consider a typical scenario: you're reviewing a dashboard page and notice five i
 - A table header is misaligned
 - The empty state message has a typo
 
-Without multi-select, this is five separate interactions. Five context switches. Five times the AI reads the same page context. With multi-select, you Shift-click all five elements, type a short instruction for each, and submit once. Frontman maps each clicked element back to its source file and line through the live DOM-to-source mapping that comes from running as [framework middleware](/blog/runtime-context-gap), then generates all five edits in a single pass.
+Without multi-select, this is five separate interactions. Five context switches. Five times the AI reads the same page context. With multi-select, you Shift-click all five elements, type a short instruction for each, and submit once. Frontman maps each clicked element back to its source file and line through the live DOM-to-source mapping that comes from running as [framework middleware](/blog/runtime-context-gap/), then generates all five edits in a single pass.
 
 The result lands with hot reload. You see all five fixes simultaneously. If one of them isn't right, you fix that one — but the other four are done.
 
@@ -70,7 +70,7 @@ It also changes the review workflow. Instead of filing five separate comments on
 
 ## How It Works Under the Hood
 
-Frontman runs as middleware inside your dev server. When you click an element, it uses the framework's source map to resolve the click target to a specific file and line number. This is the same [runtime context](/blog/runtime-context-gap) that makes single-element editing possible — the live DOM, computed styles, component tree, and server-side state are all available because Frontman is inside the framework, not observing it from outside.
+Frontman runs as middleware inside your dev server. When you click an element, it uses the framework's source map to resolve the click target to a specific file and line number. This is the same [runtime context](/blog/runtime-context-gap/) that makes single-element editing possible — the live DOM, computed styles, component tree, and server-side state are all available because Frontman is inside the framework, not observing it from outside.
 
 Multi-select extends this by collecting multiple resolved targets and batching them into a single prompt. Each selection carries its own instruction and its own source mapping. The AI sees all of them together, which means it can reason about interactions between the edits — for example, if two selections target the same component, it can apply both changes without conflicts.
 

--- a/apps/marketing/src/pages/vs/index.astro
+++ b/apps/marketing/src/pages/vs/index.astro
@@ -13,55 +13,55 @@ const SEO = {
 const comparisons = [
 	{
 		title: 'Frontman vs Cursor',
-		href: '/vs/cursor',
+		href: '/vs/cursor/',
 		description: 'AI-powered IDE vs browser-based AI agent. Cursor offers autocomplete, agent mode, and terminal integration. Frontman sees the live DOM, computed CSS, and rendered output. Different tools for different problems.',
 		tags: ['IDE', 'Agent Mode', 'Autocomplete']
 	},
 	{
 		title: 'Frontman vs Claude Code',
-		href: '/vs/claude-code',
+		href: '/vs/claude-code/',
 		description: 'Anthropic\'s terminal-native agentic coding tool vs Frontman\'s browser-based approach. Claude Code runs shell commands, handles git workflows, and spawns sub-agents. Frontman sees the rendered page and lets you click elements to edit code.',
 		tags: ['Terminal', 'Agentic', 'Anthropic']
 	},
 	{
 		title: 'Frontman vs GitHub Copilot',
-		href: '/vs/copilot',
+		href: '/vs/copilot/',
 		description: 'GitHub\'s AI coding assistant vs Frontman\'s browser-based approach. Copilot lives in your IDE with inline suggestions and agent mode. Frontman lives in your browser with visual editing and framework integration.',
 		tags: ['IDE', 'Autocomplete', 'GitHub Integration']
 	},
 	{
 		title: 'Frontman vs Windsurf',
-		href: '/vs/windsurf',
+		href: '/vs/windsurf/',
 		description: 'A VS Code fork with an embedded browser preview panel vs browser middleware. Windsurf brings a preview browser into the IDE. Frontman puts the AI agent into your real browser with framework-level runtime context.',
 		tags: ['IDE', 'Browser Preview', 'Cognition']
 	},
 	{
 		title: 'Frontman vs Stagewise',
-		href: '/vs/stagewise',
+		href: '/vs/stagewise/',
 		description: 'Two browser-based AI tools with different architectures. Stagewise is a zero-install CLI overlay that bridges to IDE agents. Frontman installs as framework middleware with its own self-contained agent and no prompt limits.',
 		tags: ['Browser-Based', 'Zero Install', 'IDE Bridge']
 	},
 	{
 		title: 'Frontman vs v0',
-		href: '/vs/v0',
+		href: '/vs/v0/',
 		description: 'v0 generates new UI in a sandbox from text prompts and Figma imports. Frontman edits your real running app in the browser with full DOM, CSS, and component-tree context. Different tools for different stages of the workflow.',
 		tags: ['Generative UI', 'Sandbox', 'Figma Import']
 	},
 	{
 		title: 'Frontman vs Bolt.new',
-		href: '/vs/bolt',
+		href: '/vs/bolt/',
 		description: 'Bolt.new generates full-stack apps from prompts in a WebContainer sandbox. Frontman edits your existing codebase by seeing your real running app in the browser. Different tools for different stages.',
 		tags: ['Generative', 'WebContainer', 'Full-Stack']
 	},
 	{
 		title: 'Frontman vs Lovable',
-		href: '/vs/lovable',
+		href: '/vs/lovable/',
 		description: 'Lovable generates complete apps from prompts for non-coders. Frontman edits existing codebases for developers who want AI that sees their running app. Different audiences, different tools.',
 		tags: ['Generative', 'No-Code', 'Full-Stack']
 	},
 	{
 		title: 'Frontman vs Onlook',
-		href: '/vs/onlook',
+		href: '/vs/onlook/',
 		description: 'Onlook is a Figma-like visual editor that outputs React code in a sandbox. Frontman hooks into your actual dev server as middleware. Design tool vs dev tool — different architectures for different audiences.',
 		tags: ['Design Tool', 'Visual Editor', 'Open Source']
 	}


### PR DESCRIPTION
## Summary

- Google Search Console flags 11 pages as **"Page with redirect"** because internal links are missing trailing slashes, causing unnecessary 308 redirects (Astro is configured with `trailingSlash: "always"`)
- Fixes all internal links across 5 files to include trailing slashes

## Changes

| File | Fix | Count |
|------|-----|-------|
| `src/pages/vs/index.astro` | Comparison card hrefs (`/vs/cursor` → `/vs/cursor/`) | 9 |
| `src/components/ui/Breadcrumbs.astro` | Dynamic path construction now appends `/` for non-root segments | 1 (systemic — affects every blog + glossary page) |
| `src/content/blog/multi-select.md` | Markdown links to `/blog/runtime-context-gap/` | 2 |
| `src/components/blocks/contact/ContactCards.astro` | `/contact` → `/contact/` | 4 |
| `src/components/blocks/features/FeatureCards.astro` | `/features` → `/features/` | 5 |

## Why this matters

Each missing trailing slash causes an extra HTTP round-trip (308 redirect) for both users and Googlebot. GSC treats the non-trailing-slash URL as "not indexed" (correctly — the canonical URL with the slash is the one that gets indexed), but the redirect hops waste crawl budget and add latency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
