### PR TITLE
fix: remove unused import FrontmanServer.ProvidersFixtures

### DIFF
--- a/apps/frontman_server/test/frontman_server/tasks/title_generator_integration_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/title_generator_integration_test.exs
@@ -6,7 +6,6 @@ defmodule FrontmanServer.Tasks.TitleGeneratorIntegrationTest do
   use FrontmanServer.DataCase, async: true
 
   import FrontmanServer.AccountsFixtures
-  import FrontmanServer.ProvidersFixtures
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers


### PR DESCRIPTION
## Summary
- Removes unused `import FrontmanServer.ProvidersFixtures` from `title_generator_integration_test.exs`
- Fixes compiler warning reported in #632

Closes #632

## Test plan
- [x] Ran `mix test` on the affected file — passes with no warnings
- [x] Full test suite (630 tests) passes with 0 failures and no compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
