### PR TITLE
fix: register log handlers at app init instead of ACP.connect

### DIFF
--- a/libs/client/src/Client__Env.res
+++ b/libs/client/src/Client__Env.res
@@ -1,0 +1,1 @@
+let isDev: bool = %raw("import.meta.env?.DEV ?? true")

--- a/libs/client/src/Client__Heap.res
+++ b/libs/client/src/Client__Heap.res
@@ -2,9 +2,7 @@
 // Dev env ID: 349428408
 // Prod env ID: 218974947
 
-let isDev: bool = %raw("import.meta.env?.DEV ?? true")
-
-let envId = if isDev {
+let envId = if Client__Env.isDev {
   "349428408"
 } else {
   "218974947"

--- a/libs/client/src/Main.res
+++ b/libs/client/src/Main.res
@@ -1,6 +1,10 @@
 %%raw("import '@radix-ui/themes/styles.css'")
 %%raw("import './index.css'")
 
+FrontmanLogs.Logs.setLogLevel(if Client__Env.isDev { Debug } else { Error })
+FrontmanLogs.Logs.addHandler(FrontmanLogs.Logs.Console.handler)
+FrontmanLogs.Logs.addHandler(FrontmanAiFrontmanClient.FrontmanClient__Sentry__LogHandler.handler)
+
 Client__Heap.init()
 
 @val external importMetaUrl: string = "import.meta.url"

--- a/libs/client/src/state/Client__StateSnapshot__Storybook.res
+++ b/libs/client/src/state/Client__StateSnapshot__Storybook.res
@@ -1,6 +1,5 @@
-// Console.* used intentionally throughout this file — Storybook stories never
-// call ACP.connect(), which is the only place the log handler is registered.
-// Using Logs.* here would silently drop all output.
+// Console.* used intentionally — Storybook stories run outside the normal
+// app entrypoint so log handlers may not be registered.
 
 S.enableJson()
 /**

--- a/libs/client/src/webpreview/Client__BrowserUrl.res
+++ b/libs/client/src/webpreview/Client__BrowserUrl.res
@@ -13,6 +13,10 @@
 // frontman-core is server-only. Keep the two implementations aligned —
 // if you change one, update the other.
 
+module Log = FrontmanLogs.Logs.Make({
+  let component = #BrowserUrl
+})
+
 // Read basePath from runtime config. Lazy — reads once on first access.
 // Falls back to "frontman" if runtime config is unavailable (e.g. in tests).
 let _getBasePath: unit => string = {
@@ -25,9 +29,7 @@ let _getBasePath: unit => string = {
         Client__RuntimeConfig.read().basePath
       } catch {
       | _ =>
-        // Console.warn used intentionally — this runs before ACP.connect() registers
-        // the log handler, so Logs.* calls would be silently dropped.
-        Console.warn("RuntimeConfig.basePath unavailable, falling back to \"frontman\"")
+        Log.warning("RuntimeConfig.basePath unavailable, falling back to \"frontman\"")
         "frontman"
       }
       cached := Some(bp)

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -152,12 +152,6 @@ let connect = async (config: config, ~signal: option<WebAPI.EventAPI.abortSignal
   connection,
   connectError,
 > => {
-  // Initialize logging
-  let isDev: bool = %raw("import.meta.env?.DEV ?? true")
-  FrontmanLogs.Logs.setLogLevel(if isDev { Debug } else { Error })
-  FrontmanLogs.Logs.addHandler(FrontmanLogs.Logs.Console.handler)
-  FrontmanLogs.Logs.addHandler(FrontmanClient__Sentry__LogHandler.handler)
-
   // Initialize Sentry on first connection
   Sentry.initialize()
   Sentry.addBreadcrumb(~category=#acp, ~message="Starting ACP connection")

--- a/libs/logs/src/LogComponent.res
+++ b/libs/logs/src/LogComponent.res
@@ -13,6 +13,7 @@ type t = [
   | #FrontmanProvider
   | #WebPreviewStage
   | #StateStore
+  | #BrowserUrl
 ]
 
 // Accepts any poly variant (open) — tags are strings at runtime


### PR DESCRIPTION
## Summary
- Move log handler registration (console + Sentry) from `ACP.connect()` to `Main.res` module init so `Log.*` calls are never silently dropped before connection
- Extract shared `Client__Env.isDev` binding to deduplicate `import.meta.env.DEV` raw JS across `libs/client`
- Replace `Console.warn` workaround in `Client__BrowserUrl` with proper `Log.warning` now that handlers are registered early

Closes #506

## Test plan
- [x] `libs/logs` — 11 tests pass
- [x] `libs/client` — 309 tests pass
- [x] `libs/frontman-client` — compiles clean
- [ ] Manual: verify Sentry receives `Log.error` events in dev/staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
