### PR TITLE
refactor: typed variant for MCP toolResultContent type_ field (#187)

### DIFF
--- a/.changeset/mcp-tool-result-content-type.md
+++ b/.changeset/mcp-tool-result-content-type.md
@@ -1,0 +1,7 @@
+---
+"@frontman/frontman-protocol": minor
+"@frontman/frontman-core": patch
+"@frontman/client": patch
+---
+
+Replace raw string `type_` field in `toolResultContent` with a typed `toolResultContentType` variant (`Text | Image | Resource`) per MCP spec. Provides compile-time validation that content type values are valid — typos like `"txt"` are now caught at build time.

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -134,12 +134,12 @@ let executeLocalTool = async (
     | Ok(output) =>
       let outputJson = output->S.reverseConvertToJsonOrThrow(T.outputSchema)
       {
-        content: [{type_: "text", text: JSON.stringify(outputJson)}],
+        content: [{type_: Text, text: JSON.stringify(outputJson)}],
         isError: None,
         _meta: meta,
       }
     | Error(msg) => {
-        content: [{type_: "text", text: msg}],
+        content: [{type_: Text, text: msg}],
         isError: Some(true),
         _meta: meta,
       }
@@ -149,7 +149,7 @@ let executeLocalTool = async (
   | S.Error(e) =>
     Log.error(~ctx={"tool": T.name}, "Schema error")
     Completed({
-      content: [{type_: "text", text: `Invalid input: ${e.message}`}],
+      content: [{type_: Text, text: `Invalid input: ${e.message}`}],
       isError: Some(true),
       _meta: meta,
     })
@@ -187,7 +187,7 @@ let resolveWriteFileImageRef = (
 }
 
 let toolError = (server: t, msg: string): Types.callToolResult => {
-  content: [{type_: "text", text: msg}],
+  content: [{type_: Text, text: msg}],
   isError: Some(true),
   _meta: server->currentMeta,
 }

--- a/libs/frontman-client/test/FrontmanClient__MCP.test.res
+++ b/libs/frontman-client/test/FrontmanClient__MCP.test.res
@@ -132,7 +132,7 @@ describe("handleToolsCall", () => {
 
     let handler: MCP.mcpHandler<unit> = {
       serverInterface: makeCompletedServerInterface({
-        content: [{type_: "text", text: "tool output"}],
+        content: [{type_: Types.Text, text: "tool output"}],
         isError: None,
         _meta: Types.emptyMeta,
       }),
@@ -182,7 +182,7 @@ describe("handleToolsCall", () => {
     // executeTool will receive invalid params that cause S.Error during schema parse
     let handler: MCP.mcpHandler<unit> = {
       serverInterface: makeCompletedServerInterface({
-        content: [{type_: "text", text: "ok"}],
+        content: [{type_: Types.Text, text: "ok"}],
         isError: None,
         _meta: Types.emptyMeta,
       }),
@@ -330,7 +330,7 @@ describe("handleMessage error safety", () => {
 
       let handler: MCP.mcpHandler<unit> = {
         serverInterface: makeCompletedServerInterface({
-          content: [{type_: "text", text: "ok"}],
+          content: [{type_: Types.Text, text: "ok"}],
           isError: None,
           _meta: Types.emptyMeta,
         }),

--- a/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
+++ b/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
@@ -78,7 +78,7 @@ let handleToolCall = async (
   switch request {
   | Error(msg) =>
     let errorResult: MCP.callToolResult = {
-      content: [{type_: "text", text: `Invalid request: ${msg}`}],
+      content: [{type_: MCP.Text, text: `Invalid request: ${msg}`}],
       isError: Some(true),
       _meta: MCP.emptyMeta,
     }
@@ -121,7 +121,7 @@ let handleToolCall = async (
               ->Option.flatMap(JsExn.message)
               ->Option.getOr("Unknown error")
             let errorResult: MCP.callToolResult = {
-              content: [{type_: "text", text: `Tool execution failed: ${msg}`}],
+              content: [{type_: MCP.Text, text: `Tool execution failed: ${msg}`}],
               isError: Some(true),
               _meta: MCP.emptyMeta,
             }

--- a/libs/frontman-core/src/FrontmanCore__Server.res
+++ b/libs/frontman-core/src/FrontmanCore__Server.res
@@ -45,13 +45,13 @@ let executeTool = async (
       | Result.Ok(output) =>
         let outputJson = output->S.reverseConvertToJsonOrThrow(T.outputSchema)
         Ok({
-          content: [{type_: "text", text: JSON.stringify(outputJson)}],
+          content: [{type_: MCP.Text, text: JSON.stringify(outputJson)}],
           isError: None,
           _meta: MCP.emptyMeta,
         })
       | Result.Error(msg) =>
         Ok({
-          content: [{type_: "text", text: msg}],
+          content: [{type_: MCP.Text, text: msg}],
           isError: Some(true),
           _meta: MCP.emptyMeta,
         })
@@ -71,17 +71,17 @@ let resultToMCP = (result: executeResult): MCP.callToolResult => {
   switch result {
   | Ok(r) => r
   | ToolNotFound(name) => {
-      content: [{type_: "text", text: `Tool not found: ${name}`}],
+      content: [{type_: MCP.Text, text: `Tool not found: ${name}`}],
       isError: Some(true),
       _meta: MCP.emptyMeta,
     }
   | InvalidInput(msg) => {
-      content: [{type_: "text", text: `Invalid input: ${msg}`}],
+      content: [{type_: MCP.Text, text: `Invalid input: ${msg}`}],
       isError: Some(true),
       _meta: MCP.emptyMeta,
     }
   | ExecutionError(msg) => {
-      content: [{type_: "text", text: `Execution error: ${msg}`}],
+      content: [{type_: MCP.Text, text: `Execution error: ${msg}`}],
       isError: Some(true),
       _meta: MCP.emptyMeta,
     }

--- a/libs/frontman-core/test/FrontmanCore__SSE.test.res
+++ b/libs/frontman-core/test/FrontmanCore__SSE.test.res
@@ -14,7 +14,7 @@ describe("SSE", _t => {
 
   test("formats result event correctly", t => {
     let result: MCP.callToolResult = {
-      content: [{type_: "text", text: "hello"}],
+      content: [{type_: MCP.Text, text: "hello"}],
       isError: None,
       _meta: MCP.emptyMeta,
     }

--- a/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
@@ -44,10 +44,17 @@ type toolCallParams = {
   arguments: option<Dict.t<JSON.t>>,
 }
 
+// Tool result content type — per MCP spec
+@schema
+type toolResultContentType =
+  | @as("text") Text
+  | @as("image") Image
+  | @as("resource") Resource
+
 // Tool result content
 @schema
 type toolResultContent = {
-  @as("type") type_: string,
+  @as("type") type_: toolResultContentType,
   text: string,
 }
 


### PR DESCRIPTION
## Summary

- Adds `toolResultContentType` variant (`Text | Image | Resource`) to `FrontmanProtocol__MCP.res` per MCP spec
- Changes `toolResultContent.type_` from `string` to the typed variant — compile-time validation of content types
- Updates all 11 call sites across `FrontmanClient__MCP__Server`, `FrontmanCore__Server`, `FrontmanCore__RequestHandlers`, and test files

## Wire Format

No change — `@as("text")` / `@as("image")` / `@as("resource")` annotations preserve the existing JSON serialization.

## Closes

Closes #187
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
