### PR TITLE
test: regression test for agent crash on GenServer.call timeout

### DIFF
--- a/apps/swarm_ai/lib/swarm_ai/testing.ex
+++ b/apps/swarm_ai/lib/swarm_ai/testing.ex
@@ -208,6 +208,36 @@ defmodule SwarmAi.Testing do
     end
   end
 
+  defmodule StreamTimeoutLLM do
+    @moduledoc """
+    LLM that returns a stream which exits with a GenServer.call timeout
+    during consumption.
+
+    Simulates the real scenario where the LLM provider stalls mid-stream:
+    `StreamServer.next/2` issues a `GenServer.call` with a timeout slightly
+    above Finch's `receive_timeout`. Under load the Finch timeout can take
+    longer than that buffer to propagate, so the GenServer.call timeout
+    fires first and exits the consumer process with
+    `{:timeout, {GenServer, :call, [server, msg, timeout]}}`.
+    """
+    defstruct timeout: 151_000, model: "stream-timeout"
+  end
+
+  defimpl SwarmAi.LLM, for: SwarmAi.Testing.StreamTimeoutLLM do
+    def stream(%{timeout: timeout}, _messages, _opts) do
+      stream =
+        Stream.resource(
+          fn -> :init end,
+          fn :init ->
+            exit({:timeout, {GenServer, :call, [self(), {:next, timeout}, timeout]}})
+          end,
+          fn _ -> :ok end
+        )
+
+      {:ok, stream}
+    end
+  end
+
   # --- Setup ---
 
   using do
@@ -218,6 +248,7 @@ defmodule SwarmAi.Testing do
       alias SwarmAi.Testing.MockLLM
       alias SwarmAi.Testing.StallingLLM
       alias SwarmAi.Testing.StreamErrorLLM
+      alias SwarmAi.Testing.StreamTimeoutLLM
       alias SwarmAi.Testing.TestAgent
       alias SwarmAi.LLM
       alias SwarmAi.ToolCall

--- a/apps/swarm_ai/test/swarm_ai/runtime_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime_test.exs
@@ -137,6 +137,26 @@ defmodule SwarmAi.RuntimeTest do
     end
   end
 
+  describe "GenServer.call timeout during stream consumption" do
+    test "dispatches :failed (not :crashed) when provider stalls and call timeout fires" do
+      runtime = start_runtime!()
+      agent = test_agent(%StreamTimeoutLLM{})
+
+      {:ok, pid} =
+        SwarmAi.Runtime.run(runtime, "task-timeout", agent, "Hello", default_opts())
+
+      await_exit(pid)
+
+      assert_receive {:test_event, "task-timeout",
+                      {:failed, {:error, reason, _loop_id}}}
+
+      assert reason =~ "timed out"
+
+      refute_receive {:test_event, "task-timeout", {:crashed, _}}, 100
+      refute SwarmAi.Runtime.running?(runtime, "task-timeout")
+    end
+  end
+
   describe "death watcher" do
     test "silent on :shutdown exit — no event dispatched" do
       runtime = start_runtime!()


### PR DESCRIPTION
## Summary

- Adds `StreamTimeoutLLM` test mock that simulates the exact `GenServer.call` timeout exit from `StreamServer.next/2` (the race between Finch's `receive_timeout` and the 1s call timeout buffer)
- Adds regression test verifying the timeout produces a `:failed` event, not `:crashed`
- The actual fix already landed in #704 (`classify_exit_reason` in `execute_llm_call`'s `catch` clause) — this PR adds test coverage for that specific scenario

Closes #686

## Test plan

- [x] New test passes: `mix test test/swarm_ai/runtime_test.exs` (17 tests, 0 failures)
- [x] Verified test fails without the #704 fix (produces `:crashed` with bare `:timeout` reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
