### PR TITLE
fix(marketing): resolve Astro type warnings and Node indexnow error

### DIFF
--- a/apps/marketing/scripts/indexnow.mjs
+++ b/apps/marketing/scripts/indexnow.mjs
@@ -1,12 +1,11 @@
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { readFileSync, existsSync } from "fs";
-import config from "../astro.config.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const distDir = join(__dirname, "..", "dist");
-const siteUrl = config.site; // e.g., "https://frontman.sh"
+const siteUrl = "https://frontman.sh";
 // Bing-issued verification token — also served as a static file in public/
 const verificationFileName = "b93ec302-3eda-4805-a374-3d5e0d5d4fa3.txt";
 const key = verificationFileName.replace(".txt", "");

--- a/apps/marketing/src/components/starlight/Head.astro
+++ b/apps/marketing/src/components/starlight/Head.astro
@@ -2,8 +2,10 @@
 // Starlight Head component override
 // Adds OG image, breadcrumb structured data, and ensures description is set
 
-import type { Props } from '@astrojs/starlight/props';
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
 import StarlightHead from '@astrojs/starlight/components/Head.astro';
+
+type Props = StarlightRouteData;
 
 const ogImage = new URL('/og.png', Astro.site).href;
 const ogImageAlt = 'Frontman — The AI agent that lives inside your framework';
@@ -67,4 +69,4 @@ const breadcrumbSchema = {
 <meta name="twitter:image:alt" content={ogImageAlt} />
 
 <!-- Breadcrumb Structured Data -->
-<script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+<script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/apps/marketing/src/env.d.ts
+++ b/apps/marketing/src/env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="astro/client" />
+
+interface Window {
+	trackEvent: (eventName: string, params?: Record<string, unknown>) => void;
+}


### PR DESCRIPTION
## Summary
- Extend `Window` interface in `env.d.ts` to declare `trackEvent`, fixing two `ts(2568)` warnings in `googleAnalytics.astro`
- Replace deprecated `Props` import in `Head.astro` with `StarlightRouteData` from `@astrojs/starlight/route-data`
- Add `is:inline` directive to JSON-LD script tag in `Head.astro` to silence `astro(4000)` hint
- Remove `astro.config.mjs` import from `indexnow.mjs` — Node 24 refuses to strip types from `hc-starlight`'s raw `.ts` exports in `node_modules`; the site URL is inlined directly instead

## Test Plan
- [ ] `astro check` reports 0 warnings on the 4 previously flagged hints
- [ ] `node apps/marketing/scripts/indexnow.mjs` runs without the `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
