### PR TITLE
fix: wait for Registry cleanup before ExecutionMonitor callbacks (#553 PR 7/17)

### DIFF
--- a/apps/swarm_ai/lib/swarm_ai/runtime/execution_monitor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime/execution_monitor.ex
@@ -11,6 +11,8 @@ defmodule SwarmAi.Runtime.ExecutionMonitor do
   - Uses synchronous registration to avoid race conditions
   - Recovers state on restart by scanning the Runtime Registry
   - Callbacks (`on_crash`, `on_cancelled`) are provided per-execution
+  - Waits for Registry cleanup before invoking callbacks, preserving the
+    `running?/2` invariant from `SwarmAi.Runtime`
   """
   use GenServer
 
@@ -56,7 +58,7 @@ defmodule SwarmAi.Runtime.ExecutionMonitor do
       )
     end
 
-    {:ok, state}
+    {:ok, Map.put(state, :registry, registry)}
   end
 
   @impl true
@@ -78,6 +80,15 @@ defmodule SwarmAi.Runtime.ExecutionMonitor do
 
     case entry do
       %{key: key} ->
+        # Wait for the Registry to process its own :DOWN and remove the entry.
+        # Both Registry and ExecutionMonitor monitor the execution process, so
+        # both receive :DOWN when it dies. Without this, callbacks can fire
+        # before Registry cleanup completes, causing running?/2 to return true
+        # when consumers check it from the callback. The normal completion path
+        # (execute/8) doesn't have this issue because it calls
+        # Registry.unregister synchronously before the callback.
+        await_registry_cleanup(state.registry, {:running, key})
+
         cond do
           cancelled?(reason) ->
             Logger.info("Execution cancelled",
@@ -134,6 +145,29 @@ defmodule SwarmAi.Runtime.ExecutionMonitor do
       end)
 
     %{monitors: monitors}
+  end
+
+  # Spins until the Registry has processed its :DOWN for the given key.
+  # The execution process is already dead at this point, so the Registry
+  # cleanup is guaranteed — we just need to let the Registry GenServer
+  # process its :DOWN message. In practice this returns on the first
+  # iteration (the Registry is fast).
+  defp await_registry_cleanup(registry, key, attempts \\ 100)
+
+  defp await_registry_cleanup(_registry, key, 0) do
+    Logger.warning("Registry cleanup timed out for key #{inspect(key)}, proceeding with callback")
+    :ok
+  end
+
+  defp await_registry_cleanup(registry, key, attempts) do
+    case Registry.lookup(registry, key) do
+      [] ->
+        :ok
+
+      _ ->
+        Process.sleep(1)
+        await_registry_cleanup(registry, key, attempts - 1)
+    end
   end
 
   defp cancelled?(:cancelled), do: true

--- a/apps/swarm_ai/test/swarm_ai/runtime/execution_monitor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime/execution_monitor_test.exs
@@ -108,6 +108,59 @@ defmodule SwarmAi.Runtime.ExecutionMonitorTest do
     end
   end
 
+  describe "registry cleanup before callbacks" do
+    test "registry entry is cleared before on_crash fires" do
+      {monitor, registry} = start_monitor!()
+      test_pid = self()
+
+      _pid =
+        spawn(fn ->
+          # Register as running (like Runtime.run does)
+          Registry.register(registry, {:running, "race-key"}, %{})
+
+          ExecutionMonitor.watch(monitor, "race-key",
+            on_crash: fn _reason ->
+              # This is the invariant: by the time this callback fires,
+              # the Registry entry must already be gone
+              result = Registry.lookup(registry, {:running, "race-key"})
+              send(test_pid, {:registry_in_callback, result})
+            end
+          )
+
+          exit(:boom)
+        end)
+
+      assert_receive {:registry_in_callback, result}, 1000
+      assert result == [], "Registry entry should be cleared before on_crash callback fires"
+    end
+
+    test "registry entry is cleared before on_cancelled fires" do
+      {monitor, registry} = start_monitor!()
+      test_pid = self()
+
+      pid =
+        spawn(fn ->
+          Registry.register(registry, {:running, "cancel-race-key"}, %{})
+
+          ExecutionMonitor.watch(monitor, "cancel-race-key",
+            on_cancelled: fn ->
+              result = Registry.lookup(registry, {:running, "cancel-race-key"})
+              send(test_pid, {:registry_in_callback, result})
+            end
+          )
+
+          Process.sleep(:infinity)
+        end)
+
+      # Give the process time to register and start watching
+      Process.sleep(20)
+      Process.exit(pid, :cancelled)
+
+      assert_receive {:registry_in_callback, result}, 1000
+      assert result == [], "Registry entry should be cleared before on_cancelled callback fires"
+    end
+  end
+
   describe "recovery from restart" do
     test "re-monitors processes found in Registry on init" do
       # Start a registry, register a fake running process, then start monitor


### PR DESCRIPTION
## Summary

- Fix race condition where `running?/2` could return `true` inside `on_crash`/`on_cancelled` callbacks because the Registry hadn't processed its own `:DOWN` message yet
- Add `await_registry_cleanup/3` that spins until the Registry entry is cleared before invoking callbacks
- Store the registry name in GenServer state so it's available in `handle_info`

## Problem

Both `Registry` and `ExecutionMonitor` monitor execution processes via `Process.monitor/1`. When a process dies, both receive `:DOWN` messages independently. The `ExecutionMonitor` could process its `:DOWN` and fire callbacks *before* the Registry processed its own `:DOWN` and removed the `{:running, key}` entry. This meant `running?/2` would incorrectly return `true` inside crash/cancel callbacks.

The normal completion path (`execute/8` in `Runtime`) doesn't have this issue because it calls `Registry.unregister` synchronously before invoking callbacks.

## Changes

| File | Change |
|---|---|
| `execution_monitor.ex` | `await_registry_cleanup/3` (spins max 100ms); store `:registry` in state; updated moduledoc |
| `execution_monitor_test.exs` | 2 new tests verifying Registry is cleared before `on_crash` and `on_cancelled` fire |

## Testing

- 9 execution_monitor tests pass (7 existing + 2 new)
- 18 runtime tests pass (unchanged)

Part of #553 — [PR split plan](../docs/issue-553-pr-split-plan.md)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
