### PR TITLE
fix: ensure trailing slashes on all constructed URLs

### DIFF
--- a/libs/client/src/webpreview/Client__BrowserUrl.res
+++ b/libs/client/src/webpreview/Client__BrowserUrl.res
@@ -7,11 +7,11 @@
 // The basePath is read from window.__frontmanRuntime.basePath (injected by
 // the server's HTML shell). Falls back to "frontman" if not present.
 //
-// NOTE: The URL construction logic in syncBrowserUrl (trailing-slash strip,
-// suffix append) is intentionally duplicated in
-// FrontmanAstro__ToolbarApp in libs/frontman-astro. The two files cannot
-// share code because frontman-core is server-only. Keep the two
-// implementations aligned — if you change one, update the other.
+// NOTE: The URL construction logic in syncBrowserUrl (suffix append with
+// trailing slash) is intentionally duplicated in FrontmanAstro__ToolbarApp
+// in libs/frontman-astro. The two files cannot share code because
+// frontman-core is server-only. Keep the two implementations aligned —
+// if you change one, update the other.
 
 // Read basePath from runtime config. Lazy — reads once on first access.
 // Falls back to "frontman" if runtime config is unavailable (e.g. in tests).
@@ -43,14 +43,18 @@ let suffix = () => `/${_getBasePath()}`
 let _escapeRegex = s =>
   s->String.replaceRegExp(%re("/[.*+?^${}()|[\\]\\\\]/g"), "\\$&")
 
-// Strip trailing /<basePath> segments (including trailing slash) from a pathname.
-// Uses a regex to replace one or more repeated suffix segments in one pass.
+// Strip trailing /<basePath> segments from a pathname, preserving a trailing
+// slash so the resulting URL matches Astro's trailingSlash: "always" default.
 let stripSuffix = pathname => {
   let sfx = _getBasePath()->_escapeRegex
   let re = RegExp.fromString(`(\\/${sfx})+\\/?$`)
   switch pathname->String.replaceRegExp(re, "") {
   | "" => "/"
-  | p => p
+  | p =>
+    switch p->String.endsWith("/") {
+    | true => p
+    | false => p ++ "/"
+    }
   }
 }
 
@@ -115,8 +119,8 @@ let syncBrowserUrl = (~previewUrl) => {
   let basePath = _getBasePath()
   let pathname = WebAPI.URL.make(~url=previewUrl).pathname->String.replaceRegExp(%re("/\/$/"), "")
   let newPath = switch pathname {
-  | "" => `/${basePath}`
-  | p => `${p}/${basePath}`
+  | "" => `/${basePath}/`
+  | p => `${p}/${basePath}/`
   }
   switch WebAPI.Global.location.pathname == newPath {
   | true => ()

--- a/libs/frontman-astro/src/FrontmanAstro__ToolbarApp.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ToolbarApp.res
@@ -1,10 +1,12 @@
 // Frontman Dev Toolbar App
 //
 // Clicking the Frontman icon in the Astro dev toolbar navigates to
-// {currentPage}/<basePath> using suffix-based routing, so the preview
-// loads the page the user was already on.
+// {currentPage}/<basePath>/ using suffix-based routing, so the preview
+// loads the page the user was already on. The trailing slash is always
+// included to match Astro's trailingSlash: "always" default and avoid
+// redirect loops or 404s from the trailing-slash middleware.
 //
-// NOTE: The URL construction logic here (trailing-slash strip, suffix
+// NOTE: The URL construction logic here (trailing-slash ensure, suffix
 // append, already-at-path check) is intentionally duplicated from
 // Client__BrowserUrl.syncBrowserUrl in libs/client. The two files
 // cannot share code because frontman-core is server-only and the client
@@ -31,19 +33,19 @@ let app: toolbarAppConfig = {
       switch state {
       | true =>
         let basePath = _getBasePath()
-        // Strip trailing slash to normalize, matching BrowserUrl.syncBrowserUrl.
-        let pathname =
-          WebAPI.Global.location.pathname->String.replaceRegExp(%re("/\/$/"), "")
-        // If already inside /<basePath>, stay put. Otherwise append it.
+        // Normalize: ensure pathname always ends with a trailing slash so the
+        // constructed URL matches Astro's trailingSlash: "always" expectation.
+        let rawPathname = WebAPI.Global.location.pathname
+        let pathname = switch rawPathname->String.endsWith("/") {
+        | true => rawPathname
+        | false => rawPathname ++ "/"
+        }
+        // If already inside /<basePath>/, stay put. Otherwise append it.
         let alreadyInFrontman =
-          pathname == `/${basePath}` || pathname->String.endsWith(`/${basePath}`)
+          pathname == `/${basePath}/` || pathname->String.endsWith(`/${basePath}/`)
         let url = switch alreadyInFrontman {
         | true => pathname
-        | false =>
-          switch pathname {
-          | "" => `/${basePath}`
-          | p => `${p}/${basePath}`
-          }
+        | false => `${pathname}${basePath}/`
         }
         WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(url)
         app->toggleState({state: false})

--- a/libs/frontman-core/src/FrontmanCore__Middleware.res
+++ b/libs/frontman-core/src/FrontmanCore__Middleware.res
@@ -40,6 +40,8 @@ let isFrontmanRoute = (~pathname: string, ~basePath: string, ~method: string): b
 // Returns None if already canonical, Some(path) if a redirect is needed.
 // Only detects actual frontman-in-frontman nesting — does NOT strip legitimate
 // user URL segments that happen to match basePath.
+// All returned paths include a trailing slash to avoid an extra redirect from
+// frameworks with trailingSlash: "always" (e.g. Astro's default).
 //
 // Cases detected:
 //   prefixPath == basePath (e.g. "frontman" from /frontman/frontman)
@@ -49,7 +51,7 @@ let getCanonicalRedirect = (~prefixPath: string, ~basePath: string): option<stri
   let suffix = "/" ++ basePath
   // Exact match: prefix IS the basePath (e.g. /frontman/frontman -> prefix "frontman")
   switch prefixPath == basePath {
-  | true => Some("/" ++ basePath)
+  | true => Some("/" ++ basePath ++ "/")
   | false =>
     // Trailing nested suffix: strip one trailing /basePath from prefix
     switch prefixPath->String.endsWith(suffix) {
@@ -60,18 +62,18 @@ let getCanonicalRedirect = (~prefixPath: string, ~basePath: string): option<stri
       | p => p
       }
       let canonical = switch cleanPrefix {
-      | "" => "/" ++ basePath
-      | p => "/" ++ p ++ "/" ++ basePath
+      | "" => "/" ++ basePath ++ "/"
+      | p => "/" ++ p ++ "/" ++ basePath ++ "/"
       }
       Some(canonical)
     | false =>
       // Leading basePath/ prefix: strip leading basePath/ from prefix
       switch prefixPath->String.startsWith(basePath ++ "/") {
       | true =>
-        let rest = prefixPath->String.sliceToEnd(~start=basePath->String.length + 1)
+        let rest = prefixPath->String.slice(~start=basePath->String.length + 1, ~end=prefixPath->String.length)
         let canonical = switch rest {
-        | "" => "/" ++ basePath
-        | p => "/" ++ p ++ "/" ++ basePath
+        | "" => "/" ++ basePath ++ "/"
+        | p => "/" ++ p ++ "/" ++ basePath ++ "/"
         }
         Some(canonical)
       | false => None
@@ -81,6 +83,8 @@ let getCanonicalRedirect = (~prefixPath: string, ~basePath: string): option<stri
 }
 
 // Build entrypoint URL from request origin + prefix. Config override takes precedence.
+// Always includes a trailing slash so frameworks with trailingSlash: "always"
+// (e.g. Astro's default) don't redirect the iframe on load.
 let buildEntrypointUrl = (
   ~config: MiddlewareConfig.t,
   ~requestUrl: string,
@@ -93,7 +97,7 @@ let buildEntrypointUrl = (
     let origin = url.origin
     let pagePath = switch prefixPath {
     | "" => "/"
-    | p => "/" ++ p
+    | p => "/" ++ p ++ "/"
     }
     Some(origin ++ pagePath)
   }


### PR DESCRIPTION
## Summary

- Fix missing trailing slashes on URLs constructed for the preview iframe and browser address bar, which caused Astro (and other frameworks with `trailingSlash: "always"`) to redirect or 404 the webview

## What was broken

When navigating to a page like `/vs/copilot/` and clicking the Frontman icon, the webview iframe would load `/vs/copilot` (no trailing slash). Astro's trailing-slash enforcement would then redirect, causing errors.

The root cause was `buildEntrypointUrl` in the server-side middleware producing URLs like `http://localhost:4321/vs/copilot` without a trailing slash. This URL gets embedded in the HTML shell and used as-is for the iframe `src`.

Three other functions had the same class of bug, creating a total of four fixes:

| Function | File | Was producing | Now produces |
|---|---|---|---|
| `buildEntrypointUrl` | `FrontmanCore__Middleware.res` | `/vs/copilot` | `/vs/copilot/` |
| `getCanonicalRedirect` | `FrontmanCore__Middleware.res` | `/frontman` (302 target) | `/frontman/` |
| `stripSuffix` | `Client__BrowserUrl.res` | `/changelog` | `/changelog/` |
| `syncBrowserUrl` | `Client__BrowserUrl.res` | `/changelog/frontman` | `/changelog/frontman/` |

Also aligned `FrontmanAstro__ToolbarApp` to normalize pathname with a trailing slash before appending basePath, fixed a `String.sliceToEnd` deprecation warning, and updated stale comments.

## Testing

- All 263 frontman-core tests pass
- All 257 client tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
