### PR TITLE
fix: handle MCP tool-level errors in MCPInitializer

### DIFF
--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
@@ -201,6 +201,16 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
   end
 
   defp handle_project_rules_response(result, state) do
+    if MCP.error?(result) do
+      report_tool_error(state, "project_rules", "load_agent_instructions", result)
+    else
+      parse_project_rules(result, state)
+    end
+
+    request_project_structure(state)
+  end
+
+  defp parse_project_rules(result, state) do
     with text when text != "" <- MCP.extract_content_text(result) |> String.trim(),
          {:ok, rules} when is_list(rules) <- Jason.decode(text) do
       Enum.each(rules, fn %{"fullPath" => path, "content" => content} ->
@@ -212,11 +222,12 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
       "" ->
         Logger.info("MCPInitializer: Initialized 0 project rules")
 
+      {:ok, _other} ->
+        Logger.warning("MCPInitializer: Unexpected project rules format (expected a list)")
+
       {:error, reason} ->
         Logger.warning("MCPInitializer: Failed to parse project rules: #{inspect(reason)}")
     end
-
-    request_project_structure(state)
   end
 
   # Step 4: Discover project structure via list_tree
@@ -245,6 +256,16 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
   end
 
   defp handle_project_structure_response(result, state) do
+    if MCP.error?(result) do
+      report_tool_error(state, "project_structure", "list_tree", result)
+    else
+      parse_project_structure(result, state)
+    end
+
+    complete_initialization(state)
+  end
+
+  defp parse_project_structure(result, state) do
     with text when text != "" <- MCP.extract_content_text(result) |> String.trim(),
          {:ok, %{"tree" => tree} = decoded} when is_binary(tree) <- Jason.decode(text) do
       monorepo_type = Map.get(decoded, "monorepoType")
@@ -271,8 +292,6 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
       {:error, reason} ->
         Logger.warning("MCPInitializer: Failed to parse project structure: #{inspect(reason)}")
     end
-
-    complete_initialization(state)
   end
 
   defp format_workspace_section(ws) when is_list(ws) and ws != [] do
@@ -309,5 +328,16 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
       })
 
     {state, [{:push_acp, notification}, {:initialization_complete, initialization_data}]}
+  end
+
+  defp report_tool_error(state, init_step, tool_name, result) do
+    text = MCP.extract_content_text(result)
+    Logger.warning("MCPInitializer: Tool error loading #{init_step}: #{text}")
+
+    Sentry.capture_message("MCP tool error during initialization",
+      level: :warning,
+      tags: %{error_type: "mcp_tool_error", init_step: init_step},
+      extra: %{task_id: state.task_id, tool_name: tool_name, error_text: text}
+    )
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
@@ -1,0 +1,125 @@
+defmodule FrontmanServerWeb.TaskChannel.MCPInitializerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias FrontmanServerWeb.TaskChannel.MCPInitializer
+
+  setup do
+    Sentry.Test.start_collecting_sentry_reports()
+    :ok
+  end
+
+  # A minimal state in the project_rules loading phase
+  defp rules_state(request_id) do
+    %{
+      status: :loading_project_rules,
+      task_id: "test_task",
+      scope: %FrontmanServer.Accounts.Scope{user: %FrontmanServer.Accounts.User{id: 1}},
+      mcp_init_request_id: nil,
+      tools_request_id: nil,
+      project_rules_request_id: request_id,
+      project_structure_request_id: nil,
+      mcp_capabilities: %{},
+      mcp_server_info: %{},
+      tools: []
+    }
+  end
+
+  # A minimal state in the project_structure loading phase
+  defp structure_state(request_id) do
+    %{
+      status: :loading_project_structure,
+      task_id: "test_task",
+      scope: %FrontmanServer.Accounts.Scope{user: %FrontmanServer.Accounts.User{id: 1}},
+      mcp_init_request_id: nil,
+      tools_request_id: nil,
+      project_rules_request_id: nil,
+      project_structure_request_id: request_id,
+      mcp_capabilities: %{},
+      mcp_server_info: %{},
+      tools: []
+    }
+  end
+
+  describe "handle_response/3 with tool-level errors (isError: true)" do
+    test "project rules: does not crash and reports to Sentry" do
+      request_id = 1
+      state = rules_state(request_id)
+
+      # This is the exact payload from the Sentry issue — a successful JSON-RPC
+      # response where the tool itself returned an error.
+      result = %{
+        "content" => [%{"text" => "Path escapes source root: .", "type" => "text"}],
+        "isError" => true
+      }
+
+      log =
+        capture_log(fn ->
+          {new_state, actions} = MCPInitializer.handle_response(state, request_id, result)
+
+          assert new_state.status == :loading_project_structure
+
+          assert Enum.any?(actions, fn
+                   {:push_mcp, _} -> true
+                   _ -> false
+                 end)
+        end)
+
+      assert log =~ "Tool error loading project_rules"
+
+      [event] = Sentry.Test.pop_sentry_reports()
+      assert event.message.formatted == "MCP tool error during initialization"
+      assert event.level == :warning
+      assert event.tags[:init_step] == "project_rules"
+      assert event.extra[:tool_name] == "load_agent_instructions"
+      assert event.extra[:error_text] =~ "Path escapes source root"
+    end
+
+    test "project structure: does not crash and reports to Sentry" do
+      request_id = 2
+      state = structure_state(request_id)
+
+      result = %{
+        "content" => [%{"text" => "Something went wrong", "type" => "text"}],
+        "isError" => true
+      }
+
+      log =
+        capture_log(fn ->
+          {new_state, actions} = MCPInitializer.handle_response(state, request_id, result)
+
+          assert new_state.status == :ready
+
+          assert Enum.any?(actions, fn
+                   {:initialization_complete, _} -> true
+                   _ -> false
+                 end)
+        end)
+
+      assert log =~ "Tool error loading project_structure"
+
+      [event] = Sentry.Test.pop_sentry_reports()
+      assert event.message.formatted == "MCP tool error during initialization"
+      assert event.tags[:init_step] == "project_structure"
+      assert event.extra[:tool_name] == "list_tree"
+    end
+  end
+
+  describe "handle_response/3 with unhandled decode results" do
+    test "project rules: handles JSON that decodes to a map (not a list)" do
+      request_id = 1
+      state = rules_state(request_id)
+
+      # JSON decodes successfully but to a map, not a list — the `when is_list` guard
+      # in the `with` block rejects it, and there's no matching `else` clause.
+      result = %{
+        "content" => [%{"text" => ~s({"key": "value"}), "type" => "text"}]
+      }
+
+      {new_state, _actions} = MCPInitializer.handle_response(state, request_id, result)
+
+      assert new_state.status == :loading_project_structure
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Check `MCP.error?(result)` before parsing content in `handle_project_rules_response` and `handle_project_structure_response` — tool-level errors (`isError: true`) are now detected early instead of falling through to JSON parsing
- Add catch-all `{:ok, _other}` clause to the `with` block in `handle_project_rules_response` to prevent `WithClauseError` when JSON decodes to a non-list shape
- Report tool errors to Sentry with `init_step` and `tool_name` tags for visibility

Fixes #688 / [ELIXIR-3C](https://frontman-gm.sentry.io/issues/102796839/)

## Test plan

- [x] New unit tests for `MCPInitializer` covering:
  - `isError: true` on project rules response → logs warning, reports to Sentry, continues to structure loading
  - `isError: true` on project structure response → logs warning, reports to Sentry, completes initialization
  - JSON decoding to a map (not a list) in project rules → handled gracefully via catch-all else clause
- [ ] Verify no regressions in existing task channel tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
