### PR TITLE
fix: replace busy-wait with message-based sync in Runtime.run

### DIFF
--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -160,14 +160,13 @@ defmodule SwarmAi.Runtime do
     case Task.Supervisor.start_child(task_sup, fn ->
            case Registry.register(registry, registry_key, %{}) do
              {:ok, _} ->
+               ExecutionMonitor.watch(monitor, key, metadata)
                send(caller, {ack_ref, :registered})
 
              {:error, {:already_registered, _}} ->
                send(caller, {ack_ref, :already_running})
                exit(:normal)
            end
-
-           ExecutionMonitor.watch(monitor, key, metadata)
 
            try do
              result = SwarmAi.run_streaming(agent, messages, streaming_opts)

--- a/apps/swarm_ai/test/swarm_ai/runtime/supervisor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime/supervisor_test.exs
@@ -10,7 +10,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-reg", agent, "Hello", default_opts())
-      Process.sleep(50)
       assert Runtime.running?(runtime, "task-reg")
 
       kill_named_process(Runtime.registry_name(runtime))
@@ -27,7 +26,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-pre", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(Runtime.registry_name(runtime))
       await_exit(pid)
@@ -48,7 +46,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-ts", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       # Killing Task.Supervisor directly — tasks exit with :killed (abnormal).
       kill_named_process(Runtime.task_supervisor_name(runtime))
@@ -62,7 +59,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-pre", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(Runtime.task_supervisor_name(runtime))
       await_exit(pid)
@@ -82,7 +78,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 2000})
 
       {:ok, pid} = Runtime.run(runtime, "task-em", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(Runtime.monitor_name(runtime))
       wait_for_process(Runtime.monitor_name(runtime))
@@ -98,7 +93,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
 
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
       {:ok, _pid} = Runtime.run(runtime, "task-ets", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(monitor)
       wait_for_process(monitor)
@@ -112,7 +106,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 2000})
 
       {:ok, _pid} = Runtime.run(runtime, "task-pre", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(Runtime.monitor_name(runtime))
       wait_for_process(Runtime.monitor_name(runtime))
@@ -131,7 +124,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-tsup", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       # Killing TasksSupervisor — it shuts down children gracefully,
       # so tasks exit with :shutdown (not abnormal).
@@ -147,7 +139,6 @@ defmodule SwarmAi.Runtime.SupervisorTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = Runtime.run(runtime, "task-pre", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       kill_named_process(:"#{runtime}.TasksSupervisor")
       await_exit(pid)

--- a/apps/swarm_ai/test/swarm_ai/runtime_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime_test.exs
@@ -72,7 +72,6 @@ defmodule SwarmAi.RuntimeTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 500})
 
       {:ok, _} = SwarmAi.Runtime.run(runtime, "task-dup", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       assert SwarmAi.Runtime.run(runtime, "task-dup", agent, "World", default_opts()) ==
                {:error, :already_running}
@@ -87,7 +86,6 @@ defmodule SwarmAi.RuntimeTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 500})
       {:ok, _} = SwarmAi.Runtime.run(runtime, "task-r", agent, "Hello", default_opts())
 
-      Process.sleep(50)
       assert SwarmAi.Runtime.running?(runtime, "task-r") == true
     end
   end
@@ -98,7 +96,6 @@ defmodule SwarmAi.RuntimeTest do
       agent = test_agent(%MockLLM{response: "slow", delay_ms: 5000})
 
       {:ok, pid} = SwarmAi.Runtime.run(runtime, "task-c", agent, "Hello", default_opts())
-      Process.sleep(50)
 
       assert SwarmAi.Runtime.cancel(runtime, "task-c") == :ok
       await_exit(pid)


### PR DESCRIPTION
## Summary

- Moved `ExecutionMonitor.watch` before the registration ack in `Runtime.run/5`, so callers receive `{:ok, pid}` only after both Registry registration **and** monitor watch are established
- Removed 12 `Process.sleep(50)` calls from test files that were compensating for the ack-before-watch race

Closes #647

## Test plan

- [x] All 52 tests in `runtime_test.exs`, `supervisor_test.exs`, `execution_monitor_test.exs`, and `swarm_ai_test.exs` pass
- [ ] Verify no flaky test failures in CI (the sleep removal makes tests faster and more deterministic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
