### PR TITLE
fix: fail tool execution on argument parse errors

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -197,39 +197,10 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
       llm_opts: llm_opts
     }
 
-    with {:ok, args} <- parse_arguments(tool_call.name, tool_call.arguments) do
-      module.execute(args, context)
-    end
-    |> case do
-      {:ok, value} ->
-        encoded = encode_result(value)
-
-        # Store tool result for interaction history and UI notification
-        Tasks.add_tool_result(
-          scope,
-          task_id,
-          %{id: tool_call.id, name: tool_call.name},
-          value,
-          false
-        )
-
-        {:ok, encoded}
-
+    case parse_arguments(tool_call.name, tool_call.arguments) do
       {:error, reason} ->
-        Logger.error("ToolExecutor: Backend tool #{tool_call.name} failed: #{inspect(reason)}")
-
-        Sentry.capture_message("Tool execution failed",
-          level: :error,
-          tags: %{error_type: "tool_soft_error"},
-          extra: %{
-            tool_name: tool_call.name,
-            tool_call_id: tool_call.id,
-            task_id: task_id,
-            reason: inspect(reason)
-          }
-        )
-
-        # Store error result for interaction history and UI notification
+        # parse_arguments already reported to Sentry and logged — just record
+        # the error result for interaction history and return
         Tasks.add_tool_result(
           scope,
           task_id,
@@ -239,6 +210,48 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
         )
 
         {:error, reason}
+
+      {:ok, args} ->
+        case module.execute(args, context) do
+          {:ok, value} ->
+            encoded = encode_result(value)
+
+            Tasks.add_tool_result(
+              scope,
+              task_id,
+              %{id: tool_call.id, name: tool_call.name},
+              value,
+              false
+            )
+
+            {:ok, encoded}
+
+          {:error, reason} ->
+            Logger.error(
+              "ToolExecutor: Backend tool #{tool_call.name} failed: #{inspect(reason)}"
+            )
+
+            Sentry.capture_message("Tool execution failed",
+              level: :error,
+              tags: %{error_type: "tool_soft_error"},
+              extra: %{
+                tool_name: tool_call.name,
+                tool_call_id: tool_call.id,
+                task_id: task_id,
+                reason: inspect(reason)
+              }
+            )
+
+            Tasks.add_tool_result(
+              scope,
+              task_id,
+              %{id: tool_call.id, name: tool_call.name},
+              reason,
+              true
+            )
+
+            {:error, reason}
+        end
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -108,6 +108,14 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       assert report.extra[:tool_name] == "todo_list"
       assert report.extra[:raw_arguments] == "{invalid json!!!}"
       assert is_binary(report.extra[:decode_error])
+
+      # No duplicate "tool execution failed" report — parse_arguments handles its own reporting
+      soft_error_reports =
+        Enum.filter(reports, fn event ->
+          event.tags[:error_type] == "tool_soft_error"
+        end)
+
+      assert soft_error_reports == []
     end
 
     test "does not report valid JSON arguments to Sentry", %{


### PR DESCRIPTION
## Summary
- **Previously**: `parse_arguments` silently fell back to `%{}` when tool arguments were malformed/empty, letting the tool execute with missing args — masking LLM bugs and producing confusing downstream errors
- **Now**: Returns `{:error, reason}` on parse failure, which flows through the existing error handling (Sentry report + interaction history + UI notification)
- Adds `tool_name` to Sentry tags/extra for easier triage (was missing — triggered by [ELIXIR-40](https://frontman-gm.sentry.io/issues/ELIXIR-40))

## Test plan
- [x] Existing `ToolErrorSentryTest` updated and passing (4/4, timeout excluded)
- [ ] CI green
- [ ] Verify no double Sentry reports in prod (parse error + soft error use same `{:error, _}` path)

Fixes ELIXIR-40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
