### PR TITLE
fix(marketing): correct canonical URLs for blog tag query params

### DIFF
--- a/apps/marketing/src/components/blocks/head/partials/Seo.astro
+++ b/apps/marketing/src/components/blocks/head/partials/Seo.astro
@@ -31,7 +31,7 @@ const canonicalUrl = (() => {
 	const url = new URL(Astro.url)
 	const tag = url.searchParams.get('tag')
 	if (tag && (url.pathname === '/blog' || url.pathname === '/blog/')) {
-		return new URL(`/blog/tags/${tag}/`, Astro.site).href
+		return new URL(`/blog/tags/${encodeURIComponent(tag)}/`, Astro.site).href
 	}
 	// Strip query params from canonical URLs
 	url.search = ''

--- a/apps/marketing/src/components/blocks/head/partials/Seo.astro
+++ b/apps/marketing/src/components/blocks/head/partials/Seo.astro
@@ -26,6 +26,18 @@ type Props = {
 
 const { title, description, ogImage, canonical, noindex, article } = Astro.props
 
+// When /blog?tag=X is accessed, canonical should point to /blog/tags/X/ instead
+const canonicalUrl = (() => {
+	const url = new URL(Astro.url)
+	const tag = url.searchParams.get('tag')
+	if (tag && (url.pathname === '/blog' || url.pathname === '/blog/')) {
+		return new URL(`/blog/tags/${tag}/`, Astro.site).href
+	}
+	// Strip query params from canonical URLs
+	url.search = ''
+	return url.href
+})()
+
 const absoluteOgImage = ogImage ? new URL(ogImage, Astro.site).href : undefined
 const absoluteTwitterImage = absoluteOgImage && article ? absoluteOgImage : new URL('/og-twitter.png', Astro.site).href
 const imageAlt = 'Frontman — The AI agent that lives inside your framework'
@@ -64,6 +76,6 @@ const ogType = article ? 'article' : 'website'
 	<meta name="twitter:image" content={absoluteTwitterImage} />
 	<meta name="twitter:image:alt" content={imageAlt} />
 
-	{canonical && <link rel="canonical" href={Astro.url} />}
+	{canonical && <link rel="canonical" href={canonicalUrl} />}
 	{noindex && <meta name="robots" content="noindex,nofollow" />}
 </Fragment>


### PR DESCRIPTION
## Summary
- `/blog?tag=X` pages had canonical pointing to `/blog/` instead of `/blog/tags/X/`, causing "Alternate page with proper canonical tag" errors in Google Search Console
- Fixed canonical URL computation in `Seo.astro` to redirect tag query params to the proper `/blog/tags/{tag}/` static page
- Also strips query params from canonical URLs on all other pages

## Test plan
- [ ] Visit `/blog?tag=claude-code` → verify `<link rel="canonical">` points to `https://frontman.sh/blog/tags/claude-code/`
- [ ] Visit `/blog?tag=ai` → verify canonical points to `https://frontman.sh/blog/tags/ai/`
- [ ] Visit `/blog` (no params) → verify canonical is `https://frontman.sh/blog/`
- [ ] Visit a non-blog page → verify canonical is unchanged (no query params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
