### PR TITLE
fix(client): scroll-to-bottom broken by CSS conflicts

### DIFF
--- a/apps/marketing/src/content/docs/docs/using/annotations.md
+++ b/apps/marketing/src/content/docs/docs/using/annotations.md
@@ -1,6 +1,5 @@
 ---
 title: Annotations
-<<<<<<< HEAD
 description: Select elements in the live preview to give the Frontman agent precise visual and source-level context for your changes.
 ---
 

--- a/libs/bindings/src/ResizeObserver.res
+++ b/libs/bindings/src/ResizeObserver.res
@@ -1,0 +1,12 @@
+type t
+
+type entry = {contentRect: WebAPI.DOMAPI.domRectReadOnly}
+
+@new
+external make: (array<entry> => unit) => t = "ResizeObserver"
+
+@send
+external observe: (t, Dom.element) => unit = "observe"
+
+@send
+external disconnect: t => unit = "disconnect"

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -380,7 +380,7 @@ let make = (
   <div className="relative flex flex-col h-full bg-[#180C2D] text-zinc-200">
     <TaskTabs onSettingsClick showProviderNudge onProviderNudgeDismiss onProviderNudgeCta />
     <Client__UpdateBanner />
-    <ScrollContainer className="flex-grow overflow-hidden">
+    <ScrollContainer className="flex-grow overflow-x-hidden">
       <ScrollContainer.ContentWrapper>
         {
           // Show loading indicator while initializing

--- a/libs/client/src/components/frontman/Client__ScrollContainer.res
+++ b/libs/client/src/components/frontman/Client__ScrollContainer.res
@@ -85,6 +85,7 @@ let make = (~className: option<string>=?, ~children: React.element) => {
 
   let sentinelRef = React.useRef(Nullable.null)
   let containerRef = React.useRef(Nullable.null)
+  let contentRef = React.useRef(Nullable.null)
   let (isAtBottom, setIsAtBottom) = React.useState(() => true)
 
   // IntersectionObserver: passively track whether the sentinel is visible.
@@ -115,6 +116,51 @@ let make = (~className: option<string>=?, ~children: React.element) => {
     }
   })
 
+  // Auto-scroll fallback (#718): two cases to handle —
+  // 1. Content grows (new messages/streaming): check if near bottom, snap down.
+  // 2. Container shrinks (todo list opens): check if was at bottom using
+  //    previous clientHeight, snap down.
+  // Both use a single ResizeObserver, fires once per frame.
+  React.useEffect0(() => {
+    switch (contentRef.current->Nullable.toOption, containerRef.current->Nullable.toOption) {
+    | (Some(content), Some(container)) =>
+      let el: WebAPI.DOMAPI.element = container->Obj.magic
+      let prevClientHeight = ref(el.clientHeight)
+
+      let contentObserver = FrontmanBindings.ResizeObserver.make(_ => {
+        let nearBottom =
+          el.scrollTop +. el.clientHeight->Int.toFloat >=
+            el.scrollHeight->Int.toFloat -. 150.0
+        if nearBottom {
+          el.scrollTop = el.scrollHeight->Int.toFloat
+        }
+      })
+      contentObserver->FrontmanBindings.ResizeObserver.observe(content)
+
+      let containerObserver = FrontmanBindings.ResizeObserver.make(_ => {
+        let newClientHeight = el.clientHeight
+        if newClientHeight < prevClientHeight.contents {
+          let wasAtBottom =
+            el.scrollTop +. prevClientHeight.contents->Int.toFloat >=
+              el.scrollHeight->Int.toFloat -. 150.0
+          if wasAtBottom {
+            el.scrollTop = el.scrollHeight->Int.toFloat
+          }
+        }
+        prevClientHeight := newClientHeight
+      })
+      containerObserver->FrontmanBindings.ResizeObserver.observe(container)
+
+      Some(
+        () => {
+          FrontmanBindings.ResizeObserver.disconnect(contentObserver)
+          FrontmanBindings.ResizeObserver.disconnect(containerObserver)
+        },
+      )
+    | _ => None
+    }
+  })
+
   let contextValue = React.useMemo2(
     () => {isAtBottom, scrollToBottom},
     (isAtBottom, scrollToBottom),
@@ -122,7 +168,9 @@ let make = (~className: option<string>=?, ~children: React.element) => {
 
   <Provider value={contextValue}>
     <div ref={ReactDOM.Ref.domRef(containerRef)} className={containerClassName} role="log">
-      {children}
+      <div ref={ReactDOM.Ref.domRef(contentRef)}>
+        {children}
+      </div>
       // Sentinel: overflow-anchor keeps it in view while the user is at the bottom.
       // All message wrappers have overflow-anchor: none (via .frontman-content-auto).
       <div

--- a/libs/client/src/styles/frontman-theme.css
+++ b/libs/client/src/styles/frontman-theme.css
@@ -118,11 +118,12 @@
  * Layout Containment - Prevents layout cascading from input to message list
  * ============================================================================ */
 
-/* Strict containment for scroll containers: prevents layout recalculations
-   inside the container when siblings (e.g. chat input) change size.
-   Requires the element to have an explicit size (flex-1 provides this). */
+/* Layout + paint containment for scroll containers: prevents layout
+   recalculations inside the container when siblings (e.g. chat input)
+   change size. Avoids size containment which interferes with
+   IntersectionObserver reporting (see #718). */
 .frontman-contain-strict {
-	contain: strict;
+	contain: layout paint;
 }
 
 /* ============================================================================

--- a/libs/client/src/webpreview/Client__WebPreview.res
+++ b/libs/client/src/webpreview/Client__WebPreview.res
@@ -71,15 +71,6 @@ module OpenInNewWindow = {
   }
 }
 
-// Raw JS binding for ResizeObserver (avoids curried callback complexity in WebAPI binding)
-type resizeObserverEntry = {contentRect: WebAPI.DOMAPI.domRectReadOnly}
-
-@new external makeResizeObserver: (array<resizeObserverEntry> => unit) => {..} = "ResizeObserver"
-
-@send external observeElement: ({..}, Dom.element) => unit = "observe"
-
-@send external disconnectObserver: {..} => unit = "disconnect"
-
 // Hook to measure the available space in the viewport container
 let useContainerSize = (ref: React.ref<Nullable.t<Dom.element>>): (int, int) => {
   let (size, setSize) = React.useState(() => (0, 0))
@@ -93,18 +84,18 @@ let useContainerSize = (ref: React.ref<Nullable.t<Dom.element>>): (int, int) => 
       setSize(_ => (rect.width->Float.toInt, rect.height->Float.toInt))
 
       // Observe resize
-      let observer = makeResizeObserver(entries => {
+      let observer = FrontmanBindings.ResizeObserver.make(entries => {
         entries
         ->Array.get(0)
         ->Option.forEach(
           entry => {
-            let cr: WebAPI.DOMAPI.domRectReadOnly = entry.contentRect
+            let cr = entry.contentRect
             setSize(_ => (cr.width->Float.toInt, cr.height->Float.toInt))
           },
         )
       })
-      observer->observeElement(element)
-      Some(() => observer->disconnectObserver)
+      observer->FrontmanBindings.ResizeObserver.observe(element)
+      Some(() => observer->FrontmanBindings.ResizeObserver.disconnect)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- Fix `overflow-hidden` overriding `overflow-y-auto` on the scroll container — changed to `overflow-x-hidden`
- Relax `contain: strict` to `contain: layout paint` so IntersectionObserver correctly tracks the scroll sentinel
- Add ResizeObserver-based auto-scroll fallback that handles both content growth (streaming/new messages) and container shrink (todo list opening)
- Extract `ResizeObserver` binding to `libs/bindings/` and migrate `Client__WebPreview` to use it
- Remove stray merge conflict marker in `annotations.md`

Closes #718

## Test plan
- [x] Manual test: send a message, verify chat auto-scrolls to bottom during streaming
- [x] Manual test: open todo list while at bottom, verify scroll stays at bottom
- [ ] Manual test: scroll up to read history, verify auto-scroll does NOT force you back down
- [ ] Manual test: click scroll-to-bottom button, verify smooth scroll works
- [ ] Verify ReScript compiles cleanly with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
