### PR TITLE
fix(mcp): surface silently swallowed promise rejections in handleMessage

### DIFF
--- a/.changeset/fix-mcp-silent-error.md
+++ b/.changeset/fix-mcp-silent-error.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+### Fixed
+- **MCP `handleMessage` promise rejections are no longer silently swallowed** — async errors in the channel message handler are now caught, logged, and reported to Sentry instead of disappearing into an unhandled promise rejection that causes the agent to hang indefinitely.

--- a/libs/frontman-client/src/FrontmanClient__MCP.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP.res
@@ -82,18 +82,34 @@ let sendError = (handler: mcpHandler<'server>, id: int, code: int, message: stri
 
 // Handle initialize request
 let handleInitialize = (handler: mcpHandler<'server>, id: int, _params: option<JSON.t>): unit => {
-  let {serverInterface} = handler
-  let result = serverInterface.buildInitializeResult(serverInterface.server)
-  let resultJson = result->S.reverseConvertToJsonOrThrow(Types.initializeResultSchema)
-  sendResponse(handler, id, resultJson)
+  try {
+    let {serverInterface} = handler
+    let result = serverInterface.buildInitializeResult(serverInterface.server)
+    let resultJson = result->S.reverseConvertToJsonOrThrow(Types.initializeResultSchema)
+    sendResponse(handler, id, resultJson)
+  } catch {
+  | exn =>
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    Log.error(`Initialize failed: ${msg}`)
+    Sentry.captureException(exn, ~operation="mcp_initialize")
+    sendError(handler, id, Types.ErrorCode.serverError, `Initialize failed: ${msg}`)
+  }
 }
 
 // Handle tools/list request
 let handleToolsList = (handler: mcpHandler<'server>, id: int): unit => {
-  let {serverInterface} = handler
-  let result = serverInterface.buildToolsListResult(serverInterface.server)
-  let resultJson = result->S.reverseConvertToJsonOrThrow(Types.toolsListResultSchema)
-  sendResponse(handler, id, resultJson)
+  try {
+    let {serverInterface} = handler
+    let result = serverInterface.buildToolsListResult(serverInterface.server)
+    let resultJson = result->S.reverseConvertToJsonOrThrow(Types.toolsListResultSchema)
+    sendResponse(handler, id, resultJson)
+  } catch {
+  | exn =>
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    Log.error(`Tools list failed: ${msg}`)
+    Sentry.captureException(exn, ~operation="mcp_tools_list")
+    sendError(handler, id, Types.ErrorCode.serverError, `Tools list failed: ${msg}`)
+  }
 }
 
 // Handle tools/call request
@@ -136,24 +152,32 @@ let handleToolsCall = async (
 }
 
 // Handle incoming MCP message
+// Guaranteed to never reject — all exceptions are caught, logged, and reported to Sentry.
 let handleMessage = async (handler: mcpHandler<'server>, payload: JSON.t): unit => {
-  handler.onMessage->Option.forEach(cb => cb(Receive, payload))
+  try {
+    handler.onMessage->Option.forEach(cb => cb(Receive, payload))
 
-  switch parse(payload) {
-  | Ok(Request({id, method, params})) =>
-    switch method {
-    | "initialize" => handleInitialize(handler, id, params)
-    | "tools/list" => handleToolsList(handler, id)
-    | "tools/call" => await handleToolsCall(handler, id, params)
-    | _ => sendError(handler, id, Types.ErrorCode.methodNotFound, `Method not found: ${method}`)
+    switch parse(payload) {
+    | Ok(Request({id, method, params})) =>
+      switch method {
+      | "initialize" => handleInitialize(handler, id, params)
+      | "tools/list" => handleToolsList(handler, id)
+      | "tools/call" => await handleToolsCall(handler, id, params)
+      | _ => sendError(handler, id, Types.ErrorCode.methodNotFound, `Method not found: ${method}`)
+      }
+    | Ok(Notification({
+        method: "notifications/initialized",
+      })) => // Agent acknowledged initialization - nothing to do
+      ()
+    | Ok(Notification(_)) => // Other notifications - ignore for now
+      ()
+    | Error(msg) => Log.error(`Failed to parse MCP message: ${msg}`)
     }
-  | Ok(Notification({
-      method: "notifications/initialized",
-    })) => // Agent acknowledged initialization - nothing to do
-    ()
-  | Ok(Notification(_)) => // Other notifications - ignore for now
-    ()
-  | Error(msg) => Log.error(`Failed to parse MCP message: ${msg}`)
+  } catch {
+  | exn =>
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    Log.error(`Unhandled error in MCP message handler: ${msg}`)
+    Sentry.captureException(exn, ~operation="mcp_message_handler")
   }
 }
 

--- a/libs/frontman-client/test/FrontmanClient__MCP.test.res
+++ b/libs/frontman-client/test/FrontmanClient__MCP.test.res
@@ -65,10 +65,65 @@ let makeThrowingServerInterface = (errorMsg: string) => {
     buildInitializeResult: _ => Obj.magic(),
     buildToolsListResult: _ => Obj.magic(),
     executeTool: async (_, ~name as _, ~arguments as _, ~taskId as _, ~callId as _, ~onProgress as _) => {
-      Exn.raiseError(errorMsg)
+      JsError.throwWithMessage(errorMsg)
     },
   }
   si
+}
+
+// Build a JSON-RPC initialize request payload
+let buildInitializePayload = (~id: int) => {
+  let params = Dict.make()
+  params->Dict.set(
+    "protocolVersion",
+    JSON.Encode.string("DRAFT-2025-v3"),
+  )
+  params->Dict.set(
+    "capabilities",
+    JSON.Encode.object(Dict.make()),
+  )
+  let clientInfo = Dict.make()
+  clientInfo->Dict.set("name", JSON.Encode.string("test"))
+  clientInfo->Dict.set("version", JSON.Encode.string("1.0"))
+  params->Dict.set("clientInfo", JSON.Encode.object(clientInfo))
+
+  let msg = Dict.make()
+  msg->Dict.set("jsonrpc", JSON.Encode.string("2.0"))
+  msg->Dict.set("id", JSON.Encode.int(id))
+  msg->Dict.set("method", JSON.Encode.string("initialize"))
+  msg->Dict.set("params", JSON.Encode.object(params))
+  JSON.Encode.object(msg)
+}
+
+// Build a JSON-RPC tools/list request payload
+let buildToolsListPayload = (~id: int) => {
+  let msg = Dict.make()
+  msg->Dict.set("jsonrpc", JSON.Encode.string("2.0"))
+  msg->Dict.set("id", JSON.Encode.int(id))
+  msg->Dict.set("method", JSON.Encode.string("tools/list"))
+  JSON.Encode.object(msg)
+}
+
+// Helper: find a pushed response by JSON-RPC id
+let _findResponseById = (calls: ref<array<MockChannel.pushCall>>, id: int) => {
+  calls.contents->Array.find(p => {
+    switch p.payload->JSON.Decode.object {
+    | Some(obj) =>
+      switch obj->Dict.get("id") {
+      | Some(idJson) => idJson == JSON.Encode.int(id)
+      | None => false
+      }
+    | None => false
+    }
+  })
+}
+
+// Helper: check if a pushed response has an "error" field
+let _hasErrorField = (push: MockChannel.pushCall) => {
+  switch push.payload->JSON.Decode.object {
+  | Some(obj) => obj->Dict.get("error")->Option.isSome
+  | None => false
+  }
 }
 
 describe("handleToolsCall", () => {
@@ -161,13 +216,12 @@ describe("handleToolsCall", () => {
   })
 
   testAsync(
-    "BUG: non-S.Error exception in executeTool silently swallows MCP response",
+    "sends error response when executeTool throws non-S.Error exception",
     async t => {
-      // This test reproduces the exact bug:
       // When executeTool throws a non-S.Error (e.g., failwith from the reducer),
-      // the catch block in handleToolsCall only handles S.Error.
-      // The exception escapes the async function as an unhandled rejection,
-      // and NO MCP response is ever sent back to the server.
+      // handleMessage must catch it and send back a JSON-RPC error response.
+      // Before the fix, the exception escaped as an unhandled promise rejection
+      // and no response was ever sent — causing the agent to hang.
 
       let (channel, calls) = MockChannel.make()
 
@@ -182,32 +236,116 @@ describe("handleToolsCall", () => {
 
       let payload = buildToolsCallPayload(~id=77, ~name="question", ~callId="call_q1")
 
-      // This should NOT throw — the exception should be caught and an error response sent.
-      // Before the fix, this would be an unhandled rejection.
-      try {
-        await MCP.handleMessage(handler, payload)
-      } catch {
-      | _ => ()
+      // handleMessage should never reject — the top-level catch guarantees this
+      await MCP.handleMessage(handler, payload)
+
+      let responsePush = _findResponseById(calls, 77)
+      t->expect(responsePush->Option.isSome)->Expect.toBe(true)
+
+      switch responsePush {
+      | Some(push) => t->expect(_hasErrorField(push))->Expect.toBe(true)
+      | None => t->expect("error response")->Expect.toBe("found")
+      }
+    },
+  )
+})
+
+describe("handleMessage error safety", () => {
+  testAsync(
+    "sends error response when buildInitializeResult throws",
+    async t => {
+      let (channel, calls) = MockChannel.make()
+
+      let si: Types.serverInterface<unit> = {
+        server: (),
+        buildInitializeResult: _ => JsError.throwWithMessage("initialize exploded"),
+        buildToolsListResult: _ => Obj.magic(),
+        executeTool: async (_, ~name as _, ~arguments as _, ~taskId as _, ~callId as _, ~onProgress as _) =>
+          Obj.magic(),
       }
 
-      let pushes = calls.contents
+      let handler: MCP.mcpHandler<unit> = {
+        serverInterface: si,
+        channel,
+        sessionId: "test-task",
+        onMessage: None,
+      }
 
-      // EXPECTED: An error response should be pushed with id=77
-      // BUG: Before the fix, pushes is empty — no response sent at all
-      let responsePush = pushes->Array.find(p => {
-        switch p.payload->JSON.Decode.object {
-        | Some(obj) =>
-          switch obj->Dict.get("id") {
-          | Some(id) => id == JSON.Encode.int(77)
-          | None => false
-          }
-        | None => false
-        }
-      })
+      let payload = buildInitializePayload(~id=10)
 
-      t
-      ->expect(responsePush->Option.isSome)
-      ->Expect.toBe(true)
+      // Must resolve without rejecting — the exception is caught internally
+      await MCP.handleMessage(handler, payload)
+
+      // handleInitialize catches the error and sends a JSON-RPC error response
+      let responsePush = _findResponseById(calls, 10)
+      t->expect(responsePush->Option.isSome)->Expect.toBe(true)
+
+      switch responsePush {
+      | Some(push) => t->expect(_hasErrorField(push))->Expect.toBe(true)
+      | None => t->expect("error response")->Expect.toBe("found")
+      }
+    },
+  )
+
+  testAsync(
+    "sends error response when buildToolsListResult throws",
+    async t => {
+      let (channel, calls) = MockChannel.make()
+
+      let si: Types.serverInterface<unit> = {
+        server: (),
+        buildInitializeResult: _ => Obj.magic(),
+        buildToolsListResult: _ => JsError.throwWithMessage("tools list exploded"),
+        executeTool: async (_, ~name as _, ~arguments as _, ~taskId as _, ~callId as _, ~onProgress as _) =>
+          Obj.magic(),
+      }
+
+      let handler: MCP.mcpHandler<unit> = {
+        serverInterface: si,
+        channel,
+        sessionId: "test-task",
+        onMessage: None,
+      }
+
+      let payload = buildToolsListPayload(~id=20)
+
+      // Must resolve without rejecting
+      await MCP.handleMessage(handler, payload)
+
+      // handleToolsList catches the error and sends a JSON-RPC error response
+      let responsePush = _findResponseById(calls, 20)
+      t->expect(responsePush->Option.isSome)->Expect.toBe(true)
+
+      switch responsePush {
+      | Some(push) => t->expect(_hasErrorField(push))->Expect.toBe(true)
+      | None => t->expect("error response")->Expect.toBe("found")
+      }
+    },
+  )
+
+  testAsync(
+    "does not reject when onMessage callback throws",
+    async t => {
+      let (channel, _calls) = MockChannel.make()
+
+      let handler: MCP.mcpHandler<unit> = {
+        serverInterface: makeCompletedServerInterface({
+          content: [{type_: "text", text: "ok"}],
+          isError: None,
+          _meta: Types.emptyMeta,
+        }),
+        channel,
+        sessionId: "test-task",
+        onMessage: Some((_, _) => JsError.throwWithMessage("onMessage exploded")),
+      }
+
+      let payload = buildToolsCallPayload(~id=30, ~name="test", ~callId="call_1")
+
+      // Must resolve without rejecting
+      await MCP.handleMessage(handler, payload)
+
+      // onMessage threw before any processing happened, so no response pushed
+      t->expect(true)->Expect.toBe(true)
     },
   )
 })


### PR DESCRIPTION
## Summary

- Adds a top-level `try/catch` inside `handleMessage` so it is guaranteed to never reject — errors are logged and reported to Sentry
- Adds `try/catch` + `sendError` to `handleInitialize` and `handleToolsList` so they send proper JSON-RPC error responses (matching the existing `handleToolsCall` pattern)
- Protects **all callsites** (`attach` in `FrontmanClient__MCP.res` and `FrontmanClient__ACP.res`) without requiring each to add its own `.catch()`
- Adds tests reproducing the failure paths

## Problem

`handleMessage` is an `async` function whose returned promise was discarded via `->ignore` at every callsite. Multiple code paths inside it can throw (schema serialization in `handleInitialize`, `handleToolsList`, `sendError` itself), and none were protected at the top level. A rejected promise would fire a browser `unhandledrejection` event but: no MCP error response sent, no log, no user feedback, agent hangs indefinitely.

This pattern existed in two places:
- `FrontmanClient__MCP.res:170` (`attach`)
- `FrontmanClient__ACP.res:300`

## Fix

Three layers of defense, matching the existing `handleToolsCall` pattern:

1. **`handleInitialize` and `handleToolsList`** — each now has its own `try/catch` that sends a JSON-RPC error response with the request `id`. Previously these had no error handling at all.

2. **`handleMessage`** — top-level `try/catch` as a last-resort safety net for anything that escapes the inner handlers (e.g. `onMessage` callback throwing before parsing).

3. **Callsites** remain `handleMessage(...)->ignore` — safe because the function now never rejects.

## Tests

| Test | What it covers |
|---|---|
| `sends error response when executeTool throws non-S.Error exception` | Tool throws a runtime error → error response pushed (was silent hang) |
| `sends error response when buildInitializeResult throws` | Schema serialization in initialize path → error response pushed |
| `sends error response when buildToolsListResult throws` | Schema serialization in tools/list path → error response pushed |
| `does not reject when onMessage callback throws` | User-provided callback throws → caught by outer handler |

Closes #410