### PR TITLE
Add Discord support link to error banner

### DIFF
--- a/libs/client/src/components/frontman/Client__ErrorBanner.res
+++ b/libs/client/src/components/frontman/Client__ErrorBanner.res
@@ -25,10 +25,22 @@ let make = (~error: string) => {
     // Error content
     <div className="flex-1 min-w-0">
       <p className="text-sm font-medium text-red-300"> {React.string("Error")} </p>
-      <p className="text-sm text-red-400/90 mt-1"> {React.string(error)} </p>
-      <p className="text-xs text-red-400/60 mt-2">
+      <p className="text-sm text-red-400/90 mt-1 break-words"> {React.string(error)} </p>
+      <p className="text-xs text-red-300/80 mt-2">
         {React.string("Send a new message to try again.")}
       </p>
+      <a
+        href="https://discord.gg/xk8uXJSvhC"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-xs text-red-400/50 hover:text-red-300 transition-colors mt-2">
+        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+          <path
+            d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"
+          />
+        </svg>
+        {React.string("Need help? Join our Discord")}
+      </a>
     </div>
   </div>
 }


### PR DESCRIPTION
## Summary
- Add a Discord invite link as a subtle escalation path in the client error banner
- Fix word breaking (`break-all` → `break-words`) so error messages stay readable — only long unbreakable tokens (IDs, URLs) break mid-word
- Improve visual hierarchy: error message → recovery hint ("Send a new message") → support link ("Need help? Join our Discord")

## Test plan
- [ ] Trigger an error in the client (e.g. bad API key) and verify the banner renders correctly
- [ ] Confirm long error messages with unbreakable tokens wrap properly without breaking normal words
- [ ] Verify the Discord link opens `https://discord.gg/xk8uXJSvhC` in a new tab
- [ ] Check Storybook stories still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
