### PR TITLE
fix: infinite reload loop with locale middleware — 4 root causes fixed (#605)

### DIFF
--- a/.changeset/fix-stripsuffix-infinite-reload-loop.md
+++ b/.changeset/fix-stripsuffix-infinite-reload-loop.md
@@ -1,0 +1,11 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/nextjs": patch
+---
+
+### Fixed
+- **Infinite reload loop with locale-based URL rewriting middleware** — four root causes fixed for apps using locale middleware (e.g. `next-intl`, `@formatjs/intl`):
+  - `stripSuffix` unconditionally appended a trailing slash to every path even without a `/frontman` suffix, causing false-positive navigate intercepts. A new `hasSuffix` predicate now gates the intercept correctly.
+  - Server-side redirects (e.g. `/en/` → `/en`) fire a `navigate` event before `onLoad`, causing a trailing-slash difference in the `url` prop to reload the iframe while `hasLoaded` was still `false`. The url-prop effect now normalizes trailing slashes before comparing.
+  - Session restore mounted all persisted task iframes eagerly (20+ concurrent requests). Inactive iframes now start with `src=""` and load lazily on first activation.
+  - The generated `proxy.ts` (Next.js ≥16) used a path guard that missed `/en/frontman/` (the trailing-slash URL written by `syncBrowserUrl`). The template now delegates directly to the core middleware via `await frontman(req)`, matching the `middleware.ts` pattern. The `/:path*/frontman/` matcher is also added to all generated configs.

--- a/libs/client/src/Client__Hooks.res
+++ b/libs/client/src/Client__Hooks.res
@@ -276,11 +276,11 @@ let useIFrameLocation = (~iframeElement: option<WebAPI.DOMAPI.element>, ~attachm
                 // If the iframe is trying to navigate to a /frontman URL, intercept
                 // and redirect to the stripped version so we never load frontman-in-frontman.
                 let parsed = WebAPI.URL.make(~url=resolvedDestinationUrl)
-                let cleanPath = Client__BrowserUrl.stripSuffix(parsed.pathname)
-                switch cleanPath != parsed.pathname {
+                switch Client__BrowserUrl.hasSuffix(parsed.pathname) {
                 | false => setLocation(_ => Some(resolvedDestinationUrl))
                 | true =>
                   WebAPI.Event.preventDefault(ev)
+                  let cleanPath = Client__BrowserUrl.stripSuffix(parsed.pathname)
                   let cleanUrl = `${parsed.origin}${cleanPath}`
                   iframeWindow->WebAPI.Window.location->WebAPI.Location.assign(cleanUrl)
                 }

--- a/libs/client/src/webpreview/Client__BrowserUrl.res
+++ b/libs/client/src/webpreview/Client__BrowserUrl.res
@@ -38,22 +38,47 @@ let _getBasePath: unit => string = {
 // Returns the URL suffix including the leading slash (e.g. "/frontman").
 let suffix = () => `/${_getBasePath()}`
 
+// Strip a single trailing slash from a URL or pathname, unless it's just "/".
+// Used to normalize trailing-slash variants (e.g. /en and /en/) so they are
+// treated as the same destination for comparison and URL building purposes.
+let removeTrailingSlash = s =>
+  switch s->String.endsWith("/") && String.length(s) > 1 {
+  | true => s->String.slice(~start=0, ~end=String.length(s) - 1)
+  | false => s
+  }
+
 // Escape regex metacharacters in a string so it can be safely interpolated
 // into a dynamically-built RegExp.
 let _escapeRegex = s =>
   s->String.replaceRegExp(%re("/[.*+?^${}()|[\\]\\\\]/g"), "\\$&")
 
-// Strip trailing /<basePath> segments from a pathname, preserving a trailing
-// slash so the resulting URL matches Astro's trailingSlash: "always" default.
-let stripSuffix = pathname => {
+// Returns true if pathname contains one or more trailing /<basePath> segments.
+// Pure predicate — does not mutate the path.
+let hasSuffix = pathname => {
   let sfx = _getBasePath()->_escapeRegex
   let re = RegExp.fromString(`(\\/${sfx})+\\/?$`)
-  switch pathname->String.replaceRegExp(re, "") {
-  | "" => "/"
-  | p =>
-    switch p->String.endsWith("/") {
-    | true => p
-    | false => p ++ "/"
+  re->RegExp.test(pathname)
+}
+
+// Strip trailing /<basePath> segments from a pathname. When a suffix is
+// present, the result is normalized with a trailing slash to match Astro's
+// trailingSlash: "always" default. When no suffix is present the original
+// pathname is returned unchanged — no trailing slash is added — to avoid
+// false positives in callers that use string equality to detect mutations
+// (e.g. the useIFrameLocation navigate intercept).
+let stripSuffix = pathname => {
+  switch hasSuffix(pathname) {
+  | false => pathname
+  | true =>
+    let sfx = _getBasePath()->_escapeRegex
+    let re = RegExp.fromString(`(\\/${sfx})+\\/?$`)
+    switch pathname->String.replaceRegExp(re, "") {
+    | "" => "/"
+    | p =>
+      switch p->String.endsWith("/") {
+      | true => p
+      | false => p ++ "/"
+      }
     }
   }
 }
@@ -117,9 +142,9 @@ let isSameOriginWithBase = (~baseUrl: string, ~targetUrl: string): bool => {
 // The preview URL is guaranteed clean (no /<basePath> suffix) by useIFrameLocation.
 let syncBrowserUrl = (~previewUrl) => {
   let basePath = _getBasePath()
-  let pathname = WebAPI.URL.make(~url=previewUrl).pathname->String.replaceRegExp(%re("/\/$/"), "")
+  let pathname = WebAPI.URL.make(~url=previewUrl).pathname->removeTrailingSlash
   let newPath = switch pathname {
-  | "" => `/${basePath}/`
+  | "" | "/" => `/${basePath}/`
   | p => `${p}/${basePath}/`
   }
   switch WebAPI.Global.location.pathname == newPath {

--- a/libs/client/src/webpreview/Client__WebPreview__Body.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Body.res
@@ -3,19 +3,45 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
   let iframeRef: React.ref<Nullable.t<Dom.element>> = React.useRef(Nullable.null)
   let (iframeElement, setIframeElement): (option<WebAPI.DOMAPI.element>, _) = React.useState(() => None)
   let (attachmentKey, setAttachmentKey) = React.useState(() => 0)
-  let (iframeSrc, setIframeSrc) = React.useState(() => url)
+  // Inactive iframes start with about:blank so the browser doesn't eagerly load
+  // the URL for every persisted task on startup. Using "" would resolve to the
+  // current document URL (the Frontman shell itself), causing each inactive iframe
+  // to load the parent page. The src is replaced with the real URL on first
+  // activation via the isActive effect below.
+  let (iframeSrc, setIframeSrc) = React.useState(() => isActive ? url : "about:blank")
   let (hasLoaded, setHasLoaded) = React.useState(() => false)
   let lastLocationRef: React.ref<option<string>> = React.useRef(None)
   let trackedIframeElement = isActive ? iframeElement : None
   let location = Client__Hooks.useIFrameLocation(~iframeElement=trackedIframeElement, ~attachmentKey)
 
+  // Sync iframeSrc when the url prop changes externally (nav bar, task creation)
+  // while the iframe hasn't loaded yet. Only applies when iframeSrc is already
+  // populated (i.e. the iframe has been activated). Trailing-slash differences are
+  // ignored — locale middleware may redirect between /en and /en/ before onLoad.
   React.useEffect(() => {
     switch hasLoaded {
-    | false => setIframeSrc(prev => prev == url ? prev : url)
     | true => ()
+    | false =>
+      setIframeSrc(prev =>
+        switch prev {
+        | "about:blank" => prev  // not yet activated — wait for isActive effect
+        | _ =>
+          Client__BrowserUrl.removeTrailingSlash(prev) == Client__BrowserUrl.removeTrailingSlash(url) ? prev : url
+        }
+      )
     }
     None
   }, (url, hasLoaded))
+
+  // Populate src on first activation so the iframe starts loading.
+  React.useEffect(() => {
+    switch isActive {
+    | false => ()
+    | true =>
+      setIframeSrc(prev => prev == "about:blank" ? url : prev)
+    }
+    None
+  }, [isActive])
 
   React.useEffect(() => {
     switch isActive {
@@ -46,23 +72,31 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
   }, (location, isActive))
 
   let onLoad = (_e: JsxEvent.Image.t) => {
-    setHasLoaded(_ => true)
-    setAttachmentKey(prev => prev + 1)
-    switch isActive {
-    | false => ()
-    | true =>
-      iframeRef.current
-      ->Nullable.toOption
-      ->Option.forEach(iframe => {
-        let iframeElement = iframe->Obj.magic
-        try {
-          let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
-          let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
-          Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
-        } catch {
-        | _ => ()
-        }
-      })
+    // Skip onLoad handling when about:blank loads. Browsers fire load for
+    // about:blank, but we don't want to mark the iframe as loaded until the
+    // real URL has loaded — otherwise hasLoaded=true would disable the
+    // url-prop sync effect before the actual page load completes.
+    switch iframeSrc {
+    | "about:blank" => ()
+    | _ =>
+      setHasLoaded(_ => true)
+      setAttachmentKey(prev => prev + 1)
+      switch isActive {
+      | false => ()
+      | true =>
+        iframeRef.current
+        ->Nullable.toOption
+        ->Option.forEach(iframe => {
+          let iframeElement = iframe->Obj.magic
+          try {
+            let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
+            let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
+            Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
+          } catch {
+          | _ => ()
+          }
+        })
+      }
     }
   }
 

--- a/libs/client/test/Client__BrowserUrl.test.res
+++ b/libs/client/test/Client__BrowserUrl.test.res
@@ -1,0 +1,122 @@
+open Vitest
+
+// _getBasePath() falls back to "frontman" in test environments (no window.__frontmanRuntime).
+// All cases below use "frontman" as the basePath.
+
+module BrowserUrl = Client__BrowserUrl
+
+// ── hasSuffix ────────────────────────────────────────────────────────────
+
+describe("hasSuffix", () => {
+  test("detects exact suffix", t => {
+    t->expect(BrowserUrl.hasSuffix("/frontman"))->Expect.toBe(true)
+  })
+
+  test("detects suffix with trailing slash", t => {
+    t->expect(BrowserUrl.hasSuffix("/frontman/"))->Expect.toBe(true)
+  })
+
+  test("detects suffix with path prefix", t => {
+    t->expect(BrowserUrl.hasSuffix("/blog/frontman"))->Expect.toBe(true)
+  })
+
+  test("detects suffix with path prefix and trailing slash", t => {
+    t->expect(BrowserUrl.hasSuffix("/blog/frontman/"))->Expect.toBe(true)
+  })
+
+  test("detects double suffix", t => {
+    t->expect(BrowserUrl.hasSuffix("/frontman/frontman"))->Expect.toBe(true)
+  })
+
+  test("returns false for locale path without trailing slash — the bug case", t => {
+    t->expect(BrowserUrl.hasSuffix("/en"))->Expect.toBe(false)
+  })
+
+  test("returns false for locale path with trailing slash", t => {
+    t->expect(BrowserUrl.hasSuffix("/en/"))->Expect.toBe(false)
+  })
+
+  test("returns false for root", t => {
+    t->expect(BrowserUrl.hasSuffix("/"))->Expect.toBe(false)
+  })
+
+  test("returns false for clean path without trailing slash", t => {
+    t->expect(BrowserUrl.hasSuffix("/blog"))->Expect.toBe(false)
+  })
+
+  test("returns false for partial match (no leading slash before basePath)", t => {
+    t->expect(BrowserUrl.hasSuffix("/notfrontman"))->Expect.toBe(false)
+  })
+})
+
+// ── stripSuffix ──────────────────────────────────────────────────────────
+
+describe("stripSuffix", () => {
+  // When suffix is present — should strip and add trailing slash
+
+  test("strips exact suffix to root", t => {
+    t->expect(BrowserUrl.stripSuffix("/frontman"))->Expect.toBe("/")
+  })
+
+  test("strips suffix with trailing slash to root", t => {
+    t->expect(BrowserUrl.stripSuffix("/frontman/"))->Expect.toBe("/")
+  })
+
+  test("strips suffix preserving path prefix", t => {
+    t->expect(BrowserUrl.stripSuffix("/blog/frontman"))->Expect.toBe("/blog/")
+  })
+
+  test("strips suffix with trailing slash preserving path prefix", t => {
+    t->expect(BrowserUrl.stripSuffix("/blog/frontman/"))->Expect.toBe("/blog/")
+  })
+
+  test("strips double suffix", t => {
+    t->expect(BrowserUrl.stripSuffix("/frontman/frontman"))->Expect.toBe("/")
+  })
+
+  // When no suffix present — must return original pathname unchanged (the bug fix)
+
+  test("returns locale path unchanged — no trailing slash added", t => {
+    t->expect(BrowserUrl.stripSuffix("/en"))->Expect.toBe("/en")
+  })
+
+  test("returns locale path with trailing slash unchanged", t => {
+    t->expect(BrowserUrl.stripSuffix("/en/"))->Expect.toBe("/en/")
+  })
+
+  test("returns root unchanged", t => {
+    t->expect(BrowserUrl.stripSuffix("/"))->Expect.toBe("/")
+  })
+
+  test("returns clean path without trailing slash unchanged", t => {
+    t->expect(BrowserUrl.stripSuffix("/blog"))->Expect.toBe("/blog")
+  })
+
+  test("returns partial match unchanged", t => {
+    t->expect(BrowserUrl.stripSuffix("/notfrontman"))->Expect.toBe("/notfrontman")
+  })
+})
+
+// ── removeTrailingSlash ──────────────────────────────────────────────────
+
+describe("removeTrailingSlash", () => {
+  test("removes trailing slash from path", t => {
+    t->expect(BrowserUrl.removeTrailingSlash("/en/"))->Expect.toBe("/en")
+  })
+
+  test("removes trailing slash from nested path", t => {
+    t->expect(BrowserUrl.removeTrailingSlash("/blog/post/"))->Expect.toBe("/blog/post")
+  })
+
+  test("leaves path without trailing slash unchanged", t => {
+    t->expect(BrowserUrl.removeTrailingSlash("/en"))->Expect.toBe("/en")
+  })
+
+  test("leaves root slash unchanged", t => {
+    t->expect(BrowserUrl.removeTrailingSlash("/"))->Expect.toBe("/")
+  })
+
+  test("removes trailing slash from full URL", t => {
+    t->expect(BrowserUrl.removeTrailingSlash("http://localhost:3000/en/"))->Expect.toBe("http://localhost:3000/en")
+  })
+})

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
@@ -37,7 +37,7 @@ export async function middleware(req: NextRequest) {
 
 export const config = {
   runtime: 'nodejs',
-  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman'],
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/'],
 };
 `
 
@@ -50,16 +50,15 @@ const frontman = createMiddleware({
   host: '${host}',
 });
 
-export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
-  if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {
-    return frontman(req) || NextResponse.next();
-  }
+export async function proxy(req: NextRequest): Promise<NextResponse> {
+  const response = await frontman(req);
+  if (response) return response;
   return NextResponse.next();
 }
 
 export const config = {
   runtime: 'nodejs',
-  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman'],
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/'],
 };
 `
 
@@ -109,7 +108,7 @@ module ManualInstructions = {
   ${bar}
   ${bar}     ${d("export const config = {")}
   ${bar}     ${d("  runtime: 'nodejs',")}
-  ${bar}     ${d("  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],")}
+  ${bar}     ${d("  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/', ...yourExistingMatchers],")}
   ${bar}     ${d("};")}
   ${bar}
   ${bar}  ${b("Docs:")} ${d("https://frontman.sh/docs/nextjs")}
@@ -136,15 +135,16 @@ module ManualInstructions = {
   ${bar}
   ${bar}  ${s("3.")} In your proxy function, add Frontman handler as the ${b("very first lines")}:
   ${bar}
-     ${bar}     ${d("if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {")}
-  ${bar}     ${d("  return frontman(req) || NextResponse.next();")}
-  ${bar}     ${d("}")}
+  ${bar}     ${d("const response = await frontman(req);")}
+  ${bar}     ${d("if (response) return response;")}
+  ${bar}
+  ${bar}     ${d("// Must run before auth, redirects, or other proxy logic")}
   ${bar}
   ${bar}  ${s("4.")} Update your config to use Node.js runtime and include Frontman routes:
   ${bar}
   ${bar}     ${d("export const config = {")}
   ${bar}     ${d("  runtime: 'nodejs',")}
-  ${bar}     ${d("  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],")}
+  ${bar}     ${d("  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/', ...yourExistingMatchers],")}
   ${bar}     ${d("};")}
   ${bar}
   ${bar}  ${b("Docs:")} ${d("https://frontman.sh/docs/nextjs")}
@@ -215,7 +215,7 @@ Add the following to your ${fileName}:
 
       export const config = {
         runtime: 'nodejs',
-        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],
+        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/', ...yourExistingMatchers],
       };
 
 For full documentation, see: https://frontman.sh/docs/nextjs
@@ -239,14 +239,13 @@ Add the following to your ${fileName}:
 
   3. In your proxy function, add as the VERY FIRST lines (before any other logic):
 
-       export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
+       export async function proxy(req: NextRequest): Promise<NextResponse> {
          // Frontman MUST run first — before auth, redirects, or any other proxy logic
-         if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/') || req.nextUrl.pathname.endsWith('/frontman')) {
-          return frontman(req) || NextResponse.next();
-        }
+         const response = await frontman(req);
+         if (response) return response;
 
-        // ... your existing proxy logic
-      }
+         // ... your existing proxy logic
+       }
 
      IMPORTANT: The Frontman handler must execute before any other proxy
      logic (auth checks, redirects, rewrites, etc.) so it can intercept its
@@ -256,7 +255,7 @@ Add the following to your ${fileName}:
 
       export const config = {
         runtime: 'nodejs',
-        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', ...yourExistingMatchers],
+        matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/', ...yourExistingMatchers],
       };
 
 For full documentation, see: https://frontman.sh/docs/nextjs

--- a/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
+++ b/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
@@ -453,7 +453,7 @@ describe("Next.js 16 Clean Install", _t => {
     | Some(c) =>
       t->expect(c->String.includes("@frontman-ai/nextjs"))->Expect.toBe(true)
       t->expect(c->String.includes("host: 'test.frontman.dev'"))->Expect.toBe(true)
-      t->expect(c->String.includes("export function proxy"))->Expect.toBe(true)
+      t->expect(c->String.includes("function proxy"))->Expect.toBe(true)
       t->expect(c->String.includes("matcher"))->Expect.toBe(true)
       t->expect(c->String.includes("/frontman"))->Expect.toBe(true)
     | None => t->expect("proxy.ts")->Expect.toBe("should exist")


### PR DESCRIPTION
## Summary

Fixes #605 — infinite reload loop and excessive concurrent iframe loads when Frontman is installed in a Next.js app that uses locale-based URL rewriting middleware (e.g. `next-intl`, `@formatjs/intl`).

Four root causes were identified and fixed across the client bundle and the Next.js integration CLI templates.

---

## Root Causes & Fixes

### 1. `hasSuffix` false positive in navigate intercept (`libs/client`)

`stripSuffix` unconditionally appended a trailing slash to any pathname, even when no `/frontman` suffix was present. The navigate intercept used `stripSuffix(pathname) != pathname` as a proxy for "this URL has a suffix" — so any clean path without a trailing slash (e.g. `/en` from locale middleware) triggered `location.assign`, which the locale middleware redirected back, creating an infinite loop.

**Fix:** Added `hasSuffix: string => bool` as a pure predicate using `RegExp.test`. The intercept now gates on `hasSuffix` — only fires when the suffix is genuinely present. `stripSuffix` returns the pathname unchanged when no suffix is found.

### 2. Trailing-slash race in `url-prop effect` (`libs/client`)

When a server-side redirect fires (e.g. locale middleware `/en/` → `/en`), the Navigation API fires a `navigate` event **before** `onLoad`. This caused `setPreviewUrl` to update the `url` prop (e.g. from `/en/` to `/en`) while `hasLoaded` was still `false`. The `url-prop effect` would then call `setIframeSrc` with the new URL, reloading the iframe, which triggered another redirect → another navigate event → infinite loop.

**Fix:** Normalize trailing slashes in the `url-prop effect` comparison so `/en` and `/en/` are treated as the same destination and don't trigger a reload.

### 3. Inactive task iframes eagerly loading on session restore (`libs/client`)

When sessions are restored from the server, every persisted task gets a hidden `Client__WebPreview__Body` iframe. Previously all of them started with `src=url`, causing the browser to fire 20+ concurrent requests (and open 20+ HMR WebSocket connections) immediately on load — one per task.

**Fix:** Inactive iframes now start with `src=""` and only have their `src` populated when they first become active (`isActive` transitions to `true`). Background task loads are deferred until the user actually switches to that task.

### 4. `proxy.ts` template path guard — fragile and incomplete (`libs/frontman-nextjs`)

The generated `proxy.ts` (Next.js ≥16) used an explicit `if (pathname.endsWith('/frontman'))` guard before calling `frontman(req)`. This missed `/en/frontman/` (locale prefix + trailing slash) — the exact URL that `syncBrowserUrl` writes to `window.location`. A hard-reload at that URL fell through to the user's locale middleware, which double-prefixed it (e.g. `/en/en/frontman/`) → 404. Additionally, `frontman(req) || NextResponse.next()` was subtly wrong — `frontman` returns `Promise<Option<Response>>`, which is always truthy, making `NextResponse.next()` dead code.

**Fix:** `proxy.ts` template now mirrors `middleware.ts` exactly — `await frontman(req); if (response) return response; return NextResponse.next()`. The core middleware already handles all path variants internally (including trailing slashes) via `isFrontmanRoute`, so no explicit guard is needed. Also adds `/:path*/frontman/` to the matcher in all generated templates and manual setup instructions.

---

## Changes

| File | Change |
|---|---|
| `libs/client/src/webpreview/Client__BrowserUrl.res` | Add `hasSuffix`, fix `stripSuffix` to return unchanged when no suffix present |
| `libs/client/src/Client__Hooks.res` | Gate navigate intercept on `hasSuffix` instead of string comparison |
| `libs/client/src/webpreview/Client__WebPreview__Body.res` | Trailing-slash normalization in `url-prop effect`; defer inactive iframe src until first activation |
| `libs/client/test/Client__BrowserUrl.test.res` | 20 new tests for `hasSuffix` and `stripSuffix` including all bug-case inputs |
| `libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res` | `proxy.ts` template uses `await` pattern; `/:path*/frontman/` added to all matchers and instructions |
| `.changeset/fix-stripsuffix-infinite-reload-loop.md` | Patch changeset |

## Tests

310/310 passing. New tests explicitly cover:
- `hasSuffix("/en")` → `false` (root cause of bug 1)
- `stripSuffix("/en")` → `"/en"` unchanged (no trailing slash added)
- All suffix-present cases continue to work correctly