### PR TITLE
fix: add coerce option to Todo Zoi schema for JSONB string keys

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/todos.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/todos.ex
@@ -20,12 +20,15 @@ defmodule FrontmanServer.Tasks.Todos do
     @valid_statuses [:pending, :in_progress, :completed]
     @valid_priorities [:high, :medium, :low]
 
-    @new_schema Zoi.object(%{
-                  content: Zoi.string() |> Zoi.min(1),
-                  active_form: Zoi.string() |> Zoi.min(1),
-                  status: Zoi.string() |> Zoi.one_of(["pending", "in_progress", "completed"]),
-                  priority: Zoi.string() |> Zoi.one_of(["high", "medium", "low"])
-                })
+    @new_schema Zoi.object(
+                  %{
+                    content: Zoi.string() |> Zoi.min(1),
+                    active_form: Zoi.string() |> Zoi.min(1),
+                    status: Zoi.string() |> Zoi.one_of(["pending", "in_progress", "completed"]),
+                    priority: Zoi.string() |> Zoi.one_of(["high", "medium", "low"])
+                  },
+                  coerce: true
+                )
     @extra_schema Zoi.object(
                     %{
                       id: Zoi.string(),

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -1,5 +1,5 @@
 defmodule FrontmanServer.Tasks.TodosTest do
-  use FrontmanServer.DataCase, async: false
+  use FrontmanServer.DataCase, async: true
 
   alias FrontmanServer.Accounts
   alias FrontmanServer.Accounts.Scope

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -1,5 +1,5 @@
 defmodule FrontmanServer.TasksTest do
-  use FrontmanServer.DataCase, async: false
+  use FrontmanServer.DataCase, async: true
 
   import FrontmanServer.InteractionCase.Helpers
 


### PR DESCRIPTION
## Summary
- Adds `coerce: true` to `Todo`'s `@new_schema` so Zoi accepts string-keyed maps from JSONB round-trips. The hex dep update in #689 changed Zoi's default coercion behavior, causing `to_todo/1` to silently fail on string keys and `list_todos` to return empty results.
- Switches `TodosTest` and `TasksTest` to `async: true` for faster test execution — neither module spawns processes requiring shared sandbox mode.

Closes #694

## Test plan
- [x] All 5 previously-failing tests now pass (`TodosTest` x3, `TasksTest` x2)
- [x] Full server test suite passes (643 tests, 0 failures)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
