### PR TITLE
fix(marketing): restore docs build and pagefind search

### DIFF
--- a/apps/marketing/public/_headers
+++ b/apps/marketing/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), shared-storage=(), attribution-reporting=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://region1.analytics.google.com https://cloudflareinsights.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube-nocookie.com; worker-src 'self' blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'self' https://rankinpublic.xyz
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://region1.analytics.google.com https://cloudflareinsights.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube-nocookie.com; worker-src 'self' blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'self' https://rankinpublic.xyz
 
 # Immutable cache for Astro hashed assets (images, JS, CSS)
 /_astro/*

--- a/apps/marketing/src/content/docs/docs/using/annotations.md
+++ b/apps/marketing/src/content/docs/docs/using/annotations.md
@@ -1,6 +1,5 @@
 ---
 title: Annotations
-<<<<<<< HEAD
 description: Select elements in the live preview to give the Frontman agent precise visual and source-level context for your changes.
 ---
 

--- a/apps/marketing/src/content/docs/docs/using/prompt-strategies.md
+++ b/apps/marketing/src/content/docs/docs/using/prompt-strategies.md
@@ -3,7 +3,6 @@ title: Prompt Strategies
 description: Advanced patterns for getting better results from Frontman — iterating, chaining, course-correcting, and knowing when to re-prompt.
 ---
 
-<<<<<<< HEAD
 [Sending Prompts](/docs/using/sending-prompts/) covers the basics — what you can attach, how to write a clear prompt, and what happens when you hit send. This page goes further: patterns for iterating on results, chaining multi-step work, recovering from wrong turns, and getting the most out of each agent run.
 
 ## Iterating on results

--- a/apps/marketing/src/content/docs/docs/using/web-preview.md
+++ b/apps/marketing/src/content/docs/docs/using/web-preview.md
@@ -3,7 +3,6 @@ title: The Web Preview
 description: Navigate, switch device modes, and understand what the Frontman agent sees in the built-in web preview.
 ---
 
-<<<<<<< HEAD
 The web preview is a live, embedded view of your running app that sits alongside the chat panel. It's where the agent looks when it takes screenshots, inspects the DOM, and verifies changes — and it's where you navigate, annotate elements, and test responsive layouts.
 
 Everything the agent can see, you can see. The preview is the shared visual context between you and the agent.


### PR DESCRIPTION
## Summary
- allow the marketing site's Pagefind search bundle to load its WASM under the deployed CSP by permitting `wasm-unsafe-eval`
- remove stray merge markers from three Starlight docs pages that were breaking Astro content parsing during `make build`
- verify the marketing build completes again, including Pagefind index generation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
