### PR TITLE
refactor(client): remove dead "Calling " prefix stripping from tool label helpers

### DIFF
--- a/.changeset/remove-calling-prefix-stripping.md
+++ b/.changeset/remove-calling-prefix-stripping.md
@@ -1,0 +1,5 @@
+---
+"@frontman/client": patch
+---
+
+Remove dead "Calling " prefix stripping from tool label helpers. No production server code sends tool names with this prefix; the branches were unreachable legacy code.

--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -11,15 +11,8 @@
 module Message = Client__State__Types.Message
 module ToolLabels = Client__ToolLabels
 
-// Strip "Calling " prefix from legacy server format and lowercase
-let cleanToolName = (toolName: string): string => {
-  let lower = String.toLowerCase(toolName)
-  if String.startsWith(lower, "calling ") {
-    String.slice(lower, ~start=8, ~end=String.length(lower))
-  } else {
-    lower
-  }
-}
+// Normalize tool name for comparison
+let cleanToolName = (toolName: string): string => String.toLowerCase(toolName)
 
 // Tools that show a target inline (path, URL, etc.) instead of expandable body
 let isInlineTool = (toolName: string): bool => {

--- a/libs/client/src/components/frontman/Client__ToolLabels.res
+++ b/libs/client/src/components/frontman/Client__ToolLabels.res
@@ -8,25 +8,17 @@
 /**
  * Convert snake_case tool name to Title Case for display
  * e.g., "get_routes" -> "Get Routes", "write_file" -> "Write File"
- * Also strips "Calling " prefix if present (legacy server format)
  */
 let toTitleCase = (str: string): string => {
-  // Strip "Calling " prefix if present (legacy server format)
-  let cleanStr = if String.startsWith(str, "Calling ") {
-    String.slice(str, ~start=8, ~end=String.length(str))
-  } else {
-    str
-  }
-  
-  cleanStr
+  str
   ->String.split("_")
   ->Array.map(word => {
-    if String.length(word) > 0 {
+    switch String.length(word) > 0 {
+    | true =>
       let first = word->String.charAt(0)->String.toUpperCase
       let rest = word->String.slice(~start=1, ~end=String.length(word))->String.toLowerCase
       first ++ rest
-    } else {
-      word
+    | false => word
     }
   })
   ->Array.join(" ")

--- a/libs/client/test/Client__ToolCallBlock.test.res
+++ b/libs/client/test/Client__ToolCallBlock.test.res
@@ -3,8 +3,8 @@ open Vitest
 module ToolCallBlock = Client__ToolCallBlock
 
 describe("cleanToolName", _t => {
-  test("strips 'Calling ' prefix and lowercases", t => {
-    t->expect(ToolCallBlock.cleanToolName("Calling write_file"))->Expect.toBe("write_file")
+  test("lowercases without stripping any prefix", t => {
+    t->expect(ToolCallBlock.cleanToolName("Calling write_file"))->Expect.toBe("calling write_file")
   })
 
   test("lowercases without prefix", t => {
@@ -34,10 +34,6 @@ describe("isInlineTool", _t => {
     t->expect(ToolCallBlock.isInlineTool("consoleLog"))->Expect.toBe(false)
   })
 
-  test("handles legacy 'Calling ' prefix", t => {
-    t->expect(ToolCallBlock.isInlineTool("Calling write_file"))->Expect.toBe(true)
-    t->expect(ToolCallBlock.isInlineTool("Calling navigate"))->Expect.toBe(true)
-  })
 })
 
 describe("isFileTool", _t => {


### PR DESCRIPTION
## Summary

- Removes unreachable `"Calling "` prefix stripping from `toTitleCase` (`Client__ToolLabels.res:13`) and `cleanToolName` (`Client__ToolCallBlock.res:15`) — no production server code sends tool names with this prefix
- Converts the inner `if/else` on word length in `toTitleCase` to `switch` per project conventions
- `cleanToolName` simplified to a one-liner

~10 lines removed, zero behavior change.

Closes #597
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
