### PR TITLE
fix: kill agent on MCP server disconnect with 1-minute grace period

### DIFF
--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -15,6 +15,8 @@ defmodule FrontmanServer.Application do
   alias FrontmanServer.Observability.OtelHandler
   alias FrontmanServer.Observability.SwarmOtelHandler
 
+  alias FrontmanServer.Tasks.Execution
+
   @impl true
   def start(_type, _args) do
     # Setup telemetry -> OTEL span translation
@@ -50,6 +52,8 @@ defmodule FrontmanServer.Application do
        event_dispatcher: {FrontmanServer.Tasks.SwarmDispatcher, :dispatch, []}},
       # Registry for MCP tool call result routing (separate from agent execution tracking)
       {Registry, keys: :unique, name: FrontmanServer.ToolCallRegistry},
+      # Grace period for MCP server disconnects before killing executions
+      {Execution.MCPAvailability, name: FrontmanServer.MCPAvailability},
       # Oban background job processing (email delivery, contact sync, etc.)
       {Oban, Application.fetch_env!(:frontman_server, Oban)},
       # Start to serve requests, typically the last entry

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -410,6 +410,30 @@ defmodule FrontmanServer.Tasks do
     Execution.cancel(scope, task_id)
   end
 
+  @doc """
+  Signal that the MCP server is available for the given task.
+  Cancels any pending disconnect grace period.
+  """
+  @spec mcp_server_available(Scope.t(), String.t()) :: :ok
+  def mcp_server_available(%Scope{} = _scope, task_id) do
+    Execution.MCPAvailability.mcp_server_available(FrontmanServer.MCPAvailability, task_id)
+  end
+
+  @doc """
+  Signal that the MCP server is no longer available for the given task.
+  Starts a grace period — if no MCP server reconnects, the execution is cancelled.
+  """
+  @spec mcp_server_unavailable(Scope.t(), String.t()) :: :ok
+  def mcp_server_unavailable(%Scope{} = scope, task_id) do
+    cancel_fn = fn -> cancel_execution(scope, task_id) end
+
+    Execution.MCPAvailability.mcp_server_unavailable(
+      FrontmanServer.MCPAvailability,
+      task_id,
+      cancel_fn
+    )
+  end
+
   # --- Title Generation ---
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/mcp_availability.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/mcp_availability.ex
@@ -1,0 +1,80 @@
+defmodule FrontmanServer.Tasks.Execution.MCPAvailability do
+  @moduledoc """
+  Tracks MCP server availability per task and manages grace period timers.
+
+  When the browser tab closes, the MCP server becomes unreachable and the
+  agent cannot execute tools. This GenServer gives the connection a grace
+  period to recover (tab reload, brief network drop) before cancelling the
+  execution.
+  """
+  use GenServer
+
+  require Logger
+
+  @default_grace_period_ms :timer.minutes(1)
+
+  # -- Public API --
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Signal that the MCP server is available for the given task.
+  Cancels any pending grace period timer.
+  """
+  @spec mcp_server_available(GenServer.server(), String.t()) :: :ok
+  def mcp_server_available(server, task_id) do
+    GenServer.cast(server, {:available, task_id})
+  end
+
+  @doc """
+  Signal that the MCP server is no longer available for the given task.
+  Starts the grace period timer. When it expires, `cancel_fn` is called.
+  """
+  @spec mcp_server_unavailable(GenServer.server(), String.t(), (-> any())) :: :ok
+  def mcp_server_unavailable(server, task_id, cancel_fn) do
+    GenServer.cast(server, {:unavailable, task_id, cancel_fn})
+  end
+
+  # -- Callbacks --
+
+  @impl true
+  def init(opts) do
+    grace_period_ms = Keyword.get(opts, :grace_period_ms, @default_grace_period_ms)
+    {:ok, %{tasks: %{}, grace_period_ms: grace_period_ms}}
+  end
+
+  @impl true
+  def handle_cast({:available, task_id}, state) do
+    case Map.pop(state.tasks, task_id) do
+      {%{timer_ref: ref}, tasks} ->
+        Process.cancel_timer(ref)
+        {:noreply, %{state | tasks: tasks}}
+
+      {nil, _tasks} ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_cast({:unavailable, task_id, cancel_fn}, state) do
+    timer_ref = Process.send_after(self(), {:grace_expired, task_id}, state.grace_period_ms)
+
+    tasks = Map.put(state.tasks, task_id, %{timer_ref: timer_ref, cancel_fn: cancel_fn})
+    {:noreply, %{state | tasks: tasks}}
+  end
+
+  @impl true
+  def handle_info({:grace_expired, task_id}, state) do
+    case Map.pop(state.tasks, task_id) do
+      {%{cancel_fn: cancel_fn}, tasks} ->
+        Logger.info("MCP grace period expired for task #{task_id}, cancelling execution")
+        cancel_fn.()
+        {:noreply, %{state | tasks: tasks}}
+
+      {nil, _tasks} ->
+        {:noreply, state}
+    end
+  end
+end

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -910,7 +910,10 @@ defmodule FrontmanServerWeb.TaskChannel do
 
         {:initialization_complete, data} ->
           task_id = socket.assigns.task_id
+          scope = socket.assigns.scope
           Logger.info("MCP initialization complete for task #{task_id}")
+
+          Tasks.mcp_server_available(scope, task_id)
 
           socket
           |> assign(:mcp_status, :ready)
@@ -1009,31 +1012,18 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   @impl true
-  def terminate(reason, socket) do
+  def terminate(_reason, socket) do
     task_id = socket.assigns[:task_id]
-    Logger.info("Client disconnected from task #{task_id}: #{inspect(reason)}")
+    scope = socket.assigns[:scope]
+    Logger.info("Client disconnected from task #{task_id}")
 
-    scope = socket.assigns.scope
-
-    # Notify any interactive tool executors waiting on this task's pending
-    # tool calls. Without this, executors block until the 24h safety-net
-    # timeout. On reconnect, reexecute_unresolved_tool_calls re-sends
-    # tools/call to the new client, which provides a fresh tool result.
     RetryCoordinator.clear(socket.assigns[:retry_state])
 
-    pending_requests = socket.assigns[:pending_requests] || %{}
-
-    for {_request_id, {:tool_call, tc}} <- pending_requests do
-      Execution.notify_tool_result(scope, tc.tool_call_id, "Client disconnected", true)
-    end
-
-    # Cancel any running execution. Without the channel, MCP tool results
-    # can never arrive — the executor processes would hang until their
-    # safety-net timeout. Cancellation is persisted by SwarmDispatcher so
-    # the user sees the interrupted state on reconnect.
-    case Tasks.cancel_execution(scope, task_id) do
-      :ok -> Logger.info("Cancelled execution for task #{task_id} on channel termination")
-      {:error, :not_running} -> :ok
+    # Signal MCP unavailability instead of killing the execution immediately.
+    # The MCPAvailability GenServer enforces a grace period — if the client
+    # reconnects before it expires, the execution continues uninterrupted.
+    if socket.assigns[:mcp_status] == :ready do
+      Tasks.mcp_server_unavailable(scope, task_id)
     end
 
     :ok

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_availability_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_availability_test.exs
@@ -1,0 +1,84 @@
+defmodule FrontmanServer.Tasks.Execution.MCPAvailabilityTest do
+  use ExUnit.Case, async: true
+
+  alias FrontmanServer.Tasks.Execution.MCPAvailability
+
+  # Use a short grace period for fast tests
+  @grace_period_ms 50
+
+  setup do
+    monitor = start_supervised!({MCPAvailability, grace_period_ms: @grace_period_ms})
+    {:ok, monitor: monitor}
+  end
+
+  describe "mcp_server_unavailable -> grace period -> cancel" do
+    test "calls cancel_fn after grace period expires", %{monitor: monitor} do
+      test_pid = self()
+      cancel_fn = fn -> send(test_pid, :cancelled) end
+
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn)
+
+      refute_receive :cancelled, 10
+      assert_receive :cancelled, 100
+    end
+
+    test "does not cancel if mcp_server_available is called within grace period", %{
+      monitor: monitor
+    } do
+      test_pid = self()
+      cancel_fn = fn -> send(test_pid, :cancelled) end
+
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn)
+      MCPAvailability.mcp_server_available(monitor, "task-1")
+
+      refute_receive :cancelled, 100
+    end
+  end
+
+  describe "mcp_server_available with no pending timer" do
+    test "is a no-op", %{monitor: monitor} do
+      MCPAvailability.mcp_server_available(monitor, "task-1")
+    end
+  end
+
+  describe "disconnect -> reconnect -> disconnect cycle" do
+    test "starts a new grace period on second disconnect", %{monitor: monitor} do
+      test_pid = self()
+      cancel_fn = fn -> send(test_pid, :cancelled) end
+
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn)
+      MCPAvailability.mcp_server_available(monitor, "task-1")
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn)
+
+      assert_receive :cancelled, 100
+    end
+  end
+
+  describe "multiple tasks" do
+    test "tracks tasks independently", %{monitor: monitor} do
+      test_pid = self()
+      cancel_fn_1 = fn -> send(test_pid, {:cancelled, "task-1"}) end
+      cancel_fn_2 = fn -> send(test_pid, {:cancelled, "task-2"}) end
+
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn_1)
+      MCPAvailability.mcp_server_unavailable(monitor, "task-2", cancel_fn_2)
+
+      MCPAvailability.mcp_server_available(monitor, "task-1")
+
+      refute_receive {:cancelled, "task-1"}, 100
+      assert_receive {:cancelled, "task-2"}, 100
+    end
+  end
+
+  describe "timer race conditions" do
+    test "expired timer for already-reconnected task is a no-op", %{monitor: monitor} do
+      test_pid = self()
+      cancel_fn = fn -> send(test_pid, :cancelled) end
+
+      MCPAvailability.mcp_server_unavailable(monitor, "task-1", cancel_fn)
+      MCPAvailability.mcp_server_available(monitor, "task-1")
+
+      refute_receive :cancelled, 100
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1965,4 +1965,145 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
     end
   end
+
+  describe "MCP disconnect grace period" do
+    setup %{scope: scope} do
+      # Replace the app-level MCPAvailability with one using a short grace period.
+      # The global process is supervised by FrontmanServer.Supervisor with a
+      # 1-minute default; we terminate that child and start our own short-lived one.
+      :ok =
+        Supervisor.terminate_child(
+          FrontmanServer.Supervisor,
+          FrontmanServer.Tasks.Execution.MCPAvailability
+        )
+
+      start_supervised!(
+        {FrontmanServer.Tasks.Execution.MCPAvailability,
+         name: FrontmanServer.MCPAvailability, grace_period_ms: 50}
+      )
+
+      on_exit(fn ->
+        # Restart the app-level child so other tests are unaffected
+        Supervisor.restart_child(
+          FrontmanServer.Supervisor,
+          FrontmanServer.Tasks.Execution.MCPAvailability
+        )
+      end)
+
+      {socket, task_id} = join_task_channel(scope)
+      {:ok, socket: socket, task_id: task_id}
+    end
+
+    test "terminate/2 signals mcp_server_unavailable when MCP was ready", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      complete_mcp_handshake(socket)
+
+      # Register a fake running execution in the runtime registry
+      test_pid = self()
+      runtime_registry = SwarmAi.Runtime.registry_name(FrontmanServer.AgentRuntime)
+
+      agent_pid =
+        spawn(fn ->
+          Registry.register(runtime_registry, {:running, task_id}, %{})
+          send(test_pid, :agent_registered)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :agent_registered
+
+      # Monitor the agent so we can detect when it's killed
+      ref = Process.monitor(agent_pid)
+
+      # Disconnect the channel cleanly — this triggers terminate/2 via
+      # GenServer {:stop, {:shutdown, :closed}} which guarantees the callback.
+      Process.unlink(socket.channel_pid)
+      close(socket)
+
+      # The grace period is 50ms — after it expires, cancel_execution kills the agent
+      assert_receive {:DOWN, ^ref, :process, ^agent_pid, :cancelled}, 1_000
+    end
+
+    test "terminate/2 does not signal when MCP was not ready", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      # Do NOT complete MCP handshake — mcp_status stays :pending
+
+      # Register a fake running execution
+      test_pid = self()
+      runtime_registry = SwarmAi.Runtime.registry_name(FrontmanServer.AgentRuntime)
+
+      agent_pid =
+        spawn(fn ->
+          Registry.register(runtime_registry, {:running, task_id}, %{})
+          send(test_pid, :agent_registered)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :agent_registered
+
+      ref = Process.monitor(agent_pid)
+
+      Process.unlink(socket.channel_pid)
+      close(socket)
+
+      # Wait longer than the grace period; the agent should NOT be killed
+      refute_receive {:DOWN, ^ref, :process, ^agent_pid, _}, 200
+
+      # Cleanup
+      Process.exit(agent_pid, :kill)
+    end
+
+    test "reconnect within grace period cancels the timer", %{
+      socket: socket,
+      task_id: task_id,
+      scope: scope
+    } do
+      complete_mcp_handshake(socket)
+
+      # Register a fake running execution
+      test_pid = self()
+      runtime_registry = SwarmAi.Runtime.registry_name(FrontmanServer.AgentRuntime)
+
+      agent_pid =
+        spawn(fn ->
+          Registry.register(runtime_registry, {:running, task_id}, %{})
+          send(test_pid, :agent_registered)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :agent_registered
+
+      ref = Process.monitor(agent_pid)
+
+      # Disconnect the channel — starts the grace period timer
+      Process.unlink(socket.channel_pid)
+      close(socket)
+
+      # Reconnect immediately (well within the 50ms grace period)
+      {:ok, _reply, socket2} =
+        UserSocket
+        |> socket("user_id", %{scope: scope})
+        |> subscribe_and_join("task:#{task_id}", %{})
+
+      complete_mcp_handshake(socket2)
+
+      # Wait longer than the grace period — agent should survive
+      refute_receive {:DOWN, ^ref, :process, ^agent_pid, _}, 200
+
+      # Cleanup
+      Process.exit(agent_pid, :kill)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #643

- Adds `Execution.MCPAvailability` GenServer that tracks MCP server availability per task and manages grace period timers
- `TaskChannel` signals availability on MCP init complete and unavailability on `terminate/2`
- When no MCP server reconnects within 1 minute, the execution is cancelled via the existing `Runtime.cancel` pipeline
- Removes the old tool-call poisoning behavior from `terminate/2` (which caused the split-brain state described in #643)
- Keeps `reexecute_unresolved_tool_calls` for within-grace-period reconnects

## Test plan

- [ ] Unit tests for MCPAvailability GenServer (grace period expiry, cancellation on reconnect, multi-task independence, race conditions)
- [ ] Channel-level integration tests: disconnect kills execution after grace period, no signal when MCP not ready, reconnect within grace period cancels timer
- [ ] Full test suite passes (728 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
