### PR TITLE
fix: enrich MCP tool results with image content parts (#847)

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -84,7 +84,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
           on_timeout_policy: tool_def.on_timeout,
           start: {__MODULE__, :start_mcp_tool, [scope, task_id]},
           message_key: tool_call.id,
-          on_timeout: {__MODULE__, :handle_timeout, [scope, task_id, tool_def.on_timeout]}
+          on_timeout: {__MODULE__, :handle_timeout, [scope, task_id, tool_def.on_timeout]},
+          process_result: {__MODULE__, :make_mcp_tool_result, [tool_call.name]}
         }
     end
   end
@@ -114,6 +115,14 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     register_mcp_tool(tool_call)
     publish_mcp_tool_call(scope, task_id, tool_call)
     :ok
+  end
+
+  @doc false
+  @spec make_mcp_tool_result(String.t(), SwarmAi.ToolCall.t(), term(), boolean()) ::
+          SwarmAi.ToolResult.t()
+  def make_mcp_tool_result(tool_name, tool_call, content, is_error) do
+    {:ok, enriched} = maybe_enrich_with_images(tool_name, {:ok, content})
+    SwarmAi.ToolResult.make(tool_call.id, enriched, is_error)
   end
 
   @doc false

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -301,5 +301,75 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
 
       assert tc_id == tc.id
     end
+
+    test "MCP tool Await has process_result set to make_mcp_tool_result MFA", %{
+      scope: scope,
+      task_id: task_id,
+      llm_opts: llm_opts
+    } do
+      tool_name = "some_mcp_tool"
+
+      mcp_def = %FrontmanServer.Tools.MCP{
+        name: tool_name,
+        description: "test",
+        input_schema: %{},
+        on_timeout: :error,
+        timeout_ms: 60_000
+      }
+
+      executor =
+        ToolExecutor.make_executor(scope, task_id,
+          backend_tool_modules: [],
+          mcp_tools: [],
+          mcp_tool_defs: [mcp_def],
+          llm_opts: llm_opts
+        )
+
+      tc = %SwarmAi.ToolCall{
+        id: "tc_#{System.unique_integer([:positive])}",
+        name: tool_name,
+        arguments: "{}"
+      }
+
+      [execution] = executor.([tc])
+
+      assert %SwarmAi.ToolExecution.Await{
+               process_result: {ToolExecutor, :make_mcp_tool_result, [^tool_name]}
+             } = execution
+    end
+  end
+
+  describe "make_mcp_tool_result/4" do
+    test "enriches screenshot tool result with image content parts" do
+      data_url = "data:image/jpeg;base64,#{Base.encode64("fake-jpeg-bytes")}"
+      json_content = Jason.encode!(%{"screenshot" => data_url})
+
+      tool_call = %SwarmAi.ToolCall{
+        id: "tc_screenshot",
+        name: "mcp_take_screenshot",
+        arguments: "{}"
+      }
+
+      result =
+        ToolExecutor.make_mcp_tool_result("mcp_take_screenshot", tool_call, json_content, false)
+
+      assert %SwarmAi.ToolResult{id: "tc_screenshot", is_error: false} = result
+      assert [%SwarmAi.Message.ContentPart{type: :image}] = result.content
+    end
+
+    test "returns plain text ToolResult for non-image tool" do
+      json_content = Jason.encode!(%{"output" => "hello world"})
+
+      tool_call = %SwarmAi.ToolCall{
+        id: "tc_read",
+        name: "mcp_read_file",
+        arguments: "{}"
+      }
+
+      result = ToolExecutor.make_mcp_tool_result("mcp_read_file", tool_call, json_content, false)
+
+      assert %SwarmAi.ToolResult{id: "tc_read", is_error: false} = result
+      assert [%SwarmAi.Message.ContentPart{type: :text, text: ^json_content}] = result.content
+    end
   end
 end

--- a/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
@@ -59,12 +59,7 @@ defmodule SwarmAi.ParallelExecutor do
     Enum.reduce(executions, {%{}, %{}}, fn exec, {pending, awaiting} ->
       case exec do
         %ToolExecution.Sync{} ->
-          task =
-            Task.Supervisor.async_nolink(task_supervisor, fn ->
-              {mod, fun, args} = exec.run
-              apply(mod, fun, args ++ [exec.tool_call])
-            end)
-
+          task = spawn_sync(exec, task_supervisor)
           timer = Process.send_after(self(), {:deadline, task.ref}, exec.timeout_ms)
           entry = %{kind: :sync, exec: exec, timer: timer, pid: task.pid}
           {Map.put(pending, task.ref, entry), awaiting}
@@ -107,7 +102,9 @@ defmodule SwarmAi.ParallelExecutor do
         # Sync task crashed.
         %{timer: timer, exec: exec} = Map.fetch!(pending, ref)
         Process.cancel_timer(timer)
-        error_result = ToolResult.make(exec.tool_call.id, "Tool crashed: #{inspect(reason)}", true)
+
+        error_result =
+          ToolResult.make(exec.tool_call.id, "Tool crashed: #{inspect(reason)}", true)
 
         collect_results(
           Map.delete(pending, ref),
@@ -121,7 +118,8 @@ defmodule SwarmAi.ParallelExecutor do
         ref = Map.fetch!(awaiting, key)
         %{exec: exec, timer: timer} = Map.fetch!(pending, ref)
         Process.cancel_timer(timer)
-        result = ToolResult.make(exec.tool_call.id, content, is_error)
+
+        result = build_await_result(exec, content, is_error)
 
         collect_results(
           Map.delete(pending, ref),
@@ -204,6 +202,22 @@ defmodule SwarmAi.ParallelExecutor do
           :ok
       end
     end)
+  end
+
+  @spec spawn_sync(ToolExecution.Sync.t(), pid() | atom()) :: Task.t()
+  defp spawn_sync(exec, task_supervisor) do
+    Task.Supervisor.async_nolink(task_supervisor, fn ->
+      {mod, fun, args} = exec.run
+      apply(mod, fun, args ++ [exec.tool_call])
+    end)
+  end
+
+  @spec build_await_result(ToolExecution.Await.t(), term(), boolean()) :: ToolResult.t()
+  defp build_await_result(exec, content, is_error) do
+    case exec.process_result do
+      nil -> ToolResult.make(exec.tool_call.id, content, is_error)
+      {mod, fun, args} -> apply(mod, fun, args ++ [exec.tool_call, content, is_error])
+    end
   end
 
   # Re-order results map into a list matching the original tool_calls order.

--- a/apps/swarm_ai/lib/swarm_ai/tool_execution/await.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_execution/await.ex
@@ -16,17 +16,21 @@ defmodule SwarmAi.ToolExecution.Await do
   alias SwarmAi.ToolCall
 
   typedstruct enforce: true do
-    field :tool_call, ToolCall.t()
-    field :timeout_ms, pos_integer()
-    field :on_timeout_policy, :error | :pause_agent
+    field(:tool_call, ToolCall.t())
+    field(:timeout_ms, pos_integer())
+    field(:on_timeout_policy, :error | :pause_agent)
 
     # apply(mod, fun, args ++ [tool_call]) :: :ok  (called in PE's own process)
-    field :start, {module(), atom(), list()}
+    field(:start, {module(), atom(), list()})
 
     # PE matches {:tool_result, message_key, content, is_error} in its receive loop
-    field :message_key, term()
+    field(:message_key, term())
 
     # apply(mod, fun, args ++ [tool_call, :triggered | :cancelled]) :: :ok
-    field :on_timeout, {module(), atom(), list()}
+    field(:on_timeout, {module(), atom(), list()})
+
+    # apply(mod, fun, args ++ [tool_call, content, is_error]) :: ToolResult.t()
+    # When nil, PE falls back to bare ToolResult.make/3.
+    field(:process_result, {module(), atom(), list()} | nil, enforce: false, default: nil)
   end
 end

--- a/apps/swarm_ai/test/swarm_ai/parallel_executor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/parallel_executor_test.exs
@@ -128,6 +128,24 @@ defmodule SwarmAi.ParallelExecutorTest do
       assert content_text(r) == "await result"
     end
 
+    test "process_result MFA is called and its return value becomes the ToolResult" do
+      sup = start_sup()
+      tc = make_tc("id1", "mcp1")
+
+      exec = %ToolExecution.Await{
+        tool_call: tc,
+        timeout_ms: 5_000,
+        on_timeout_policy: :error,
+        start: {__MODULE__, :start_await_soon, ["raw content"]},
+        message_key: tc.id,
+        on_timeout: {__MODULE__, :noop_timeout, []},
+        process_result: {__MODULE__, :make_custom_result, []}
+      }
+
+      {:ok, [result]} = ParallelExecutor.run([exec], sup)
+      assert content_text(result) == "enriched!"
+    end
+
     test "Await error result propagates is_error flag" do
       sup = start_sup()
       tc = make_tc("id1", "mcp1")
@@ -357,6 +375,10 @@ defmodule SwarmAi.ParallelExecutorTest do
   end
 
   # --- Additional MFA helpers needed by tests above ---
+
+  def make_custom_result(tool_call, _content, _is_error) do
+    ToolResult.make(tool_call.id, "enriched!", false)
+  end
 
   def start_await_error(pe_pid, tool_call) do
     spawn(fn -> send(pe_pid, {:tool_result, tool_call.id, "mcp error", true}) end)


### PR DESCRIPTION
## Summary

- Adds optional `process_result` MFA field to `ToolExecution.Await` — when set, PE calls it instead of bare `ToolResult.make/3` to build the final `ToolResult`
- `ToolExecutor` sets `process_result: {ToolExecutor, :make_mcp_tool_result, [tool_name]}` for every MCP tool, routing the result through the existing `maybe_enrich_with_images` path (same enrichment backend tools already use)
- Screenshot tool results (and any future image-returning MCP tools) now reach the LLM as proper `ContentPart.image` parts instead of a JSON text blob

## Test Plan

- [x] `parallel_executor_test.exs` — new test: `process_result` MFA is called and its return value becomes the ToolResult
- [x] `tool_executor_test.exs` — new tests: MCP Await has `process_result` set; `make_mcp_tool_result/4` enriches screenshot data URL → `[ContentPart{type: :image}]`; non-image tools return plain JSON text
- [x] Removed wrong-layer tests from `execution_test.exs` (tested `notify_tool_result` mailbox, not PE enrichment)
- [x] 147 swarm_ai tests, 839 frontman_server tests — 0 failures

## Notes

The req_llm fork currently has a band-aid that detects `data:image/` in text tool results and extracts them into image blocks. Once this lands, that can be removed — tracked at frontman-ai/req_llm#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
