### PR TITLE
fix(astro): replace generic toolbar icon with Frontman "F" glyph

### DIFF
--- a/libs/frontman-astro/src/FrontmanAstro__Integration.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Integration.res
@@ -22,8 +22,9 @@ external frontmanPropsInjectionPlugin: unit => Bindings.vitePlugin = "frontmanPr
 @module("./annotation-capture.mjs")
 external annotationCaptureScript: string = "annotationCaptureScript"
 
-// SVG icon for the toolbar
-let icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/></svg>`
+// SVG icon for the toolbar — Frontman "F" glyph from favicon.svg (no background)
+// Uses currentColor so it adapts to Astro's toolbar theming.
+let icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="90 70 230 270" fill="none"><path d="M145.925 316.925C136.175 316.925 129.242 315.517 125.125 312.7C121.008 309.667 118.517 305.875 117.65 301.325C116.783 296.558 116.35 291.792 116.35 287.025V119C116.35 107.733 118.517 100.042 122.85 95.925C127.4 91.5917 135.417 89.425 146.9 89.425H265.85C270.833 89.425 275.492 89.8583 279.825 90.725C284.375 91.5917 288.058 94.0833 290.875 98.2C293.692 102.317 295.1 109.358 295.1 119.325C295.1 129.075 293.583 136.008 290.55 140.125C287.733 144.242 284.05 146.733 279.5 147.6C274.95 148.467 270.183 148.9 265.2 148.9H175.825V177.825H235.625C240.608 177.825 245.05 178.258 248.95 179.125C253.067 179.775 256.208 181.942 258.375 185.625C260.758 189.092 261.95 195.158 261.95 203.825C261.95 212.058 260.758 217.908 258.375 221.375C255.992 224.842 252.742 226.9 248.625 227.55C244.725 228.2 240.283 228.525 235.3 228.525H175.825V287.35C175.825 292.117 175.392 296.775 174.525 301.325C173.658 305.875 171.167 309.667 167.05 312.7C162.933 315.517 155.892 316.925 145.925 316.925Z" fill="currentColor"/></svg>`
 
 // Get the path to the toolbar app entrypoint
 // Uses import.meta.url to resolve relative to this file


### PR DESCRIPTION
## Summary

- Replaces the placeholder circle SVG icon in the Astro dev toolbar with the actual Frontman "F" glyph extracted from `favicon.svg`
- Uses `currentColor` fill so the icon adapts to Astro's toolbar light/dark theming automatically
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
