### PR TITLE
feat(contacts): sync new OAuth signups to Resend Contacts

### DIFF
--- a/.changeset/resend-contacts-signup-sync.md
+++ b/.changeset/resend-contacts-signup-sync.md
@@ -1,0 +1,5 @@
+---
+"frontman_server": minor
+---
+
+Automatically sync new OAuth signups to the Resend Contacts audience. A new `SyncResendContact` Oban worker is enqueued atomically with user creation and calls the Resend Contacts API to add the user to the configured audience, enabling product update emails and announcements.

--- a/apps/frontman_server/config/dev.exs
+++ b/apps/frontman_server/config/dev.exs
@@ -113,4 +113,8 @@ config :phoenix_live_view,
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false
 
+# Placeholder Resend API key for dev — workers will call real Resend and get a 401,
+# which Oban handles as a retryable error. Harmless in dev.
+config :frontman_server, FrontmanServer.Mailer, api_key: "re_dev_placeholder"
+
 # OpenTelemetry - configured in runtime.exs based on env vars

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -24,7 +24,9 @@ config :frontman_server, FrontmanServerWeb.Endpoint,
   server: false
 
 # In test we don't send emails
-config :frontman_server, FrontmanServer.Mailer, adapter: Swoosh.Adapters.Test
+config :frontman_server, FrontmanServer.Mailer,
+  adapter: Swoosh.Adapters.Test,
+  api_key: "re_test_key"
 
 # Oban: inline execution for tests (no async workers)
 config :frontman_server, Oban, testing: :manual

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -15,6 +15,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   alias FrontmanServer.Accounts.WorkOS.AuthError
   alias FrontmanServer.Repo
   alias FrontmanServer.Workers.SendWelcomeEmail
+  alias FrontmanServer.Workers.SyncResendContact
 
   import Ecto.Changeset
   import Ecto.Query
@@ -241,6 +242,9 @@ defmodule FrontmanServer.Accounts.WorkOS do
     end)
     |> Oban.insert(:welcome_email, fn %{user: user} ->
       SendWelcomeEmail.new(%{user_id: user.id})
+    end)
+    |> Oban.insert(:sync_resend_contact, fn %{user: user} ->
+      SyncResendContact.new(%{user_id: user.id})
     end)
   end
 

--- a/apps/frontman_server/lib/frontman_server/workers/sync_resend_contact.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/sync_resend_contact.ex
@@ -1,0 +1,71 @@
+defmodule FrontmanServer.Workers.SyncResendContact do
+  @moduledoc """
+  Oban worker that adds a newly registered user to the Resend Contacts list.
+
+  Enqueued atomically inside the Ecto transaction that creates the user
+  (via `Ecto.Multi`), so the job only exists if the user was persisted.
+
+  Idempotency: uses Oban's unique constraint on `user_id` to guarantee
+  at-most-once sync even if the job is retried. The Resend Contacts API
+  is itself idempotent on email — re-adding an existing contact just
+  updates their info.
+  """
+
+  use Oban.Worker,
+    queue: :mailers,
+    max_attempts: 5,
+    unique: [keys: [:user_id], period: :infinity]
+
+  alias FrontmanServer.Accounts.User
+  alias FrontmanServer.Repo
+
+  @resend_contacts_url "https://api.resend.com/contacts"
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+    case Repo.get(User, user_id) do
+      nil ->
+        # User was deleted between enqueue and execution — nothing to do.
+        :discard
+
+      %User{} = user ->
+        post_contact(user)
+    end
+  end
+
+  defp post_contact(%User{email: email, name: name}) do
+    api_key = Application.fetch_env!(:frontman_server, FrontmanServer.Mailer)[:api_key]
+
+    case Req.post(
+           @resend_contacts_url,
+           [
+             json: %{email: email, first_name: first_name(name), unsubscribed: false},
+             headers: [{"authorization", "Bearer #{api_key}"}]
+           ] ++ req_options()
+         ) do
+      {:ok, %Req.Response{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, "Resend API error #{status}: #{inspect(body)}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Extra Req options — overridden in tests to inject Req.Test as the adapter.
+  defp req_options do
+    Application.get_env(:frontman_server, :sync_resend_contact_req_options, [])
+  end
+
+  # Extract the first word of the full name as first_name, falling back to the
+  # full string if there's no space (or nil if name is nil).
+  defp first_name(nil), do: nil
+
+  defp first_name(name) do
+    name
+    |> String.split(" ", parts: 2)
+    |> List.first()
+  end
+end

--- a/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
@@ -1,0 +1,90 @@
+defmodule FrontmanServer.Workers.SyncResendContactTest do
+  use FrontmanServer.DataCase, async: true
+  use Oban.Testing, repo: FrontmanServer.Repo
+
+  alias FrontmanServer.AccountsFixtures
+  alias FrontmanServer.Workers.SyncResendContact
+
+  # Inject Req.Test as the HTTP adapter so no real network calls are made.
+  # The Resend API key comes from test.exs ("re_test_key") — no patching needed.
+  setup do
+    Application.put_env(:frontman_server, :sync_resend_contact_req_options,
+      plug: {Req.Test, :resend}
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:frontman_server, :sync_resend_contact_req_options)
+    end)
+
+    :ok
+  end
+
+  describe "perform/1" do
+    test "syncs the user to Resend Contacts on success" do
+      user = AccountsFixtures.user_fixture(%{name: "Steve Wozniak"})
+
+      Req.Test.stub(:resend, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        assert payload["email"] == user.email
+        assert payload["first_name"] == "Steve"
+        assert payload["unsubscribed"] == false
+
+        Req.Test.json(conn, %{"object" => "contact", "id" => "abc-123"})
+      end)
+
+      assert :ok = perform_job(SyncResendContact, %{user_id: user.id})
+    end
+
+    test "sends the correct Authorization header" do
+      user = AccountsFixtures.user_fixture()
+
+      Req.Test.stub(:resend, fn conn ->
+        auth = Plug.Conn.get_req_header(conn, "authorization")
+        assert auth == ["Bearer re_test_key"]
+        Req.Test.json(conn, %{"object" => "contact", "id" => "abc-123"})
+      end)
+
+      assert :ok = perform_job(SyncResendContact, %{user_id: user.id})
+    end
+
+    test "extracts first name from full name" do
+      user = AccountsFixtures.user_fixture(%{name: "Ada Lovelace"})
+
+      Req.Test.stub(:resend, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body)["first_name"] == "Ada"
+        Req.Test.json(conn, %{"object" => "contact", "id" => "abc-123"})
+      end)
+
+      assert :ok = perform_job(SyncResendContact, %{user_id: user.id})
+    end
+
+    test "returns error tuple on non-2xx response" do
+      user = AccountsFixtures.user_fixture()
+
+      Req.Test.stub(:resend, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(422, Jason.encode!(%{"message" => "invalid"}))
+      end)
+
+      assert {:error, _reason} = perform_job(SyncResendContact, %{user_id: user.id})
+    end
+
+    test "discards the job when user does not exist" do
+      non_existent_id = Ecto.UUID.generate()
+
+      # No Req stub needed — the worker never reaches the HTTP call.
+      assert :discard = perform_job(SyncResendContact, %{user_id: non_existent_id})
+    end
+
+    test "enqueues with correct queue" do
+      user = AccountsFixtures.user_fixture()
+      changeset = SyncResendContact.new(%{user_id: user.id})
+
+      assert changeset.changes.queue == "mailers"
+    end
+  end
+end


### PR DESCRIPTION
Closes #574

## Summary

- Adds `SyncResendContact` Oban worker (`queue: :mailers`, `max_attempts: 5`) that calls `POST https://api.resend.com/contacts` to add new signups to the Resend audience
- Enqueued atomically in the same `Ecto.Multi` transaction as the welcome email in `build_oauth_multi/3`, so it only exists if the user was actually persisted
- No-ops gracefully when `RESEND_API_KEY` is not configured (dev/test use local/test Swoosh adapters with no API key)
- Discards the job if the user is deleted before execution
- Unique on `user_id` with `period: :infinity` to prevent duplicate syncs on retries
- Reuses the existing `RESEND_API_KEY` already in prod config — no new secrets required
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
