### PR TITLE
docs(marketing): write integration docs, fix sitemap bloat and duplicate paths

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -192,6 +192,10 @@ export default defineConfig({
     serverName: "marketing",
   }), icon(), brokenLinksChecker({ throwError: true, checkExternalLinks: false }), sitemap({
     serialize: (item) => {
+      // Exclude tag pages — thin filtered lists that add sitemap bloat
+      // without meaningful indexable content.
+      if (/\/blog\/tags\//.test(item.url)) return undefined;
+
       // Use the real pubDate for blog and release posts; fall back to
       // build date for everything else.
       const blogMatch = item.url.match(/\/blog\/([^/]+)\/?$/);
@@ -203,6 +207,28 @@ export default defineConfig({
       } else {
         item.lastmod = new Date();
       }
+
+      // Assign priority and changefreq by page type.
+      if (item.url === 'https://frontman.sh/') {
+        item.priority = 1.0;
+        item.changefreq = 'weekly';
+      } else if (/\/(pricing|features|how-it-works)\/?$/.test(item.url)) {
+        item.priority = 0.9;
+        item.changefreq = 'monthly';
+      } else if (/\/vs\//.test(item.url) || /\/integrations\//.test(item.url)) {
+        item.priority = 0.8;
+        item.changefreq = 'monthly';
+      } else if (/\/blog\/(?!tags\/)/.test(item.url) || /\/open-source-ai-releases\//.test(item.url)) {
+        item.priority = 0.7;
+        item.changefreq = 'never';
+      } else if (/\/docs\//.test(item.url)) {
+        item.priority = 0.7;
+        item.changefreq = 'monthly';
+      } else {
+        item.priority = 0.5;
+        item.changefreq = 'monthly';
+      }
+
       return item;
     },
     // Split sitemap into content-grouped child sitemaps instead of a
@@ -211,9 +237,6 @@ export default defineConfig({
     chunks: {
       posts: (item) => {
         if (/\/blog\/(?!tags\/)/.test(item.url)) return item;
-      },
-      tags: (item) => {
-        if (/\/blog\/tags\//.test(item.url)) return item;
       },
       releases: (item) => {
         if (/\/open-source-ai-releases\//.test(item.url)) return item;

--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -215,7 +215,7 @@ export default defineConfig({
       } else if (/\/(pricing|features|how-it-works)\/?$/.test(item.url)) {
         item.priority = 0.9;
         item.changefreq = 'monthly';
-      } else if (/\/vs\//.test(item.url) || /\/integrations\//.test(item.url)) {
+      } else if (/\/vs\//.test(item.url) || /(?<!\/docs)\/integrations\//.test(item.url)) {
         item.priority = 0.8;
         item.changefreq = 'monthly';
       } else if (/\/blog\/(?!tags\/)/.test(item.url) || /\/open-source-ai-releases\//.test(item.url)) {

--- a/apps/marketing/src/content/docs/docs/integrations/astro.md
+++ b/apps/marketing/src/content/docs/docs/integrations/astro.md
@@ -1,6 +1,180 @@
 ---
 title: Astro
-description: Full guide for using Frontman with Astro — setup, Islands architecture, content collections, and framework-specific tools.
+description: Complete reference for the @frontman-ai/astro integration — installation, configuration options, dev server hooks, element source detection, and troubleshooting.
 ---
 
-Content coming soon.
+## Overview
+
+`@frontman-ai/astro` is an Astro integration that embeds the Frontman AI agent directly into your Astro dev server. It combines Astro integration lifecycle hooks with a Vite plugin chain, giving the AI access to your source files, dev server logs, and resolved route manifest.
+
+**Frontman is a development-only tool.** The integration is a no-op in production builds — nothing is injected into your deployment bundle.
+
+## Requirements
+
+- Node.js 18 or later
+- Astro 5.x or 6.x
+
+## Installation
+
+Use Astro's built-in integration installer:
+
+```sh
+npx astro add @frontman-ai/astro
+```
+
+This adds the integration to your `astro.config.mjs` automatically. Alternatively, install the package manually:
+
+```sh
+npm install --save-dev @frontman-ai/astro
+```
+
+Then register it in your config:
+
+```js
+import frontman from '@frontman-ai/astro';
+import path from 'node:path';
+
+const appRoot = path.resolve(import.meta.dirname);
+
+export default defineConfig({
+  integrations: [
+    frontman({
+      projectRoot: appRoot,
+    }),
+  ],
+});
+```
+
+## Configuration
+
+All options are optional. Defaults are inferred from environment variables and the Astro config.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `projectRoot` | `string` | `process.env.PROJECT_ROOT` \| `process.env.PWD` \| `"."` | Absolute path to your project root. Scopes all file operations performed by the AI. |
+| `sourceRoot` | `string` | Same as `projectRoot` | Root for resolving source file paths. Set this to the monorepo root when `projectRoot` is a workspace package so the AI can reach files outside the Astro package. |
+| `basePath` | `string` | `"frontman"` | URL prefix for all Frontman routes. Leading and trailing slashes are stripped automatically. |
+| `host` | `string` | `process.env.FRONTMAN_HOST` \| `"api.frontman.sh"` | Frontman server host used for WebSocket client connections. Accepts bare hostnames, full URLs, or local dev server addresses (e.g. `frontman.local:4000`). |
+| `serverName` | `string` | `"frontman-astro"` | Identifier included in every tool response. Useful when multiple Frontman instances run concurrently. |
+| `serverVersion` | `string` | Package version | Version string included in tool responses. |
+| `clientUrl` | `string` | Auto-derived from `host` | Override the URL of the Frontman client JS bundle. Must include a `host` query parameter. |
+| `clientCssUrl` | `string` | Production CDN URL; `undefined` in dev | Override the URL of the Frontman client CSS stylesheet. |
+| `entrypointUrl` | `string` | — | Custom entrypoint URL for the AI API. |
+| `isLightTheme` | `boolean` | `false` | Render the Frontman UI with a light color scheme instead of the default dark theme. |
+
+### Monorepo configuration
+
+For monorepos where the Astro app is a workspace package but source files span the whole repository, set `sourceRoot` to the repo root:
+
+```js
+import path from 'node:path';
+
+const appRoot = path.resolve(import.meta.dirname);
+const monorepoRoot = path.resolve(appRoot, '../..');
+
+frontman({
+  projectRoot: appRoot,
+  sourceRoot: monorepoRoot,
+})
+```
+
+File edits are resolved relative to `sourceRoot`, letting the AI reach files outside the Astro package boundary.
+
+## Accessing Frontman
+
+Start your dev server (`astro dev`) and open `http://localhost:4321/frontman`. The port matches whatever Astro binds to. If you've set a custom `basePath`, replace `frontman` in the URL accordingly.
+
+## How It Works
+
+### Astro lifecycle hooks
+
+The integration registers handlers at three Astro lifecycle points:
+
+**`astro:config:setup`** — Registers the Vite plugin chain (described below), injects the element annotation capture script into every page, and registers a Dev Toolbar app that provides element-to-source-file mapping.
+
+**`astro:server:setup`** — Initializes the log capture buffer, registers the Frontman request handler on the Vite Connect server, and rewrites bare `/frontman` requests (no trailing slash) to `/frontman/`.
+
+**`astro:routes:resolved`** *(Astro 5+ only)* — Captures the complete resolved route manifest from Astro's internal routing system. This catches content collection routes, config-level redirects, API endpoints, and routes injected by other integrations. On Astro 4, routes are discovered by scanning the `src/pages/` filesystem instead.
+
+### Vite plugin chain
+
+Three Vite plugins run inside the Astro Vite instance:
+
+**`frontman-middleware`** — Installs a Connect middleware that intercepts all `/{basePath}/*` requests. Serves the Frontman UI, handles tool call requests (`POST /frontman/tools/call`), manages SSE streams for streaming responses (`GET /frontman/tools`), and resolves source locations. CORS is enabled for all `/frontman/*` routes.
+
+**`frontman-props-injection`** — During HTML transformation, injects component props as HTML comments. The Frontman client reads these comments to give the AI component props without requiring a React/Vue runtime on the page.
+
+**`rehype-content-file`** — Enriches rendered content with source file metadata, mapping DOM elements back to their originating content collection or Markdown files.
+
+### Log capture
+
+A circular buffer of 1024 entries is maintained for the lifetime of the dev server. It captures:
+
+- All `console.*` methods (`log`, `warn`, `error`, `info`, `debug`)
+- Astro/Vite build and HMR output (compilation results, module graph updates, hot reload events)
+- Uncaught exceptions with full stack traces
+
+The AI queries this buffer with the `get_logs` tool. Queries support: `pattern` (regex), `level` (log level filter), `since` (ISO 8601 timestamp lower bound), and `tail` (N most recent entries).
+
+### Element source detection
+
+Frontman identifies the source file and line number for a clicked DOM element using two mechanisms:
+
+**Dev Toolbar attributes** *(default)* — Astro's dev toolbar injects `data-astro-source-file` and `data-astro-source-loc` attributes onto elements during development. Frontman reads these for exact file and line information.
+
+**CSS selector fallback** — When `devToolbar.enabled` is `false` in your Astro config, Frontman falls back to matching DOM elements by CSS selector against the parsed AST. This is less precise.
+
+Keep `devToolbar.enabled: true` (the Astro default) for accurate source detection.
+
+## Available Tools
+
+### Astro-specific
+
+| Tool | Description |
+|------|-------------|
+| `get_client_pages` | Returns all Astro pages with their file paths and URL route patterns. On Astro 5+, uses the resolved route manifest (includes content collection routes and integration-injected routes). On Astro 4, scans `src/pages/`. |
+| `get_logs` | Queries the dev server log buffer. Parameters: `pattern` (regex string), `level` (`log`/`warn`/`error`/`info`/`debug`), `since` (ISO 8601 timestamp), `tail` (integer). |
+
+### File system
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read a file with an optional line range. |
+| `edit_file` | Apply targeted edits or replace file contents. Runs a post-edit log check to surface errors introduced by the change. |
+| `write_file` | Write a new file. |
+| `search_files` | Search file contents with a regex pattern. |
+| `list_files` | List files in a directory. |
+| `list_tree` | Recursive directory tree. |
+| `file_exists` | Check whether a path exists. |
+
+### Other
+
+| Tool | Description |
+|------|-------------|
+| `lighthouse` | Run a Lighthouse performance audit against a URL using a local Chrome instance. |
+| `load_agent_instructions` | Fetch agent instructions from the project (e.g. `AGENTS.md`). |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `FRONTMAN_HOST` | Override the default server host. Takes precedence over the `host` config option. |
+| `PROJECT_ROOT` | Override the default project root. Takes precedence over `projectRoot`. |
+
+## Troubleshooting
+
+**`/frontman` returns 404**
+
+The middleware is not registered. Verify the integration appears in `integrations` in `astro.config.mjs` and that you are running the dev server (`astro dev`), not `astro build` or `astro preview`.
+
+**Clicked element shows the wrong source file**
+
+Ensure `devToolbar.enabled` is not set to `false` in your Astro config. Without dev toolbar attributes, Frontman falls back to CSS selector-based detection, which is less precise for deeply nested elements or generated markup.
+
+**`get_client_pages` returns no routes**
+
+On Astro 4, routes are discovered by scanning `src/pages/`. If your pages live in a custom `srcDir`, the scanner will not find them. Upgrade to Astro 5+ to use the hook-based route manifest, which is `srcDir`-agnostic.
+
+**The log buffer is empty**
+
+Logs are captured from the moment the dev server starts. Earlier logs are gone after a restart. Reproduce the action that generates the log you need, then query immediately.

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.md
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.md
@@ -1,6 +1,250 @@
 ---
 title: Next.js
-description: Full guide for using Frontman with Next.js — setup, App Router and Pages Router support, server logs, and middleware.
+description: Complete reference for the @frontman-ai/nextjs integration — installation, middleware setup, App Router vs Pages Router, OpenTelemetry instrumentation, and troubleshooting.
 ---
 
-Content coming soon.
+## Overview
+
+`@frontman-ai/nextjs` integrates the Frontman AI agent into your Next.js dev server via the Next.js middleware system. It intercepts requests to `/frontman/*`, giving the AI access to your source files, dev server logs, route manifest, and optionally OpenTelemetry spans covering HTTP requests and route render timing.
+
+**Frontman is a development-only tool.** The middleware and instrumentation have no effect in production. Your deployment bundle is identical whether Frontman is installed or not.
+
+## Requirements
+
+- Node.js 18 or later
+- Next.js 13.2 or later (`^13.2.0 || ^14.0 || ^15.0 || ^16.0`)
+
+## Installation
+
+Run the Frontman CLI installer from your project directory:
+
+```sh
+npx @frontman-ai/nextjs install
+```
+
+The CLI detects your Next.js version and writes the appropriate middleware file. To install manually without the CLI:
+
+```sh
+npm install --save-dev @frontman-ai/nextjs
+```
+
+## Middleware Setup
+
+The integration API differs depending on your Next.js version.
+
+### Next.js 13–15 (`middleware.ts`)
+
+Create or update `middleware.ts` in your project root (or `src/middleware.ts`):
+
+```ts
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  projectRoot: process.cwd(),
+});
+
+export async function middleware(req: NextRequest) {
+  const response = await frontman(req);
+  if (response) return response;
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/frontman', '/frontman/:path*'],
+};
+```
+
+The `matcher` is required. Without it, Next.js runs the middleware on every request, adding unnecessary overhead across your entire application.
+
+### Next.js 16+ (`proxy.ts`)
+
+Next.js 16 introduced a dedicated proxy mechanism. Create `proxy.ts` in your project root:
+
+```ts
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  projectRoot: process.cwd(),
+});
+
+export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
+  if (
+    req.nextUrl.pathname === '/frontman' ||
+    req.nextUrl.pathname.startsWith('/frontman/')
+  ) {
+    return frontman(req) ?? NextResponse.next();
+  }
+  return NextResponse.next();
+}
+```
+
+## Configuration
+
+All options are optional.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `projectRoot` | `string` | `process.env.PROJECT_ROOT` \| `process.cwd()` | Absolute path to your project root. Scopes all file operations performed by the AI. |
+| `sourceRoot` | `string` | Same as `projectRoot` | Root for file path resolution. Set to the monorepo root when the Next.js app is a workspace package. |
+| `basePath` | `string` | `"frontman"` | URL prefix for Frontman routes. Must match the `matcher` pattern in `middleware.ts`. |
+| `host` | `string` | `process.env.FRONTMAN_HOST` \| `"api.frontman.sh"` | Frontman server host for WebSocket client connections. Accepts bare hostnames, full URLs, or local addresses. |
+| `serverName` | `string` | `"frontman-nextjs"` | Identifier included in every tool response. |
+| `serverVersion` | `string` | Package version | Version string included in tool responses. |
+| `clientUrl` | `string` | Auto-derived from `host` | Override the Frontman client JS bundle URL. Must include a `host` query parameter. |
+| `clientCssUrl` | `string` | Production CDN URL; `undefined` in dev | Override the Frontman client CSS URL. |
+| `entrypointUrl` | `string` | — | Custom entrypoint URL for the AI API. |
+| `isLightTheme` | `boolean` | `false` | Render the Frontman UI with a light color scheme. |
+| `isDev` | `boolean` | `true` unless `host === "api.frontman.sh"` | Override dev/prod mode detection. |
+
+### Monorepo configuration
+
+```ts
+const frontman = createMiddleware({
+  projectRoot: path.resolve(process.cwd()),         // Next.js app root
+  sourceRoot: path.resolve(process.cwd(), '../..'), // monorepo root
+});
+```
+
+## Accessing Frontman
+
+Start your dev server (`next dev` or `npm run dev`) and open `http://localhost:3000/frontman`. The port matches whatever `next dev` binds to.
+
+## How It Works
+
+### Request handling
+
+`createMiddleware` returns an async function compatible with both the Next.js middleware API and the Next.js 16+ proxy API. When a request arrives at `/frontman/*`:
+
+1. The path is parsed to determine the handler: UI, tool call, SSE event stream, or source location resolution.
+2. **Tool calls** (`POST /frontman/tools/call`) execute the requested tool and return the result as JSON.
+3. **SSE** (`GET /frontman/tools`) opens a server-sent event stream for streaming tool responses.
+4. All other requests to `/frontman/` serve the Frontman UI, injecting the client JS and CSS.
+
+When the request does not match a Frontman path, `frontman(req)` returns `undefined` (Next.js 13–15) or a pass-through `NextResponse.next()` (Next.js 16+).
+
+### Route discovery
+
+The `get_routes` tool discovers your Next.js routes by scanning the file system:
+
+**App Router** — Scans the `app/` directory for `page.tsx`, `page.ts`, `page.jsx`, `page.js`, `route.tsx`, and `route.ts` files. Returns route patterns and HTTP methods for API routes.
+
+**Pages Router** — Scans the `pages/` directory. Returns route patterns and identifies API routes under `pages/api/`.
+
+Both routers can coexist in the same project; Frontman reports routes from both.
+
+### Log capture
+
+A circular buffer of 1024 entries captures:
+
+- All `console.*` output across all Next.js contexts (startup, page render, API routes, middleware)
+- Build output from Webpack or Turbopack (compilation messages, module errors, HMR updates)
+- Uncaught exceptions and unhandled Promise rejections with stack traces
+
+Log capture starts when the middleware module is first imported. To capture startup-time logs (config evaluation, dependency initialization), add the instrumentation setup described below.
+
+### OpenTelemetry instrumentation (optional)
+
+For deeper observability — HTTP request spans, route render timing, API route execution — enable OTEL instrumentation.
+
+**Install peer dependencies:**
+
+```sh
+npm install --save-dev @opentelemetry/api @opentelemetry/sdk-trace-base @opentelemetry/sdk-logs
+```
+
+**Create `instrumentation.ts`** in your project root (or `src/`):
+
+```ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { setup } = await import('@frontman-ai/nextjs/Instrumentation');
+    setup();
+  }
+}
+```
+
+The `NEXT_RUNTIME === 'nodejs'` guard is required — OTEL SDKs are Node.js-only and cannot run in the Next.js Edge runtime. When instrumentation is active, the `get_logs` tool also returns OTEL spans containing:
+
+- HTTP method, path, status code, and duration
+- Route render times per page
+- API route execution spans
+
+:::note
+Before Next.js 15.3, you must enable `experimental.instrumentationHook: true` in `next.config.js` for `instrumentation.ts` to be recognized.
+:::
+
+## Available Tools
+
+### Next.js-specific
+
+| Tool | Description |
+|------|-------------|
+| `get_routes` | Returns all discovered routes from `app/` and `pages/` directories, including dynamic segments (`[param]`, `[[...slug]]`) and API routes with their supported HTTP methods. |
+| `get_logs` | Queries the log buffer. Parameters: `pattern` (regex string), `level` (`console`/`build`/`error`), `since` (ISO 8601 timestamp), `tail` (integer). When OTEL is enabled, also returns spans. |
+
+### File system
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read a file with an optional line range. |
+| `edit_file` | Apply targeted edits or replace file contents. Runs a post-edit log check to surface compilation errors introduced by the change. |
+| `write_file` | Write a new file. |
+| `search_files` | Search file contents with a regex pattern. |
+| `list_files` | List directory contents. |
+| `list_tree` | Recursive directory tree. |
+| `file_exists` | Check whether a path exists. |
+
+### Other
+
+| Tool | Description |
+|------|-------------|
+| `lighthouse` | Run a Lighthouse performance audit against a URL using a local Chrome instance. |
+| `load_agent_instructions` | Fetch agent instructions from the project (e.g. `AGENTS.md`). |
+
+## App Router vs Pages Router
+
+Frontman works with both routing systems simultaneously.
+
+**App Router:**
+- The route manifest includes server components, client components, layouts, and error boundaries.
+- API routes (`route.ts`) are reported with their supported HTTP methods (`GET`, `POST`, etc.).
+- Server-side render timing is available per-route when OTEL instrumentation is configured.
+- The server/client component boundary is visible in the client-side component tree inspection.
+
+**Pages Router:**
+- Route patterns follow the `pages/` filesystem conventions, including `[param]` and `[[...slug]]` dynamic segments.
+- API routes under `pages/api/` are reported separately from page routes.
+
+**Turbopack vs Webpack:** Both bundlers are supported. Frontman hooks at the middleware level, not the bundler level, so HMR works identically with either.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `FRONTMAN_HOST` | Override the default server host. Takes precedence over the `host` config option. |
+| `PROJECT_ROOT` | Override the default project root. Takes precedence over `projectRoot`. |
+| `NEXT_RUNTIME` | Set by Next.js. Used in instrumentation setup to gate OTEL initialization to the Node.js runtime. |
+
+## Troubleshooting
+
+**`/frontman` returns 404**
+
+Verify the `matcher` in your `middleware.ts` `config` export includes `/frontman` and `/frontman/:path*`. Without the matcher, Next.js does not route those requests through middleware at all.
+
+**Middleware runs on every request**
+
+The `matcher` export is missing or too broad. Add an explicit matcher scoped to `/frontman` paths.
+
+**Logs are empty**
+
+Log capture starts when the middleware module is imported. For logs from the earliest Next.js lifecycle stages (startup, config evaluation), add `instrumentation.ts` as described above.
+
+**OTEL spans are not appearing in `get_logs`**
+
+Ensure `instrumentation.ts` is in the project root or `src/`, that the `NEXT_RUNTIME === 'nodejs'` guard is present, and that `experimental.instrumentationHook` is enabled if you're on Next.js < 15.3.
+
+**AI edits are not reflected in the browser**
+
+Frontman writes to source files directly. Next.js HMR picks up the change automatically. If hot reload does not trigger, check the dev server terminal for compilation errors — the `get_logs` tool will surface these as `build` level entries.

--- a/apps/marketing/src/content/docs/docs/integrations/vite.md
+++ b/apps/marketing/src/content/docs/docs/integrations/vite.md
@@ -1,6 +1,207 @@
 ---
 title: Vite
-description: Full guide for using Frontman with Vite — setup for React, Vue, Svelte, Solid, and any Vite-based framework.
+description: Complete reference for the @frontman-ai/vite plugin — installation, configuration, framework auto-detection, Vue SFC source mapping, SvelteKit support, and troubleshooting.
 ---
 
-Content coming soon.
+## Overview
+
+`@frontman-ai/vite` is a Vite plugin that embeds the Frontman AI agent in your Vite dev server. It auto-detects your framework — React, Vue, Svelte, or SolidJS — from the Vite plugin array and provides framework-appropriate runtime context to the AI.
+
+**Frontman is a development-only tool.** The plugin registers a Connect middleware in the dev server only. In production builds, it is a complete no-op.
+
+## Requirements
+
+- Node.js 18 or later
+- Vite 5.x or 6.x
+
+## Installation
+
+Run the Frontman CLI from your project directory:
+
+```sh
+npx @frontman-ai/vite install
+```
+
+The CLI adds the plugin to your existing `vite.config.ts` (or `.js`). To install manually:
+
+```sh
+npm install --save-dev @frontman-ai/vite
+```
+
+Then add the plugin to your Vite config:
+
+```ts
+import { defineConfig } from 'vite';
+import { frontmanPlugin } from '@frontman-ai/vite';
+
+export default defineConfig({
+  plugins: [
+    frontmanPlugin(),
+  ],
+});
+```
+
+### Plugin ordering
+
+Place `frontmanPlugin()` **before** framework-specific plugins so the Frontman middleware is registered first in the Connect server:
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { frontmanPlugin } from '@frontman-ai/vite';
+
+export default defineConfig({
+  plugins: [
+    frontmanPlugin(), // before react()
+    react(),
+  ],
+});
+```
+
+## Configuration
+
+All options are optional.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `projectRoot` | `string` | `process.env.PROJECT_ROOT` \| `process.cwd()` | Absolute path to your project root. Scopes all file operations performed by the AI. |
+| `sourceRoot` | `string` | Same as `projectRoot` | Root for file path resolution. Set to the monorepo root when the project is a workspace package. |
+| `basePath` | `string` | `"frontman"` | URL prefix for Frontman routes. Leading and trailing slashes are stripped automatically. |
+| `host` | `string` | `process.env.FRONTMAN_HOST` \| `"api.frontman.sh"` | Frontman server host for WebSocket client connections. Accepts bare hostnames or full URLs. |
+| `serverName` | `string` | `"frontman-vite"` | Identifier included in every tool response. |
+| `serverVersion` | `string` | Package version | Version string included in tool responses. |
+| `clientUrl` | `string` | Auto-derived from `host` | Override the Frontman client JS bundle URL. Must include a `host` query parameter. |
+| `clientCssUrl` | `string` | Production CDN URL; `undefined` in dev | Override the Frontman client CSS URL. |
+| `entrypointUrl` | `string` | — | Custom entrypoint URL for the AI API. |
+| `isLightTheme` | `boolean` | `false` | Render the Frontman UI with a light color scheme. |
+| `isDev` | `boolean` | `true` unless `host === "api.frontman.sh"` | Override dev/prod mode detection. |
+
+## Accessing Frontman
+
+Start your Vite dev server (`npm run dev` or `vite`) and open `http://localhost:5173/frontman`. The port matches whatever Vite binds to.
+
+## How It Works
+
+### Plugin internals
+
+`frontmanPlugin()` returns an array of two Vite plugins, which Vite flattens automatically:
+
+**Main middleware plugin** — Registers a Connect middleware via the `configureServer` hook. The middleware intercepts all `/{basePath}/*` requests and routes them to the appropriate handler: Frontman UI, tool call API (`POST /frontman/tools/call`), or SSE event stream (`GET /frontman/tools`). The middleware bridges between the Node.js `IncomingMessage`/`ServerResponse` API (used by Vite's Connect server) and the Web Fetch `Request`/`Response` API used internally.
+
+**Vue source plugin** — A dev-only plugin that enriches `.vue` Single File Components with precise source location metadata. It reads each `.vue` file to find the `<template>` block's starting line number and injects it as `__frontman_templateLine` into the compiled component options object. The Frontman client combines this with `__file` (provided by `@vitejs/plugin-vue`) to resolve any clicked template element back to its exact file and line. This plugin is inactive in production builds.
+
+### Framework auto-detection
+
+Frontman reads the resolved Vite plugin array after config loading to determine which framework is active:
+
+| Detected plugin | Framework |
+|-----------------|-----------|
+| `@vitejs/plugin-react` | React |
+| `@vitejs/plugin-vue` | Vue |
+| `@sveltejs/vite-plugin-svelte` | Svelte |
+| `vite-plugin-solid` | SolidJS |
+
+No manual framework configuration is needed. If multiple frameworks are detected (e.g. micro-frontend setups), Frontman activates context for all of them.
+
+### Log capture
+
+A circular buffer of 1024 entries is maintained for the lifetime of the dev server. It captures:
+
+- All `console.*` output (`log`, `warn`, `error`, `info`, `debug`)
+- Vite build and HMR output (compilation results, module errors, hot update events)
+- Uncaught exceptions and unhandled Promise rejections with full stack traces
+
+The buffer is initialized when the plugin loads and persists until the dev server stops.
+
+## Available Tools
+
+### Vite-specific
+
+| Tool | Description |
+|------|-------------|
+| `get_logs` | Queries the dev server log buffer. Parameters: `pattern` (regex string), `level` (`console`/`build`/`error`), `since` (ISO 8601 timestamp), `tail` (integer). |
+
+### File system
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read a file with an optional line range. |
+| `edit_file` | Apply targeted edits or replace file contents. Runs a post-edit log check to surface compilation errors introduced by the change. |
+| `write_file` | Write a new file. |
+| `search_files` | Search file contents with a regex pattern. |
+| `list_files` | List directory contents. |
+| `list_tree` | Recursive directory tree. |
+| `file_exists` | Check whether a path exists. |
+
+### Other
+
+| Tool | Description |
+|------|-------------|
+| `lighthouse` | Run a Lighthouse performance audit against a URL using a local Chrome instance. |
+| `load_agent_instructions` | Fetch agent instructions from the project (e.g. `AGENTS.md`). |
+
+## Framework-Specific Notes
+
+### React
+
+When `@vitejs/plugin-react` is detected, the AI has access to the React component tree via fiber node inspection on the client side. For any clicked element, the client identifies:
+
+- The exact component that rendered it
+- Its current props and state
+- Its position in the component hierarchy
+- Context providers and consumers above it
+
+React Router and TanStack Router routes are visible in the client context alongside the component tree.
+
+### Vue
+
+The Vue source plugin provides precise `<template>` line numbers for every `.vue` SFC. Combined with `__file` from `@vitejs/plugin-vue`, the AI resolves clicked elements to their exact line in the template.
+
+The Composition API is understood at the client level. `ref()`, `reactive()`, `computed()`, and `watch()` calls are inspected, giving the AI the reactive state graph rather than just the final rendered output. Emitted events, slot content, and the component's props interface are also reported, so edits respect the component contract.
+
+Single File Component structure is preserved: the AI knows whether to edit `<template>`, `<script setup>`, or `<style scoped>` — it does not conflate them.
+
+Vue Router navigation guards, route params, and nested routes are visible in the client context.
+
+### Svelte
+
+When `@sveltejs/vite-plugin-svelte` is detected, the AI walks the compiled Svelte component tree. Reactive declarations (`$:`), Svelte stores, event dispatchers, and prop bindings are reported alongside the component hierarchy — the AI works with the reactive model, not just the compiled output.
+
+**SvelteKit**: SvelteKit uses Vite internally, so `@frontman-ai/vite` works with SvelteKit projects without any additional setup. Load functions, form actions, and SvelteKit routing are visible in the client context alongside the component tree.
+
+### SolidJS
+
+When `vite-plugin-solid` is detected, Frontman activates SolidJS-aware client context. SolidJS's fine-grained reactivity is inspected at the signal level, giving the AI visibility into reactive computations and memos.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `FRONTMAN_HOST` | Override the default server host. Takes precedence over the `host` config option. |
+| `PROJECT_ROOT` | Override the default project root. Takes precedence over `projectRoot`. |
+
+## Troubleshooting
+
+**`/frontman` returns 404**
+
+The plugin is not registered. Ensure `frontmanPlugin()` appears in the `plugins` array in your `vite.config.ts` and that you are running the Vite dev server, not `vite build` or `vite preview`.
+
+**Framework is not detected**
+
+Frontman reads the Vite plugin array after config resolution. If your framework plugin is conditionally included (e.g. wrapped in an environment check), detection may fail. Use the CLI installer (`npx @frontman-ai/vite install`) which performs detection at install time.
+
+**Vue template elements resolve to the wrong line**
+
+The Vue source plugin runs in dev mode only. Ensure you are running `vite dev` (not `vite preview`) and that `@vitejs/plugin-vue` appears in your Vite config — Frontman needs `__file` from that plugin to complete source resolution.
+
+**Svelte component tree is not visible**
+
+Verify `@sveltejs/vite-plugin-svelte` is installed and listed in your Vite config. The plugin must be present in the resolved Vite config for framework detection to succeed.
+
+**Log buffer is empty**
+
+The buffer captures output from the moment the dev server starts. A browser refresh does not clear the server-side buffer. If the buffer is empty, the dev server was recently restarted — reproduce the action and query immediately.
+
+**AI edits are not reflected in the browser**
+
+Frontman writes to source files directly. Vite HMR picks up the change automatically. If the browser does not update, check the terminal for compilation errors — the `get_logs` tool with `level: "build"` will surface them.

--- a/apps/marketing/src/pages/integrations/astro.astro
+++ b/apps/marketing/src/pages/integrations/astro.astro
@@ -1,4 +1,8 @@
 ---
+// Redirect to the canonical docs page. The /docs/integrations/astro/ page is the
+// authoritative reference; this path is preserved for existing inbound links.
+return Astro.redirect('/docs/integrations/astro/', 301);
+
 // /integrations/astro — Frontman + Astro Integration Page
 // Targets: "frontman astro", "AI coding tool astro", "visual editing astro",
 // "astro AI agent", "astro integration AI"

--- a/apps/marketing/src/pages/integrations/nextjs.astro
+++ b/apps/marketing/src/pages/integrations/nextjs.astro
@@ -1,4 +1,8 @@
 ---
+// Redirect to the canonical docs page. The /docs/integrations/nextjs/ page is the
+// authoritative reference; this path is preserved for existing inbound links.
+return Astro.redirect('/docs/integrations/nextjs/', 301);
+
 // /integrations/nextjs — Frontman + Next.js Integration Page
 // Targets: "frontman nextjs", "AI coding tool nextjs", "visual editing nextjs",
 // "AI that sees React components", "browser AI agent nextjs"

--- a/apps/marketing/src/pages/integrations/vite.astro
+++ b/apps/marketing/src/pages/integrations/vite.astro
@@ -1,4 +1,8 @@
 ---
+// Redirect to the canonical docs page. The /docs/integrations/vite/ page is the
+// authoritative reference; this path is preserved for existing inbound links.
+return Astro.redirect('/docs/integrations/vite/', 301);
+
 // /integrations/vite — Frontman + Vite Integration Page
 // Targets: "frontman vite", "AI coding tool react vite", "AI coding vue",
 // "AI coding svelte", "visual editing vite", "browser AI agent react"


### PR DESCRIPTION
## Summary

- **Integration docs written**: Complete technical reference docs for `@frontman-ai/astro`, `@frontman-ai/nextjs`, and `@frontman-ai/vite` — previously stubs with "Content coming soon." Now covers config options (with types and defaults from source), lifecycle hooks, plugin internals, log capture, element source detection, framework auto-detection, OpenTelemetry setup, and troubleshooting
- **Duplicate path fix**: `/integrations/{astro,nextjs,vite}/` marketing pages 301 redirect to `/docs/integrations/*`. Docs are now the canonical URL; marketing pages were soft 404s (empty stubs competing with rich landing pages)
- **Sitemap cleanup**: `/blog/tags/*` excluded (thin content bloat); `tags` chunk removed; `priority` + `changefreq` added by page type (homepage 1.0/weekly, core marketing 0.9, vs/integrations 0.8, blog/docs 0.7, blog posts `changefreq: never`)

## Test Plan
- [x] `yarn build` passes (105 pages, no broken links, sitemap generated)
- [ ] Verify `/integrations/astro/` 301s to `/docs/integrations/astro/`
- [ ] Check sitemap-index.xml — no `/blog/tags/` entries, priority/changefreq present
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
