### PR TITLE
fix(acp): rename metadata to _meta for ACP spec compliance

### DIFF
--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -469,10 +469,10 @@ defmodule FrontmanServerWeb.TaskChannel do
     scope = socket.assigns.scope
     mcp_tools = socket.assigns[:mcp_tools] || []
 
-    # Extract env API key from prompt metadata (sent with each prompt request)
+    # Extract env API key from prompt _meta (sent with each prompt request)
     env_api_key = extract_env_api_key_from_params(params)
 
-    # Extract model selection from prompt metadata
+    # Extract model selection from prompt _meta
     model = extract_model_from_params(params)
     # model is either a %Model{} struct or nil
 
@@ -514,17 +514,17 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
   end
 
-  # Extract env API keys from prompt params metadata (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
+  # Extract env API keys from prompt params _meta (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
   defp extract_env_api_key_from_params(params) when is_map(params) do
-    params |> get_in(["metadata"]) |> Registry.extract_env_keys()
+    params |> get_in(["_meta"]) |> Registry.extract_env_keys()
   end
 
   defp extract_env_api_key_from_params(_), do: %{}
 
-  # Extract model selection from prompt params metadata.
+  # Extract model selection from prompt params _meta.
   # Returns a %Model{} struct or nil.
   defp extract_model_from_params(params) when is_map(params) do
-    case Model.from_client_params(get_in(params, ["metadata", "model"])) do
+    case Model.from_client_params(get_in(params, ["_meta", "model"])) do
       {:ok, model} -> model
       :error -> nil
     end

--- a/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
@@ -82,7 +82,7 @@ defmodule FrontmanServerWeb.TasksChannel do
        ) do
     Logger.info("ACP initialize from #{inspect(params["clientInfo"])}")
 
-    # Extract env API key from clientInfo metadata (if provided by the project)
+    # Extract env API key from clientInfo _meta (if provided by the project)
     env_api_key = extract_env_api_key(params["clientInfo"])
 
     socket =
@@ -192,14 +192,14 @@ defmodule FrontmanServerWeb.TasksChannel do
     if Regex.match?(@uuid_regex, string), do: :ok, else: :error
   end
 
-  defp extract_framework(%{"metadata" => %{"framework" => framework}}) when is_binary(framework),
+  defp extract_framework(%{"_meta" => %{"framework" => framework}}) when is_binary(framework),
     do: framework
 
   defp extract_framework(_), do: nil
 
-  # Extract env API keys from clientInfo metadata (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
+  # Extract env API keys from clientInfo _meta (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
   defp extract_env_api_key(client_info) when is_map(client_info) do
-    client_info |> get_in(["metadata"]) |> Registry.extract_env_keys()
+    client_info |> get_in(["_meta"]) |> Registry.extract_env_keys()
   end
 
   defp extract_env_api_key(_), do: %{}

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -14,8 +14,8 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
     {:ok, socket: socket}
   end
 
-  defp push_prompt_and_assert_accepted(socket, metadata \\ %{}) do
-    push(socket, "acp:message", prompt_request(metadata: metadata))
+  defp push_prompt_and_assert_accepted(socket, meta \\ %{}) do
+    push(socket, "acp:message", prompt_request(_meta: meta))
     :sys.get_state(socket.channel_pid)
 
     assert_receive {:interaction, %Tasks.Interaction.UserMessage{}}

--- a/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
@@ -97,7 +97,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "test-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "nextjs"}
+            "_meta" => %{"framework" => "nextjs"}
           }
         }
       })
@@ -139,7 +139,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "frontman-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "Next.js"}
+            "_meta" => %{"framework" => "Next.js"}
           }
         }
       })
@@ -187,7 +187,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "frontman-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "Vite"}
+            "_meta" => %{"framework" => "Vite"}
           }
         }
       })
@@ -222,7 +222,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "test-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "nextjs"}
+            "_meta" => %{"framework" => "nextjs"}
           }
         }
       })
@@ -260,7 +260,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "test-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "nextjs"}
+            "_meta" => %{"framework" => "nextjs"}
           }
         }
       })
@@ -301,7 +301,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
           "clientInfo" => %{
             "name" => "test-client",
             "version" => "1.0.0",
-            "metadata" => %{"framework" => "nextjs"}
+            "_meta" => %{"framework" => "nextjs"}
           }
         }
       })

--- a/apps/frontman_server/test/support/channel_case.ex
+++ b/apps/frontman_server/test/support/channel_case.ex
@@ -166,21 +166,21 @@ defmodule FrontmanServerWeb.ChannelCase do
 
     * `:id` - JSON-RPC request id (default: `1`)
     * `:text` - prompt text (default: `"Hello"`)
-    * `:metadata` - metadata map (default: `%{}`)
+    * `:_meta` - _meta map (default: `%{}`)
 
   ## Examples
 
       build_prompt_request()
       build_prompt_request(id: 42, text: "Next question")
-      build_prompt_request(metadata: %{"model" => %{"provider" => "anthropic"}})
+      build_prompt_request(_meta: %{"model" => %{"provider" => "anthropic"}})
   """
   def build_prompt_request(opts \\ []) do
     id = Keyword.get(opts, :id, 1)
     text = Keyword.get(opts, :text, "Hello")
-    metadata = Keyword.get(opts, :metadata, %{})
+    meta = Keyword.get(opts, :_meta, %{})
 
     params = %{"prompt" => [%{"type" => "text", "text" => text}]}
-    params = if metadata == %{}, do: params, else: Map.put(params, "metadata", metadata)
+    params = if meta == %{}, do: params, else: Map.put(params, "_meta", meta)
 
     build_acp_request("session/prompt", id, params)
   end

--- a/apps/frontman_server/test/support/fixtures/providers_fixtures.ex
+++ b/apps/frontman_server/test/support/fixtures/providers_fixtures.ex
@@ -102,12 +102,12 @@ defmodule FrontmanServer.ProvidersFixtures do
   @doc """
   Builds a JSON-RPC `session/prompt` message for channel tests.
 
-  Options: `:id`, `:text`, `:metadata`.
+  Options: `:id`, `:text`, `:_meta`.
   """
   def prompt_request(opts \\ []) do
     id = Keyword.get(opts, :id, 1)
     text = Keyword.get(opts, :text, "Hello")
-    metadata = Keyword.get(opts, :metadata, %{})
+    meta = Keyword.get(opts, :_meta, %{})
 
     params = %{
       "prompt" => [
@@ -115,7 +115,7 @@ defmodule FrontmanServer.ProvidersFixtures do
       ]
     }
 
-    params = if metadata == %{}, do: params, else: Map.put(params, "metadata", metadata)
+    params = if meta == %{}, do: params, else: Map.put(params, "_meta", meta)
 
     %{"jsonrpc" => "2.0", "id" => id, "method" => "session/prompt", "params" => params}
   end

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -22,8 +22,8 @@ type initConfig = {
   clientVersion: string,
   baseUrl: string,
   onACPMessage: (ACP.messageDirection, JSON.t) => unit,
-  // Metadata to pass in ACP clientInfo (framework, env key detection, etc.)
-  metadata: JSON.t,
+  // _meta to pass in ACP clientInfo (framework, env key detection, etc.)
+  _meta: JSON.t,
   // Called when the server pushes a title update for a task
   onTitleUpdated: option<(string, string) => unit>,
 }
@@ -91,7 +91,7 @@ type action =
       text: string,
       additionalBlocks: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
       onComplete: result<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
-      metadata: option<JSON.t>,
+      _meta: option<JSON.t>,
     })
   | PromptSent
   | CancelPrompt
@@ -127,7 +127,7 @@ type effect =
       text: string,
       additionalBlocks: array<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.contentBlock>,
       onComplete: result<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.promptResult, string> => unit,
-      metadata: option<JSON.t>,
+      _meta: option<JSON.t>,
     })
   | CancelPromptEffect({session: ACP.session})
   | FetchSessionsEffect(ACP.connection)
@@ -230,7 +230,7 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
       ~loginUrl=config.loginUrl,
       ~name=config.clientName,
       ~version=config.clientVersion,
-      ~metadata=config.metadata,
+      ~_meta=config._meta,
       ~onMessage=config.onACPMessage,
       ~onTitleUpdated=?config.onTitleUpdated,
     )
@@ -347,10 +347,10 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
       [CreateSessionEffect({connection: conn, mcpServer, onUpdate, onMcpMessage, onComplete})],
     )
 
-  | ({session: SessionActive(session), isSendingPrompt: false}, SendPrompt({text, additionalBlocks, onComplete, metadata})) =>
+  | ({session: SessionActive(session), isSendingPrompt: false}, SendPrompt({text, additionalBlocks, onComplete, _meta})) =>
     (
       {...state, isSendingPrompt: true},
-      [SendPromptEffect({session, text, additionalBlocks, onComplete, metadata})],
+      [SendPromptEffect({session, text, additionalBlocks, onComplete, _meta})],
     )
 
    | (_, PromptSent) =>
@@ -574,10 +574,10 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
       }
     }
     create()->ignore
-  | SendPromptEffect({session, text, additionalBlocks, onComplete, metadata}) =>
+  | SendPromptEffect({session, text, additionalBlocks, onComplete, _meta}) =>
     let send = async () => {
       try {
-        let result = await ACP.sendPrompt(session, text, ~additionalBlocks, ~metadata)
+        let result = await ACP.sendPrompt(session, text, ~additionalBlocks, ~_meta)
         dispatch(PromptSent)
         onComplete(result)
       } catch {

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -44,7 +44,7 @@ type contextValue = {
     string,
     ~additionalBlocks: array<Types.contentBlock>,
     ~onComplete: result<Types.promptResult, string> => unit,
-    ~metadata: option<JSON.t>,
+    ~_meta: option<JSON.t>,
   ) => unit,
   cancelPrompt: unit => unit,
   loadTask: (string, ~needsHistory: bool, ~onComplete: result<unit, string> => unit) => unit,
@@ -61,7 +61,7 @@ let defaultContextValue: contextValue = {
   authRedirectUrl: None,
   createSession: (~onComplete as _) => (),
   clearSession: () => (),
-  sendPrompt: (_, ~additionalBlocks as _, ~onComplete as _, ~metadata as _) => (),
+  sendPrompt: (_, ~additionalBlocks as _, ~onComplete as _, ~_meta as _) => (),
   cancelPrompt: () => (),
   loadTask: (_, ~needsHistory as _, ~onComplete as _) => (),
   deleteSession: (_, ~onComplete as _) => (),
@@ -110,7 +110,7 @@ module Provider = {
 
       // Read runtime config from window.__frontmanRuntime (injected by framework middleware)
       let runtimeConfig = RuntimeConfig.read()
-      let metadata = RuntimeConfig.toMetadata(runtimeConfig)
+      let _meta = RuntimeConfig.toMeta(runtimeConfig)
 
       let relay = Relay.make(~baseUrl)
       let toolRegistry = Client__ToolRegistry.coreBrowserTools()
@@ -148,7 +148,7 @@ module Provider = {
         clientVersion,
         baseUrl,
         onACPMessage: logACPMessage,
-        metadata,
+        _meta,
         onTitleUpdated: Some((taskId, title) => {
           Client__State.Actions.updateTaskTitle(~taskId, ~title)
         }),
@@ -251,8 +251,8 @@ module Provider = {
     let clearSession = React.useCallback1(() => dispatch(ClearSession), [dispatch])
 
     let sendPrompt = React.useCallback1(
-      (text: string, ~additionalBlocks, ~onComplete, ~metadata) => {
-        dispatch(SendPrompt({text, additionalBlocks, onComplete, metadata}))
+      (text: string, ~additionalBlocks, ~onComplete, ~_meta) => {
+        dispatch(SendPrompt({text, additionalBlocks, onComplete, _meta}))
       },
       [dispatch],
     )

--- a/libs/client/src/Client__RuntimeConfig.res
+++ b/libs/client/src/Client__RuntimeConfig.res
@@ -88,10 +88,10 @@ let frameworkToNpmPackage = (id: frameworkId): string =>
   | Astro => "@frontman-ai/astro"
   }
 
-// Convert runtime config to metadata JSON for ACP prompt requests
+// Convert runtime config to _meta JSON for ACP requests
 // Includes framework and openrouterKeyValue so the server knows
 // which framework the client is running in and can use the project's env key
-let toMetadata = (config: t): JSON.t => {
+let toMeta = (config: t): JSON.t => {
   let configObj = Dict.fromArray([
     ("framework", JSON.Encode.string(frameworkIdToString(config.framework))),
     ("basePath", JSON.Encode.string(config.basePath)),

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -600,24 +600,24 @@ let sendMessageToAPIImpl = (
     let attachmentBlocks = buildAttachmentContentBlocks(attachments)
     let additionalBlocks = Array.concat(pageContextBlocks, annotationBlocks)->Array.concat(attachmentBlocks)
 
-    // Include runtime config metadata (e.g., framework, openrouterKeyValue) with each prompt
+    // Include runtime config _meta (e.g., framework, openrouterKeyValue) with each prompt
     let runtimeConfig = Client__RuntimeConfig.read()
-    let baseMetadata = Client__RuntimeConfig.toMetadata(runtimeConfig)
+    let baseMeta = Client__RuntimeConfig.toMeta(runtimeConfig)
 
-    // Add selected model to metadata if present
-    let metadata = switch state.selectedModel {
+    // Add selected model to _meta if present
+    let _meta = switch state.selectedModel {
     | Some(model) =>
       let modelJson: JSON.t = %raw(`(function(provider, value) {
         return { provider: provider, value: value };
       })`)(model.provider, model.value)
-      switch baseMetadata->JSON.Decode.object {
+      switch baseMeta->JSON.Decode.object {
       | Some(dict) =>
         let newDict = dict->Dict.copy
         newDict->Dict.set("model", modelJson)
         Some(newDict->Obj.magic)
-      | None => Some(baseMetadata)
+      | None => Some(baseMeta)
       }
-    | None => Some(baseMetadata)
+    | None => Some(baseMeta)
     }
 
     sendPrompt(
@@ -633,7 +633,7 @@ let sendMessageToAPIImpl = (
         // are no-ops.
         dispatch(TaskAction({target: ForTask(taskId), action: TurnCompleted}))
       },
-      ~metadata,
+      ~_meta,
     )
   | NoAcpSession => Log.error("Cannot send message: no active ACP session")
   }

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -21,7 +21,7 @@ type sendPromptFn = (
   string,
   ~additionalBlocks: array<ACPTypes.contentBlock>,
   ~onComplete: result<ACPTypes.promptResult, string> => unit,
-  ~metadata: option<JSON.t>,
+  ~_meta: option<JSON.t>,
 ) => unit
 
 // Callback for loading a persisted task's messages

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -79,7 +79,7 @@ describe("Connection Reducer", () => {
         baseUrl: "http://test",
         onACPMessage: (_, _) => (),
         onTitleUpdated: None,
-        metadata: JSON.Encode.object(Dict.fromArray([("framework", JSON.Encode.string("test"))])),
+        _meta: JSON.Encode.object(Dict.fromArray([("framework", JSON.Encode.string("test"))])),
       }
       let (nextState, effects) = Reducer.reduce(
         Reducer.initialState,
@@ -106,7 +106,7 @@ describe("Connection Reducer", () => {
         baseUrl: "http://test",
         onACPMessage: (_, _) => (),
         onTitleUpdated: None,
-        metadata: JSON.Encode.object(Dict.fromArray([("framework", JSON.Encode.string("test"))])),
+        _meta: JSON.Encode.object(Dict.fromArray([("framework", JSON.Encode.string("test"))])),
       }
       let state = {...Reducer.initialState, acp: ACPConnecting}
       let (_, effects) = Reducer.reduce(

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -4,7 +4,7 @@ module Reducer = Client__State__StateReducer
 module Types = Client__State__Types
 
 // Dummy callbacks for AcpSessionActive (reducer only checks the variant, not the callbacks)
-let _dummySendPrompt: Types.sendPromptFn = (_, ~additionalBlocks as _, ~onComplete as _, ~metadata as _) => ()
+let _dummySendPrompt: Types.sendPromptFn = (_, ~additionalBlocks as _, ~onComplete as _, ~_meta as _) => ()
 let _dummyCancelPrompt: Types.cancelPromptFn = () => ()
 let _dummyLoadTask: Types.loadTaskFn = (_, ~needsHistory as _, ~onComplete as _) => ()
 let _dummyDeleteSession: Types.deleteSessionFn = (_, ~onComplete as _) => ()

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -30,7 +30,7 @@ let makeConfig = (
   ~loginUrl: string,
   ~name: string,
   ~version: string,
-  ~metadata: JSON.t,
+  ~_meta: JSON.t,
   ~onMessage: option<(messageDirection, JSON.t) => unit>=?,
   ~onTitleUpdated: option<(string, string) => unit>=?,
 ): config => {
@@ -41,7 +41,7 @@ let makeConfig = (
     name,
     version,
     title: None,
-    metadata: Some(metadata),
+    _meta: Some(_meta),
   },
   onTitleUpdated,
   clientCapabilities: {
@@ -365,7 +365,7 @@ let sendPrompt = async (
   session: session,
   text: string,
   ~additionalBlocks: array<Types.contentBlock>=[],
-  ~metadata: option<JSON.t>=None,
+  ~_meta: option<JSON.t>=None,
 ): result<Types.promptResult, string> => {
   // Build prompt array starting with the text block
   let textBlock: Types.contentBlock = TextContent({text, _meta: None, annotations: None})
@@ -385,7 +385,7 @@ let sendPrompt = async (
     ~state=session.connection.state,
     ~sessionId=session.sessionId,
     ~prompt=allBlocks,
-    ~metadata,
+    ~_meta,
     ~onMessage=session.connection.onMessage,
   )
 }

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -82,16 +82,16 @@ let sendPrompt = (
   ~state: ref<Client.state>,
   ~sessionId: string,
   ~prompt: array<JSON.t>,
-  ~metadata: option<JSON.t>,
+  ~_meta: option<JSON.t>,
   ~onMessage: option<(messageDirection, JSON.t) => unit>,
 ): promise<result<Types.promptResult, string>> => {
   let entries = [
     ("sessionId", JSON.Encode.string(sessionId)),
     ("prompt", JSON.Encode.array(prompt)),
   ]
-  // Add metadata if provided
-  let entries = switch metadata {
-  | Some(meta) => Array.concat(entries, [("metadata", meta)])
+  // Add _meta if provided
+  let entries = switch _meta {
+  | Some(meta) => Array.concat(entries, [("_meta", meta)])
   | None => entries
   }
   let promptParams = JSON.Encode.object(Dict.fromArray(entries))

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -45,7 +45,7 @@ describe("ACP Client State Reducer", _t => {
     let initResult: Types.initializeResult = {
       protocolVersion: 1,
       agentCapabilities: None,
-      agentInfo: Some({name: "test", version: "1.0", title: None, metadata: None}),
+      agentInfo: Some({name: "test", version: "1.0", title: None, _meta: None}),
       authMethods: None,
     }
 
@@ -103,7 +103,7 @@ describe("ACP Client buildInitializeParams", _t => {
 
     let config: Client.config = {
       channel: mockChannel,
-      clientInfo: {name: "test-client", version: "1.0.0", title: None, metadata: None},
+      clientInfo: {name: "test-client", version: "1.0.0", title: None, _meta: None},
       clientCapabilities: {
         fs: Some({readTextFile: Some(true), writeTextFile: Some(false)}),
         terminal: Some(true),

--- a/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Types.test.res
@@ -11,7 +11,7 @@ describe("ACP Types encoding/decoding", _t => {
         terminal: Some(false),
         elicitation: None,
       }),
-      clientInfo: Some({name: "test-client", version: "1.0.0", title: None, metadata: None}),
+      clientInfo: Some({name: "test-client", version: "1.0.0", title: None, _meta: None}),
     }
 
     let _encoded = params->S.reverseConvertToJsonOrThrow(Types.initializeParamsSchema)
@@ -21,7 +21,7 @@ describe("ACP Types encoding/decoding", _t => {
     let params: Types.initializeParams = {
       protocolVersion: 1,
       clientCapabilities: None,
-      clientInfo: Some({name: "test", version: "1.0", title: Some("Test Client"), metadata: None}),
+      clientInfo: Some({name: "test", version: "1.0", title: Some("Test Client"), _meta: None}),
     }
 
     let json = params->S.reverseConvertToJsonOrThrow(Types.initializeParamsSchema)

--- a/libs/frontman-protocol/schemas/acp/implementation.json
+++ b/libs/frontman-protocol/schemas/acp/implementation.json
@@ -10,7 +10,7 @@
     "title": {
       "type": "string"
     },
-    "metadata": {}
+    "_meta": {}
   },
   "additionalProperties": true,
   "required": [

--- a/libs/frontman-protocol/schemas/acp/initializeParams.json
+++ b/libs/frontman-protocol/schemas/acp/initializeParams.json
@@ -45,7 +45,7 @@
         "title": {
           "type": "string"
         },
-        "metadata": {}
+        "_meta": {}
       },
       "additionalProperties": true,
       "required": [

--- a/libs/frontman-protocol/schemas/acp/initializeResult.json
+++ b/libs/frontman-protocol/schemas/acp/initializeResult.json
@@ -55,7 +55,7 @@
         "title": {
           "type": "string"
         },
-        "metadata": {}
+        "_meta": {}
       },
       "additionalProperties": true,
       "required": [

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -13,8 +13,9 @@ type implementation = {
   name: string,
   version: string,
   title: option<string>,
-  // Frontman extension: optional metadata for passing extra info (e.g., env key detection)
-  metadata: option<JSON.t>,
+  // ACP spec extensibility: optional metadata for passing extra info (e.g., env key detection)
+  @as("_meta")
+  _meta: option<JSON.t>,
 }
 
 // File system capabilities


### PR DESCRIPTION
## Summary

Closes #536

- Rename the custom `metadata` field to `_meta` on both the `implementation` type (`clientInfo`/`agentInfo`) and prompt-level params, aligning with the ACP spec's standard extensibility mechanism
- Add `@as("_meta")` annotation to the protocol type so the wire format matches the spec (consistent with the pattern already used on `annotations`, `embeddedResource`, and `contentBlock` types)
- Update server-side Elixir to read `"_meta"` instead of `"metadata"` from channel payloads

### Changed files (21)

**Protocol** — type definition + JSON schemas  
**Client library** — `makeConfig`, `sendPrompt`, protocol wire format  
**Client app** — reducer, provider, runtime config, state types  
**Server** — `tasks_channel.ex`, `task_channel.ex` extraction helpers  
**Tests** — all ReScript and Elixir test files updated

### Verification

- ReScript build: clean (628 modules)
- `libs/frontman-client` vitest: 63/63 passed
- `libs/client` vitest: 272/272 passed
- Elixir `mix compile`: clean
- Elixir tests require PostgreSQL (CI will validate)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
