### PR TITLE
fix: prevent CI test race with ExecutionMonitor dispatch

### DIFF
--- a/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
@@ -20,8 +20,13 @@ defmodule FrontmanServer.Tasks.Execution.ErrorPropagationTest do
 
   describe "LLM stream error propagation" do
     setup do
-      pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
-      on_exit(fn -> Sandbox.stop_owner(pid) end)
+      db_pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
+
+      on_exit(fn ->
+        monitor = SwarmAi.Runtime.monitor_name(FrontmanServer.AgentRuntime)
+        if pid = Process.whereis(monitor), do: :sys.get_state(pid)
+        Sandbox.stop_owner(db_pid)
+      end)
 
       {:ok, user} =
         Accounts.register_user(%{

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -45,8 +45,13 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
       end
     end
 
-    pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
-    on_exit(fn -> Sandbox.stop_owner(pid) end)
+    db_pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
+
+    on_exit(fn ->
+      monitor = SwarmAi.Runtime.monitor_name(FrontmanServer.AgentRuntime)
+      if pid = Process.whereis(monitor), do: :sys.get_state(pid)
+      Sandbox.stop_owner(db_pid)
+    end)
 
     {:ok, user} =
       Accounts.register_user(%{

--- a/apps/swarm_ai/test/swarm_ai/runtime_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime_test.exs
@@ -150,6 +150,29 @@ defmodule SwarmAi.RuntimeTest do
     end
   end
 
+  describe "sys.get_state barrier prevents dispatch race" do
+    test "slow dispatcher completes before :sys.get_state returns" do
+      runtime = start_runtime_with_slow_dispatch!()
+      agent = test_agent(%StreamErrorLLM{error_message: "barrier boom"})
+
+      {:ok, pid} =
+        SwarmAi.Runtime.run(runtime, "task-barrier", agent, "Hello", default_opts())
+
+      # Step 1: execution process is dead, :DOWN is queued in the monitor
+      await_exit(pid)
+
+      # Step 2: slow dispatch (200ms) hasn't finished yet — race window is open
+      refute_received {:slow_event, "task-barrier", {:crashed, _}}
+
+      # Step 3: sync barrier — blocks until the monitor processes the :DOWN message
+      monitor = SwarmAi.Runtime.monitor_name(runtime)
+      :sys.get_state(monitor)
+
+      # Step 4: dispatch has completed after the barrier
+      assert_received {:slow_event, "task-barrier", {:crashed, _}}
+    end
+  end
+
   # --- Test Dispatchers ---
 
   defmodule TestDispatcher do
@@ -161,6 +184,13 @@ defmodule SwarmAi.RuntimeTest do
   defmodule MetadataTestDispatcher do
     def dispatch(test_pid, key, event, metadata) do
       send(test_pid, {:test_event_with_meta, key, event, metadata})
+    end
+  end
+
+  defmodule SlowDispatcher do
+    def dispatch(test_pid, key, event, _metadata) do
+      Process.sleep(200)
+      send(test_pid, {:slow_event, key, event})
     end
   end
 
@@ -185,6 +215,18 @@ defmodule SwarmAi.RuntimeTest do
     start_supervised!(
       {SwarmAi.Runtime,
        name: name, event_dispatcher: {__MODULE__.MetadataTestDispatcher, :dispatch, [test_pid]}}
+    )
+
+    name
+  end
+
+  defp start_runtime_with_slow_dispatch! do
+    name = :"TestRuntime_#{:erlang.unique_integer([:positive])}"
+    test_pid = self()
+
+    start_supervised!(
+      {SwarmAi.Runtime,
+       name: name, event_dispatcher: {__MODULE__.SlowDispatcher, :dispatch, [test_pid]}}
     )
 
     name


### PR DESCRIPTION
## Summary

- Add `:sys.get_state/1` sync barrier in `on_exit` callbacks of `ErrorPropagationTest` and `ExecutionSentryTest` to ensure `ExecutionMonitor`'s async `:DOWN` handler (which performs DB writes via `SwarmDispatcher.dispatch`) completes before Ecto sandbox teardown
- Add regression test in `runtime_test.exs` with a `SlowDispatcher` (200ms delay) proving the barrier pattern works

## Context

Issue #681: `ErrorPropagationTest` flakes in CI with `{:crashed, ...}` instead of `{:failed, ...}` due to a race between sandbox teardown and the monitor's async dispatch. Zero production code changes — test-only fix using a standard OTP synchronization pattern.

## Test plan

- [x] Regression test passes (`mix test apps/swarm_ai/test/swarm_ai/runtime_test.exs --trace`)
- [x] Fixed tests pass (`mix test apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs --trace`)
- [x] Stress tested error_propagation_test 20 iterations with varying seeds — 0 failures

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
