### PR TITLE
fix: use @return(nullable) for contentWindow/contentDocument to eliminate cross-origin SecurityError

### DIFF
--- a/libs/client/src/Client__Hooks.res
+++ b/libs/client/src/Client__Hooks.res
@@ -17,7 +17,7 @@ module EventHelpers = {
       ->Array.forEach(element => {
         //note(itay): This will return null (None) in case the IFrame is cross-origin to the
         //running script, and not an error like `contentWindow.document`
-        let iframeDoc = element->WebAPI.HTMLIFrameElement.contentDocument->Null.toOption
+        let iframeDoc = element->WebAPI.HTMLIFrameElement.contentDocument
         iframeExecuteEventListener(eventListener, handler, iframeDoc)->Option.ignore
         iframeDoc
         ->Option.map(
@@ -33,9 +33,7 @@ module EventHelpers = {
     iframeRef
     ->Nullable.toOption
     ->Option.flatMap(iframe =>
-      WebAPI.Element.unsafeAsHTMLIFrameElement(iframe)
-      ->WebAPI.HTMLIFrameElement.contentDocument
-      ->Null.toOption
+      WebAPI.Element.unsafeAsHTMLIFrameElement(iframe)->WebAPI.HTMLIFrameElement.contentDocument
     )
 
   // Shared hook: subscribes a handler to a DOM event on a document and all its
@@ -66,7 +64,12 @@ module EventHelpers = {
         // Stable wrapper: delegates to the ref so the DOM listener never changes
         let stableHandler = (ev: WebAPI.EventAPI.event) => handlerRef.current(ev)
 
-        WebAPI.Document.addEventListener(doc, eventType, stableHandler, ~options={capture: withCapture})
+        WebAPI.Document.addEventListener(
+          doc,
+          eventType,
+          stableHandler,
+          ~options={capture: withCapture},
+        )
         iframeExecuteEventListener(
           (d, h) =>
             WebAPI.Document.addEventListener(d, eventType, h, ~options={capture: withCapture}),
@@ -228,7 +231,7 @@ module Scroll = {
 let getIframeWindowSafe = (iframe: WebAPI.DOMAPI.element): option<WebAPI.DOMAPI.window> => {
   let iframeElement = iframe->Obj.magic
   try {
-    switch WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption {
+    switch WebAPI.HTMLIFrameElement.contentWindow(iframeElement) {
     | None => None
     | Some(iframeWindow) =>
       ignore(iframeWindow->WebAPI.Window.location->WebAPI.Location.href)

--- a/libs/client/src/webpreview/Client__WebPreview__Body.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Body.res
@@ -1,7 +1,9 @@
 @react.component
 let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=?) => {
   let iframeRef: React.ref<Nullable.t<Dom.element>> = React.useRef(Nullable.null)
-  let (iframeElement, setIframeElement): (option<WebAPI.DOMAPI.element>, _) = React.useState(() => None)
+  let (iframeElement, setIframeElement): (option<WebAPI.DOMAPI.element>, _) = React.useState(() =>
+    None
+  )
   let (attachmentKey, setAttachmentKey) = React.useState(() => 0)
   // Inactive iframes start with about:blank so the browser doesn't eagerly load
   // the URL for every persisted task on startup. Using "" would resolve to the
@@ -12,7 +14,10 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
   let (hasLoaded, setHasLoaded) = React.useState(() => false)
   let lastLocationRef: React.ref<option<string>> = React.useRef(None)
   let trackedIframeElement = isActive ? iframeElement : None
-  let location = Client__Hooks.useIFrameLocation(~iframeElement=trackedIframeElement, ~attachmentKey)
+  let location = Client__Hooks.useIFrameLocation(
+    ~iframeElement=trackedIframeElement,
+    ~attachmentKey,
+  )
 
   // Sync iframeSrc when the url prop changes externally (nav bar, task creation)
   // while the iframe hasn't loaded yet. Only applies when iframeSrc is already
@@ -24,9 +29,12 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
     | false =>
       setIframeSrc(prev =>
         switch prev {
-        | "about:blank" => prev  // not yet activated — wait for isActive effect
+        | "about:blank" => prev // not yet activated — wait for isActive effect
         | _ =>
-          Client__BrowserUrl.removeTrailingSlash(prev) == Client__BrowserUrl.removeTrailingSlash(url) ? prev : url
+          Client__BrowserUrl.removeTrailingSlash(prev) ==
+            Client__BrowserUrl.removeTrailingSlash(url)
+            ? prev
+            : url
         }
       )
     }
@@ -37,8 +45,7 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
   React.useEffect(() => {
     switch isActive {
     | false => ()
-    | true =>
-      setIframeSrc(prev => prev == "about:blank" ? url : prev)
+    | true => setIframeSrc(prev => prev == "about:blank" ? url : prev)
     }
     None
   }, [isActive])
@@ -89,8 +96,8 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
         ->Option.forEach(iframe => {
           let iframeElement = iframe->Obj.magic
           try {
-            let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
-            let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
+            let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)
+            let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)
             Client__State.Actions.setPreviewFrame(~contentDocument, ~contentWindow)
           } catch {
           | _ => ()
@@ -109,8 +116,8 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
       ->Option.forEach(iframe => {
         let iframeElement = iframe->Obj.magic
         try {
-          let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)->Null.toOption
-          let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)->Null.toOption
+          let contentDocument = WebAPI.HTMLIFrameElement.contentDocument(iframeElement)
+          let contentWindow = WebAPI.HTMLIFrameElement.contentWindow(iframeElement)
 
           switch contentDocument->Option.isSome {
           | false => ()
@@ -140,11 +147,15 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
   switch (isActive, viewportStyle) {
   | (false, _) =>
     <div className="absolute -left-[9999px] -top-[9999px] invisible size-full">
-      <iframe className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback} />
+      <iframe
+        className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback}
+      />
     </div>
   | (true, None) =>
     <div className="flex-1 size-full">
-      <iframe className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback} />
+      <iframe
+        className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback}
+      />
     </div>
   | (true, Some((deviceWidth, deviceHeight, scale))) =>
     let widthPx = Int.toString(deviceWidth) ++ "px"
@@ -166,7 +177,9 @@ let make = (~taskId, ~url, ~isActive, ~viewportStyle: option<(int, int, float)>=
         boxShadow: "0 0 0 1px rgba(0,0,0,0.1), 0 2px 8px rgba(0,0,0,0.08)",
       }
     >
-      <iframe className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback} />
+      <iframe
+        className="size-full" src={iframeSrc} title={`Preview - ${taskId}`} onLoad ref={refCallback}
+      />
     </div>
   }
 }

--- a/libs/experimental-rescript-webapi/src/DOMAPI/HTMLIFrameElement.res
+++ b/libs/experimental-rescript-webapi/src/DOMAPI/HTMLIFrameElement.res
@@ -5,8 +5,8 @@ include HTMLElement.Impl({type t = htmliFrameElement})
 @send
 external getSVGDocument: htmliFrameElement => document = "getSVGDocument"
 
-@get
-external contentDocument: htmliFrameElement => Null.t<document> = "contentDocument"
+@get @return(nullable)
+external contentDocument: htmliFrameElement => option<document> = "contentDocument"
 
-@get
-external contentWindow: htmliFrameElement => Null.t<WebAPI.DOMAPI.window> = "contentWindow"
+@get @return(nullable)
+external contentWindow: htmliFrameElement => option<WebAPI.DOMAPI.window> = "contentWindow"


### PR DESCRIPTION
## Summary

- Changes `contentWindow` and `contentDocument` bindings in `HTMLIFrameElement.res` to use `@return(nullable)`, returning `option<T>` directly instead of `Null.t<T>`
- Removes `->Null.toOption` at all call sites (6 total across `Client__Hooks.res` and `Client__WebPreview__Body.res`)
- Eliminates the `Primitive_option.some()` → `isNestedMaybe()` → `BS_PRIVATE_NESTED_SOME_NONE` property probe that triggered `SecurityError` on cross-origin iframes

The `@return(nullable)` annotation compiles to `val == null ? undefined : val` — no property access on the window object.

Fixes #854 / Sentry ELIXIR-5A

## Test Plan

- [x] ReScript build clean (`yarn rescript build`)
- [x] All 333 client tests pass
- [x] reanalyze reports 0 issues across all packages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
