### PR TITLE
fix(marketing): add trailing slashes to JSON-LD schema URLs

### DIFF
--- a/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
+++ b/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
@@ -33,7 +33,7 @@ const breadcrumbJsonLd = {
 	"@context": "https://schema.org",
 	"@type": "Organization",
 	"name": "Frontman",
-	"url": "https://frontman.sh",
+	"url": "https://frontman.sh/",
 	"description": "An open-source AI agent that lets designers and developers edit production UI like they're working in Figma. Point at any element, describe the change in plain English, get real code.",
 	"foundingDate": "2025",
 	"logo": "https://frontman.sh/logo.svg",
@@ -54,14 +54,14 @@ const breadcrumbJsonLd = {
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		"name": "Frontman",
-		"url": "https://frontman.sh",
+		"url": "https://frontman.sh/",
 		"applicationCategory": "DeveloperApplication",
 		"operatingSystem": "Web",
 		"description": "Point at any element in your running app, describe what you want in plain English, and get real code edits. Frontman lets designers work on production code the way they work in Figma. Supports Next.js, Astro, and Vite.",
 		"author": {
 			"@type": "Organization",
 			"name": "Frontman",
-			"url": "https://frontman.sh"
+			"url": "https://frontman.sh/"
 		},
 		"license": "https://github.com/frontman-ai/frontman/blob/main/LICENSE",
 		"codeRepository": "https://github.com/frontman-ai/frontman",

--- a/apps/marketing/src/layouts/GlossaryPostLayout.astro
+++ b/apps/marketing/src/layouts/GlossaryPostLayout.astro
@@ -26,7 +26,7 @@ const jsonLd = {
 	inDefinedTermSet: {
 		'@type': 'DefinedTermSet',
 		name: 'Frontend Development Glossary',
-		url: 'https://frontman.sh/glossary'
+		url: 'https://frontman.sh/glossary/'
 	},
 	url: Astro.url.href
 }

--- a/apps/marketing/src/layouts/LighthousePostLayout.astro
+++ b/apps/marketing/src/layouts/LighthousePostLayout.astro
@@ -45,7 +45,7 @@ const articleJsonLd = {
 	"author": {
 		"@type": "Organization",
 		"name": "Frontman",
-		"url": "https://frontman.sh"
+		"url": "https://frontman.sh/"
 	},
 	"publisher": {
 		"@type": "Organization",

--- a/apps/marketing/src/pages/about.astro
+++ b/apps/marketing/src/pages/about.astro
@@ -42,7 +42,7 @@ const personSchemas = founders.map((founder) => ({
 	worksFor: {
 		'@type': 'Organization',
 		name: 'Frontman',
-		url: 'https://frontman.sh',
+		url: 'https://frontman.sh/',
 	},
 	sameAs: [founder.github, founder.linkedin, founder.twitter].filter(Boolean),
 }))


### PR DESCRIPTION
## Summary
- Astro is configured with `trailingSlash: "always"` but 6 hardcoded URLs in JSON-LD structured data were missing trailing slashes
- Fixes `StructuredData.astro` (Organization + SoftwareApplication schemas), `LighthousePostLayout.astro` (Article author), `GlossaryPostLayout.astro` (DefinedTermSet), and `about.astro` (Person worksFor)
- Aligns schema URLs with canonical URLs to avoid inconsistency flagged by GSC "pages with redirect"

## Test plan
- [ ] Build the marketing site (`make build` in `apps/marketing/`) and verify no errors
- [ ] Inspect JSON-LD output in page source for `/`, `/glossary/*`, `/lighthouse/*`, and `/about/`
- [ ] Validate structured data with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
