### PR TITLE
fix: make ToolCall.title required per ACP spec

### DIFF
--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -165,7 +165,7 @@ module Provider = {
       | ToolCall({toolCallId, title, parentAgentId, spawningToolName}) =>
         Client__State.Actions.toolCallReceived(~taskId, ~toolCall={
           id: toolCallId,
-          toolName: title->Option.getOr("unknown_tool"),
+          toolName: title,
           inputBuffer: "",
           input: None,
           result: None,

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -474,7 +474,8 @@
               "additionalProperties": true,
               "required": [
                 "sessionUpdate",
-                "toolCallId"
+                "toolCallId",
+                "title"
               ]
             },
             {

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -362,7 +362,7 @@ type sessionUpdate =
   | UserMessageChunk({content: contentBlock, timestamp: string})
   | ToolCall({
       toolCallId: string,
-      title: option<string>,
+      title: string,
       kind: option<string>,
       status: option<toolCallStatus>,
       parentAgentId: option<string>, // If present, this is a sub-agent tool call
@@ -396,7 +396,7 @@ let sessionUpdateSchema = S.union([
     s.tag("sessionUpdate", "tool_call")
     ToolCall({
       toolCallId: s.field("toolCallId", S.string),
-      title: s.field("title", S.option(S.string)),
+      title: s.field("title", S.string),
       kind: s.field("kind", S.option(S.string)),
       status: s.field("status", S.option(toolCallStatusSchema)),
       parentAgentId: s.field("parentAgentId", S.option(S.string)),


### PR DESCRIPTION
## Summary

- Makes `ToolCall.title` a required `string` instead of `option<string>` in the ACP protocol types and Sury schema, matching the ACP spec's `"required": ["toolCallId", "title"]`
- Removes the defensive `Option.getOr("unknown_tool")` fallback in `Client__FrontmanProvider` — Sury now rejects payloads missing `title` at parse time instead of silently degrading

Closes #526
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
