### PR TITLE
feat: add all_pending_tools_resolved?/1 to Interaction (issue-553 PR 3/17)

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -900,6 +900,37 @@ defmodule FrontmanServer.Tasks.Interaction do
   def user_message?(_), do: false
 
   @doc """
+  Checks whether all tool_calls from the last AgentResponse have matching
+  ToolResult interactions.
+
+  Returns `true` when there is no pending AgentResponse, or when every
+  tool_call in the last AgentResponse has a corresponding ToolResult
+  (matched by tool_call_id, appearing after the AgentResponse by sequence).
+
+  Used to gate re-execution after a late-arriving interactive tool result:
+  we only restart the agent loop when ALL tool results are present so the
+  conversation is valid for the LLM.
+  """
+  @spec all_pending_tools_resolved?(list(t())) :: boolean()
+  def all_pending_tools_resolved?(interactions) do
+    with %AgentResponse{metadata: meta, sequence: agent_seq}
+         when is_map(meta) <-
+           interactions |> Enum.filter(&match?(%AgentResponse{}, &1)) |> List.last(),
+         tool_calls when tool_calls != [] <- get_field(meta, "tool_calls") || [] do
+      expected_ids = MapSet.new(tool_calls, &get_field(&1, "id"))
+
+      result_ids =
+        interactions
+        |> Enum.filter(&match?(%ToolResult{sequence: seq} when seq > agent_seq, &1))
+        |> MapSet.new(& &1.tool_call_id)
+
+      MapSet.subset?(expected_ids, result_ids)
+    else
+      _ -> true
+    end
+  end
+
+  @doc """
   Converts interactions to LLM message format.
 
   This is the boundary translation from Tasks domain (Interactions)

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -4,6 +4,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   alias FrontmanServer.Tasks.Interaction
 
   alias FrontmanServer.Tasks.Interaction.{
+    AgentResponse,
     Annotation,
     ToolCall,
     ToolResult,
@@ -355,6 +356,147 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
       assert [tc] = msg.tool_calls
       assert tc == existing_struct
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # all_pending_tools_resolved?/1
+  # ---------------------------------------------------------------------------
+
+  describe "all_pending_tools_resolved?/1" do
+    test "returns true when no interactions or no AgentResponse present" do
+      assert Interaction.all_pending_tools_resolved?([]) == true
+      assert Interaction.all_pending_tools_resolved?([user_msg("Hello")]) == true
+    end
+
+    test "returns true when last AgentResponse has nil/empty/no tool_calls" do
+      for metadata <- [nil, %{}, %{"tool_calls" => []}, %{"tool_calls" => nil}] do
+        interactions = [agent_resp("Done", metadata)]
+        assert Interaction.all_pending_tools_resolved?(interactions) == true
+      end
+    end
+
+    test "returns true when all tool_calls have matching ToolResults" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          sequence: 10,
+          content: "Let me use tools",
+          timestamp: DateTime.utc_now(),
+          metadata: %{
+            "tool_calls" => [
+              db_tool_call("call_1", "read_file"),
+              db_tool_call("call_2", "question")
+            ]
+          }
+        },
+        tool_result("call_1", "read_file", "file contents", sequence: 11),
+        tool_result("call_2", "question", "user answer", sequence: 12)
+      ]
+
+      assert Interaction.all_pending_tools_resolved?(interactions) == true
+    end
+
+    test "returns false when some tool_calls are missing ToolResults" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          sequence: 10,
+          content: "Let me use tools",
+          timestamp: DateTime.utc_now(),
+          metadata: %{
+            "tool_calls" => [
+              db_tool_call("call_1", "read_file"),
+              db_tool_call("call_2", "question")
+            ]
+          }
+        },
+        tool_result("call_1", "read_file", "file contents", sequence: 11)
+        # call_2 has no matching ToolResult
+      ]
+
+      assert Interaction.all_pending_tools_resolved?(interactions) == false
+    end
+
+    test "returns false when no tool_calls have matching ToolResults" do
+      interactions = [
+        %AgentResponse{
+          id: "1",
+          sequence: 10,
+          content: "Asking a question",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => [flat_tool_call("call_q", "question", "{}")]}
+        }
+      ]
+
+      assert Interaction.all_pending_tools_resolved?(interactions) == false
+    end
+
+    test "only checks the LAST AgentResponse, not earlier ones" do
+      interactions = [
+        # First AgentResponse with unresolved tool call
+        %AgentResponse{
+          id: "1",
+          sequence: 1,
+          content: "First response",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => [flat_tool_call("call_old", "read_file", "{}")]}
+        },
+        # Second (last) AgentResponse with no tool calls
+        %AgentResponse{
+          id: "2",
+          sequence: 5,
+          content: "Final response",
+          timestamp: DateTime.utc_now(),
+          metadata: %{}
+        }
+      ]
+
+      assert Interaction.all_pending_tools_resolved?(interactions) == true
+    end
+
+    test "ignores ToolResults that appear BEFORE the last AgentResponse" do
+      interactions = [
+        tool_result("call_1", "question", "old answer", sequence: 5),
+        %AgentResponse{
+          id: "1",
+          sequence: 10,
+          content: "Asking again",
+          timestamp: DateTime.utc_now(),
+          metadata: %{"tool_calls" => [flat_tool_call("call_1", "question", "{}")]}
+        }
+        # No ToolResult AFTER sequence 10
+      ]
+
+      assert Interaction.all_pending_tools_resolved?(interactions) == false
+    end
+
+    test "handles tool_calls as atom-key maps and ReqLLM.ToolCall structs" do
+      tc_struct = ReqLLM.ToolCall.new("call_struct", "question", "{}")
+
+      for tool_calls <- [
+            [%{id: "call_a", name: "question", arguments: "{}"}],
+            [tc_struct]
+          ] do
+        call_id =
+          case hd(tool_calls) do
+            %ReqLLM.ToolCall{id: id} -> id
+            %{id: id} -> id
+          end
+
+        interactions = [
+          %AgentResponse{
+            id: "1",
+            sequence: 10,
+            content: "Using tool",
+            timestamp: DateTime.utc_now(),
+            metadata: %{tool_calls: tool_calls}
+          },
+          tool_result(call_id, "question", "answer", sequence: 11)
+        ]
+
+        assert Interaction.all_pending_tools_resolved?(interactions) == true
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Add `Interaction.all_pending_tools_resolved?/1` — checks whether all `tool_calls` from the last `AgentResponse` have matching `ToolResult` interactions (by `tool_call_id`, respecting sequence ordering)
- Foundation for suspend/resume logic: gates re-execution after late-arriving interactive tool results so the agent loop only restarts when ALL tool results are present and the conversation is valid for the LLM
- 7 new tests covering: empty interactions, nil/empty tool_calls, all resolved, partial resolution, no resolution, last-AgentResponse-only semantics, sequence ordering, and atom-key/struct format support

## Details

The function uses `with` to find the last `AgentResponse`, extract its `tool_calls` from metadata, build a `MapSet` of expected IDs, then compare against `ToolResult` IDs that appear *after* the `AgentResponse` by sequence number. Returns `true` when there's nothing pending (no agent response, no tool calls, or all resolved).

Handles all metadata formats: string-key maps (from DB), atom-key maps (fresh from response), and `ReqLLM.ToolCall` structs.

## PR Split Context

This is **PR 3 of 17** for issue #553 (question tool architecture). See `docs/issue-553-pr-split-plan.md` for the full dependency graph.

- **Depends on:** PR 2 (interaction sequences) ✅ merged
- **Blocks:** PR 12 (channel elicitation handling)

~170 lines, 2 files changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
