### PR TITLE
refactor: DRY up channel test helpers and task reducer lenses (issue-553 PR A+E)

### DIFF
--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -7,19 +7,10 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
   import FrontmanServer.ProvidersFixtures
 
   alias FrontmanServer.Tasks
-  alias FrontmanServerWeb.UserSocket
 
   setup %{scope: scope} do
-    task_id = Ecto.UUID.generate()
-    {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-    {:ok, _reply, socket} =
-      UserSocket
-      |> socket("user_id", %{scope: scope})
-      |> subscribe_and_join("task:#{task_id}", %{})
-
+    {socket, _task_id} = join_task_channel(scope)
     complete_mcp_handshake(socket)
-
     {:ok, socket: socket}
   end
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
@@ -11,20 +11,10 @@ defmodule FrontmanServerWeb.TaskChannelSentryTest do
 
   import FrontmanServer.InteractionCase.Helpers
 
-  alias FrontmanServer.Tasks
-  alias FrontmanServerWeb.UserSocket
-
   setup %{scope: scope} do
     Sentry.Test.start_collecting_sentry_reports()
 
-    task_id = Ecto.UUID.generate()
-    {:ok, ^task_id} = Tasks.create_task(scope, task_id, "test-framework")
-
-    {:ok, _reply, socket} =
-      UserSocket
-      |> socket("user_id", %{scope: scope})
-      |> subscribe_and_join("task:#{task_id}", %{})
-
+    {socket, task_id} = join_task_channel(scope, framework: "test-framework")
     complete_mcp_handshake(socket)
 
     {:ok, socket: socket, task_id: task_id}

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -46,24 +46,13 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "session/prompt" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       {:ok, socket: socket, task_id: task_id}
     end
 
     test "returns error for unknown method", %{socket: socket} do
       ref =
-        push(socket, "acp:message", %{
-          "jsonrpc" => "2.0",
-          "id" => 2,
-          "method" => "unknown/method"
-        })
+        push(socket, "acp:message", build_acp_request("unknown/method", 2, %{}))
 
       assert_reply(ref, :ok, %{"acp:message" => response})
       assert response["error"]["code"] == -32_601
@@ -81,16 +70,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     """
 
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 
@@ -224,16 +205,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "agent_error handling" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 
@@ -267,18 +240,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       task_id: task_id
     } do
       # First, send a prompt to set pending_prompt_id
-      prompt_request = %{
-        "jsonrpc" => "2.0",
-        "id" => 42,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Hello"}
-          ]
-        }
-      }
-
-      push(socket, "acp:message", prompt_request)
+      push(socket, "acp:message", build_prompt_request(id: 42))
       # Wait for the prompt to be processed
       :sys.get_state(socket.channel_pid)
 
@@ -369,14 +331,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "agent_completed without pending prompt (resume scenario)" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
       {:ok, socket: socket, task_id: task_id}
     end
@@ -430,16 +385,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       :sys.get_state(socket.channel_pid)
 
       # Then: send a real prompt and complete it normally
-      push(socket, "acp:message", %{
-        "jsonrpc" => "2.0",
-        "id" => 50,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Next question"}
-          ]
-        }
-      })
+      push(socket, "acp:message", build_prompt_request(id: 50, text: "Next question"))
 
       :sys.get_state(socket.channel_pid)
 
@@ -459,16 +405,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "MCP tool call result extraction" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 
@@ -511,13 +449,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "MCP initialization" do
     test "sends MCP initialize request on join", %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, _socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
+      {_socket, _task_id} = join_task_channel(scope)
 
       expected_version = ModelContextProtocol.protocol_version()
 
@@ -533,13 +465,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
 
     test "completes handshake and sends initialized notification", %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
+      {socket, _task_id} = join_task_channel(scope)
 
       assert_push("mcp:message", %{"id" => request_id})
 
@@ -563,16 +489,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     import ExUnit.CaptureLog
 
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 
@@ -665,16 +583,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     @moduletag timeout: 30_000
 
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket, tools: [@mcp_get_logs_tool])
-
       {:ok, socket: socket, task_id: task_id, scope: scope}
     end
 
@@ -682,13 +592,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       # Tool responses should always be delivered to waiting executors.
       # This ensures agents can function even if tool calls happen early in the session.
 
-      fresh_task_id = Ecto.UUID.generate()
-      {:ok, ^fresh_task_id} = Tasks.create_task(scope, fresh_task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{fresh_task_id}", %{})
+      {socket, _fresh_task_id} = join_task_channel(scope)
 
       # Drain the initialize request without responding - initialization is incomplete
       assert_push("mcp:message", %{"id" => _init_request_id, "method" => "initialize"})
@@ -806,30 +710,13 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       # 2. MCP init completes, storing tools in socket assigns
       # 3. Queued prompt is processed with the loaded MCP tools
 
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
+      {socket, _task_id} = join_task_channel(scope)
 
       # MCP init has started - we receive the initialize request
       assert_push("mcp:message", %{"id" => init_request_id, "method" => "initialize"})
 
       # Send prompt BEFORE completing MCP handshake
-      prompt_request = %{
-        "jsonrpc" => "2.0",
-        "id" => 1,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Hello"}
-          ]
-        }
-      }
-
-      push(socket, "acp:message", prompt_request)
+      push(socket, "acp:message", build_prompt_request())
       :sys.get_state(socket.channel_pid)
 
       # NOW complete MCP init with tools
@@ -903,16 +790,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "session/cancel" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 
@@ -921,13 +800,11 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     } do
       # ACP spec: session/cancel is a notification, not a request.
       # No JSON-RPC response should be sent back.
-      cancel_notification = %{
-        "jsonrpc" => "2.0",
-        "method" => "session/cancel",
-        "params" => %{"sessionId" => "irrelevant"}
-      }
-
-      push(socket, "acp:message", cancel_notification)
+      push(
+        socket,
+        "acp:message",
+        build_acp_request("session/cancel", nil, %{"sessionId" => "irrelevant"})
+      )
 
       # Allow time for processing
       :sys.get_state(socket.channel_pid)
@@ -941,18 +818,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       task_id: task_id
     } do
       # Send a prompt to set pending_prompt_id
-      prompt_request = %{
-        "jsonrpc" => "2.0",
-        "id" => 99,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Hello"}
-          ]
-        }
-      }
-
-      push(socket, "acp:message", prompt_request)
+      push(socket, "acp:message", build_prompt_request(id: 99))
       :sys.get_state(socket.channel_pid)
 
       # Simulate the agent being cancelled via PubSub
@@ -993,16 +859,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       task_id: task_id
     } do
       # Send first prompt
-      push(socket, "acp:message", %{
-        "jsonrpc" => "2.0",
-        "id" => 1,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Hello"}
-          ]
-        }
-      })
+      push(socket, "acp:message", build_prompt_request(id: 1))
 
       :sys.get_state(socket.channel_pid)
 
@@ -1019,16 +876,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
 
       # Send a second prompt - this should work normally
-      push(socket, "acp:message", %{
-        "jsonrpc" => "2.0",
-        "id" => 2,
-        "method" => "session/prompt",
-        "params" => %{
-          "prompt" => [
-            %{"type" => "text", "text" => "Follow up"}
-          ]
-        }
-      })
+      push(socket, "acp:message", build_prompt_request(id: 2, text: "Follow up"))
 
       :sys.get_state(socket.channel_pid)
 
@@ -1048,16 +896,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   describe "tool_call_start streaming" do
     setup %{scope: scope} do
-      task_id = Ecto.UUID.generate()
-      {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
-
-      {:ok, _reply, socket} =
-        UserSocket
-        |> socket("user_id", %{scope: scope})
-        |> subscribe_and_join("task:#{task_id}", %{})
-
+      {socket, task_id} = join_task_channel(scope)
       complete_mcp_handshake(socket)
-
       {:ok, socket: socket, task_id: task_id}
     end
 

--- a/apps/frontman_server/test/support/channel_case.ex
+++ b/apps/frontman_server/test/support/channel_case.ex
@@ -112,6 +112,93 @@ defmodule FrontmanServerWeb.ChannelCase do
     end
   end
 
+  @doc """
+  Creates a task and joins the task channel, returning `{socket, task_id}`.
+
+  Extracts the repeated pattern of `Tasks.create_task` + `subscribe_and_join`
+  that appears in virtually every channel test setup block.
+
+  ## Options
+
+    * `:framework` - framework name for the task (default: `"nextjs"`)
+
+  ## Examples
+
+      {socket, task_id} = join_task_channel(scope)
+      {socket, task_id} = join_task_channel(scope, framework: "test-framework")
+  """
+  defmacro join_task_channel(scope, opts \\ []) do
+    quote do
+      scope = unquote(scope)
+      framework = unquote(opts) |> Keyword.get(:framework, "nextjs")
+      task_id = Ecto.UUID.generate()
+      {:ok, ^task_id} = FrontmanServer.Tasks.create_task(scope, task_id, framework)
+
+      {:ok, _reply, socket} =
+        FrontmanServerWeb.UserSocket
+        |> socket("user_id", %{scope: scope})
+        |> subscribe_and_join("task:#{task_id}", %{})
+
+      {socket, task_id}
+    end
+  end
+
+  @doc """
+  Builds a JSON-RPC request map for ACP messages.
+
+  ## Examples
+
+      build_acp_request("session/prompt", 42, %{"prompt" => [%{"type" => "text", "text" => "Hello"}]})
+      build_acp_request("session/cancel", nil, %{"sessionId" => "irrelevant"})
+  """
+  def build_acp_request(method, id, params) do
+    base = %{"jsonrpc" => "2.0", "method" => method, "params" => params}
+
+    if id, do: Map.put(base, "id", id), else: base
+  end
+
+  @doc """
+  Builds a JSON-RPC `session/prompt` request for channel tests.
+
+  Convenience wrapper around `build_acp_request/3`.
+
+  ## Options
+
+    * `:id` - JSON-RPC request id (default: `1`)
+    * `:text` - prompt text (default: `"Hello"`)
+    * `:metadata` - metadata map (default: `%{}`)
+
+  ## Examples
+
+      build_prompt_request()
+      build_prompt_request(id: 42, text: "Next question")
+      build_prompt_request(metadata: %{"model" => %{"provider" => "anthropic"}})
+  """
+  def build_prompt_request(opts \\ []) do
+    id = Keyword.get(opts, :id, 1)
+    text = Keyword.get(opts, :text, "Hello")
+    metadata = Keyword.get(opts, :metadata, %{})
+
+    params = %{"prompt" => [%{"type" => "text", "text" => text}]}
+    params = if metadata == %{}, do: params, else: Map.put(params, "metadata", metadata)
+
+    build_acp_request("session/prompt", id, params)
+  end
+
+  @doc """
+  Drains all messages from the test process mailbox.
+
+  Useful after setup blocks that trigger PubSub broadcasts, ensuring
+  subsequent assertions aren't polluted by leftover messages.
+  """
+  def flush_mailbox do
+    receive do
+      _ -> flush_mailbox()
+    after
+      0 -> :ok
+    end
+  end
+
   setup tags do
     if tags[:shared_sandbox] && tags[:async] do
       raise "Cannot combine shared_sandbox: true with async: true - shared sandbox requires synchronous execution"

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -20,6 +20,18 @@ module ACPTypes = Types.ACPTypes
 module MessageStore = Client__MessageStore
 
 module Lens = {
+  // ---- Generic helpers to eliminate repetitive 4-way switches ----
+
+  // Update the previewFrame on New/Loading/Loaded (crashes on Unloaded)
+  let updatePreviewFrame = (task: Task.t, fn: Task.previewFrame => Task.previewFrame): Task.t =>
+    switch task {
+    | Task.New(data) => Task.New({...data, previewFrame: fn(data.previewFrame)})
+    | Task.Loading(data) => Task.Loading({...data, previewFrame: fn(data.previewFrame)})
+    | Task.Loaded(data) => Task.Loaded({...data, previewFrame: fn(data.previewFrame)})
+    | Task.Unloaded(_) =>
+      failwith("[Lens.updatePreviewFrame] Cannot update preview frame on Unloaded task")
+    }
+
   // Update messages within a task (crashes if New or Unloaded - they have no messages)
   let updateMessages = (task: Task.t, fn: MessageStore.t => MessageStore.t): Task.t => {
     switch task {
@@ -75,109 +87,50 @@ module Lens = {
     )
   }
 
-  // Update preview frame URL
-  let setPreviewUrl = (task: Task.t, url: string): Task.t => {
-    switch task {
-    | Task.New(data) => Task.New({...data, previewFrame: {...data.previewFrame, url}})
-    | Task.Loading(data) => Task.Loading({...data, previewFrame: {...data.previewFrame, url}})
-    | Task.Loaded(data) => Task.Loaded({...data, previewFrame: {...data.previewFrame, url}})
-    | Task.Unloaded(_) => failwith("[Lens.setPreviewUrl] Cannot set preview URL on Unloaded task")
-    }
-  }
+  // ---- PreviewFrame lenses (delegate to updatePreviewFrame) ----
 
-  // Update preview frame content
+  let setPreviewUrl = (task: Task.t, url: string): Task.t =>
+    updatePreviewFrame(task, pf => {...pf, url})
+
   let setPreviewFrame = (
     task: Task.t,
     ~contentDocument: option<WebAPI.DOMAPI.document>,
     ~contentWindow: option<WebAPI.DOMAPI.window>,
-  ): Task.t => {
-    switch task {
-    | Task.New(data) =>
-      Task.New({...data, previewFrame: {...data.previewFrame, contentDocument, contentWindow}})
-    | Task.Loading(data) =>
-      Task.Loading({...data, previewFrame: {...data.previewFrame, contentDocument, contentWindow}})
-    | Task.Loaded(data) =>
-      Task.Loaded({...data, previewFrame: {...data.previewFrame, contentDocument, contentWindow}})
-    | Task.Unloaded(_) =>
-      failwith("[Lens.setPreviewFrame] Cannot set preview frame on Unloaded task")
-    }
-  }
+  ): Task.t =>
+    updatePreviewFrame(task, pf => {...pf, contentDocument, contentWindow})
 
-  // Update device mode
-  let setDeviceMode = (task: Task.t, deviceMode: Client__DeviceMode.deviceMode): Task.t => {
-    switch task {
-    | Task.New(data) =>
-      Task.New({...data, previewFrame: {...data.previewFrame, deviceMode}})
-    | Task.Loading(data) =>
-      Task.Loading({...data, previewFrame: {...data.previewFrame, deviceMode}})
-    | Task.Loaded(data) =>
-      Task.Loaded({...data, previewFrame: {...data.previewFrame, deviceMode}})
-    | Task.Unloaded(_) =>
-      failwith("[Lens.setDeviceMode] Cannot set device mode on Unloaded task")
-    }
-  }
+  let setDeviceMode = (task: Task.t, deviceMode: Client__DeviceMode.deviceMode): Task.t =>
+    updatePreviewFrame(task, pf => {...pf, deviceMode})
 
-  // Update orientation
-  let setOrientation = (task: Task.t, orientation: Client__DeviceMode.orientation): Task.t => {
-    switch task {
-    | Task.New(data) =>
-      Task.New({...data, previewFrame: {...data.previewFrame, orientation}})
-    | Task.Loading(data) =>
-      Task.Loading({...data, previewFrame: {...data.previewFrame, orientation}})
-    | Task.Loaded(data) =>
-      Task.Loaded({...data, previewFrame: {...data.previewFrame, orientation}})
-    | Task.Unloaded(_) =>
-      failwith("[Lens.setOrientation] Cannot set orientation on Unloaded task")
-    }
-  }
+  let setOrientation = (task: Task.t, orientation: Client__DeviceMode.orientation): Task.t =>
+    updatePreviewFrame(task, pf => {...pf, orientation})
 
-  // Set annotation mode
-  let setAnnotationMode = (task: Task.t, mode: Annotation.annotationMode): Task.t => {
-    switch task {
-    | Task.New(data) => Task.New({...data, annotationMode: mode})
-    | Task.Loading(data) => Task.Loading({...data, annotationMode: mode})
-    | Task.Loaded(data) => Task.Loaded({...data, annotationMode: mode})
-    | Task.Unloaded(_) =>
-      failwith("[Lens.setAnnotationMode] Cannot set mode on Unloaded task")
-    }
-  }
+  // ---- Annotation / UI lenses ----
 
-  // Set annotations array
-  let setAnnotations = (task: Task.t, annotations: array<Annotation.t>): Task.t => {
+  // Like Task.updateLoadedData but crashes on Unloaded (crash-early contract)
+  let updateTaskData = (task: Task.t, fn: Task.loadedData => Task.loadedData): Task.t =>
     switch task {
-    | Task.New(data) => Task.New({...data, annotations})
-    | Task.Loading(data) => Task.Loading({...data, annotations})
-    | Task.Loaded(data) => Task.Loaded({...data, annotations})
-    | Task.Unloaded(_) => failwith("[Lens.setAnnotations] Cannot set annotations on Unloaded task")
+    | Task.Unloaded(_) => failwith("[Lens.updateTaskData] Cannot update Unloaded task")
+    | _ => Task.updateLoadedData(task, fn)
     }
-  }
 
-  // Update a single annotation by ID
+  let setAnnotationMode = (task: Task.t, mode: Annotation.annotationMode): Task.t =>
+    updateTaskData(task, d => {...d, annotationMode: mode})
+
+  let setAnnotations = (task: Task.t, annotations: array<Annotation.t>): Task.t =>
+    updateTaskData(task, d => {...d, annotations})
+
   let updateAnnotation = (task: Task.t, id: string, fn: Annotation.t => Annotation.t): Task.t => {
     let annotations = Task.getAnnotations(task)
     let updated = annotations->Array.map(a => a.id == id ? fn(a) : a)
     setAnnotations(task, updated)
   }
 
-  // Set animation frozen state
-  let setAnimationFrozen = (task: Task.t, frozen: bool): Task.t => {
-    switch task {
-    | Task.New(data) => Task.New({...data, isAnimationFrozen: frozen})
-    | Task.Loading(data) => Task.Loading({...data, isAnimationFrozen: frozen})
-    | Task.Loaded(data) => Task.Loaded({...data, isAnimationFrozen: frozen})
-    | Task.Unloaded(_) => failwith("[Lens.setAnimationFrozen] Cannot set on Unloaded task")
-    }
-  }
+  let setAnimationFrozen = (task: Task.t, frozen: bool): Task.t =>
+    updateTaskData(task, d => {...d, isAnimationFrozen: frozen})
 
-  // Set active popup annotation ID
-  let setActivePopupAnnotationId = (task: Task.t, id: option<string>): Task.t => {
-    switch task {
-    | Task.New(data) => Task.New({...data, activePopupAnnotationId: id})
-    | Task.Loading(data) => Task.Loading({...data, activePopupAnnotationId: id})
-    | Task.Loaded(data) => Task.Loaded({...data, activePopupAnnotationId: id})
-    | Task.Unloaded(_) => failwith("[Lens.setActivePopupAnnotationId] Cannot set on Unloaded task")
-    }
-  }
+  let setActivePopupAnnotationId = (task: Task.t, id: option<string>): Task.t =>
+    updateTaskData(task, d => {...d, activePopupAnnotationId: id})
 
 }
 


### PR DESCRIPTION
## Summary

- Extract shared `ChannelCase` helpers (`join_task_channel`, `build_acp_request`, `build_prompt_request`, `flush_mailbox`) and refactor all channel tests to use them, eliminating ~15 duplicated setup patterns
- Simplify task reducer `Lens` module with a generic `updatePreviewFrame` helper and delegation to `Task.updateLoadedData`, replacing 8 repetitive 4-way switch statements with one-liner delegations
- Net: **+146 / -292 lines** — pure refactor, no behavior change

## Context

Combines PR A (test helpers) and PR E (lens cleanup) from the [issue-553 split plan](docs/issue-553-pr-split-plan.md). Both are independent cleanup tasks that clear the path for the question tool implementation (PRs B→C→D).

## Changes

### PR A: Test infrastructure — shared ChannelCase helpers

| File | Change |
|---|---|
| `test/support/channel_case.ex` | New: `join_task_channel/2` macro, `build_acp_request/3`, `build_prompt_request/1`, `flush_mailbox/0` |
| `task_channel_test.exs` | 9 setup blocks → `join_task_channel`, 6 inline prompt requests → `build_prompt_request`, 1 cancel notification → `build_acp_request` |
| `task_channel_sentry_test.exs` | Setup block → `join_task_channel`, removed unused `Tasks` alias |
| `task_channel_env_key_test.exs` | Setup block → `join_task_channel`, removed unused `UserSocket` alias |

### PR E: Task reducer lens cleanup

| File | Change |
|---|---|
| `Client__Task__Reducer.res` | New `updatePreviewFrame` generic helper; `setPreviewUrl`, `setPreviewFrame`, `setDeviceMode`, `setOrientation` delegate to it; `setAnnotationMode`, `setAnnotations`, `setAnimationFrozen`, `setActivePopupAnnotationId` delegate to `Task.updateLoadedData` |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
