### PR TITLE
fix(tasks): forward title generation key context

### DIFF
--- a/.changeset/fair-timers-wave.md
+++ b/.changeset/fair-timers-wave.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Fix task title generation so the background worker receives the same model selection and forwarded env API keys as the original prompt, preventing titles from getting stuck on `New Task` when chat execution succeeds.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -11,6 +11,7 @@ defmodule FrontmanServer.Tasks do
   require Logger
 
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers.Model
   alias FrontmanServer.Repo
 
   alias FrontmanServer.Tasks.{
@@ -355,10 +356,13 @@ defmodule FrontmanServer.Tasks do
   @doc """
   Enqueues an Oban job to generate a title for a task from the user's prompt.
   """
-  @spec enqueue_title_generation(Scope.t(), String.t(), String.t()) ::
+  @spec enqueue_title_generation(Scope.t(), String.t(), String.t(), keyword()) ::
           {:ok, Oban.Job.t()} | {:error, Oban.Job.changeset()}
-  def enqueue_title_generation(%Scope{} = scope, task_id, user_prompt_text) do
-    GenerateTitle.new_job(scope.user.id, task_id, user_prompt_text)
+  def enqueue_title_generation(%Scope{} = scope, task_id, user_prompt_text, opts \\ []) do
+    env_api_key = Keyword.get(opts, :env_api_key, %{})
+    model = opts |> Keyword.get(:model) |> Model.resolve_string()
+
+    GenerateTitle.new_job(scope.user.id, task_id, user_prompt_text, env_api_key, model)
     |> Oban.insert()
   end
 

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -37,33 +37,44 @@ defmodule FrontmanServer.Workers.GenerateTitle do
   @type job_args :: %{
           user_id: String.t(),
           task_id: String.t(),
-          user_prompt_text: String.t()
+          user_prompt_text: String.t(),
+          env_api_key: %{optional(String.t()) => String.t()},
+          model: String.t() | nil
         }
 
   @doc """
   Builds an Oban job changeset for title generation.
   """
-  @spec new_job(String.t(), String.t(), String.t()) :: Oban.Job.changeset()
-  def new_job(user_id, task_id, user_prompt_text) do
+  @spec new_job(String.t(), String.t(), String.t(), map(), String.t() | nil) ::
+          Oban.Job.changeset()
+  def new_job(user_id, task_id, user_prompt_text, env_api_key \\ %{}, model \\ nil) do
     new(%{
       user_id: user_id,
       task_id: task_id,
-      user_prompt_text: user_prompt_text
+      user_prompt_text: user_prompt_text,
+      env_api_key: env_api_key,
+      model: model
     })
   end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{
-          "user_id" => user_id,
-          "task_id" => task_id,
-          "user_prompt_text" => user_prompt_text
-        }
-      }) do
+  def perform(%Oban.Job{args: args}) do
+    user_id = Map.fetch!(args, "user_id")
+    task_id = Map.fetch!(args, "task_id")
+    user_prompt_text = Map.fetch!(args, "user_prompt_text")
+    env_api_key = Map.get(args, "env_api_key", %{})
+    model = Map.get(args, "model")
+
     user = Accounts.get_user!(user_id)
     scope = Scope.for_user(user)
+
     with {:ok, resolved_key} <-
-           Providers.prepare_api_key(scope, @fallback_model, %{}, skip_quota: true),
+           Providers.prepare_api_key(
+             scope,
+             model || @fallback_model,
+             env_api_key,
+             skip_quota: true
+           ),
          {:ok, raw_title} <- call_llm(resolved_key, user_prompt_text),
          title = String.trim(raw_title),
          false <- title == "",

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -522,7 +522,10 @@ defmodule FrontmanServerWeb.TaskChannel do
       {:ok, _interaction} ->
         Logger.info("User message added, agent spawned for task #{task_id}")
 
-        Tasks.enqueue_title_generation(scope, task_id, prompt.text_summary)
+        Tasks.enqueue_title_generation(scope, task_id, prompt.text_summary,
+          env_api_key: env_api_key,
+          model: model
+        )
 
         {:noreply, socket}
 

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -5,6 +5,7 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
   import FrontmanServer.AccountsFixtures
 
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers.Model
   alias FrontmanServer.Tasks
   alias FrontmanServer.Workers.GenerateTitle
 
@@ -13,30 +14,47 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
     {:ok, user: user}
   end
 
-  describe "new_job/3" do
+  describe "new_job/5" do
     test "builds a job changeset with the correct args", %{user: user} do
-      changeset = GenerateTitle.new_job(user.id, "task-123", "Help me build a login page")
+      changeset =
+        GenerateTitle.new_job(
+          user.id,
+          "task-123",
+          "Help me build a login page",
+          %{"openrouter" => "sk-or-test"},
+          "openrouter:openai/gpt-5.1-codex"
+        )
 
       assert changeset.changes.args == %{
                user_id: user.id,
                task_id: "task-123",
-               user_prompt_text: "Help me build a login page"
+               user_prompt_text: "Help me build a login page",
+               env_api_key: %{"openrouter" => "sk-or-test"},
+               model: "openrouter:openai/gpt-5.1-codex"
              }
     end
   end
 
   describe "perform/1" do
-    test "enqueues via Tasks context", %{user: user} do
+    test "enqueues via Tasks context with forwarded model and env key", %{user: user} do
       scope = Scope.for_user(user)
       task_id = Ecto.UUID.generate()
       {:ok, ^task_id} = Tasks.create_task(scope, task_id, "nextjs")
 
       {:ok, _job} =
-        Tasks.enqueue_title_generation(scope, task_id, "Help me build a login page")
+        Tasks.enqueue_title_generation(scope, task_id, "Help me build a login page",
+          env_api_key: %{"openrouter" => "sk-or-test"},
+          model: Model.new("openrouter", "openai/gpt-5.1-codex")
+        )
 
       assert_enqueued(
         worker: GenerateTitle,
-        args: %{user_id: user.id, task_id: task_id}
+        args: %{
+          user_id: user.id,
+          task_id: task_id,
+          env_api_key: %{"openrouter" => "sk-or-test"},
+          model: "openrouter:openai/gpt-5.1-codex"
+        }
       )
     end
   end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1,10 +1,12 @@
 defmodule FrontmanServerWeb.TaskChannelTest do
   use FrontmanServerWeb.ChannelCase, async: true
+  use Oban.Testing, repo: FrontmanServer.Repo
 
   import FrontmanServer.InteractionCase.Helpers
 
   alias AgentClientProtocol.Content.{ContentItem, TextBlock}
   alias FrontmanServer.Tasks
+  alias FrontmanServer.Workers.GenerateTitle
   alias FrontmanServerWeb.UserSocket
 
   # --- Swarm event builders (match production shapes from Runtime) ---
@@ -84,6 +86,37 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert_reply(ref, :ok, %{"acp:message" => response})
       assert response["error"]["code"] == -32_601
       assert response["error"]["message"] =~ "Method not found"
+    end
+
+    test "forwards prompt model and env API key to title generation job", %{
+      socket: socket,
+      task_id: task_id,
+      user: user
+    } do
+      complete_mcp_handshake(socket)
+
+      push(
+        socket,
+        "acp:message",
+        build_prompt_request(
+          _meta: %{
+            "openrouterKeyValue" => "sk-or-test",
+            "model" => %{"provider" => "openrouter", "value" => "openai/gpt-5.1-codex"}
+          }
+        )
+      )
+
+      :sys.get_state(socket.channel_pid)
+
+      assert_enqueued(
+        worker: GenerateTitle,
+        args: %{
+          user_id: user.id,
+          task_id: task_id,
+          env_api_key: %{"openrouter" => "sk-or-test"},
+          model: "openrouter:openai/gpt-5.1-codex"
+        }
+      )
     end
   end
 


### PR DESCRIPTION
## Summary
- forward prompt `model` and `env_api_key` metadata into the `GenerateTitle` Oban job so title generation resolves keys the same way chat execution does
- update the worker to use forwarded context before falling back to the default OpenRouter model
- add worker and channel regression coverage to catch tasks getting stuck on `New Task`

## Testing
- `mix test test/frontman_server/workers/generate_title_test.exs test/frontman_server_web/channels/task_channel_test.exs`
- `make precommit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
