### PR TITLE
fix: resolve Caddy bind mount path in caddy-regen.sh

### DIFF
--- a/infra/local/caddy-regen.sh
+++ b/infra/local/caddy-regen.sh
@@ -2,8 +2,8 @@
 # caddy-regen.sh — Regenerate Caddyfile from running worktree pods.
 #
 # Scans all running worktree-* pods, reads their published port mappings,
-# generates reverse proxy routes for each one, writes infra/local/Caddyfile,
-# and reloads Caddy.
+# generates reverse proxy routes for each one, writes the Caddyfile that
+# Caddy's bind mount points to, and reloads Caddy.
 #
 # Networking: Caddy runs with --network=host and routes to localhost:<port>.
 # Each pod publishes deterministic ports derived from its hash.
@@ -13,8 +13,20 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CADDYFILE="$SCRIPT_DIR/Caddyfile"
 CADDY_CONTAINER="frontman-caddy"
+
+# Resolve the Caddyfile path from the container's bind mount so we always
+# write to the file Caddy is actually reading, regardless of which worktree
+# invokes this script. Falls back to $SCRIPT_DIR/Caddyfile if the container
+# isn't running yet (e.g. first-time infra-up).
+CADDYFILE="$SCRIPT_DIR/Caddyfile"
+if podman container inspect "$CADDY_CONTAINER" &>/dev/null; then
+    MOUNT_SRC=$(podman inspect "$CADDY_CONTAINER" \
+        --format '{{range .Mounts}}{{if eq .Destination "/etc/caddy/Caddyfile"}}{{.Source}}{{end}}{{end}}' 2>/dev/null || true)
+    if [ -n "$MOUNT_SRC" ]; then
+        CADDYFILE="$MOUNT_SRC"
+    fi
+fi
 
 # Collect running worktree pods
 PODS=$(podman pod ls --format '{{.Name}}' --filter status=running 2>/dev/null | grep '^worktree-' || true)


### PR DESCRIPTION
## Summary
- `caddy-regen.sh` now inspects the Caddy container's actual bind mount source for `/etc/caddy/Caddyfile` and writes there, instead of always writing to `$SCRIPT_DIR/Caddyfile`
- Fixes the bug where regen from a worktree other than the one that ran `infra-up` silently wrote to the wrong file, leaving Caddy with stale config
- Falls back to `$SCRIPT_DIR/Caddyfile` when the container doesn't exist yet (first-time setup)

Closes #671

## Test plan
- [ ] Run `make infra-up` from the main worktree
- [ ] Create a new worktree with `make wt-new BRANCH=...`
- [ ] From the new worktree, run `./infra/local/caddy-regen.sh` and verify it writes to the original worktree's Caddyfile (the one Caddy is bind-mounted to)
- [ ] Verify `caddy reload` picks up the new routes (no "config is unchanged" message)
- [ ] Verify `make wt-stop` / `make wt-start` correctly update Caddy routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
