### PR TITLE
refactor: deduplicate setup in execution integration tests

### DIFF
--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -328,7 +328,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   # -- MCP tool timeout — DB invariant (bug 7) ---------------------------------
 
   describe "interactive tool timeout — ToolResult DB persistence" do
-    setup :setup_task
+    setup [:setup_sandbox, :setup_user, :setup_task]
 
     test "ToolResult is persisted in DB when question tool times out", %{
       task_id: task_id,
@@ -383,7 +383,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   # -- MCP tool timeout with on_timeout: :error — DB invariant -------------------
 
   describe "MCP tool timeout with on_timeout: :error" do
-    setup :setup_task
+    setup [:setup_sandbox, :setup_user, :setup_task]
 
     test "ToolResult is persisted in DB when MCP tool times out (on_timeout: :error)", %{
       task_id: task_id,
@@ -476,7 +476,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   # -- Backend tool execution — regression: parallel executor missing backend tool_defs ------
 
   describe "backend tool execution — Tasks facade level" do
-    setup :setup_task
+    setup [:setup_sandbox, :setup_user, :setup_task]
 
     # Regression: execution.ex passes `tool_defs: mcp_tools` to Runtime.run, where
     # `mcp_tools` only contains the agent's MCP (SwarmAi.Tool.t()) entries.
@@ -723,7 +723,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   # -- Backend tool crash — DB invariant ----------------------------------------
 
   describe "backend tool crash — ToolResult DB persistence" do
-    setup :setup_task
+    setup [:setup_sandbox, :setup_user, :setup_task]
 
     test "ToolResult is persisted when backend tool raises", %{
       task_id: task_id,
@@ -761,7 +761,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   # -- Backend tool timeout (ParallelExecutor) — DB invariant -------------------
 
   describe "backend tool timeout (ParallelExecutor) — ToolResult DB persistence" do
-    setup :setup_task
+    setup [:setup_sandbox, :setup_user, :setup_task]
 
     test "ToolResult is persisted when ParallelExecutor deadline fires before tool returns", %{
       task_id: task_id,


### PR DESCRIPTION
## Summary
- Extract composable setup functions (`setup_sandbox`, `setup_user`, `setup_task`, `setup_task_only`, `setup_channel`) replacing three near-identical setup blocks
- Chain them via ExUnit's `setup [:fn1, :fn2, ...]` so each describe block declares exactly what it needs
- Registry cancel test now uses `setup [:setup_sandbox]` instead of inlining sandbox boilerplate

Closes #766

## Test plan
- [x] All 8 existing tests pass (verified in container: `mix test test/frontman_server/tasks/execution_test.exs`)
- [x] `mix format --check-formatted` passes
- [x] `mix credo` passes (no issues)
- [x] Lefthook pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
