### PR TITLE
refactor: move env_api_keys into Scope struct (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
+- Refactor: move `env_api_keys` into `Scope` struct — eliminates ad-hoc `env_api_key` parameter threading across `Providers`, channels, and the execution pipeline. `Providers.prepare_api_key`, `resolve_api_key`, `available_provider_tiers`, and `model_config_data` all drop their `env_api_key` parameter and read from `scope.env_api_keys` instead.
+
 ## [0.15.0] - 2026-04-08
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Refactor: move `env_api_keys` into `Scope` struct — eliminates ad-hoc `env_api_key` parameter threading across `Providers`, channels, and the execution pipeline. `Providers.prepare_api_key`, `resolve_api_key`, `available_provider_tiers`, and `model_config_data` all drop their `env_api_key` parameter and read from `scope.env_api_keys` instead.
+- Allow `.net` and `.org` origins in the server's allowed origin and external return URL allowlists.
 
 ## [0.15.0] - 2026-04-08
 
@@ -67,11 +68,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Patch Changes
 
 - [#762](https://github.com/frontman-ai/frontman/pull/762) [`e963100`](https://github.com/frontman-ai/frontman/commit/e963100f6fef33839cddc16c1a9bab850519c248) Thanks [@BlueHotDog](https://github.com/BlueHotDog)! - Improve error UX: human-readable categorized errors, automatic retry with exponential backoff for transient failures, live countdown during retry, and manual retry button.
-
-## [Unreleased]
-
-### Changed
-- Allow `.net` and `.org` origins in the server's allowed origin and external return URL allowlists.
 
 ## [0.14.0] - 2026-03-27
 

--- a/apps/frontman_server/lib/frontman_server/accounts/scope.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/scope.ex
@@ -30,7 +30,20 @@ defmodule FrontmanServer.Accounts.Scope do
   typedstruct do
     field :user, %User{}
     field :organization, %Organization{}
+    field :env_api_keys, %{String.t() => String.t()}, default: %{}
   end
+
+  @doc """
+  Returns a scope enriched with environment-provided API keys.
+
+  Keys set here travel with the scope to all domain functions, so callers
+  don't need to pass env_api_key as a separate argument.
+  """
+  def with_env_api_keys(%__MODULE__{} = scope, keys) when is_map(keys) do
+    %{scope | env_api_keys: keys}
+  end
+
+  def with_env_api_keys(%__MODULE__{} = scope, _), do: scope
 
   @doc """
   Creates a scope for the given user.

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -55,9 +55,9 @@ defmodule FrontmanServer.Providers do
   Call this before making LLM calls, not inside LLM implementations.
 
   ## Parameters
-    - scope: The user scope (or nil for anonymous)
+    - scope: The user scope (or nil for anonymous). Must have `env_api_keys`
+      populated if project-level keys should be considered.
     - model: The model string (e.g., "openrouter:openai/gpt-4"), or nil for default
-    - env_api_key: Map of provider => api_key from client's environment
 
   ## Options
 
@@ -70,13 +70,13 @@ defmodule FrontmanServer.Providers do
     - `{:error, :no_api_key}` - No API key available
     - `{:error, :usage_limit_exceeded}` - Server key quota exhausted
   """
-  @spec prepare_api_key(Scope.t() | nil, String.t() | nil, map(), keyword()) ::
+  @spec prepare_api_key(Scope.t() | nil, String.t() | nil, keyword()) ::
           {:ok, ResolvedKey.t()} | {:error, :no_api_key | :usage_limit_exceeded}
-  def prepare_api_key(scope, model, env_api_key \\ %{}, opts \\ []) do
+  def prepare_api_key(scope, model, opts \\ []) do
     model = model || @default_model
     provider = provider_from_model(model)
 
-    case resolve_api_key(scope, provider, env_api_key) do
+    case resolve_api_key(scope, provider) do
       {:oauth_token, access_token, oauth_opts} ->
         {:ok, ResolvedKey.new(provider, access_token, :oauth_token, model, oauth_opts)}
 
@@ -275,40 +275,35 @@ defmodule FrontmanServer.Providers do
   Resolves which API key to use for a provider.
 
   Resolution order:
-  1. User's saved key (highest priority)
-  2. Env key from the project (e.g., Next.js OPENROUTER_API_KEY)
-  3. Server env key (fallback)
+  1. OAuth token (for supported providers)
+  2. User's saved key
+  3. Env key from `scope.env_api_keys` (e.g., OPENROUTER_API_KEY from project)
+  4. Server env key (fallback)
 
   ## Parameters
-    - scope: The user scope (or nil)
+    - scope: The user scope (or nil). env_api_keys are read from `scope.env_api_keys`.
     - provider: The provider name (e.g., "openrouter")
-    - env_api_key: Map of provider => api_key from client's environment (or %{})
   """
-  def resolve_api_key(scope, provider, env_api_key \\ %{})
+  def resolve_api_key(scope, provider)
 
-  def resolve_api_key(%Scope{} = scope, provider, env_api_key)
-      when is_binary(provider) and is_map(env_api_key) do
-    # For Anthropic, check OAuth token first (highest priority)
+  def resolve_api_key(%Scope{} = scope, provider) when is_binary(provider) do
     case maybe_resolve_oauth_token(scope, provider) do
       {:oauth_token, _, _} = result ->
         result
 
       :no_oauth_token ->
-        # Then check user's saved API key
         case get_api_key_value(scope, provider) do
           key when is_binary(key) and key != "" ->
             {:user_key, key}
 
           _ ->
-            # Then check env key (from project environment)
-            resolve_env_or_server_key(provider, env_api_key)
+            resolve_env_or_server_key(provider, scope.env_api_keys)
         end
     end
   end
 
-  def resolve_api_key(nil, provider, env_api_key)
-      when is_binary(provider) and is_map(env_api_key) do
-    resolve_env_or_server_key(provider, env_api_key)
+  def resolve_api_key(nil, provider) when is_binary(provider) do
+    resolve_env_or_server_key(provider, %{})
   end
 
   # Claude Code identity for Anthropic OAuth
@@ -588,8 +583,8 @@ defmodule FrontmanServer.Providers do
 
   ## Parameters
 
-    * `scope` – the user's `%Scope{}` struct
-    * `env_api_key` – map of env-provided keys from client metadata
+    * `scope` – the user's `%Scope{}` struct. `env_api_keys` must be populated
+      if project-level keys should be considered.
 
   ## Returns
 
@@ -599,12 +594,12 @@ defmodule FrontmanServer.Providers do
       `value` is a serialized `"provider:model"` string)
     * `:default_model` – serialized `"provider:model"` string for the best default
   """
-  @spec model_config_data(Scope.t(), map()) :: %{
+  @spec model_config_data(Scope.t()) :: %{
           groups: [map()],
           default_model: String.t()
         }
-  def model_config_data(%Scope{} = scope, env_api_key \\ %{}) do
-    provider_tiers = available_provider_tiers(scope, env_api_key)
+  def model_config_data(%Scope{} = scope) do
+    provider_tiers = available_provider_tiers(scope)
 
     groups =
       Enum.map(provider_tiers, fn {provider, tier} ->
@@ -635,18 +630,18 @@ defmodule FrontmanServer.Providers do
 
   Returns a list of `{provider_id, tier}` tuples sorted by provider
   priority.  Iterates all catalog providers and classifies each using
-  `resolve_api_key/3`.
+  `resolve_api_key/2`.
 
   ## Parameters
 
-    * `scope` – the user's `%Scope{}` struct
-    * `env_api_key` – map of env-provided keys from client metadata
+    * `scope` – the user's `%Scope{}` struct. `env_api_keys` must be populated
+      if project-level keys should be considered.
   """
-  @spec available_provider_tiers(Scope.t(), map()) :: [{String.t(), :full | :free}]
-  def available_provider_tiers(%Scope{} = scope, env_api_key \\ %{}) do
+  @spec available_provider_tiers(Scope.t()) :: [{String.t(), :full | :free}]
+  def available_provider_tiers(%Scope{} = scope) do
     ModelCatalog.catalog_providers()
     |> Enum.flat_map(fn provider ->
-      case {key_type(scope, provider, env_api_key), ModelCatalog.has_free_tier?(provider)} do
+      case {key_type(scope, provider), ModelCatalog.has_free_tier?(provider)} do
         {:own_key, _} -> [{provider, :full}]
         {:server_key, true} -> [{provider, :free}]
         {:server_key, false} -> []
@@ -656,8 +651,8 @@ defmodule FrontmanServer.Providers do
     end)
   end
 
-  defp key_type(scope, provider, env_api_key) do
-    case resolve_api_key(scope, provider, env_api_key) do
+  defp key_type(scope, provider) do
+    case resolve_api_key(scope, provider) do
       {:oauth_token, _, _} -> :own_key
       {:user_key, _} -> :own_key
       {:env_key, _} -> :own_key

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -418,10 +418,9 @@ defmodule FrontmanServer.Tasks do
   @spec enqueue_title_generation(Scope.t(), String.t(), String.t(), keyword()) ::
           {:ok, Oban.Job.t()} | {:error, Oban.Job.changeset()}
   def enqueue_title_generation(%Scope{} = scope, task_id, user_prompt_text, opts \\ []) do
-    env_api_key = Keyword.get(opts, :env_api_key, %{})
     model = opts |> Keyword.get(:model) |> Model.resolve_string()
 
-    GenerateTitle.new_job(scope.user.id, task_id, user_prompt_text, model, env_api_key)
+    GenerateTitle.new_job(scope, task_id, user_prompt_text, model)
     |> Oban.insert()
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -59,7 +59,6 @@ defmodule FrontmanServer.Tasks.Execution do
   ## Options
   - `:tools` - List of tool definitions for LLM (default: [])
   - `:model` - LLM model spec (defaults to provider default)
-  - `:env_api_key` - Map of provider => api_key from client's environment
   - `:agent` - Custom agent struct implementing SwarmAi.Agent (for testing)
 
   ## Returns
@@ -72,11 +71,10 @@ defmodule FrontmanServer.Tasks.Execution do
           {:ok, pid() | :already_running} | {:error, :no_api_key | :usage_limit_exceeded | term()}
   def run(%Scope{} = scope, %Task{} = task, opts \\ []) do
     tools = Keyword.get(opts, :tools, [])
-    env_api_key = Keyword.get(opts, :env_api_key, %{})
     model = opts |> Keyword.get(:model) |> Model.resolve_string()
 
     # Resolve API key at the domain layer (earliest point)
-    case Providers.prepare_api_key(scope, model, env_api_key) do
+    case Providers.prepare_api_key(scope, model) do
       {:ok, api_key_info} ->
         task_id = task.task_id
         agent = build_agent(task, tools, opts, api_key_info)

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -50,15 +50,14 @@ defmodule FrontmanServer.Workers.GenerateTitle do
   @doc """
   Builds an Oban job changeset for title generation.
   """
-  @spec new_job(String.t(), String.t(), String.t(), String.t() | nil, map()) ::
-          Oban.Job.changeset()
-  def new_job(user_id, task_id, user_prompt_text, model, env_api_key) do
+  @spec new_job(Scope.t(), String.t(), String.t(), String.t() | nil) :: Oban.Job.changeset()
+  def new_job(%Scope{user: user} = scope, task_id, user_prompt_text, model) do
     new(%{
-      user_id: user_id,
+      user_id: user.id,
       task_id: task_id,
       user_prompt_text: user_prompt_text,
       model: model,
-      encrypted_env_api_key: encrypt_env_api_key(env_api_key)
+      encrypted_env_api_key: encrypt_env_api_key(scope.env_api_keys)
     })
   end
 
@@ -72,12 +71,12 @@ defmodule FrontmanServer.Workers.GenerateTitle do
           } = args
       }) do
     user = Accounts.get_user!(user_id)
-    scope = Scope.for_user(user)
+    env_api_keys = args |> Map.get("encrypted_env_api_key") |> decrypt_env_api_key()
+    scope = user |> Scope.for_user() |> Scope.with_env_api_keys(env_api_keys)
     model = Map.get(args, "model")
-    env_api_key = args |> Map.get("encrypted_env_api_key") |> decrypt_env_api_key()
 
     with {:ok, resolved_key} <-
-           Providers.prepare_api_key(scope, model, env_api_key, skip_quota: true),
+           Providers.prepare_api_key(scope, model, skip_quota: true),
          {:ok, raw_title} <- call_llm(resolved_key, user_prompt_text),
          title = String.trim(raw_title),
          false <- title == "",

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -502,6 +502,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     # Enrich scope with env keys from prompt _meta (sent with each prompt request)
     scope = enrich_scope_from_params(scope, params)
+    socket = assign(socket, :scope, scope)
 
     # Extract model selection from prompt _meta
     model = extract_model_from_params(params)

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -231,7 +231,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
       {:ok, _interaction, :no_executor} ->
         # No live executor (agent dead after server restart). If all pending
-        # tools are now resolved, resume the agent using env_api_key + model
+        # tools are now resolved, resume the agent using scope.env_api_keys + model
         # from the tool result's _meta (sent by the client per MCP spec).
         {:ok, task} = Tasks.get_task(scope, task_id)
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -16,6 +16,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   require Logger
 
   alias AgentClientProtocol, as: ACP
+  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
   alias FrontmanServer.Providers.{Model, Registry}
   alias FrontmanServer.Tasks
@@ -245,7 +246,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   defp maybe_resume_agent(socket, scope, task_id, meta) do
-    env_api_key = Registry.extract_env_keys(meta)
+    scope = Scope.with_env_api_keys(scope, Registry.extract_env_keys(meta))
 
     model =
       case Model.from_client_params(meta["model"]) do
@@ -258,7 +259,6 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     opts =
       build_execution_opts(socket,
-        env_api_key: env_api_key,
         model: model,
         mcp_tool_defs: mcp_tools
       )
@@ -427,12 +427,10 @@ defmodule FrontmanServerWeb.TaskChannel do
         stream_session_history(socket, task)
 
         # Return ACP-compliant LoadSessionResponse with config options.
-        # Extract env API keys from _meta (forwarded from clientInfo metadata)
-        # since the task channel doesn't receive the ACP initialize request.
-        env_api_key = extract_env_api_key_from_params(params)
-
+        # Enrich scope with env keys from _meta if present in params.
         config_options =
-          Providers.model_config_data(scope, env_api_key)
+          enrich_scope_from_params(scope, params)
+          |> Providers.model_config_data()
           |> ACP.build_model_config_options()
 
         push(
@@ -502,8 +500,8 @@ defmodule FrontmanServerWeb.TaskChannel do
     scope = socket.assigns.scope
     mcp_tools = socket.assigns[:mcp_tools] || []
 
-    # Extract env API key from prompt _meta (sent with each prompt request)
-    env_api_key = extract_env_api_key_from_params(params)
+    # Enrich scope with env keys from prompt _meta (sent with each prompt request)
+    scope = enrich_scope_from_params(scope, params)
 
     # Extract model selection from prompt _meta
     model = extract_model_from_params(params)
@@ -528,7 +526,6 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     opts =
       build_execution_opts(socket,
-        env_api_key: env_api_key,
         model: model,
         mcp_tool_defs: mcp_tools
       )
@@ -553,10 +550,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
         Logger.info("User message added, agent spawned for task #{task_id}")
 
-        Tasks.enqueue_title_generation(scope, task_id, prompt.text_summary,
-          env_api_key: env_api_key,
-          model: model
-        )
+        Tasks.enqueue_title_generation(scope, task_id, prompt.text_summary, model: model)
 
         {:noreply, socket}
 
@@ -567,12 +561,12 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
   end
 
-  # Extract env API keys from prompt params _meta (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
-  defp extract_env_api_key_from_params(params) when is_map(params) do
-    params |> get_in(["_meta"]) |> Registry.extract_env_keys()
+  # Enrich scope with env API keys from params _meta (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
+  defp enrich_scope_from_params(scope, params) when is_map(params) do
+    Scope.with_env_api_keys(scope, params |> get_in(["_meta"]) |> Registry.extract_env_keys())
   end
 
-  defp extract_env_api_key_from_params(_), do: %{}
+  defp enrich_scope_from_params(scope, _), do: scope
 
   # Builds execution opts, forwarding an injected agent if present in socket assigns.
   # In production, :agent_override is never set. Tests can assign it to avoid real

--- a/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
@@ -17,6 +17,7 @@ defmodule FrontmanServerWeb.TasksChannel do
   require Logger
 
   alias AgentClientProtocol, as: ACP
+  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
   alias FrontmanServer.Providers.Registry
   alias FrontmanServer.Tasks
@@ -89,15 +90,16 @@ defmodule FrontmanServerWeb.TasksChannel do
        ) do
     Logger.info("ACP initialize from #{inspect(params["clientInfo"])}")
 
-    # Extract env API key from clientInfo _meta (if provided by the project)
-    env_api_key = extract_env_api_key(params["clientInfo"])
+    # Enrich scope with env API keys from clientInfo _meta (if provided by the project)
+    env_api_keys = extract_env_api_keys(params["clientInfo"])
+    enriched_scope = Scope.with_env_api_keys(socket.assigns.scope, env_api_keys)
 
     socket =
       socket
       |> assign(:acp_initialized, true)
       |> assign(:acp_client_info, params["clientInfo"])
       |> assign(:acp_client_capabilities, params["clientCapabilities"])
-      |> assign(:env_api_key, env_api_key)
+      |> assign(:scope, enriched_scope)
 
     # Push config options immediately so the model selector is populated
     # before any session is created.
@@ -214,10 +216,8 @@ defmodule FrontmanServerWeb.TasksChannel do
   end
 
   defp current_config_options(socket) do
-    Providers.model_config_data(
-      socket.assigns.scope,
-      socket.assigns[:env_api_key] || %{}
-    )
+    socket.assigns.scope
+    |> Providers.model_config_data()
     |> ACP.build_model_config_options()
   end
 
@@ -233,11 +233,11 @@ defmodule FrontmanServerWeb.TasksChannel do
   defp extract_framework(_), do: nil
 
   # Extract env API keys from clientInfo _meta (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY from project env)
-  defp extract_env_api_key(client_info) when is_map(client_info) do
+  defp extract_env_api_keys(client_info) when is_map(client_info) do
     client_info |> get_in(["_meta"]) |> Registry.extract_env_keys()
   end
 
-  defp extract_env_api_key(_), do: %{}
+  defp extract_env_api_keys(_), do: %{}
 
   # Parse errors
   defp handle_parse_error(reason, %{"id" => id}, socket) do

--- a/apps/frontman_server/test/frontman_server/accounts/scope_test.exs
+++ b/apps/frontman_server/test/frontman_server/accounts/scope_test.exs
@@ -1,0 +1,30 @@
+defmodule FrontmanServer.Accounts.ScopeTest do
+  use FrontmanServer.DataCase, async: true
+
+  import FrontmanServer.Test.Fixtures.Accounts
+
+  alias FrontmanServer.Accounts.Scope
+
+  describe "env_api_keys field" do
+    test "defaults to empty map" do
+      user = user_fixture()
+      scope = Scope.for_user(user)
+      assert scope.env_api_keys == %{}
+    end
+
+    test "with_env_api_keys/2 sets the field" do
+      user = user_fixture()
+      scope = Scope.for_user(user)
+      enriched = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-test"})
+      assert enriched.env_api_keys == %{"openrouter" => "sk-or-test"}
+      assert enriched.user == scope.user
+    end
+
+    test "with_env_api_keys/2 defaults to empty map when nil passed" do
+      user = user_fixture()
+      scope = Scope.for_user(user)
+      enriched = Scope.with_env_api_keys(scope, nil)
+      assert enriched.env_api_keys == %{}
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -1,6 +1,6 @@
 defmodule FrontmanServer.Providers.PrepareApiKeyTest do
   @moduledoc """
-  Integration tests for the full `Providers.prepare_api_key/4` resolution chain.
+  Integration tests for the full `Providers.prepare_api_key/3` resolution chain.
 
   Tests the priority order: OAuth > user key > env key > server key,
   plus quota checks on server keys. This is the primary entry point for
@@ -21,7 +21,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     {:ok, scope: scope}
   end
 
-  describe "prepare_api_key/4 resolution priority" do
+  describe "prepare_api_key/3 resolution priority" do
     test "resolves OAuth token as highest priority for anthropic", %{scope: scope} do
       expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
 
@@ -29,10 +29,10 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
         Providers.upsert_oauth_token(scope, "anthropic", "oauth_access", "refresh", expires_at)
 
       {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
-      env_api_key = %{"anthropic" => "env_key_789"}
+      scope = Scope.with_env_api_keys(scope, %{"anthropic" => "env_key_789"})
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", env_api_key)
+        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
 
       assert resolved.key_source == :oauth_token
       assert resolved.api_key == "oauth_access"
@@ -44,10 +44,10 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
     test "falls back to user key when no OAuth token", %{scope: scope} do
       {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
-      env_api_key = %{"anthropic" => "env_key_789"}
+      scope = Scope.with_env_api_keys(scope, %{"anthropic" => "env_key_789"})
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", env_api_key)
+        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
 
       assert resolved.key_source == :user_key
       assert resolved.api_key == "user_key_456"
@@ -58,10 +58,10 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "falls back to env key when no OAuth or user key", %{scope: scope} do
-      env_api_key = %{"anthropic" => "env_key_789"}
+      scope = Scope.with_env_api_keys(scope, %{"anthropic" => "env_key_789"})
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", env_api_key)
+        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
 
       assert resolved.key_source == :env_key
       assert resolved.api_key == "env_key_789"
@@ -72,7 +72,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       with_server_key("anthropic", "server_key_abc")
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", %{})
+        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
 
       assert resolved.key_source == :server_key
       assert resolved.api_key == "server_key_abc"
@@ -83,7 +83,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       without_server_key("anthropic")
 
       assert {:error, :no_api_key} =
-               Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", %{})
+               Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
     end
 
     test "server key checks usage quota", %{scope: scope} do
@@ -94,7 +94,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       end
 
       assert {:error, :usage_limit_exceeded} =
-               Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", %{})
+               Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5")
     end
 
     test "skip_quota bypasses usage limit on server key", %{scope: scope} do
@@ -105,17 +105,17 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       end
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", %{}, skip_quota: true)
+        Providers.prepare_api_key(scope, "anthropic:claude-sonnet-4-5", skip_quota: true)
 
       assert resolved.key_source == :server_key
       assert resolved.api_key == "server_key_skip"
     end
 
     test "openrouter env key resolves correctly", %{scope: scope} do
-      env_api_key = %{"openrouter" => "sk-or-env-test"}
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-env-test"})
 
       {:ok, %ResolvedKey{} = resolved} =
-        Providers.prepare_api_key(scope, "openrouter:openai/gpt-5.1-codex", env_api_key)
+        Providers.prepare_api_key(scope, "openrouter:openai/gpt-5.1-codex")
 
       assert resolved.key_source == :env_key
       assert resolved.api_key == "sk-or-env-test"
@@ -126,7 +126,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     test "defaults to openrouter when model is nil", %{scope: scope} do
       with_server_key("openrouter", "server_or_key")
 
-      {:ok, %ResolvedKey{} = resolved} = Providers.prepare_api_key(scope, nil, %{})
+      {:ok, %ResolvedKey{} = resolved} = Providers.prepare_api_key(scope, nil)
 
       assert resolved.provider == "openrouter"
     end

--- a/apps/frontman_server/test/frontman_server/providers/providers_oauth_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/providers_oauth_test.exs
@@ -151,7 +151,7 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
     # which is out of scope for unit tests - integration tests would cover this
   end
 
-  describe "resolve_api_key/3 with OAuth" do
+  describe "resolve_api_key/2 with OAuth" do
     test "returns oauth_token with transformation opts when available for anthropic" do
       user = user_fixture()
       scope = %Scope{user: user}
@@ -160,8 +160,9 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
       {:ok, _} =
         Providers.upsert_oauth_token(scope, "anthropic", "oauth_access", "refresh", expires_at)
 
-      # Even with env_api_key, OAuth should take priority
-      result = Providers.resolve_api_key(scope, "anthropic", %{"anthropic" => "env_key"})
+      # Even with env_api_keys in scope, OAuth should take priority
+      scope = Scope.with_env_api_keys(scope, %{"anthropic" => "env_key"})
+      result = Providers.resolve_api_key(scope, "anthropic")
 
       # OAuth returns 3-tuple with transformation options for Claude Code
       assert {:oauth_token, "oauth_access", opts} = result
@@ -176,7 +177,7 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
       # Save a user API key
       {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_api_key")
 
-      result = Providers.resolve_api_key(scope, "anthropic", %{})
+      result = Providers.resolve_api_key(scope, "anthropic")
 
       assert {:user_key, "user_api_key"} = result
     end
@@ -186,7 +187,8 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
       scope = %Scope{user: user}
 
       # OAuth is not supported for openrouter, so should use other resolution
-      result = Providers.resolve_api_key(scope, "openrouter", %{"openrouter" => "env_key"})
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "env_key"})
+      result = Providers.resolve_api_key(scope, "openrouter")
 
       assert {:env_key, "env_key"} = result
     end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
@@ -16,6 +16,7 @@ defmodule FrontmanServer.Tasks.Execution.ErrorPropagationTest do
   import FrontmanServer.Test.Fixtures.Tasks
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.ExecutionEvent
 
@@ -46,10 +47,11 @@ defmodule FrontmanServer.Tasks.Execution.ErrorPropagationTest do
 
       agent = test_agent(error_llm, "ErrorPropTestAgent")
 
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-test"})
+
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Take a screenshot"), [],
-          agent: agent,
-          env_api_key: %{"openrouter" => "sk-or-test"}
+          agent: agent
         )
 
       # Stream errors are now caught and surfaced as graceful failures
@@ -68,11 +70,10 @@ defmodule FrontmanServer.Tasks.Execution.ErrorPropagationTest do
       # ErrorLLM always returns {:error, reason}
       agent = test_agent(%ErrorLLM{error: :llm_api_failure}, "AlwaysErrorAgent")
 
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-test"})
+
       {:ok, _} =
-        Tasks.submit_user_message(scope, task_id, user_content("Hello"), [],
-          agent: agent,
-          env_api_key: %{"openrouter" => "sk-or-test"}
-        )
+        Tasks.submit_user_message(scope, task_id, user_content("Hello"), [], agent: agent)
 
       # Should receive a failed event broadcast
       assert_receive {:execution_event,

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -13,6 +13,7 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
   import FrontmanServer.Test.Fixtures.Tasks
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.ExecutionEvent
 
@@ -37,11 +38,10 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
       # ErrorLLM always returns {:error, reason}, triggering a :failed event
       agent = test_agent(%ErrorLLM{error: :llm_api_failure}, "ErrorSentryAgent")
 
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-test"})
+
       {:ok, _} =
-        Tasks.submit_user_message(scope, task_id, user_content("Hello"), [],
-          agent: agent,
-          env_api_key: %{"openrouter" => "sk-or-test"}
-        )
+        Tasks.submit_user_message(scope, task_id, user_content("Hello"), [], agent: agent)
 
       # Wait for the failed event broadcast (Sentry call completes before broadcast)
       assert_receive {:execution_event, %ExecutionEvent{type: :failed}}, 5_000
@@ -79,11 +79,10 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
 
       agent = test_agent(error_llm, "ErrorSentryAgent")
 
+      scope = Scope.with_env_api_keys(scope, %{"openrouter" => "sk-or-test"})
+
       {:ok, _} =
-        Tasks.submit_user_message(scope, task_id, user_content("Trigger error"), [],
-          agent: agent,
-          env_api_key: %{"openrouter" => "sk-or-test"}
-        )
+        Tasks.submit_user_message(scope, task_id, user_content("Trigger error"), [], agent: agent)
 
       # Stream errors now produce {:failed, ...} instead of {:crashed, ...}
       assert_receive {:execution_event,

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -15,15 +15,19 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
     {:ok, user: user}
   end
 
-  describe "new_job/5" do
+  describe "new_job/4" do
     test "builds a job changeset with model and encrypted env_api_key", %{user: user} do
+      scope =
+        user
+        |> Scope.for_user()
+        |> Scope.with_env_api_keys(%{"anthropic" => "sk-test-123"})
+
       changeset =
         GenerateTitle.new_job(
-          user.id,
+          scope,
           "task-123",
           "Help me build a login page",
-          "anthropic:claude-sonnet-4-20250514",
-          %{"anthropic" => "sk-test-123"}
+          "anthropic:claude-sonnet-4-20250514"
         )
 
       args = changeset.changes.args
@@ -36,7 +40,8 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
     end
 
     test "stores nil encrypted_env_api_key when env keys are empty", %{user: user} do
-      changeset = GenerateTitle.new_job(user.id, "task-123", "Hello", nil, %{})
+      scope = Scope.for_user(user)
+      changeset = GenerateTitle.new_job(scope, "task-123", "Hello", nil)
 
       assert changeset.changes.args.encrypted_env_api_key == nil
     end
@@ -44,12 +49,15 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
 
   describe "perform/1" do
     test "enqueues via Tasks context with forwarded model and encrypted env key", %{user: user} do
-      scope = Scope.for_user(user)
+      scope =
+        user
+        |> Scope.for_user()
+        |> Scope.with_env_api_keys(%{"openrouter" => "sk-or-test"})
+
       task_id = task_fixture(scope)
 
       {:ok, _job} =
         Tasks.enqueue_title_generation(scope, task_id, "Help me build a login page",
-          env_api_key: %{"openrouter" => "sk-or-test"},
           model: Model.new("openrouter", "openai/gpt-5.1-codex")
         )
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -8,6 +8,7 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
 
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.LLMError
+  alias FrontmanServer.Tasks.ExecutionEvent
 
   defp push_prompt_and_assert_accepted(socket, meta \\ %{}) do
     push(socket, "acp:message", prompt_request(_meta: meta))
@@ -69,13 +70,15 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
 
       # Trigger a transient error so the retry coordinator starts.
       # We send directly to the channel pid (not via PubSub) to avoid
-      # interference from the concurrent outer-setup socket under CI load.
+      # interference from concurrent sockets under CI load.
       error = %LLMError{message: "Rate limited", category: "rate_limit", retryable: true}
 
-      send(
-        socket.channel_pid,
-        {:swarm_event, {:failed, {:error, error, System.unique_integer([:positive])}}}
-      )
+      event = %ExecutionEvent{
+        type: :failed,
+        payload: {:error, error, System.unique_integer([:positive])}
+      }
+
+      send(socket.channel_pid, {:execution_event, event})
 
       :sys.get_state(socket.channel_pid)
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -7,6 +7,7 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
   import FrontmanServer.ProvidersFixtures
 
   alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Execution.LLMError
 
   setup %{scope: scope} do
     {socket, _task_id} = join_task_channel(scope)
@@ -47,6 +48,44 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
 
     test "falls back when no env keys or model provided", %{socket: socket} do
       push_prompt_and_assert_accepted(socket)
+    end
+  end
+
+  describe "env key persistence across retries" do
+    setup %{scope: scope} do
+      {socket, task_id} = join_task_channel(scope)
+      complete_mcp_handshake(socket)
+      {:ok, socket: socket, task_id: task_id}
+    end
+
+    test "env key in prompt _meta is still on scope when :fire_retry fires", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      push_prompt_and_assert_accepted(socket, %{"anthropicKeyValue" => "sk-ant-retry-test"})
+
+      # Confirm the enriched scope was persisted to socket assigns after the prompt
+      %{assigns: %{scope: scope_after_prompt}} = :sys.get_state(socket.channel_pid)
+      assert scope_after_prompt.env_api_keys["anthropic"] == "sk-ant-retry-test"
+
+      # Trigger a transient error so the retry coordinator starts
+      error = %LLMError{message: "Rate limited", category: "rate_limit", retryable: true}
+
+      Phoenix.PubSub.broadcast(
+        FrontmanServer.PubSub,
+        Tasks.topic(task_id),
+        {:swarm_event, {:failed, {:error, error, System.unique_integer([:positive])}}}
+      )
+
+      :sys.get_state(socket.channel_pid)
+
+      # Fire the retry — this reads scope from socket.assigns.scope
+      send(socket.channel_pid, :fire_retry)
+      :sys.get_state(socket.channel_pid)
+
+      # The scope on the socket must still carry the env key after the retry fires
+      %{assigns: %{scope: scope_after_retry}} = :sys.get_state(socket.channel_pid)
+      assert scope_after_retry.env_api_keys["anthropic"] == "sk-ant-retry-test"
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -59,8 +59,7 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
     end
 
     test "env key in prompt _meta is still on scope when :fire_retry fires", %{
-      socket: socket,
-      task_id: task_id
+      socket: socket
     } do
       push_prompt_and_assert_accepted(socket, %{"anthropicKeyValue" => "sk-ant-retry-test"})
 
@@ -68,12 +67,13 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
       %{assigns: %{scope: scope_after_prompt}} = :sys.get_state(socket.channel_pid)
       assert scope_after_prompt.env_api_keys["anthropic"] == "sk-ant-retry-test"
 
-      # Trigger a transient error so the retry coordinator starts
+      # Trigger a transient error so the retry coordinator starts.
+      # We send directly to the channel pid (not via PubSub) to avoid
+      # interference from the concurrent outer-setup socket under CI load.
       error = %LLMError{message: "Rate limited", category: "rate_limit", retryable: true}
 
-      Phoenix.PubSub.broadcast(
-        FrontmanServer.PubSub,
-        Tasks.topic(task_id),
+      send(
+        socket.channel_pid,
         {:swarm_event, {:failed, {:error, error, System.unique_integer([:positive])}}}
       )
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_env_key_test.exs
@@ -9,12 +9,6 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.LLMError
 
-  setup %{scope: scope} do
-    {socket, _task_id} = join_task_channel(scope)
-    complete_mcp_handshake(socket)
-    {:ok, socket: socket}
-  end
-
   defp push_prompt_and_assert_accepted(socket, meta \\ %{}) do
     push(socket, "acp:message", prompt_request(_meta: meta))
     :sys.get_state(socket.channel_pid)
@@ -24,6 +18,12 @@ defmodule FrontmanServerWeb.TaskChannelEnvKeyTest do
   end
 
   describe "env key extraction through channel" do
+    setup %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      complete_mcp_handshake(socket)
+      {:ok, socket: socket}
+    end
+
     test "accepts prompt with anthropicKeyValue", %{socket: socket} do
       push_prompt_and_assert_accepted(socket, %{
         "anthropicKeyValue" => "sk-ant-test-key-123",


### PR DESCRIPTION
## Summary

- Adds `env_api_keys` field (`%{String.t() => String.t()}`, default `%{}`) to `Scope` with `with_env_api_keys/2` helper
- Drops `env_api_key` param from `Providers.prepare_api_key`, `resolve_api_key`, `available_provider_tiers`, and `model_config_data` — all now read from `scope.env_api_keys`
- Channel handlers enrich scope with env keys at the extraction point (tasks_channel `initialize`, task_channel per-prompt/load/resume) instead of threading a separate arg through every call

Closes #610

## Test Plan
- [ ] 834 tests, 0 failures (`mix test apps/frontman_server/`)
- [ ] `mix format --check-formatted` passes
- [ ] `mix credo --strict` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
