### PR TITLE
refactor: add executionMode plumbing and tool signature changes (issue-553 PR B1)

### DIFF
--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -9,6 +9,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.getDom
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Inspect a specific section of the DOM in the web preview.
 
 **Always target the smallest subtree you need.** Do NOT request "body" or "html" unless you need a high-level page overview.
@@ -348,7 +349,7 @@ let successResult = (~html: string, ~nodeCount: option<int>=?, ~hint: option<str
 // Tool execution
 // ============================================================================
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   Client__Tool__ElementResolver.withPreviewDoc(
     ~onUnavailable=() =>
       errorResult(~error="Preview frame not available"),

--- a/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
+++ b/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
@@ -8,6 +8,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.getInteractiveElements
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Discover interactive elements on the current web preview page. Returns a list of clickable/interactive elements with their ARIA roles, accessible names, CSS selectors, and visible text.
 
 Use this tool to understand what elements are available for interaction before calling interact_with_element.
@@ -63,7 +64,7 @@ type output = {
   error: option<string>,
 }
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   Client__Tool__ElementResolver.withPreviewDoc(
     ~onUnavailable=() =>
       Ok({

--- a/libs/client/src/tools/Client__Tool__InteractWithElement.res
+++ b/libs/client/src/tools/Client__Tool__InteractWithElement.res
@@ -8,6 +8,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.interactWithElement
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Interact with an element in the web preview. Supports click, hover, and focus actions.
 
 Element targeting (use one strategy):
@@ -160,7 +161,7 @@ let errorResult = (error: string, ~matchCount: option<int>=?): result<output, _>
     error: Some(error),
   })
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   let action = input.action->Option.getOr(#click)
   let index = Math.Int.max(0, input.index->Option.getOr(0))
 

--- a/libs/client/src/tools/Client__Tool__Navigate.res
+++ b/libs/client/src/tools/Client__Tool__Navigate.res
@@ -7,6 +7,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.navigate
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Navigate in the web preview. Supports multiple navigation actions:
 
 - **goto**: Navigate to a specific URL. Pass {"action": "goto", "url": "/path"}
@@ -68,7 +69,7 @@ let locationReload: WebAPI.DOMAPI.window => unit = %raw(`
   }
 `)
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   let state = StateStore.getState(Client__State__Store.store)
 
   // Get the current task's preview frame

--- a/libs/client/src/tools/Client__Tool__SearchText.res
+++ b/libs/client/src/tools/Client__Tool__SearchText.res
@@ -8,6 +8,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.searchText
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Search for visible text on the current web preview page. Works like Ctrl+F — finds elements whose visible text contains the query string (case-insensitive).
 
 Returns matching elements with surrounding text context, CSS selectors for targeting, and accessibility metadata.
@@ -102,7 +103,7 @@ let buildContextSnippet = (~text: string, ~query: string, ~contextChars: int): s
   }
 }
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   switch input.query->String.trim {
   | "" => errorResult(~error="Query string cannot be empty")
   | _ =>

--- a/libs/client/src/tools/Client__Tool__SetDeviceMode.res
+++ b/libs/client/src/tools/Client__Tool__SetDeviceMode.res
@@ -7,6 +7,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.setDeviceMode
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Set the device emulation mode in the web preview for responsive design testing.
 
 Actions:
@@ -85,7 +86,7 @@ let makeOutput = (
 let okOutput = (~success, ~error) => Ok(makeOutput(~success, ~error, ~presets=None))
 let okOutputWithPresets = (~success, ~presets) => Ok(makeOutput(~success, ~error=None, ~presets=Some(presets)))
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   switch input.action {
   | #set_preset =>
     switch input.device {

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -7,6 +7,7 @@ type toolResult<'a> = Tool.toolResult<'a>
 
 let name = Tool.ToolNames.takeScreenshot
 let visibleToAgent = true
+let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = "Take a screenshot of the current web preview page. By default captures only the visible viewport. Set fullPage to true to capture the entire scrollable page. Returns a base64-encoded JPEG image data URL."
 
 @schema
@@ -85,7 +86,7 @@ let _cropCanvasToViewport = (
   }
 }
 
-let execute = async (input: input): toolResult<output> => {
+let execute = async (input: input, ~taskId as _taskId: string, ~toolCallId as _toolCallId: string): toolResult<output> => {
   let fullPage = input.fullPage->Option.getOr(false)
 
   await Client__Tool__ElementResolver.withPreviewDoc(

--- a/libs/frontman-client/src/FrontmanClient__MCP.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP.res
@@ -104,7 +104,7 @@ let handleToolsCall = async (
   switch params {
   | Some(paramsJson) =>
     try {
-      let {name, arguments}: Types.toolCallParams =
+      let {callId, name, arguments}: Types.toolCallParams =
         paramsJson->S.parseOrThrow(Types.toolCallParamsSchema)
       let {serverInterface} = handler
       let result = await serverInterface.executeTool(
@@ -112,10 +112,15 @@ let handleToolsCall = async (
         ~name,
         ~arguments,
         ~taskId=handler.sessionId,
+        ~callId,
         ~onProgress=None,
       )
-      let resultJson = result->S.reverseConvertToJsonOrThrow(Types.callToolResultSchema)
-      sendResponse(handler, id, resultJson)
+      switch result {
+      | Completed(callToolResult) =>
+        let resultJson = callToolResult->S.reverseConvertToJsonOrThrow(Types.callToolResultSchema)
+        sendResponse(handler, id, resultJson)
+      | Suspended => () // Interactive tool — result will be delivered separately
+      }
     } catch {
     | S.Error(e) =>
       sendError(handler, id, Types.ErrorCode.invalidParams, `Invalid params: ${e.message}`)

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -52,6 +52,14 @@ let registerToolModule = (server: t, toolModule: module(Tool.Tool)): t => {
 // JSONSchema.t is JSON.t at runtime
 external jsonSchemaAsJson: JSONSchema.t => JSON.t = "%identity"
 
+module ToolTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+
+// Schema for executionMode serialization
+let executionModeSchema = S.union([
+  S.literal(ToolTypes.Synchronous),
+  S.literal(ToolTypes.Interactive),
+])
+
 // Tool wire format schema - serialized directly to JSON
 let toolWireSchema = S.object(s => {
   {
@@ -59,6 +67,7 @@ let toolWireSchema = S.object(s => {
     "description": s.field("description", S.string),
     "inputSchema": s.field("inputSchema", S.json),
     "visibleToAgent": s.field("visibleToAgent", S.bool),
+    "executionMode": s.field("executionMode", executionModeSchema),
   }
 })
 
@@ -70,6 +79,7 @@ let serializeTool = (m: module(Tool.Tool)): JSON.t => {
     "description": T.description,
     "inputSchema": T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
     "visibleToAgent": T.visibleToAgent,
+    "executionMode": T.executionMode,
   }->S.reverseConvertToJsonOrThrow(toolWireSchema)
 }
 
@@ -91,16 +101,18 @@ let getToolByName = (server: t, name: string): option<module(Tool.Tool)> => {
 let executeLocalTool = async (
   toolModule: module(Tool.Tool),
   ~arguments: option<Dict.t<JSON.t>>,
-): Types.callToolResult => {
+  ~taskId: string,
+  ~toolCallId: string,
+): Types.executeToolResult => {
   module T = unpack(toolModule)
   Log.debug(~ctx={"tool": T.name}, "Executing local tool")
   let inputJson = arguments->Option.getOr(Dict.make())->JSON.Encode.object
   try {
     let input = inputJson->S.parseOrThrow(T.inputSchema)
     Log.debug(~ctx={"tool": T.name}, "Calling execute")
-    let result = await T.execute(input)
+    let result = await T.execute(input, ~taskId, ~toolCallId)
     Log.debug(~ctx={"tool": T.name}, "Execute returned")
-    switch result {
+    let callToolResult: Types.callToolResult = switch result {
     | Ok(output) =>
       let outputJson = output->S.reverseConvertToJsonOrThrow(T.outputSchema)
       {
@@ -112,13 +124,14 @@ let executeLocalTool = async (
         isError: Some(true),
       }
     }
+    Completed(callToolResult)
   } catch {
   | S.Error(e) =>
     Log.error(~ctx={"tool": T.name}, "Schema error")
-    {
+    Completed({
       content: [{type_: "text", text: `Invalid input: ${e.message}`}],
       isError: Some(true),
-    }
+    })
   }
 }
 
@@ -163,14 +176,15 @@ let executeTool = async (
   ~name: string,
   ~arguments: option<Dict.t<JSON.t>>=?,
   ~taskId: string,
+  ~callId: string,
   ~onProgress: option<string => unit>=?,
-): Types.callToolResult => {
+): Types.executeToolResult => {
   // Try local tools first
   switch getToolByName(server, name) {
-  | Some(toolModule) => await executeLocalTool(toolModule, ~arguments)
+  | Some(toolModule) => await executeLocalTool(toolModule, ~arguments, ~taskId, ~toolCallId=callId)
   | None =>
     switch server.relay->Relay.hasTool(name) {
-    | false => toolError(`Tool not found: ${name}`)
+    | false => Completed(toolError(`Tool not found: ${name}`))
     | true =>
       // Intercept write_file with image_ref to resolve from the correct task
       let resolvedArgs = switch name == ToolNames.writeFile {
@@ -179,12 +193,12 @@ let executeTool = async (
       }
 
       switch resolvedArgs {
-      | Error(msg) => toolError(msg)
+      | Error(msg) => Completed(toolError(msg))
       | Ok(finalArgs) =>
         let result = await server.relay->Relay.executeTool(~name, ~arguments=?finalArgs, ~onProgress?)
         switch result {
-        | Ok(toolResult) => toolResult
-        | Error(msg) => toolError(msg)
+        | Ok(toolResult) => Completed(toolResult)
+        | Error(msg) => Completed(toolError(msg))
         }
       }
     }
@@ -214,6 +228,6 @@ let toInterface = (server: t): Types.serverInterface<t> => {
   server,
   buildInitializeResult,
   buildToolsListResult,
-  executeTool: (server, ~name, ~arguments, ~taskId, ~onProgress) =>
-    executeTool(server, ~name, ~arguments?, ~taskId, ~onProgress?),
+  executeTool: (server, ~name, ~arguments, ~taskId, ~callId, ~onProgress) =>
+    executeTool(server, ~name, ~arguments?, ~taskId, ~callId, ~onProgress?),
 }

--- a/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
@@ -69,6 +69,12 @@ type callToolResult = {
 @schema
 type toolsListResult = {tools: array<JSON.t>}
 
+// Result of executing a tool — either completed immediately or suspended
+// waiting for external input (e.g. interactive tool awaiting user response).
+type executeToolResult =
+  | Completed(callToolResult)
+  | Suspended
+
 // MCP Error codes
 module ErrorCode = {
   let invalidParams = -32602
@@ -86,8 +92,9 @@ type serverInterface<'server> = {
     ~name: string,
     ~arguments: option<Dict.t<JSON.t>>,
     ~taskId: string,
+    ~callId: string,
     ~onProgress: option<string => unit>,
-  ) => promise<callToolResult>,
+  ) => promise<executeToolResult>,
 }
 
 // Server module type - implement this to create an MCP server
@@ -100,6 +107,7 @@ module type Server = {
     ~name: string,
     ~arguments: option<Dict.t<JSON.t>>=?,
     ~taskId: string,
+    ~callId: string,
     ~onProgress: option<string => unit>=?,
-  ) => promise<callToolResult>
+  ) => promise<executeToolResult>
 }

--- a/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
@@ -11,6 +11,12 @@ type serverExecutionContext = {
   sourceRoot: string,
 }
 
+// How a browser tool delivers its result back to the MCP caller.
+// - Synchronous: execute returns a resolved promise (normal flow).
+// - Interactive: execute returns a promise that blocks until user input is provided
+//   (e.g. question tool waits for user to answer before resolving).
+type executionMode = Synchronous | Interactive
+
 // Well-known tool names — used by both server (frontman-core) and client (frontman-client)
 // to avoid fragile string comparisons across packages.
 module ToolNames = {
@@ -33,6 +39,7 @@ module ToolNames = {
   let getInteractiveElements = "get_interactive_elements"
   let getDom = "get_dom"
   let searchText = "search_text"
+  let question = "question"
 }
 
 // Browser tool - executes in browser, no context needed
@@ -43,9 +50,10 @@ module type BrowserTool = {
   type output
   let inputSchema: S.t<input>
   let outputSchema: S.t<output>
-  let execute: input => promise<toolResult<output>>
+  let execute: (input, ~taskId: string, ~toolCallId: string) => promise<toolResult<output>>
   //some tools we want to execute manually, and never have the llm see them
   let visibleToAgent: bool
+  let executionMode: executionMode
 }
 
 // Server tool - executes on server with context


### PR DESCRIPTION
## Summary

Pure refactor — adds `executionMode` infrastructure for interactive browser tools. Zero user-facing behavior change. All existing tools declare `Synchronous` and ignore the new params.

This is **PR B1** from the [issue-553 split plan](docs/issue-553-pr-split-plan.md), unblocking PR B2 (the complete question tool feature).

## Changes

**Protocol layer** (`frontman-protocol`):

- `executionMode` type: `Synchronous | Interactive`
- `executeToolResult` variant: `Completed(callToolResult) | Suspended`
- `ToolNames.question` constant
- `BrowserTool.execute` signature gains `~taskId`, `~toolCallId`
- `serverInterface.executeTool` gains `~callId`, returns `executeToolResult`

**MCP layer** (`frontman-client`):

- Serialize `executionMode` in `tools/list` wire format
- Thread `taskId`/`toolCallId` through `executeLocalTool`
- `handleToolsCall` switches on `Completed`/`Suspended` (sends MCP response vs no-op)

**Tool implementations** (7 files in `client`):

- All add `let executionMode = Synchronous`
- All accept `~taskId`, `~toolCallId` (unused, aliased to `_`)

## Verification

- ReScript build: clean, zero warnings
- Client vitest: 262/262 tests pass (16/16 files)
- No changeset needed (pure plumbing refactor, no user-facing change)

## Related

- Part of #553
- Preceded by #595 (test helpers + lens cleanup)
- Unblocks PR B2: complete question feature (tool + state machine + UI)
- ToolLabels cleanup tracked separately in #597