### PR TITLE
fix: show guidance when embedded auth cookies are blocked

### DIFF
--- a/.changeset/early-donkeys-film.md
+++ b/.changeset/early-donkeys-film.md
@@ -1,0 +1,10 @@
+---
+"@frontman-ai/client": patch
+---
+
+fix: show cookie guidance when embedded sign-in may be blocked
+
+Embedded Frontman now shows a browser-specific notice when Safari or a likely
+third-party-cookie block prevents sign-in from completing. The modal explains
+how to enable the needed cookie setting and lets the user retry sign-in after
+updating their browser configuration.

--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -1,4 +1,6 @@
 module SettingsModal = Client__SettingsModal
+module CookieAuthHelp = Client__CookieAuthHelp
+module CookieNoticeModal = Client__CookieNoticeModal
 
 @react.component
 let make = (~apiBaseUrl: string) => {
@@ -11,6 +13,7 @@ let make = (~apiBaseUrl: string) => {
   React.useEffect(() => {
     switch connectionState {
     | Connected | SessionActive(_) =>
+      CookieAuthHelp.clearLoginRedirect()
       Client__Debug.init()
       Client__State.Actions.setAcpSession(~sendPrompt, ~cancelPrompt, ~loadTask, ~deleteSession, ~apiBaseUrl)
     | Disconnected | Error(_) => Client__State.Actions.clearAcpSession()
@@ -76,6 +79,18 @@ let make = (~apiBaseUrl: string) => {
     openSettingsProviders()
   }
 
+  let markWelcomeShown = () => {
+    Client__FtueState.setWelcomeShown()
+    setFtueState(_ => Client__FtueState.WelcomeShown)
+  }
+
+  let handleCookieNoticeShown = () => {
+    switch ftueState {
+    | Client__FtueState.New => markWelcomeShown()
+    | Client__FtueState.WelcomeShown | Client__FtueState.Completed => ()
+    }
+  }
+
   // Reset initialTab after settings modal closes so it doesn't stick
   let handleSettingsOpenChange = (value: bool) => {
     setSettingsOpen(_ => value)
@@ -91,9 +106,17 @@ let make = (~apiBaseUrl: string) => {
       onOpenChange={handleSettingsOpenChange}
       initialTab=?{settingsInitialTab}
     />
-    // FTUE: Welcome modal for first-time unauthenticated users
-    {switch (authRedirectUrl, ftueState) {
-    | (Some(loginUrl), Client__FtueState.New) => <Client__WelcomeModal loginUrl />
+    // Auth modals for first-time login and third-party cookie guidance.
+    {switch authRedirectUrl {
+    | Some(loginUrl) =>
+      switch CookieAuthHelp.shouldShowNotice(~loginUrl) {
+      | true => <CookieNoticeModal loginUrl markWelcomeShown={handleCookieNoticeShown} />
+      | false =>
+        switch ftueState {
+        | Client__FtueState.New => <Client__WelcomeModal loginUrl />
+        | Client__FtueState.WelcomeShown | Client__FtueState.Completed => React.null
+        }
+      }
     | _ => React.null
     }}
     // FTUE: Post-signup celebration overlay

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -12,6 +12,7 @@ module ACP = FrontmanAiFrontmanClient.FrontmanClient__ACP
 module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
 module MCPServer = FrontmanAiFrontmanClient.FrontmanClient__MCP__Server
 module Channel = FrontmanAiFrontmanClient.FrontmanClient__Phoenix__Channel
+module CookieAuthHelp = Client__CookieAuthHelp
 
 // Configuration for initialization
 type initConfig = {
@@ -534,21 +535,34 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
       | Ok(conn) => dispatch(ACPConnectSuccess(conn))
       | Error(err) =>
         // Don't dispatch error for aborted connections - component is unmounting
-        if signal.aborted {
-          Log.info("ACP connection aborted (cleanup)")
-        } else {
+        switch signal.aborted {
+        | true => Log.info("ACP connection aborted (cleanup)")
+        | false =>
           switch err {
           | ACP.AuthRequired({loginUrl}) =>
-            let encodeURIComponent: string => string = %raw(`encodeURIComponent`)
             let currentUrl =
               WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href
-            let returnTo = encodeURIComponent(currentUrl)
-            let fullUrl = `${loginUrl}?return_to=${returnTo}`
-            switch initialAuthBehavior {
-            | Client__FtueState.ShowWelcomeModal =>
+            let fullUrl =
+              try {
+                let authUrl = WebAPI.URL.make(~url=loginUrl)
+                authUrl.searchParams->WebAPI.URLSearchParams.set(
+                  ~name="return_to",
+                  ~value=currentUrl,
+                )
+                authUrl.href
+              } catch {
+              | _ => loginUrl
+              }
+            switch CookieAuthHelp.shouldShowNotice(~loginUrl=fullUrl) {
+            | true =>
               dispatch(ACPConnectError(`auth_required:${fullUrl}`))
-            | Client__FtueState.RedirectToLogin =>
-              WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(fullUrl)
+            | false =>
+              switch initialAuthBehavior {
+              | Client__FtueState.ShowWelcomeModal =>
+                dispatch(ACPConnectError(`auth_required:${fullUrl}`))
+              | Client__FtueState.RedirectToLogin =>
+                CookieAuthHelp.continueToLogin(~loginUrl=fullUrl)
+              }
             }
           | ACP.ConnectionFailed(msg) => dispatch(ACPConnectError(msg))
           }

--- a/libs/client/src/Client__CookieAuthHelp.res
+++ b/libs/client/src/Client__CookieAuthHelp.res
@@ -1,0 +1,84 @@
+let redirectStorageKey = "frontman:auth_redirect_started_at"
+let redirectWindowMs = 5. *. 60_000.
+
+type browser =
+  | Safari
+  | Chrome
+  | Firefox
+  | Edge
+  | Unknown
+
+let currentOrigin = (): string => {
+  let location = WebAPI.Global.location
+  `${location.protocol}//${location.host}`
+}
+
+let browserFromUserAgent = (userAgent: string): browser => {
+  let ua = userAgent->String.toLowerCase
+
+  switch () {
+  | _ when ua->String.includes("edg") => Edge
+  | _ when ua->String.includes("firefox") || ua->String.includes("fxios") => Firefox
+  | _ when ua->String.includes("chrome") || ua->String.includes("crios") || ua->String.includes("chromium") => Chrome
+  | _ when ua->String.includes("safari") => Safari
+  | _ => Unknown
+  }
+}
+
+let currentBrowser = (): browser => WebAPI.Global.navigator.userAgent->browserFromUserAgent
+
+let isCrossSiteLogin = (~loginUrl: string): bool => {
+  try {
+    WebAPI.URL.make(~url=loginUrl).origin != currentOrigin()
+  } catch {
+  | _ => false
+  }
+}
+
+let recordLoginRedirect = () => {
+  try {
+    FrontmanBindings.LocalStorage.setItem(redirectStorageKey, Js.Date.now()->Float.toString)
+  } catch {
+  | _ => ()
+  }
+}
+
+let clearLoginRedirect = () => {
+  try {
+    FrontmanBindings.LocalStorage.removeItem(redirectStorageKey)
+  } catch {
+  | _ => ()
+  }
+}
+
+let hasRecentLoginRedirect = (): bool => {
+  try {
+    switch FrontmanBindings.LocalStorage.getItem(redirectStorageKey)->Nullable.toOption {
+    | Some(value) =>
+      switch value->Float.fromString {
+      | Some(timestamp) => Js.Date.now() -. timestamp <= redirectWindowMs
+      | None => false
+      }
+    | None => false
+    }
+  } catch {
+  | _ => false
+  }
+}
+
+let shouldShowNotice = (~loginUrl: string): bool => {
+  switch isCrossSiteLogin(~loginUrl) {
+  | false => false
+  | true =>
+    switch (currentBrowser(), hasRecentLoginRedirect()) {
+    | (Safari, _) => true
+    | (_, true) => true
+    | (_, false) => false
+    }
+  }
+}
+
+let continueToLogin = (~loginUrl: string) => {
+  recordLoginRedirect()
+  WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(loginUrl)
+}

--- a/libs/client/src/Client__CookieNoticeModal.res
+++ b/libs/client/src/Client__CookieNoticeModal.res
@@ -1,0 +1,111 @@
+module Dialog = Bindings__UI__Dialog
+module Button = Bindings__UI__Button
+module CookieAuthHelp = Client__CookieAuthHelp
+
+@react.component
+let make = (~loginUrl: string, ~markWelcomeShown: unit => unit) => {
+  React.useEffect0(() => {
+    markWelcomeShown()
+    None
+  })
+
+  let browser = CookieAuthHelp.currentBrowser()
+
+  let (title, description, steps) = switch browser {
+  | Safari =>
+    (
+      "Safari is blocking the Frontman sign-in cookie.",
+      "Frontman signs you in on a different Frontman domain, and Safari often blocks that cookie by default in embedded experiences.",
+      [
+        "Open Safari Settings (or Preferences) and go to Privacy.",
+        "Turn off ‘Prevent cross-site tracking’. If ‘Block all cookies’ is on, turn that off too.",
+        "Reload this page, then sign in again.",
+      ],
+    )
+  | Chrome =>
+    (
+      "Your browser may be blocking Frontman's sign-in cookie.",
+      "Chrome privacy settings or extensions can block the cross-site cookie Frontman needs to finish signing you in.",
+      [
+        "Open Chrome Settings → Privacy and security → Third-party cookies.",
+        "Allow third-party cookies, or add an exception for Frontman on this site.",
+        "Reload this page, then sign in again.",
+      ],
+    )
+  | Firefox =>
+    (
+      "Your browser may be blocking Frontman's sign-in cookie.",
+      "Firefox Enhanced Tracking Protection can stop the cross-site cookie Frontman uses during sign-in.",
+      [
+        "Open Firefox Settings → Privacy & Security.",
+        "Turn off Enhanced Tracking Protection for this site, or allow cross-site cookies in your Custom settings.",
+        "Reload this page, then sign in again.",
+      ],
+    )
+  | Edge =>
+    (
+      "Your browser may be blocking Frontman's sign-in cookie.",
+      "Edge privacy or cookie settings can block the cross-site cookie Frontman needs during sign-in.",
+      [
+        "Open Edge Settings → Cookies and site permissions → Manage and delete cookies and site data.",
+        "Turn off ‘Block third-party cookies’, or allow Frontman for this site.",
+        "Reload this page, then sign in again.",
+      ],
+    )
+  | Unknown =>
+    (
+      "Frontman needs cross-site cookies to finish signing you in.",
+      "This browser appears to be blocking the Frontman sign-in cookie while the app is embedded on another site.",
+      [
+        "Allow third-party or cross-site cookies for Frontman in your browser settings.",
+        "Reload this page after changing the setting.",
+        "Try signing in again.",
+      ],
+    )
+  }
+
+  <Dialog.Dialog open_={true} onOpenChange={_ => ()}>
+    <Dialog.DialogContent
+      className="sm:max-w-lg max-w-lg border-zinc-700 bg-zinc-900 p-0"
+      showCloseButton={false}>
+      <div className="px-8 py-10 text-center">
+        <div className="mx-auto mb-6">
+          <Client__FrontmanLogo size=48 />
+        </div>
+        <Dialog.DialogTitle className="text-xl font-bold text-zinc-100">
+          {React.string(title)}
+        </Dialog.DialogTitle>
+        <Dialog.DialogDescription className="mt-3 text-sm leading-relaxed text-zinc-400">
+          {React.string(description)}
+        </Dialog.DialogDescription>
+
+        <div className="mt-8 rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 text-left">
+          <ol className="list-decimal space-y-3 pl-5 text-sm leading-relaxed text-zinc-300">
+            {steps
+            ->Array.map(step =>
+              <li key={step}>
+                {React.string(step)}
+              </li>
+            )
+            ->React.array}
+          </ol>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button.Button
+            variant=#secondary
+            className="sm:min-w-44"
+            onClick={_ => CookieAuthHelp.continueToLogin(~loginUrl)}>
+            {React.string("Sign in again")}
+          </Button.Button>
+          <Button.Button
+            variant=#outline
+            className="sm:min-w-44"
+            onClick={_ => WebAPI.Location.reload(WebAPI.Global.location)}>
+            {React.string("Reload after enabling")}
+          </Button.Button>
+        </div>
+      </div>
+    </Dialog.DialogContent>
+  </Dialog.Dialog>
+}

--- a/libs/client/src/Client__WelcomeModal.res
+++ b/libs/client/src/Client__WelcomeModal.res
@@ -3,6 +3,7 @@
 
 module Dialog = Bindings__UI__Dialog
 module Button = Bindings__UI__Button
+module CookieAuthHelp = Client__CookieAuthHelp
 
 let redirectDelaySec = 4
 
@@ -26,7 +27,7 @@ let make = (~loginUrl: string) => {
         switch next <= 0 {
         | true =>
           intervalId.contents->Option.forEach(WebAPI.Global.clearInterval)
-          WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(loginUrl)
+          CookieAuthHelp.continueToLogin(~loginUrl)
         | false => ()
         }
         next
@@ -75,8 +76,7 @@ let make = (~loginUrl: string) => {
           <Button.Button
             variant=#secondary
             className="mt-2"
-            onClick={_ =>
-              WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(loginUrl)}>
+            onClick={_ => CookieAuthHelp.continueToLogin(~loginUrl)}>
             {React.string("Sign in now")}
           </Button.Button>
         </div>


### PR DESCRIPTION
## Summary
- replace the previous popup bearer-token approach with a safer client-side notice for browsers that block the embedded Frontman sign-in cookie
- detect Safari immediately, and detect likely third-party-cookie blocking after a failed sign-in redirect in other browsers
- show browser-specific instructions for enabling the required cookie setting, then let the user retry sign-in

## Testing
- `make rescript-build`
- `cd libs/client && make test`
- `cd apps/frontman_server && make precommit`

Closes #779