### PR TITLE
fix(acp): make AgentMessageChunk content required per ContentChunk spec

### DIFF
--- a/.changeset/agent-message-chunk-content-required.md
+++ b/.changeset/agent-message-chunk-content-required.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/frontman-protocol": patch
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+---
+
+Make AgentMessageChunk content field required per ACP ContentChunk spec. Removes unnecessary option wrapper and simplifies downstream consumer code.

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -170,7 +170,7 @@ module Provider = {
         // Message end is signaled by session/prompt response with stopReason.
         // Buffer text deltas and flush once per animation frame to avoid
         // dozens of full state rebuilds per second during fast streaming.
-        content->Option.flatMap(getContentBlockText)->Option.forEach(text => {
+        getContentBlockText(content)->Option.forEach(text => {
           textDeltaBuffer.add(~taskId, ~text, ~timestamp)
         })
       | UserMessageChunk({content, timestamp}) =>

--- a/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
@@ -119,7 +119,7 @@ describe("sessionUpdate schema parsing", () => {
     let parsed = json->S.parseOrThrow(Types.sessionUpdateSchema)
 
     switch parsed {
-    | Types.AgentMessageChunk({content: Some(Types.TextContent({text})), timestamp}) =>
+    | Types.AgentMessageChunk({content: Types.TextContent({text}), timestamp}) =>
       t->expect(text)->Expect.toBe("Hello from the agent")
       t->expect(timestamp)->Expect.toBe("2024-01-15T10:00:30Z")
     | _ => t->expect("AgentMessageChunk")->Expect.toBe("not matched")

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -226,6 +226,7 @@
               "additionalProperties": true,
               "required": [
                 "sessionUpdate",
+                "content",
                 "timestamp"
               ]
             },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -366,7 +366,7 @@ let planEntrySchema = S.object(s => {
 // Per ACP spec: only agent_message_chunk exists (first chunk implicitly starts message,
 // session/prompt response with stopReason signals message end)
 type sessionUpdate =
-  | AgentMessageChunk({content: option<contentBlock>, timestamp: string})
+  | AgentMessageChunk({content: contentBlock, timestamp: string})
   | UserMessageChunk({content: contentBlock, timestamp: string})
   | ToolCall({
       toolCallId: string,
@@ -392,7 +392,7 @@ let sessionUpdateSchema = S.union([
   S.object(s => {
     s.tag("sessionUpdate", "agent_message_chunk")
     AgentMessageChunk({
-      content: s.field("content", S.option(contentBlockSchema)),
+      content: s.field("content", contentBlockSchema),
       timestamp: s.field("timestamp", S.string),
     })
   }),


### PR DESCRIPTION
## Summary

Fixes #540 — ACP compliance: `AgentMessageChunk.content` should be **required**, not optional.

- **Protocol type & schema** (`FrontmanProtocol__ACP.res`): `content: option<contentBlock>` → `content: contentBlock`, schema drops `S.option` wrapper
- **Consumer** (`Client__FrontmanProvider.res`): Simplifies `Option.flatMap(getContentBlockText)` → direct `getContentBlockText(content)` call
- **Test** (`FrontmanClient__ACP__Types.test.res`): Pattern match drops `Some(...)` wrapper to match new required type

### Why

The ACP spec defines `ContentChunk.content` as `"required": ["content"]`. Our implementation incorrectly had it as optional, which accepted malformed messages and forced unnecessary defensive code downstream. `UserMessageChunk` already had it correct — this brings `AgentMessageChunk` in line.

### Verification

- ReScript build passes cleanly
- All 63 frontman-client tests pass (including 8 ACP type parsing tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
