### PR TITLE
refactor(swarm_ai): split Message into role-specific structs

### DIFF
--- a/apps/frontman_server/lib/frontman_server/observability/swarm_otel_handler.ex
+++ b/apps/frontman_server/lib/frontman_server/observability/swarm_otel_handler.ex
@@ -518,7 +518,9 @@ defmodule FrontmanServer.Observability.SwarmOtelHandler do
     [role_attr | content_attr] ++ tool_attrs
   end
 
-  defp flatten_message(%{role: role} = msg, prefix) do
+  defp flatten_message(%{__struct__: _} = msg, prefix) do
+    role = SwarmAi.Message.role(msg)
+
     base = [
       {String.to_atom("#{prefix}.message.role"), to_string(role)},
       {String.to_atom("#{prefix}.message.content"),
@@ -538,7 +540,7 @@ defmodule FrontmanServer.Observability.SwarmOtelHandler do
 
   defp flatten_message(_, _), do: []
 
-  defp flatten_msg_tool_calls(%{role: :assistant, tool_calls: tcs}, prefix)
+  defp flatten_msg_tool_calls(%SwarmAi.Message.Assistant{tool_calls: tcs}, prefix)
        when is_list(tcs) and tcs != [] do
     Enum.flat_map(Enum.with_index(tcs), fn {tc, idx} ->
       tc_prefix = "#{prefix}.message.tool_calls.#{idx}"

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -258,15 +258,28 @@ defmodule FrontmanServer.Tasks.Execution do
 
   # --- SwarmAi Message Conversion ---
 
-  defp to_swarm_message(%ReqLLM.Message{} = msg) do
-    content = convert_content(msg.content)
+  defp to_swarm_message(%ReqLLM.Message{role: :system} = msg) do
+    %Message.System{content: convert_content(msg.content)}
+  end
 
-    %Message{
-      role: msg.role,
-      content: content,
+  defp to_swarm_message(%ReqLLM.Message{role: :user} = msg) do
+    %Message.User{content: convert_content(msg.content)}
+  end
+
+  defp to_swarm_message(%ReqLLM.Message{role: :assistant} = msg) do
+    %Message.Assistant{
+      content: convert_content(msg.content),
       tool_calls: to_swarm_tool_calls(msg.tool_calls),
+      metadata: %{}
+    }
+  end
+
+  defp to_swarm_message(%ReqLLM.Message{role: :tool} = msg) do
+    %Message.Tool{
+      content: convert_content(msg.content),
       tool_call_id: msg.tool_call_id,
-      name: msg.name
+      name: msg.name,
+      metadata: %{}
     }
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
@@ -319,14 +319,30 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
 
   # --- SwarmAi.Message -> ReqLLM.Message conversion ---
 
-  defp to_reqllm_message(%Message{} = msg, requires_mcp_prefix?) do
+  defp to_reqllm_message(%Message.System{} = msg, _requires_mcp_prefix?) do
+    %ReqLLM.Message{role: :system, content: Enum.map(msg.content, &to_reqllm_content_part/1)}
+  end
+
+  defp to_reqllm_message(%Message.User{} = msg, _requires_mcp_prefix?) do
+    %ReqLLM.Message{role: :user, content: Enum.map(msg.content, &to_reqllm_content_part/1)}
+  end
+
+  defp to_reqllm_message(%Message.Assistant{} = msg, requires_mcp_prefix?) do
     %ReqLLM.Message{
-      role: msg.role,
+      role: :assistant,
       content: Enum.map(msg.content, &to_reqllm_content_part/1),
       tool_calls: to_reqllm_tool_calls(msg.tool_calls, requires_mcp_prefix?),
+      metadata: msg.metadata
+    }
+  end
+
+  defp to_reqllm_message(%Message.Tool{} = msg, requires_mcp_prefix?) do
+    %ReqLLM.Message{
+      role: :tool,
+      content: Enum.map(msg.content, &to_reqllm_content_part/1),
       tool_call_id: msg.tool_call_id,
       name: maybe_prefix_name(msg.name, requires_mcp_prefix?),
-      metadata: msg.metadata || %{}
+      metadata: msg.metadata
     }
   end
 

--- a/apps/swarm_ai/lib/swarm_ai.ex
+++ b/apps/swarm_ai/lib/swarm_ai.ex
@@ -57,6 +57,8 @@ defmodule SwarmAi do
   alias SwarmAi.{ChildResult, Loop, Message, SpawnChildAgent, Telemetry, ToolResult}
   alias SwarmAi.LLM.{Chunk, Response}
 
+  import SwarmAi.Message, only: [is_message: 1]
+
   @typedoc """
   Message input can be a string, a single Message, or a list of Messages.
   Strings are automatically wrapped as user messages.
@@ -575,7 +577,7 @@ defmodule SwarmAi do
   end
 
   defp normalize_messages(msg) when is_binary(msg), do: [Message.user(msg)]
-  defp normalize_messages(%Message{} = msg), do: [msg]
+  defp normalize_messages(msg) when is_message(msg), do: [msg]
   defp normalize_messages(msgs) when is_list(msgs), do: msgs
 
   defp pending_tool_calls(%Loop{} = loop) do

--- a/apps/swarm_ai/lib/swarm_ai/message.ex
+++ b/apps/swarm_ai/lib/swarm_ai/message.ex
@@ -1,33 +1,33 @@
 defmodule SwarmAi.Message do
   @moduledoc """
-  Represents a message in the agentic loop.
+  Namespace for role-specific message structs used in the agentic loop.
 
-  Messages form the conversation history passed to LLMs. Each message has a role
-  (system, user, assistant, or tool) and content parts that can include text,
-  images, and other modalities.
-
-  This module is designed to be compatible with external LLM libraries while
-  remaining self-contained within the SwarmAi framework.
+  Messages form the conversation history passed to LLMs. Each role has its own
+  struct so that invalid states (e.g. a system message with tool_calls) are
+  unrepresentable at compile time.
   """
 
-  use TypedStruct
+  alias SwarmAi.Message.{System, User, Assistant, Tool}
   alias SwarmAi.Message.ContentPart
 
   @type role :: :system | :user | :assistant | :tool
+  @type t :: System.t() | User.t() | Assistant.t() | Tool.t()
 
-  typedstruct do
-    field(:role, role(), enforce: true)
-    field(:content, [ContentPart.t()], default: [])
-    field(:tool_calls, [SwarmAi.ToolCall.t()], default: [])
-    field(:tool_call_id, String.t())
-    field(:name, String.t())
-    field(:metadata, map(), default: %{})
-  end
+  defguard is_message(msg)
+           when is_struct(msg, System) or is_struct(msg, User) or
+                  is_struct(msg, Assistant) or is_struct(msg, Tool)
+
+  @doc "Derives the role atom from a message struct."
+  @spec role(t()) :: role()
+  def role(%System{}), do: :system
+  def role(%User{}), do: :user
+  def role(%Assistant{}), do: :assistant
+  def role(%Tool{}), do: :tool
 
   @doc "Creates a system message from text or a list of content parts"
-  @spec system(String.t() | [String.t() | ContentPart.t()]) :: t()
+  @spec system(String.t() | [String.t() | ContentPart.t()]) :: System.t()
   def system(text) when is_binary(text) do
-    %__MODULE__{role: :system, content: [ContentPart.text(text)]}
+    %System{content: [ContentPart.text(text)]}
   end
 
   def system(parts) when is_list(parts) do
@@ -37,20 +37,19 @@ defmodule SwarmAi.Message do
         %ContentPart{} = part -> part
       end)
 
-    %__MODULE__{role: :system, content: content}
+    %System{content: content}
   end
 
   @doc "Creates a user message"
-  @spec user(String.t()) :: t()
+  @spec user(String.t()) :: User.t()
   def user(text) when is_binary(text) do
-    %__MODULE__{role: :user, content: [ContentPart.text(text)]}
+    %User{content: [ContentPart.text(text)]}
   end
 
   @doc "Creates an assistant message"
-  @spec assistant(String.t() | nil, [SwarmAi.ToolCall.t()], map()) :: t()
+  @spec assistant(String.t() | nil, [SwarmAi.ToolCall.t()], map()) :: Assistant.t()
   def assistant(text, tool_calls \\ [], metadata \\ %{}) do
-    %__MODULE__{
-      role: :assistant,
+    %Assistant{
       content: [ContentPart.text(text || "")],
       tool_calls: tool_calls,
       metadata: metadata
@@ -58,10 +57,9 @@ defmodule SwarmAi.Message do
   end
 
   @doc "Creates a tool result message from content parts"
-  @spec tool_result(String.t(), String.t(), [ContentPart.t()], map()) :: t()
+  @spec tool_result(String.t(), String.t(), [ContentPart.t()], map()) :: Tool.t()
   def tool_result(name, tool_call_id, content, metadata \\ %{}) when is_list(content) do
-    %__MODULE__{
-      role: :tool,
+    %Tool{
       name: name,
       tool_call_id: tool_call_id,
       content: content,
@@ -71,7 +69,7 @@ defmodule SwarmAi.Message do
 
   @doc "Extracts text content from a message"
   @spec text(t()) :: String.t() | nil
-  def text(%__MODULE__{content: parts}) do
+  def text(%{content: parts}) do
     Enum.find_value(parts, fn
       %ContentPart{type: :text, text: text} -> text
       _ -> nil

--- a/apps/swarm_ai/lib/swarm_ai/message/assistant.ex
+++ b/apps/swarm_ai/lib/swarm_ai/message/assistant.ex
@@ -1,0 +1,10 @@
+defmodule SwarmAi.Message.Assistant do
+  use TypedStruct
+  alias SwarmAi.Message.ContentPart
+
+  typedstruct do
+    field(:content, [ContentPart.t()], default: [])
+    field(:tool_calls, [SwarmAi.ToolCall.t()], default: [])
+    field(:metadata, map(), default: %{})
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/message/system.ex
+++ b/apps/swarm_ai/lib/swarm_ai/message/system.ex
@@ -1,0 +1,8 @@
+defmodule SwarmAi.Message.System do
+  use TypedStruct
+  alias SwarmAi.Message.ContentPart
+
+  typedstruct do
+    field(:content, [ContentPart.t()], default: [])
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/message/tool.ex
+++ b/apps/swarm_ai/lib/swarm_ai/message/tool.ex
@@ -1,0 +1,11 @@
+defmodule SwarmAi.Message.Tool do
+  use TypedStruct
+  alias SwarmAi.Message.ContentPart
+
+  typedstruct do
+    field(:content, [ContentPart.t()], default: [])
+    field(:tool_call_id, String.t(), enforce: true)
+    field(:name, String.t(), enforce: true)
+    field(:metadata, map(), default: %{})
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/message/user.ex
+++ b/apps/swarm_ai/lib/swarm_ai/message/user.ex
@@ -1,0 +1,8 @@
+defmodule SwarmAi.Message.User do
+  use TypedStruct
+  alias SwarmAi.Message.ContentPart
+
+  typedstruct do
+    field(:content, [ContentPart.t()], default: [])
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/testing.ex
+++ b/apps/swarm_ai/lib/swarm_ai/testing.ex
@@ -121,7 +121,7 @@ defmodule SwarmAi.Testing do
     alias SwarmAi.LLM.{Chunk, Usage}
 
     def stream(_client, messages, _opts) do
-      user_msg = Enum.find(messages, &(&1.role == :user))
+      user_msg = Enum.find(messages, &match?(%SwarmAi.Message.User{}, &1))
       text_content = SwarmAi.Message.text(user_msg)
       content = "Echo: #{text_content}"
 

--- a/apps/swarm_ai/test/swarm_ai/child_agent_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/child_agent_test.exs
@@ -51,7 +51,7 @@ defmodule SwarmAi.ChildAgentTest do
         SwarmAi.run_child(parent_loop, "tc_1", spawn_request, fn _ -> {:ok, ""} end)
 
       [step | _] = child_result.loop.steps
-      user_message = Enum.find(step.input_messages, &(&1.role == :user))
+      user_message = Enum.find(step.input_messages, &match?(%Message.User{}, &1))
 
       assert Message.text(user_message) == "Please analyze module X"
     end

--- a/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
@@ -25,8 +25,8 @@ defmodule SwarmAi.Loop.RunnerTest do
       assert [%Step{input_messages: messages}] = updated_loop.steps
 
       assert [
-               %Message{role: :system} = system_msg,
-               %Message{role: :user} = user_msg
+               %Message.System{} = system_msg,
+               %Message.User{} = user_msg
              ] = messages
 
       assert Message.text(system_msg) == "You are TestBot"

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -216,7 +216,7 @@ defmodule SwarmTest do
       assert {:completed, loop} = SwarmAi.run(agent, messages)
       # Both user messages should be in step input
       [step] = loop.steps
-      user_msgs = Enum.filter(step.input_messages, &(&1.role == :user))
+      user_msgs = Enum.filter(step.input_messages, &match?(%SwarmAi.Message.User{}, &1))
       assert length(user_msgs) == 2
     end
 
@@ -230,7 +230,7 @@ defmodule SwarmTest do
         ContentPart.image_url("https://example.com/image.png")
       ]
 
-      message = %SwarmAi.Message{role: :user, content: content}
+      message = %SwarmAi.Message.User{content: content}
 
       assert {:completed, loop} = SwarmAi.run(agent, message)
       assert loop.result == "I see an image"
@@ -407,11 +407,10 @@ defmodule SwarmTest do
       # Second step should have full conversation history
       [_step1, step2] = loop.steps
 
-      roles = Enum.map(step2.input_messages, & &1.role)
-      assert :system in roles
-      assert :user in roles
-      assert :assistant in roles
-      assert :tool in roles
+      assert Enum.any?(step2.input_messages, &match?(%SwarmAi.Message.System{}, &1))
+      assert Enum.any?(step2.input_messages, &match?(%SwarmAi.Message.User{}, &1))
+      assert Enum.any?(step2.input_messages, &match?(%SwarmAi.Message.Assistant{}, &1))
+      assert Enum.any?(step2.input_messages, &match?(%SwarmAi.Message.Tool{}, &1))
     end
   end
 


### PR DESCRIPTION
## Summary
- Replace single `SwarmAi.Message` struct with 4 role-specific structs (`System`, `User`, `Assistant`, `Tool`) so invalid states are unrepresentable
- Parent `SwarmAi.Message` module stays as namespace with union type `t()`, factory functions, `role/1` helper, and `is_message/1` guard
- Update all consumers: `execution.ex`, `llm_client.ex`, `swarm_otel_handler.ex`, `testing.ex`, and test pattern matches

## Test plan
- [x] `mix compile --warnings-as-errors` passes for both `swarm_ai` and `frontman_server`
- [x] `swarm_ai` tests pass (130 tests, 0 failures)
- [x] `frontman_server` execution tests pass (62 tests, 0 failures)
- [x] Task channel tests pass (35 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
