### PR TITLE
feat: capture GitHub OAuth token with repo scope from WorkOS

### DIFF
--- a/apps/frontman_server/config/dev.exs
+++ b/apps/frontman_server/config/dev.exs
@@ -110,6 +110,10 @@ config :phoenix_live_view,
   # Enable helpful, but potentially expensive runtime checks
   enable_expensive_runtime_checks: true
 
+# WorkOS and GitHub OAuth — not required in dev
+config :workos, WorkOS.Client, api_key: nil, client_id: nil
+config :frontman_server, :github_oauth, client_id: nil, client_secret: nil
+
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false
 

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -30,16 +30,6 @@ if config_env() in [:dev, :test] do
   config :frontman_server, api_key_config
 end
 
-# WorkOS configuration for OAuth (GitHub, Google)
-config :workos, WorkOS.Client,
-  api_key: env!("WORKOS_API_KEY", :string, nil),
-  client_id: env!("WORKOS_CLIENT_ID", :string, nil)
-
-# GitHub OAuth credentials for direct token refresh (same app configured in WorkOS)
-config :frontman_server, :github_oauth,
-  client_id: env!("GITHUB_OAUTH_CLIENT_ID", :string, nil),
-  client_secret: env!("GITHUB_OAUTH_CLIENT_SECRET", :string, nil)
-
 # OpenTelemetry configuration
 # Arize export enabled if both ARIZE_API_KEY and ARIZE_SPACE_ID are set
 # Optional in all environments - when not set, tracing export is disabled
@@ -94,6 +84,14 @@ if config_env() in [:dev, :test] do
 end
 
 if config_env() == :prod do
+  config :workos, WorkOS.Client,
+    api_key: env!("WORKOS_API_KEY", :string!),
+    client_id: env!("WORKOS_CLIENT_ID", :string!)
+
+  config :frontman_server, :github_oauth,
+    client_id: env!("GITHUB_OAUTH_CLIENT_ID", :string!),
+    client_secret: env!("GITHUB_OAUTH_CLIENT_SECRET", :string!)
+
   config :frontman_server,
     discord_new_users_webhook_url: env!("DISCORD_NEW_USERS_WEBHOOK_URL", :string!)
 

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -35,6 +35,11 @@ config :workos, WorkOS.Client,
   api_key: env!("WORKOS_API_KEY", :string, nil),
   client_id: env!("WORKOS_CLIENT_ID", :string, nil)
 
+# GitHub OAuth credentials for direct token refresh (same app configured in WorkOS)
+config :frontman_server, :github_oauth,
+  client_id: env!("GITHUB_OAUTH_CLIENT_ID", :string, nil),
+  client_secret: env!("GITHUB_OAUTH_CLIENT_SECRET", :string, nil)
+
 # OpenTelemetry configuration
 # Arize export enabled if both ARIZE_API_KEY and ARIZE_SPACE_ID are set
 # Optional in all environments - when not set, tracing export is disabled

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -40,6 +40,10 @@ config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: true
 config :frontman_server, FrontmanServer.Workers.SyncResendContact, enabled: true
 config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser, enabled: true
 
+# WorkOS and GitHub OAuth — not required in test
+config :workos, WorkOS.Client, api_key: nil, client_id: nil
+config :frontman_server, :github_oauth, client_id: nil, client_secret: nil
+
 # Disable swoosh api client as it is only required for production adapters
 config :swoosh, :api_client, false
 

--- a/apps/frontman_server/lib/frontman_server/accounts/user.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user.ex
@@ -12,6 +12,8 @@ defmodule FrontmanServer.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "users" do

--- a/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
@@ -17,6 +17,8 @@ defmodule FrontmanServer.Accounts.UserIdentity do
 
   @providers ~w(github google)
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "user_identities" do

--- a/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
@@ -20,14 +20,14 @@ defmodule FrontmanServer.Accounts.UserIdentity do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "user_identities" do
-    field :provider, :string
-    field :provider_id, :string
-    field :provider_email, :string
-    field :provider_name, :string
-    field :provider_avatar_url, :string
-    field :last_signed_in_at, :utc_datetime
+    field(:provider, :string)
+    field(:provider_id, :string)
+    field(:provider_email, :string)
+    field(:provider_name, :string)
+    field(:provider_avatar_url, :string)
+    field(:last_signed_in_at, :utc_datetime)
 
-    belongs_to :user, FrontmanServer.Accounts.User
+    belongs_to(:user, FrontmanServer.Accounts.User)
 
     timestamps(type: :utc_datetime)
   end
@@ -42,8 +42,7 @@ defmodule FrontmanServer.Accounts.UserIdentity do
       :provider_id,
       :provider_email,
       :provider_name,
-      :provider_avatar_url,
-      :user_id
+      :provider_avatar_url
     ])
     |> validate_required([:provider, :provider_id, :user_id])
     |> validate_inclusion(:provider, @providers)

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -27,7 +27,10 @@ defmodule FrontmanServer.Accounts.WorkOS do
   import Ecto.Changeset
   import Ecto.Query
 
+  require Logger
+
   @supported_providers ~w(github google)
+  @http_timeout_ms 15_000
   @workos_api_base "https://api.workos.com"
 
   @doc """
@@ -39,6 +42,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
       {:ok, "https://api.workos.com/..."}
 
   """
+  @spec get_authorization_url(String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, String.t()}
   def get_authorization_url(provider, redirect_uri, state \\ nil)
 
   def get_authorization_url(provider, redirect_uri, state)
@@ -75,6 +80,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
   Note: We use a raw HTTP call instead of the SDK to capture the full error
   response, including `pending_authentication_token` for email verification.
   """
+  @spec authenticate_with_code(String.t()) ::
+          {:ok, User.t(), {:ok, map()} | :none} | {:error, term()}
   def authenticate_with_code(code) do
     with {:ok, auth_response} <- authenticate_with_code_raw(code) do
       resolve_user_from_auth(auth_response)
@@ -88,9 +95,9 @@ defmodule FrontmanServer.Accounts.WorkOS do
   receives a verification code via email, which is then submitted along with
   the pending authentication token to complete the flow.
   """
+  @spec authenticate_with_email_verification(String.t(), String.t()) ::
+          {:ok, User.t(), {:ok, map()} | :none} | {:error, term()}
   def authenticate_with_email_verification(code, pending_authentication_token) do
-    require Logger
-
     body = %{
       client_id: workos_client_id(),
       client_secret: workos_api_key(),
@@ -99,7 +106,10 @@ defmodule FrontmanServer.Accounts.WorkOS do
       pending_authentication_token: pending_authentication_token
     }
 
-    case Req.post("#{@workos_api_base}/user_management/authenticate", json: body) do
+    case Req.post("#{@workos_api_base}/user_management/authenticate",
+           json: body,
+           receive_timeout: @http_timeout_ms
+         ) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         with {:ok, auth_response} <- parse_auth_response(response_body) do
           resolve_user_from_auth(auth_response)
@@ -123,6 +133,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
   Returns `{:ok, identity}` on success or `{:error, changeset}` on failure.
   """
+  @spec link_provider(User.t(), String.t()) :: {:ok, UserIdentity.t()} | {:error, term()}
   def link_provider(user, code) do
     with {:ok, auth_response} <- authenticate_with_code_raw(code),
          {:ok, profile} <- extract_profile(auth_response) do
@@ -135,6 +146,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
   Returns `{:ok, identity}` on success or `{:error, :not_found}` if the identity doesn't exist.
   """
+  @spec unlink_provider(User.t(), String.t()) ::
+          {:ok, UserIdentity.t()} | {:error, :not_found | String.t()}
   def unlink_provider(user, provider) when provider in @supported_providers do
     case get_identity_by_provider(user, provider) do
       nil -> {:error, :not_found}
@@ -149,6 +162,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   @doc """
   Lists all OAuth identities for a user.
   """
+  @spec list_identities(User.t()) :: [UserIdentity.t()]
   def list_identities(user) do
     UserIdentity
     |> where([i], i.user_id == ^user.id)
@@ -158,6 +172,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   @doc """
   Gets a specific identity by provider for a user.
   """
+  @spec get_identity_by_provider(User.t(), String.t()) :: UserIdentity.t() | nil
   def get_identity_by_provider(user, provider) do
     UserIdentity
     |> where([i], i.user_id == ^user.id and i.provider == ^provider)
@@ -209,19 +224,17 @@ defmodule FrontmanServer.Accounts.WorkOS do
   defp workos_to_provider("GitHubOAuth"), do: "github"
   defp workos_to_provider("GoogleOAuth"), do: "google"
 
-  defp extract_name(user) do
-    first_name = user[:first_name]
-    last_name = user[:last_name]
-    email = user[:email]
+  defp extract_name(%{first_name: first, last_name: last})
+       when is_binary(first) and is_binary(last),
+       do: "#{first} #{last}"
 
-    cond do
-      first_name && last_name -> "#{first_name} #{last_name}"
-      first_name -> first_name
-      last_name -> last_name
-      email -> email |> String.split("@") |> List.first()
-      true -> "Unknown"
-    end
-  end
+  defp extract_name(%{first_name: first}) when is_binary(first), do: first
+  defp extract_name(%{last_name: last}) when is_binary(last), do: last
+
+  defp extract_name(%{email: email}) when is_binary(email),
+    do: email |> String.split("@") |> List.first()
+
+  defp extract_name(_user), do: "Unknown"
 
   defp find_or_create_user_from_oauth(profile) do
     identity = get_identity_by_provider_id(profile.provider, profile.provider_id)
@@ -285,9 +298,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
   end
 
   defp build_identity_changeset(user, profile) do
-    %UserIdentity{}
+    %UserIdentity{user_id: user.id}
     |> UserIdentity.changeset(%{
-      user_id: user.id,
       provider: profile.provider,
       provider_id: profile.provider_id,
       provider_email: profile.provider_email,
@@ -322,8 +334,6 @@ defmodule FrontmanServer.Accounts.WorkOS do
   # Raw HTTP authentication to capture full error responses
 
   defp authenticate_with_code_raw(code) do
-    require Logger
-
     body = %{
       client_id: workos_client_id(),
       client_secret: workos_api_key(),
@@ -331,7 +341,10 @@ defmodule FrontmanServer.Accounts.WorkOS do
       code: code
     }
 
-    case Req.post("#{@workos_api_base}/user_management/authenticate", json: body) do
+    case Req.post("#{@workos_api_base}/user_management/authenticate",
+           json: body,
+           receive_timeout: @http_timeout_ms
+         ) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         parse_auth_response(response_body)
 
@@ -345,16 +358,16 @@ defmodule FrontmanServer.Accounts.WorkOS do
     end
   end
 
-  defp parse_auth_response(body) do
+  defp parse_auth_response(%{"user" => %{} = user_data} = body) do
     user = %{
-      id: body["user"]["id"],
-      email: body["user"]["email"],
-      email_verified: body["user"]["email_verified"],
-      first_name: body["user"]["first_name"],
-      last_name: body["user"]["last_name"],
-      profile_picture_url: body["user"]["profile_picture_url"],
-      created_at: body["user"]["created_at"],
-      updated_at: body["user"]["updated_at"]
+      id: user_data["id"],
+      email: user_data["email"],
+      email_verified: user_data["email_verified"],
+      first_name: user_data["first_name"],
+      last_name: user_data["last_name"],
+      profile_picture_url: user_data["profile_picture_url"],
+      created_at: user_data["created_at"],
+      updated_at: user_data["updated_at"]
     }
 
     {:ok,
@@ -365,6 +378,11 @@ defmodule FrontmanServer.Accounts.WorkOS do
        authentication_method: body["authentication_method"],
        oauth_tokens: extract_oauth_tokens(body)
      }}
+  end
+
+  defp parse_auth_response(_body) do
+    {:error,
+     %AuthError{code: "invalid_response", message: "Missing user data in authentication response"}}
   end
 
   defp workos_api_key do

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -75,13 +75,13 @@ defmodule FrontmanServer.Accounts.WorkOS do
   5. Creates a new user + identity → logs in
 
   Returns `{:ok, user, oauth_tokens}` on success or `{:error, reason}` on failure.
-  `oauth_tokens` is `{:ok, tokens_map}` when the provider returned tokens, or `:none`.
+  `oauth_tokens` is `%{provider: "github", ...}` or `nil`.
 
   Note: We use a raw HTTP call instead of the SDK to capture the full error
   response, including `pending_authentication_token` for email verification.
   """
   @spec authenticate_with_code(String.t()) ::
-          {:ok, User.t(), {String.t(), {:ok, map()} | :none}} | {:error, term()}
+          {:ok, User.t(), map() | nil} | {:error, term()}
   def authenticate_with_code(code) do
     with {:ok, auth_response} <- authenticate_with_code_raw(code) do
       resolve_user_from_auth(auth_response)
@@ -96,7 +96,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   the pending authentication token to complete the flow.
   """
   @spec authenticate_with_email_verification(String.t(), String.t()) ::
-          {:ok, User.t(), {String.t(), {:ok, map()} | :none}} | {:error, term()}
+          {:ok, User.t(), map() | nil} | {:error, term()}
   def authenticate_with_email_verification(code, pending_authentication_token) do
     body = %{
       client_id: workos_client_id(),
@@ -106,10 +106,9 @@ defmodule FrontmanServer.Accounts.WorkOS do
       pending_authentication_token: pending_authentication_token
     }
 
-    case Req.post("#{@workos_api_base}/user_management/authenticate",
-           json: body,
-           receive_timeout: @http_timeout_ms
-         ) do
+    opts = [json: body, receive_timeout: @http_timeout_ms] ++ workos_req_options()
+
+    case Req.post("#{@workos_api_base}/user_management/authenticate", opts) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         with {:ok, auth_response} <- parse_auth_response(response_body) do
           resolve_user_from_auth(auth_response)
@@ -182,31 +181,36 @@ defmodule FrontmanServer.Accounts.WorkOS do
   @doc """
   Extracts provider OAuth tokens from the raw WorkOS authentication response body.
 
-  Returns `{:ok, tokens_map}` when present, or `:none` when absent.
+  Returns a plain map of token fields when present, or `nil` when absent.
   """
-  @spec extract_oauth_tokens(map()) :: {:ok, map()} | :none
+  @spec extract_oauth_tokens(map()) :: map() | nil
   def extract_oauth_tokens(%{"oauth_tokens" => %{"access_token" => _} = tokens}) do
-    {:ok,
-     %{
-       access_token: tokens["access_token"],
-       refresh_token: tokens["refresh_token"],
-       expires_at: tokens["expires_at"],
-       scopes: tokens["scopes"]
-     }}
+    %{
+      access_token: tokens["access_token"],
+      refresh_token: tokens["refresh_token"],
+      expires_at: tokens["expires_at"],
+      scopes: tokens["scopes"]
+    }
   end
 
-  def extract_oauth_tokens(_body), do: :none
+  def extract_oauth_tokens(_body), do: nil
 
   # Private functions
 
   defp resolve_user_from_auth(auth_response) do
     with {:ok, profile} <- extract_profile(auth_response) do
       case find_or_create_user_from_oauth(profile) do
-        {:ok, user} -> {:ok, user, {profile.provider, auth_response[:oauth_tokens]}}
-        {:error, _} = error -> error
+        {:ok, user} ->
+          {:ok, user, build_oauth_tokens(profile.provider, auth_response[:oauth_tokens])}
+
+        {:error, _} = error ->
+          error
       end
     end
   end
+
+  defp build_oauth_tokens(provider, %{} = tokens), do: Map.put(tokens, :provider, provider)
+  defp build_oauth_tokens(_provider, nil), do: nil
 
   defp extract_profile(%{user: user, authentication_method: auth_method}) do
     provider = workos_to_provider(auth_method)
@@ -341,10 +345,9 @@ defmodule FrontmanServer.Accounts.WorkOS do
       code: code
     }
 
-    case Req.post("#{@workos_api_base}/user_management/authenticate",
-           json: body,
-           receive_timeout: @http_timeout_ms
-         ) do
+    opts = [json: body, receive_timeout: @http_timeout_ms] ++ workos_req_options()
+
+    case Req.post("#{@workos_api_base}/user_management/authenticate", opts) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         parse_auth_response(response_body)
 
@@ -391,5 +394,9 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
   defp workos_client_id do
     Application.get_env(:workos, WorkOS.Client)[:client_id]
+  end
+
+  defp workos_req_options do
+    Application.get_env(:frontman_server, :workos_req_options, [])
   end
 end

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -69,15 +69,15 @@ defmodule FrontmanServer.Accounts.WorkOS do
   4. Checks if a user exists with matching email → links identity and logs in
   5. Creates a new user + identity → logs in
 
-  Returns `{:ok, user}` on success or `{:error, reason}` on failure.
+  Returns `{:ok, user, oauth_tokens}` on success or `{:error, reason}` on failure.
+  `oauth_tokens` is `{:ok, tokens_map}` when the provider returned tokens, or `:none`.
 
   Note: We use a raw HTTP call instead of the SDK to capture the full error
   response, including `pending_authentication_token` for email verification.
   """
   def authenticate_with_code(code) do
-    with {:ok, auth_response} <- authenticate_with_code_raw(code),
-         {:ok, profile} <- extract_profile(auth_response) do
-      find_or_create_user_from_oauth(profile)
+    with {:ok, auth_response} <- authenticate_with_code_raw(code) do
+      resolve_user_from_auth(auth_response)
     end
   end
 
@@ -101,9 +101,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
     case Req.post("#{@workos_api_base}/user_management/authenticate", json: body) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
-        with {:ok, auth_response} <- parse_auth_response(response_body),
-             {:ok, profile} <- extract_profile(auth_response) do
-          find_or_create_user_from_oauth(profile)
+        with {:ok, auth_response} <- parse_auth_response(response_body) do
+          resolve_user_from_auth(auth_response)
         end
 
       {:ok, %Req.Response{status: status, body: error_body}} ->
@@ -165,7 +164,34 @@ defmodule FrontmanServer.Accounts.WorkOS do
     |> Repo.one()
   end
 
+  @doc """
+  Extracts provider OAuth tokens from the raw WorkOS authentication response body.
+
+  Returns `{:ok, tokens_map}` when present, or `:none` when absent.
+  """
+  @spec extract_oauth_tokens(map()) :: {:ok, map()} | :none
+  def extract_oauth_tokens(%{"oauth_tokens" => %{"access_token" => _} = tokens}) do
+    {:ok,
+     %{
+       access_token: tokens["access_token"],
+       refresh_token: tokens["refresh_token"],
+       expires_at: tokens["expires_at"],
+       scopes: tokens["scopes"]
+     }}
+  end
+
+  def extract_oauth_tokens(_body), do: :none
+
   # Private functions
+
+  defp resolve_user_from_auth(auth_response) do
+    with {:ok, profile} <- extract_profile(auth_response) do
+      case find_or_create_user_from_oauth(profile) do
+        {:ok, user} -> {:ok, user, auth_response[:oauth_tokens]}
+        {:error, _} = error -> error
+      end
+    end
+  end
 
   defp extract_profile(%{user: user, authentication_method: auth_method}) do
     provider = workos_to_provider(auth_method)
@@ -336,7 +362,8 @@ defmodule FrontmanServer.Accounts.WorkOS do
        user: user,
        access_token: body["access_token"],
        refresh_token: body["refresh_token"],
-       authentication_method: body["authentication_method"]
+       authentication_method: body["authentication_method"],
+       oauth_tokens: extract_oauth_tokens(body)
      }}
   end
 

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -81,7 +81,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   response, including `pending_authentication_token` for email verification.
   """
   @spec authenticate_with_code(String.t()) ::
-          {:ok, User.t(), {:ok, map()} | :none} | {:error, term()}
+          {:ok, User.t(), {String.t(), {:ok, map()} | :none}} | {:error, term()}
   def authenticate_with_code(code) do
     with {:ok, auth_response} <- authenticate_with_code_raw(code) do
       resolve_user_from_auth(auth_response)
@@ -96,7 +96,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   the pending authentication token to complete the flow.
   """
   @spec authenticate_with_email_verification(String.t(), String.t()) ::
-          {:ok, User.t(), {:ok, map()} | :none} | {:error, term()}
+          {:ok, User.t(), {String.t(), {:ok, map()} | :none}} | {:error, term()}
   def authenticate_with_email_verification(code, pending_authentication_token) do
     body = %{
       client_id: workos_client_id(),
@@ -202,7 +202,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   defp resolve_user_from_auth(auth_response) do
     with {:ok, profile} <- extract_profile(auth_response) do
       case find_or_create_user_from_oauth(profile) do
-        {:ok, user} -> {:ok, user, auth_response[:oauth_tokens]}
+        {:ok, user} -> {:ok, user, {profile.provider, auth_response[:oauth_tokens]}}
         {:error, _} = error -> error
       end
     end

--- a/apps/frontman_server/lib/frontman_server/projects.ex
+++ b/apps/frontman_server/lib/frontman_server/projects.ex
@@ -7,6 +7,7 @@ defmodule FrontmanServer.Projects do
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Projects.Project
+  alias FrontmanServer.Providers
   alias FrontmanServer.Repo
 
   @doc """
@@ -47,6 +48,14 @@ defmodule FrontmanServer.Projects do
     %Project{}
     |> Project.repo_changeset(user.id, attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Returns the user's valid GitHub OAuth access token, refreshing if expired.
+  """
+  @spec github_token(Scope.t()) :: {:ok, String.t()} | {:error, term()}
+  def github_token(%Scope{} = scope) do
+    Providers.get_valid_oauth_token(scope, "github")
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -485,9 +485,8 @@ defmodule FrontmanServer.Providers do
   Dispatches to the correct provider's refresh_token implementation.
   Returns `{:ok, new_access_token}` or `{:error, reason}`.
   """
-  # GitHub OAuth App tokens don't expire — "none" refresh_token signals this.
-  # Return the existing access_token directly.
-  def refresh_oauth_token(_scope, %OAuthToken{provider: "github", refresh_token: "none"} = token) do
+  # GitHub OAuth App tokens don't expire and have no refresh_token.
+  def refresh_oauth_token(_scope, %OAuthToken{provider: "github", refresh_token: nil} = token) do
     {:ok, token.access_token}
   end
 
@@ -498,7 +497,7 @@ defmodule FrontmanServer.Providers do
         expires_at =
           case new_tokens[:expires_in] do
             seconds when is_integer(seconds) -> OAuthToken.calculate_expires_at(seconds)
-            _ -> OAuthToken.calculate_expires_at(28_800)
+            _ -> nil
           end
 
         metadata = if is_map(token.metadata), do: token.metadata, else: %{}
@@ -715,11 +714,11 @@ defmodule FrontmanServer.Providers do
       refresh_token: refresh_token
     }
 
-    case Req.post("https://github.com/login/oauth/access_token",
-           json: body,
-           headers: [{"accept", "application/json"}],
-           receive_timeout: 15_000
-         ) do
+    opts =
+      [json: body, headers: [{"accept", "application/json"}], receive_timeout: 15_000] ++
+        github_req_options()
+
+    case Req.post("https://github.com/login/oauth/access_token", opts) do
       {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token} = resp}} ->
         {:ok,
          %{
@@ -737,6 +736,10 @@ defmodule FrontmanServer.Providers do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp github_req_options do
+    Application.get_env(:frontman_server, :github_oauth_req_options, [])
   end
 
   defp github_client_id do

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -45,6 +45,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns the default model.
   """
+  @spec default_model() :: String.t()
   def default_model, do: @default_model
 
   @doc """
@@ -101,10 +102,15 @@ defmodule FrontmanServer.Providers do
   end
 
   defp prepare_server_key(scope, provider, key, model, opts) do
-    if opts[:skip_quota] || has_remaining_usage?(scope, provider) do
-      {:ok, ResolvedKey.new(provider, key, :server_key, model)}
-    else
-      {:error, :usage_limit_exceeded}
+    case opts[:skip_quota] do
+      true ->
+        {:ok, ResolvedKey.new(provider, key, :server_key, model)}
+
+      _ ->
+        case has_remaining_usage?(scope, provider) do
+          true -> {:ok, ResolvedKey.new(provider, key, :server_key, model)}
+          false -> {:error, :usage_limit_exceeded}
+        end
     end
   end
 
@@ -148,6 +154,7 @@ defmodule FrontmanServer.Providers do
   On success, broadcasts a config change notification so subscribers
   (e.g. the tasks channel) can push updated config options to the client.
   """
+  @spec upsert_api_key(Scope.t(), String.t(), String.t()) :: {:ok, ApiKey.t()} | {:error, term()}
   def upsert_api_key(%Scope{user: %User{} = user} = scope, provider, key) do
     provider = String.downcase(provider)
     # Build struct with user_id set explicitly (not via changeset for security)
@@ -171,6 +178,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Fetches a user API key for a provider.
   """
+  @spec get_api_key(Scope.t(), String.t()) :: ApiKey.t() | nil
   def get_api_key(%Scope{user: %User{} = user}, provider) do
     ApiKey
     |> ApiKey.for_user_and_provider(user.id, provider)
@@ -180,6 +188,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns the user's API key value for a provider, if present.
   """
+  @spec get_api_key_value(Scope.t(), String.t()) :: String.t() | nil
   def get_api_key_value(%Scope{} = scope, provider) do
     case get_api_key(scope, provider) do
       %ApiKey{key: key} -> key
@@ -190,6 +199,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns true if the user has a stored API key for the provider.
   """
+  @spec has_api_key?(Scope.t(), String.t()) :: boolean()
   def has_api_key?(%Scope{} = scope, provider) do
     case get_api_key(scope, provider) do
       %ApiKey{} -> true
@@ -202,6 +212,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns the server key usage limit from config.
   """
+  @spec usage_limit() :: non_neg_integer()
   def usage_limit do
     Application.get_env(:frontman_server, :user_key_usage_limit, 10)
   end
@@ -209,6 +220,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns the user key usage record if it exists.
   """
+  @spec get_usage(Scope.t(), String.t()) :: UserKeyUsage.t() | nil
   def get_usage(%Scope{user: %User{} = user}, provider) do
     Repo.get_by(UserKeyUsage, user_id: user.id, provider: provider)
   end
@@ -216,6 +228,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns the remaining server-key requests for the user and provider.
   """
+  @spec get_usage_remaining(Scope.t(), String.t()) :: non_neg_integer()
   def get_usage_remaining(%Scope{} = scope, provider) do
     case get_usage(scope, provider) do
       %UserKeyUsage{count: count} -> max(usage_limit() - count, 0)
@@ -226,6 +239,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns true if the user has remaining server-key requests.
   """
+  @spec has_remaining_usage?(Scope.t(), String.t()) :: boolean()
   def has_remaining_usage?(%Scope{} = scope, provider) do
     get_usage_remaining(scope, provider) > 0
   end
@@ -233,6 +247,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns usage details for the user's server key usage.
   """
+  @spec get_usage_status(Scope.t(), String.t()) :: map()
   def get_usage_status(%Scope{} = scope, provider) do
     limit = usage_limit()
     used = usage_count(get_usage(scope, provider))
@@ -257,6 +272,7 @@ defmodule FrontmanServer.Providers do
   in a check-then-act pattern where two concurrent requests could both find nil
   and both attempt to insert.
   """
+  @spec increment_usage(Scope.t(), String.t()) :: {:ok, UserKeyUsage.t()} | {:error, term()}
   def increment_usage(%Scope{user: %User{} = user}, provider) do
     now = DateTime.utc_now(:second)
     usage = %UserKeyUsage{user_id: user.id}
@@ -271,22 +287,16 @@ defmodule FrontmanServer.Providers do
 
   ## API Key Resolution
 
-  @doc """
-  Resolves which API key to use for a provider.
+  # Resolves which API key to use for a provider.
+  #
+  # Resolution order:
+  # 1. OAuth token (for supported providers)
+  # 2. User's saved key
+  # 3. Env key from scope.env_api_keys (e.g., OPENROUTER_API_KEY from project)
+  # 4. Server env key (fallback)
+  defp resolve_api_key(scope, provider)
 
-  Resolution order:
-  1. OAuth token (for supported providers)
-  2. User's saved key
-  3. Env key from `scope.env_api_keys` (e.g., OPENROUTER_API_KEY from project)
-  4. Server env key (fallback)
-
-  ## Parameters
-    - scope: The user scope (or nil). env_api_keys are read from `scope.env_api_keys`.
-    - provider: The provider name (e.g., "openrouter")
-  """
-  def resolve_api_key(scope, provider)
-
-  def resolve_api_key(%Scope{} = scope, provider) when is_binary(provider) do
+  defp resolve_api_key(%Scope{} = scope, provider) when is_binary(provider) do
     case maybe_resolve_oauth_token(scope, provider) do
       {:oauth_token, _, _} = result ->
         result
@@ -302,7 +312,7 @@ defmodule FrontmanServer.Providers do
     end
   end
 
-  def resolve_api_key(nil, provider) when is_binary(provider) do
+  defp resolve_api_key(nil, provider) when is_binary(provider) do
     resolve_env_or_server_key(provider, %{})
   end
 
@@ -364,6 +374,7 @@ defmodule FrontmanServer.Providers do
 
   Delegates to `Registry.get_server_api_key/1`.
   """
+  @spec get_server_api_key(String.t()) :: String.t() | nil
   def get_server_api_key(provider) when is_binary(provider) do
     Registry.get_server_api_key(provider)
   end
@@ -376,6 +387,8 @@ defmodule FrontmanServer.Providers do
   Use this for user-initiated OAuth connections (e.g. completing an OAuth flow).
   For internal token refreshes, use `upsert_oauth_token/6` directly.
   """
+  @spec save_oauth_connection(Scope.t(), String.t(), String.t(), String.t(), DateTime.t(), map()) ::
+          {:ok, OAuthToken.t()} | {:error, term()}
   def save_oauth_connection(
         %Scope{user: %User{}} = scope,
         provider,
@@ -402,6 +415,14 @@ defmodule FrontmanServer.Providers do
 
   Accepts an optional `metadata` map for provider-specific data (e.g., `account_id`).
   """
+  @spec upsert_oauth_token(
+          Scope.t(),
+          String.t(),
+          String.t(),
+          String.t() | nil,
+          DateTime.t() | nil,
+          map()
+        ) :: {:ok, OAuthToken.t()} | {:error, term()}
   def upsert_oauth_token(
         %Scope{user: %User{} = user},
         provider,
@@ -443,6 +464,7 @@ defmodule FrontmanServer.Providers do
   @doc """
   Fetches an OAuth token for a provider (may be expired).
   """
+  @spec get_oauth_token(Scope.t(), String.t()) :: OAuthToken.t() | nil
   def get_oauth_token(%Scope{user: %User{} = user}, provider) do
     OAuthToken
     |> OAuthToken.for_user_and_provider(user.id, provider)
@@ -465,6 +487,7 @@ defmodule FrontmanServer.Providers do
 
   Returns `{:ok, access_token}` or `{:error, reason}`.
   """
+  @spec get_valid_oauth_token(Scope.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
   def get_valid_oauth_token(%Scope{} = scope, provider) do
     case get_oauth_token(scope, provider) do
       nil ->
@@ -485,6 +508,7 @@ defmodule FrontmanServer.Providers do
   Dispatches to the correct provider's refresh_token implementation.
   Returns `{:ok, new_access_token}` or `{:error, reason}`.
   """
+  @spec refresh_oauth_token(Scope.t(), OAuthToken.t()) :: {:ok, String.t()} | {:error, term()}
   # GitHub OAuth App tokens don't expire and have no refresh_token.
   def refresh_oauth_token(_scope, %OAuthToken{provider: "github", refresh_token: nil} = token) do
     {:ok, token.access_token}
@@ -492,72 +516,50 @@ defmodule FrontmanServer.Providers do
 
   # GitHub App tokens expire and have real refresh_tokens.
   def refresh_oauth_token(%Scope{} = scope, %OAuthToken{provider: "github"} = token) do
-    case refresh_github_token(token.refresh_token) do
-      {:ok, new_tokens} ->
-        expires_at =
-          case new_tokens[:expires_in] do
-            seconds when is_integer(seconds) -> OAuthToken.calculate_expires_at(seconds)
-            _ -> nil
-          end
-
-        metadata = if is_map(token.metadata), do: token.metadata, else: %{}
-
-        case upsert_oauth_token(
-               scope,
-               "github",
-               new_tokens.access_token,
-               new_tokens.refresh_token || token.refresh_token,
-               expires_at,
-               metadata
-             ) do
-          {:ok, _} -> {:ok, new_tokens.access_token}
-          {:error, reason} -> {:error, {:failed_to_store_refreshed_token, reason}}
-        end
-
-      {:error, reason} ->
-        {:error, {:refresh_failed, reason}}
+    expires_at_fn = fn new_tokens ->
+      case new_tokens[:expires_in] do
+        seconds when is_integer(seconds) -> OAuthToken.calculate_expires_at(seconds)
+        _ -> nil
+      end
     end
+
+    do_refresh(scope, token, &refresh_github_token/1, expires_at_fn)
   end
 
   def refresh_oauth_token(%Scope{} = scope, %OAuthToken{provider: "chatgpt"} = token) do
-    case ChatGPTOAuth.refresh_token(token.refresh_token) do
-      {:ok, new_tokens} ->
-        expires_in = new_tokens.expires_in || 3600
-        expires_at = OAuthToken.calculate_expires_at(expires_in)
-
-        # Preserve existing metadata (account_id) when refreshing.
-        # Metadata should always be a map (schema default is %{}), but guard against
-        # nil from pre-migration rows that were never backfilled.
-        metadata = if is_map(token.metadata), do: token.metadata, else: %{}
-
-        case upsert_oauth_token(
-               scope,
-               "chatgpt",
-               new_tokens.access_token,
-               new_tokens.refresh_token || token.refresh_token,
-               expires_at,
-               metadata
-             ) do
-          {:ok, _} -> {:ok, new_tokens.access_token}
-          {:error, reason} -> {:error, {:failed_to_store_refreshed_token, reason}}
-        end
-
-      {:error, reason} ->
-        {:error, {:refresh_failed, reason}}
+    expires_at_fn = fn new_tokens ->
+      expires_in = new_tokens.expires_in || 3600
+      OAuthToken.calculate_expires_at(expires_in)
     end
+
+    do_refresh(scope, token, &ChatGPTOAuth.refresh_token/1, expires_at_fn)
   end
 
   def refresh_oauth_token(%Scope{} = scope, %OAuthToken{} = token) do
-    case AnthropicOAuth.refresh_token(token.refresh_token) do
+    expires_at_fn = fn new_tokens ->
+      AnthropicOAuth.calculate_expires_at(new_tokens.expires_in)
+    end
+
+    do_refresh(scope, token, &AnthropicOAuth.refresh_token/1, expires_at_fn)
+  end
+
+  # Shared refresh-then-store flow for all OAuth providers.
+  defp do_refresh(scope, token, refresh_fn, expires_at_fn) do
+    case refresh_fn.(token.refresh_token) do
       {:ok, new_tokens} ->
-        expires_at = AnthropicOAuth.calculate_expires_at(new_tokens.expires_in)
+        expires_at = expires_at_fn.(new_tokens)
+
+        # Preserve existing metadata (account_id etc.) when refreshing.
+        # Guard against nil from pre-migration rows that were never backfilled.
+        metadata = if is_map(token.metadata), do: token.metadata, else: %{}
 
         case upsert_oauth_token(
                scope,
                token.provider,
                new_tokens.access_token,
-               new_tokens.refresh_token,
-               expires_at
+               new_tokens[:refresh_token] || token.refresh_token,
+               expires_at,
+               metadata
              ) do
           {:ok, _} -> {:ok, new_tokens.access_token}
           {:error, reason} -> {:error, {:failed_to_store_refreshed_token, reason}}
@@ -574,6 +576,7 @@ defmodule FrontmanServer.Providers do
   On success, broadcasts a config change notification so subscribers
   can push updated config options to the client.
   """
+  @spec delete_oauth_token(Scope.t(), String.t()) :: :ok | {:error, :not_found}
   def delete_oauth_token(%Scope{user: %User{} = user}, provider) do
     query = OAuthToken.for_user_and_provider(OAuthToken, user.id, provider)
 
@@ -672,8 +675,8 @@ defmodule FrontmanServer.Providers do
   Resolves which providers a user can access and at what tier.
 
   Returns a list of `{provider_id, tier}` tuples sorted by provider
-  priority.  Iterates all catalog providers and classifies each using
-  `resolve_api_key/2`.
+  priority.  Iterates all catalog providers and classifies each by
+  key availability.
 
   ## Parameters
 

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -476,6 +476,41 @@ defmodule FrontmanServer.Providers do
   Dispatches to the correct provider's refresh_token implementation.
   Returns `{:ok, new_access_token}` or `{:error, reason}`.
   """
+  # GitHub OAuth App tokens don't expire — "none" refresh_token signals this.
+  # Return the existing access_token directly.
+  def refresh_oauth_token(_scope, %OAuthToken{provider: "github", refresh_token: "none"} = token) do
+    {:ok, token.access_token}
+  end
+
+  # GitHub App tokens expire and have real refresh_tokens.
+  def refresh_oauth_token(%Scope{} = scope, %OAuthToken{provider: "github"} = token) do
+    case refresh_github_token(token.refresh_token) do
+      {:ok, new_tokens} ->
+        expires_at =
+          case new_tokens[:expires_in] do
+            seconds when is_integer(seconds) -> OAuthToken.calculate_expires_at(seconds)
+            _ -> OAuthToken.calculate_expires_at(28_800)
+          end
+
+        metadata = if is_map(token.metadata), do: token.metadata, else: %{}
+
+        case upsert_oauth_token(
+               scope,
+               "github",
+               new_tokens.access_token,
+               new_tokens.refresh_token || token.refresh_token,
+               expires_at,
+               metadata
+             ) do
+          {:ok, _} -> {:ok, new_tokens.access_token}
+          {:error, reason} -> {:error, {:failed_to_store_refreshed_token, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:refresh_failed, reason}}
+    end
+  end
+
   def refresh_oauth_token(%Scope{} = scope, %OAuthToken{provider: "chatgpt"} = token) do
     case ChatGPTOAuth.refresh_token(token.refresh_token) do
       {:ok, new_tokens} ->
@@ -659,5 +694,46 @@ defmodule FrontmanServer.Providers do
       {:server_key, key} when is_binary(key) and key != "" -> :server_key
       {:server_key, _} -> :no_key
     end
+  end
+
+  ## GitHub OAuth Token Refresh
+
+  defp refresh_github_token(refresh_token) when is_binary(refresh_token) do
+    body = %{
+      client_id: github_client_id(),
+      client_secret: github_client_secret(),
+      grant_type: "refresh_token",
+      refresh_token: refresh_token
+    }
+
+    case Req.post("https://github.com/login/oauth/access_token",
+           json: body,
+           headers: [{"accept", "application/json"}]
+         ) do
+      {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token} = resp}} ->
+        {:ok,
+         %{
+           access_token: access_token,
+           refresh_token: resp["refresh_token"],
+           expires_in: resp["expires_in"]
+         }}
+
+      {:ok, %Req.Response{status: 200, body: %{"error" => error}}} ->
+        {:error, {:github_error, error}}
+
+      {:ok, %Req.Response{status: status, body: resp_body}} ->
+        {:error, {:http_error, status, resp_body}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp github_client_id do
+    Application.get_env(:frontman_server, :github_oauth)[:client_id]
+  end
+
+  defp github_client_secret do
+    Application.get_env(:frontman_server, :github_oauth)[:client_secret]
   end
 end

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -414,14 +414,15 @@ defmodule FrontmanServer.Providers do
     # Build struct with user_id set explicitly (not via changeset for security)
     oauth_token = %OAuthToken{user_id: user.id}
 
-    changeset =
-      OAuthToken.changeset(oauth_token, %{
-        provider: provider,
-        access_token: access_token,
-        refresh_token: refresh_token,
-        expires_at: expires_at,
-        metadata: metadata
-      })
+    attrs = %{
+      provider: provider,
+      access_token: access_token,
+      refresh_token: refresh_token,
+      expires_at: expires_at,
+      metadata: metadata
+    }
+
+    changeset = changeset_for_provider(oauth_token, provider, attrs)
 
     Repo.insert(
       changeset,
@@ -429,6 +430,14 @@ defmodule FrontmanServer.Providers do
         {:replace, [:access_token, :refresh_token, :expires_at, :metadata, :updated_at]},
       conflict_target: [:user_id, :provider]
     )
+  end
+
+  defp changeset_for_provider(oauth_token, "github", attrs) do
+    OAuthToken.github_changeset(oauth_token, attrs)
+  end
+
+  defp changeset_for_provider(oauth_token, _provider, attrs) do
+    OAuthToken.changeset(oauth_token, attrs)
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -708,7 +708,8 @@ defmodule FrontmanServer.Providers do
 
     case Req.post("https://github.com/login/oauth/access_token",
            json: body,
-           headers: [{"accept", "application/json"}]
+           headers: [{"accept", "application/json"}],
+           receive_timeout: 15_000
          ) do
       {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token} = resp}} ->
         {:ok,

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -387,7 +387,14 @@ defmodule FrontmanServer.Providers do
   Use this for user-initiated OAuth connections (e.g. completing an OAuth flow).
   For internal token refreshes, use `upsert_oauth_token/6` directly.
   """
-  @spec save_oauth_connection(Scope.t(), String.t(), String.t(), String.t(), DateTime.t(), map()) ::
+  @spec save_oauth_connection(
+          Scope.t(),
+          String.t(),
+          String.t(),
+          String.t() | nil,
+          DateTime.t() | nil,
+          map()
+        ) ::
           {:ok, OAuthToken.t()} | {:error, term()}
   def save_oauth_connection(
         %Scope{user: %User{}} = scope,

--- a/apps/frontman_server/lib/frontman_server/providers/api_key.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/api_key.ex
@@ -16,6 +16,8 @@ defmodule FrontmanServer.Providers.ApiKey do
 
   alias FrontmanServer.Accounts.User
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "api_keys" do

--- a/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
@@ -16,6 +16,8 @@ defmodule FrontmanServer.Providers.OAuthToken do
 
   alias FrontmanServer.Accounts.User
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "oauth_tokens" do

--- a/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
@@ -30,6 +30,8 @@ defmodule FrontmanServer.Providers.OAuthToken do
     timestamps(type: :utc_datetime)
   end
 
+  @supported_providers ~w(github anthropic chatgpt)
+
   @doc """
   Changeset for storing OAuth tokens.
   Does not accept user_id - it must be set explicitly via the struct to prevent
@@ -39,9 +41,34 @@ defmodule FrontmanServer.Providers.OAuthToken do
     oauth_token
     |> cast(attrs, [:provider, :access_token, :refresh_token, :expires_at, :metadata])
     |> validate_required([:provider, :access_token, :refresh_token, :expires_at])
-    |> validate_length(:provider, min: 1, max: 64)
+    |> validate_inclusion(:provider, @supported_providers)
+    |> validate_length(:access_token, min: 1)
+    |> validate_length(:refresh_token, min: 1)
     |> unique_constraint([:user_id, :provider], name: :oauth_tokens_user_id_provider_index)
   end
+
+  @doc """
+  Changeset for GitHub OAuth tokens.
+
+  GitHub OAuth App tokens may not have refresh_token or expires_at.
+  Normalizes unix timestamp expires_at to DateTime.
+  """
+  def github_changeset(oauth_token, attrs) do
+    attrs = normalize_expires_at(attrs)
+
+    oauth_token
+    |> cast(attrs, [:access_token, :refresh_token, :expires_at, :metadata])
+    |> put_change(:provider, "github")
+    |> validate_required([:provider, :access_token])
+    |> validate_length(:access_token, min: 1)
+    |> unique_constraint([:user_id, :provider], name: :oauth_tokens_user_id_provider_index)
+  end
+
+  defp normalize_expires_at(%{expires_at: ts} = attrs) when is_integer(ts) do
+    %{attrs | expires_at: DateTime.from_unix!(ts) |> DateTime.truncate(:second)}
+  end
+
+  defp normalize_expires_at(attrs), do: attrs
 
   @doc """
   Query helpers.
@@ -56,7 +83,11 @@ defmodule FrontmanServer.Providers.OAuthToken do
 
   @doc """
   Returns true if the token is expired.
+
+  A nil expires_at means the token never expires (e.g. GitHub OAuth App tokens).
   """
+  def expired?(%__MODULE__{expires_at: nil}), do: false
+
   def expired?(%__MODULE__{expires_at: expires_at}) do
     DateTime.compare(expires_at, DateTime.utc_now()) == :lt
   end

--- a/apps/frontman_server/lib/frontman_server/providers/user_key_usage.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/user_key_usage.ex
@@ -14,6 +14,8 @@ defmodule FrontmanServer.Providers.UserKeyUsage do
 
   alias FrontmanServer.Accounts.User
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "user_key_usages" do

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -9,6 +9,7 @@ defmodule FrontmanServerWeb.OAuthController do
 
   alias FrontmanServer.Accounts
   alias FrontmanServer.Accounts.WorkOS.AuthError
+  alias FrontmanServer.Providers
   alias FrontmanServerWeb.UserAuth
 
   import FrontmanServerWeb.UserAuth, only: [require_sudo_mode: 2]
@@ -25,7 +26,9 @@ defmodule FrontmanServerWeb.OAuthController do
     require Logger
 
     case Accounts.authenticate_with_oauth(code) do
-      {:ok, user} ->
+      {:ok, user, oauth_tokens} ->
+        maybe_store_github_token(user, oauth_tokens)
+
         conn
         |> put_flash(:info, "Welcome!")
         |> UserAuth.log_in_user(user, %{"remember_me" => "true"})
@@ -88,7 +91,9 @@ defmodule FrontmanServerWeb.OAuthController do
       |> redirect(to: ~p"/users/log-in")
     else
       case Accounts.authenticate_with_email_verification(code, token) do
-        {:ok, user} ->
+        {:ok, user, oauth_tokens} ->
+          maybe_store_github_token(user, oauth_tokens)
+
           conn
           |> delete_session(:pending_auth_token)
           |> delete_session(:pending_auth_email)
@@ -145,6 +150,34 @@ defmodule FrontmanServerWeb.OAuthController do
     |> put_flash(:info, "#{provider_display_name(provider)} disconnected.")
     |> redirect(to: ~p"/users/settings")
   end
+
+  defp maybe_store_github_token(user, {:ok, tokens}) do
+    require Logger
+    scope = Accounts.Scope.for_user(user)
+
+    expires_at =
+      case tokens.expires_at do
+        ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
+        _ -> DateTime.utc_now() |> DateTime.add(28_800, :second) |> DateTime.truncate(:second)
+      end
+
+    case Providers.save_oauth_connection(
+           scope,
+           "github",
+           tokens.access_token,
+           tokens.refresh_token || "",
+           expires_at,
+           %{"scopes" => tokens.scopes || []}
+         ) do
+      {:ok, _token} ->
+        Logger.debug("Stored GitHub OAuth token for user #{user.id}")
+
+      {:error, reason} ->
+        Logger.error("Failed to store GitHub OAuth token: #{inspect(reason)}")
+    end
+  end
+
+  defp maybe_store_github_token(_user, _no_tokens), do: :ok
 
   defp generate_state_token do
     :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -26,8 +26,8 @@ defmodule FrontmanServerWeb.OAuthController do
     require Logger
 
     case Accounts.authenticate_with_oauth(code) do
-      {:ok, user, oauth_tokens} ->
-        maybe_store_github_token(user, oauth_tokens)
+      {:ok, user, {provider, oauth_tokens}} ->
+        maybe_store_github_token(user, provider, oauth_tokens)
 
         conn
         |> put_flash(:info, "Welcome!")
@@ -91,8 +91,8 @@ defmodule FrontmanServerWeb.OAuthController do
       |> redirect(to: ~p"/users/log-in")
     else
       case Accounts.authenticate_with_email_verification(code, token) do
-        {:ok, user, oauth_tokens} ->
-          maybe_store_github_token(user, oauth_tokens)
+        {:ok, user, {provider, oauth_tokens}} ->
+          maybe_store_github_token(user, provider, oauth_tokens)
 
           conn
           |> delete_session(:pending_auth_token)
@@ -151,7 +151,7 @@ defmodule FrontmanServerWeb.OAuthController do
     |> redirect(to: ~p"/users/settings")
   end
 
-  defp maybe_store_github_token(user, {:ok, tokens}) do
+  defp maybe_store_github_token(user, "github", {:ok, tokens}) do
     require Logger
     scope = Accounts.Scope.for_user(user)
 
@@ -177,7 +177,7 @@ defmodule FrontmanServerWeb.OAuthController do
     end
   end
 
-  defp maybe_store_github_token(_user, _no_tokens), do: :ok
+  defp maybe_store_github_token(_user, _provider, _tokens), do: :ok
 
   defp generate_state_token do
     :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -165,7 +165,7 @@ defmodule FrontmanServerWeb.OAuthController do
            scope,
            "github",
            tokens.access_token,
-           tokens.refresh_token || "",
+           tokens.refresh_token || "none",
            expires_at,
            %{"scopes" => tokens.scopes || []}
          ) do

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -12,6 +12,8 @@ defmodule FrontmanServerWeb.OAuthController do
   alias FrontmanServer.Providers
   alias FrontmanServerWeb.UserAuth
 
+  require Logger
+
   import FrontmanServerWeb.UserAuth, only: [require_sudo_mode: 2]
 
   plug(:require_sudo_mode when action in [:link_request, :link_callback, :unlink])
@@ -23,11 +25,9 @@ defmodule FrontmanServerWeb.OAuthController do
   end
 
   def callback(conn, %{"code" => code}) do
-    require Logger
-
     case Accounts.authenticate_with_oauth(code) do
-      {:ok, user, {provider, oauth_tokens}} ->
-        maybe_store_github_token(user, provider, oauth_tokens)
+      {:ok, user, oauth_tokens} ->
+        store_provider_token(user, oauth_tokens)
 
         conn
         |> put_flash(:info, "Welcome!")
@@ -91,8 +91,8 @@ defmodule FrontmanServerWeb.OAuthController do
       |> redirect(to: ~p"/users/log-in")
     else
       case Accounts.authenticate_with_email_verification(code, token) do
-        {:ok, user, {provider, oauth_tokens}} ->
-          maybe_store_github_token(user, provider, oauth_tokens)
+        {:ok, user, oauth_tokens} ->
+          store_provider_token(user, oauth_tokens)
 
           conn
           |> delete_session(:pending_auth_token)
@@ -151,22 +151,17 @@ defmodule FrontmanServerWeb.OAuthController do
     |> redirect(to: ~p"/users/settings")
   end
 
-  defp maybe_store_github_token(user, "github", {:ok, tokens}) do
-    require Logger
-    scope = Accounts.Scope.for_user(user)
+  defp store_provider_token(_user, nil), do: :ok
 
-    expires_at =
-      case tokens.expires_at do
-        ts when is_integer(ts) -> DateTime.from_unix!(ts) |> DateTime.truncate(:second)
-        _ -> DateTime.utc_now() |> DateTime.add(28_800, :second) |> DateTime.truncate(:second)
-      end
+  defp store_provider_token(user, %{provider: "github"} = tokens) do
+    scope = Accounts.Scope.for_user(user)
 
     case Providers.save_oauth_connection(
            scope,
            "github",
            tokens.access_token,
-           tokens.refresh_token || "none",
-           expires_at,
+           tokens.refresh_token,
+           tokens.expires_at,
            %{"scopes" => tokens.scopes || []}
          ) do
       {:ok, _token} ->
@@ -176,8 +171,6 @@ defmodule FrontmanServerWeb.OAuthController do
         Logger.error("Failed to store GitHub OAuth token: #{inspect(reason)}")
     end
   end
-
-  defp maybe_store_github_token(_user, _provider, _tokens), do: :ok
 
   defp generate_state_token do
     :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -172,6 +172,12 @@ defmodule FrontmanServerWeb.OAuthController do
     end
   end
 
+  defp store_provider_token(_user, %{provider: provider}) do
+    Logger.warning(
+      "OAuth tokens received for provider #{provider} — storage not implemented, skipping"
+    )
+  end
+
   defp generate_state_token do
     :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
   end

--- a/apps/frontman_server/priv/repo/migrations/20260415200547_allow_nullable_refresh_and_expires.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260415200547_allow_nullable_refresh_and_expires.exs
@@ -1,0 +1,10 @@
+defmodule FrontmanServer.Repo.Migrations.AllowNullableRefreshAndExpires do
+  use Ecto.Migration
+
+  def change do
+    alter table(:oauth_tokens) do
+      modify :refresh_token, :binary, null: true, from: {:binary, null: false}
+      modify :expires_at, :utc_datetime, null: true, from: {:utc_datetime, null: false}
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/accounts/user_identity_test.exs
+++ b/apps/frontman_server/test/frontman_server/accounts/user_identity_test.exs
@@ -11,20 +11,20 @@ defmodule FrontmanServer.Accounts.UserIdentityTest do
     end
 
     test "valid attributes", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id)
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes()
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert changeset.valid?
     end
 
     test "requires provider", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id) |> Map.delete(:provider)
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes() |> Map.delete(:provider)
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert %{provider: ["can't be blank"]} = errors_on(changeset)
     end
 
     test "requires provider_id", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id) |> Map.delete(:provider_id)
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes() |> Map.delete(:provider_id)
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert %{provider_id: ["can't be blank"]} = errors_on(changeset)
     end
 
@@ -35,20 +35,20 @@ defmodule FrontmanServer.Accounts.UserIdentityTest do
     end
 
     test "validates provider is github or google", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id, provider: "invalid")
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes(provider: "invalid")
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert %{provider: ["is invalid"]} = errors_on(changeset)
     end
 
     test "accepts github provider", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id, provider: "github")
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes(provider: "github")
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert changeset.valid?
     end
 
     test "accepts google provider", %{user: user} do
-      attrs = valid_identity_attributes(user_id: user.id, provider: "google")
-      changeset = UserIdentity.changeset(%UserIdentity{}, attrs)
+      attrs = valid_identity_attributes(provider: "google")
+      changeset = UserIdentity.changeset(%UserIdentity{user_id: user.id}, attrs)
       assert changeset.valid?
     end
 
@@ -56,8 +56,8 @@ defmodule FrontmanServer.Accounts.UserIdentityTest do
       _existing = identity_fixture(user, provider: "github")
 
       {:error, changeset} =
-        %UserIdentity{}
-        |> UserIdentity.changeset(valid_identity_attributes(user_id: user.id, provider: "github"))
+        %UserIdentity{user_id: user.id}
+        |> UserIdentity.changeset(valid_identity_attributes(provider: "github"))
         |> Repo.insert()
 
       assert %{user_id: ["you have already connected this provider"]} = errors_on(changeset)
@@ -68,10 +68,9 @@ defmodule FrontmanServer.Accounts.UserIdentityTest do
       other_user = user_fixture()
 
       {:error, changeset} =
-        %UserIdentity{}
+        %UserIdentity{user_id: other_user.id}
         |> UserIdentity.changeset(
           valid_identity_attributes(
-            user_id: other_user.id,
             provider: "github",
             provider_id: existing.provider_id
           )

--- a/apps/frontman_server/test/frontman_server/accounts/workos_test.exs
+++ b/apps/frontman_server/test/frontman_server/accounts/workos_test.exs
@@ -1,0 +1,38 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Accounts.WorkOSTest do
+  use FrontmanServer.DataCase, async: true
+
+  alias FrontmanServer.Accounts.WorkOS
+
+  describe "extract_oauth_tokens/1" do
+    test "extracts GitHub oauth tokens from response body" do
+      body = %{
+        "oauth_tokens" => %{
+          "access_token" => "gho_abc123",
+          "refresh_token" => "ghr_def456",
+          "expires_at" => 1_700_000_000,
+          "scopes" => ["repo"]
+        }
+      }
+
+      assert {:ok, tokens} = WorkOS.extract_oauth_tokens(body)
+      assert tokens.access_token == "gho_abc123"
+      assert tokens.refresh_token == "ghr_def456"
+      assert tokens.expires_at == 1_700_000_000
+      assert tokens.scopes == ["repo"]
+    end
+
+    test "returns :none when oauth_tokens is absent" do
+      assert :none = WorkOS.extract_oauth_tokens(%{})
+    end
+
+    test "returns :none when oauth_tokens is nil" do
+      assert :none = WorkOS.extract_oauth_tokens(%{"oauth_tokens" => nil})
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/accounts/workos_test.exs
+++ b/apps/frontman_server/test/frontman_server/accounts/workos_test.exs
@@ -10,7 +10,7 @@ defmodule FrontmanServer.Accounts.WorkOSTest do
   alias FrontmanServer.Accounts.WorkOS
 
   describe "extract_oauth_tokens/1" do
-    test "extracts GitHub oauth tokens from response body" do
+    test "extracts GitHub oauth tokens from response body as a plain map" do
       body = %{
         "oauth_tokens" => %{
           "access_token" => "gho_abc123",
@@ -20,19 +20,35 @@ defmodule FrontmanServer.Accounts.WorkOSTest do
         }
       }
 
-      assert {:ok, tokens} = WorkOS.extract_oauth_tokens(body)
-      assert tokens.access_token == "gho_abc123"
-      assert tokens.refresh_token == "ghr_def456"
-      assert tokens.expires_at == 1_700_000_000
-      assert tokens.scopes == ["repo"]
+      assert %{
+               access_token: "gho_abc123",
+               refresh_token: "ghr_def456",
+               expires_at: 1_700_000_000,
+               scopes: ["repo"]
+             } = WorkOS.extract_oauth_tokens(body)
     end
 
-    test "returns :none when oauth_tokens is absent" do
-      assert :none = WorkOS.extract_oauth_tokens(%{})
+    test "returns nil when oauth_tokens is absent" do
+      assert is_nil(WorkOS.extract_oauth_tokens(%{}))
     end
 
-    test "returns :none when oauth_tokens is nil" do
-      assert :none = WorkOS.extract_oauth_tokens(%{"oauth_tokens" => nil})
+    test "returns nil when oauth_tokens is nil" do
+      assert is_nil(WorkOS.extract_oauth_tokens(%{"oauth_tokens" => nil}))
+    end
+
+    test "passes through nil refresh_token as-is" do
+      body = %{
+        "oauth_tokens" => %{
+          "access_token" => "gho_abc123",
+          "refresh_token" => nil,
+          "expires_at" => nil,
+          "scopes" => ["repo"]
+        }
+      }
+
+      tokens = WorkOS.extract_oauth_tokens(body)
+      assert is_nil(tokens.refresh_token)
+      assert is_nil(tokens.expires_at)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/accounts_key_usage_test.exs
+++ b/apps/frontman_server/test/frontman_server/accounts_key_usage_test.exs
@@ -35,13 +35,15 @@ defmodule FrontmanServer.ProvidersTest do
     end
   end
 
-  describe "resolve_api_key" do
+  describe "prepare_api_key resolves user key" do
     test "returns user key when present" do
       user = user_fixture()
       scope = Scope.for_user(user)
       {:ok, _} = Providers.upsert_api_key(scope, "openrouter", "sk-user-123")
 
-      assert {:user_key, "sk-user-123"} = Providers.resolve_api_key(scope, "openrouter")
+      assert {:ok, resolved} = Providers.prepare_api_key(scope, "openrouter:some-model")
+      assert resolved.api_key == "sk-user-123"
+      assert resolved.key_source == :user_key
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/projects_test.exs
+++ b/apps/frontman_server/test/frontman_server/projects_test.exs
@@ -6,6 +6,7 @@ defmodule FrontmanServer.ProjectsTest do
 
   alias FrontmanServer.Projects
   alias FrontmanServer.Projects.Project
+  alias FrontmanServer.Providers
 
   setup do
     scope = user_scope_fixture()
@@ -125,6 +126,31 @@ defmodule FrontmanServer.ProjectsTest do
       other_project = project_fixture(other_scope)
 
       assert {:error, :not_found} = Projects.record_analysis(scope, other_project, %{})
+    end
+  end
+
+  describe "github_token/1" do
+    test "returns {:ok, token} when user has a valid GitHub OAuth token", %{scope: scope} do
+      expires_at =
+        DateTime.utc_now()
+        |> DateTime.add(28_800, :second)
+        |> DateTime.truncate(:second)
+
+      {:ok, _} =
+        Providers.save_oauth_connection(
+          scope,
+          "github",
+          "gho_test_token",
+          "none",
+          expires_at,
+          %{"scopes" => ["repo"]}
+        )
+
+      assert {:ok, "gho_test_token"} = Projects.github_token(scope)
+    end
+
+    test "returns {:error, :no_oauth_token} when user has no GitHub token", %{scope: scope} do
+      assert {:error, :no_oauth_token} = Projects.github_token(scope)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/providers/github_oauth_refresh_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/github_oauth_refresh_test.exs
@@ -1,0 +1,53 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Providers.GitHubOAuthRefreshTest do
+  use FrontmanServer.DataCase, async: true
+
+  import FrontmanServer.Test.Fixtures.Accounts
+
+  alias FrontmanServer.Providers
+
+  setup do
+    scope = user_scope_fixture()
+    %{scope: scope}
+  end
+
+  describe "refresh_oauth_token/2 for github" do
+    test "returns existing access_token when refresh_token is empty (non-expiring token)",
+         %{scope: scope} do
+      # GitHub OAuth App tokens don't expire — "none" refresh_token signals this
+      {:ok, _} =
+        Providers.upsert_oauth_token(
+          scope,
+          "github",
+          "gho_still_valid",
+          "none",
+          DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+        )
+
+      token = Providers.get_oauth_token(scope, "github")
+      assert {:ok, "gho_still_valid"} = Providers.refresh_oauth_token(scope, token)
+    end
+
+    test "returns error when refresh_token is present but refresh fails",
+         %{scope: scope} do
+      # GitHub App tokens expire and have refresh_tokens. Without real
+      # GitHub App credentials configured, the refresh HTTP call will fail.
+      {:ok, _} =
+        Providers.upsert_oauth_token(
+          scope,
+          "github",
+          "gho_expired",
+          "ghr_refresh_token",
+          DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+        )
+
+      token = Providers.get_oauth_token(scope, "github")
+      assert {:error, _} = Providers.refresh_oauth_token(scope, token)
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/providers/github_oauth_refresh_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/github_oauth_refresh_test.exs
@@ -12,42 +12,85 @@ defmodule FrontmanServer.Providers.GitHubOAuthRefreshTest do
   alias FrontmanServer.Providers
 
   setup do
+    Application.put_env(:frontman_server, :github_oauth_req_options,
+      plug: {Req.Test, :github_oauth}
+    )
+
+    Application.put_env(:frontman_server, :github_oauth,
+      client_id: "test_client_id",
+      client_secret: "test_client_secret"
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:frontman_server, :github_oauth_req_options)
+    end)
+
     scope = user_scope_fixture()
     %{scope: scope}
   end
 
+  defp expired_datetime do
+    DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+  end
+
   describe "refresh_oauth_token/2 for github" do
-    test "returns existing access_token when refresh_token is empty (non-expiring token)",
+    test "returns existing access_token when refresh_token is nil (non-expiring)",
          %{scope: scope} do
-      # GitHub OAuth App tokens don't expire — "none" refresh_token signals this
       {:ok, _} =
         Providers.upsert_oauth_token(
           scope,
           "github",
           "gho_still_valid",
-          "none",
-          DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+          nil,
+          nil
         )
 
       token = Providers.get_oauth_token(scope, "github")
       assert {:ok, "gho_still_valid"} = Providers.refresh_oauth_token(scope, token)
     end
 
-    test "returns error when refresh_token is present but refresh fails",
+    test "refreshes token successfully when GitHub returns new tokens",
          %{scope: scope} do
-      # GitHub App tokens expire and have refresh_tokens. Without real
-      # GitHub App credentials configured, the refresh HTTP call will fail.
       {:ok, _} =
         Providers.upsert_oauth_token(
           scope,
           "github",
           "gho_expired",
-          "ghr_refresh_token",
-          DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+          "ghr_real_refresh",
+          expired_datetime()
         )
 
+      Req.Test.stub(:github_oauth, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "gho_refreshed",
+          "refresh_token" => "ghr_new_refresh",
+          "expires_in" => 3600
+        })
+      end)
+
       token = Providers.get_oauth_token(scope, "github")
-      assert {:error, _} = Providers.refresh_oauth_token(scope, token)
+      assert {:ok, "gho_refreshed"} = Providers.refresh_oauth_token(scope, token)
+    end
+
+    test "returns error when GitHub refresh endpoint returns an error",
+         %{scope: scope} do
+      {:ok, _} =
+        Providers.upsert_oauth_token(
+          scope,
+          "github",
+          "gho_expired",
+          "ghr_bad",
+          expired_datetime()
+        )
+
+      Req.Test.stub(:github_oauth, fn conn ->
+        Req.Test.json(conn, %{"error" => "bad_refresh_token"})
+      end)
+
+      token = Providers.get_oauth_token(scope, "github")
+
+      assert {:error, {:refresh_failed, {:github_error, "bad_refresh_token"}}} =
+               Providers.refresh_oauth_token(scope, token)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/providers/oauth_token_storage_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/oauth_token_storage_test.exs
@@ -1,0 +1,59 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Providers.OAuthTokenStorageTest do
+  use FrontmanServer.DataCase, async: true
+
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers
+
+  import FrontmanServer.Test.Fixtures.Accounts
+
+  setup do
+    %{user: user_fixture()}
+  end
+
+  describe "GitHub OAuth token storage via Providers" do
+    test "stores and retrieves GitHub OAuth token", %{user: user} do
+      scope = Scope.for_user(user)
+
+      expires_at =
+        DateTime.utc_now()
+        |> DateTime.add(28_800, :second)
+        |> DateTime.truncate(:second)
+
+      assert {:ok, _token} =
+               Providers.save_oauth_connection(
+                 scope,
+                 "github",
+                 "gho_test_token",
+                 "ghr_test_refresh",
+                 expires_at,
+                 %{"scopes" => ["repo"]}
+               )
+
+      assert {:ok, "gho_test_token"} =
+               Providers.get_valid_oauth_token(scope, "github")
+    end
+
+    test "stores token with nil refresh_token and nil expires_at", %{user: user} do
+      scope = Scope.for_user(user)
+
+      assert {:ok, _token} =
+               Providers.save_oauth_connection(
+                 scope,
+                 "github",
+                 "gho_non_expiring",
+                 nil,
+                 nil,
+                 %{"scopes" => ["repo"]}
+               )
+
+      assert {:ok, "gho_non_expiring"} =
+               Providers.get_valid_oauth_token(scope, "github")
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/providers/oauth_token_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/oauth_token_test.exs
@@ -66,9 +66,9 @@ defmodule FrontmanServer.Providers.OAuthTokenTest do
       assert "can't be blank" in errors_on(changeset).expires_at
     end
 
-    test "validates provider length" do
+    test "validates provider inclusion" do
       attrs = %{
-        provider: String.duplicate("a", 65),
+        provider: "unknown_provider",
         access_token: "access_123",
         refresh_token: "refresh_456",
         expires_at: DateTime.utc_now()
@@ -76,7 +76,7 @@ defmodule FrontmanServer.Providers.OAuthTokenTest do
 
       changeset = OAuthToken.changeset(%OAuthToken{}, attrs)
       refute changeset.valid?
-      assert "should be at most 64 character(s)" in errors_on(changeset).provider
+      assert "is invalid" in errors_on(changeset).provider
     end
 
     test "does not accept user_id from attrs (security)" do

--- a/apps/frontman_server/test/frontman_server/providers/providers_oauth_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/providers_oauth_test.exs
@@ -151,7 +151,7 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
     # which is out of scope for unit tests - integration tests would cover this
   end
 
-  describe "resolve_api_key/2 with OAuth" do
+  describe "prepare_api_key/3 with OAuth" do
     test "returns oauth_token with transformation opts when available for anthropic" do
       user = user_fixture()
       scope = %Scope{user: user}
@@ -162,12 +162,12 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
 
       # Even with env_api_keys in scope, OAuth should take priority
       scope = Scope.with_env_api_keys(scope, %{"anthropic" => "env_key"})
-      result = Providers.resolve_api_key(scope, "anthropic")
+      assert {:ok, resolved} = Providers.prepare_api_key(scope, "anthropic:claude-sonnet")
 
-      # OAuth returns 3-tuple with transformation options for Claude Code
-      assert {:oauth_token, "oauth_access", opts} = result
-      assert Keyword.get(opts, :requires_mcp_prefix) == true
-      assert Keyword.get(opts, :identity_override) =~ "Claude Code"
+      assert resolved.api_key == "oauth_access"
+      assert resolved.key_source == :oauth_token
+      assert resolved.requires_mcp_prefix == true
+      assert resolved.identity_override =~ "Claude Code"
     end
 
     test "falls back to user_key when no OAuth token" do
@@ -177,20 +177,22 @@ defmodule FrontmanServer.Providers.ProvidersOAuthTest do
       # Save a user API key
       {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_api_key")
 
-      result = Providers.resolve_api_key(scope, "anthropic")
+      assert {:ok, resolved} = Providers.prepare_api_key(scope, "anthropic:claude-sonnet")
 
-      assert {:user_key, "user_api_key"} = result
+      assert resolved.api_key == "user_api_key"
+      assert resolved.key_source == :user_key
     end
 
-    test "OAuth only applies to anthropic provider" do
+    test "OAuth only applies to supported providers" do
       user = user_fixture()
       scope = %Scope{user: user}
 
       # OAuth is not supported for openrouter, so should use other resolution
       scope = Scope.with_env_api_keys(scope, %{"openrouter" => "env_key"})
-      result = Providers.resolve_api_key(scope, "openrouter")
+      assert {:ok, resolved} = Providers.prepare_api_key(scope, "openrouter:some-model")
 
-      assert {:env_key, "env_key"} = result
+      assert resolved.api_key == "env_key"
+      assert resolved.key_source == :env_key
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
@@ -1,10 +1,57 @@
 defmodule FrontmanServerWeb.OAuthControllerTest do
-  use FrontmanServerWeb.ConnCase, async: true
+  use FrontmanServerWeb.ConnCase, async: false
 
   import FrontmanServer.Test.Fixtures.Accounts
 
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers
+
   setup do
+    Application.put_env(:workos, WorkOS.Client,
+      api_key: "sk_test_workos",
+      client_id: "client_test_workos"
+    )
+
+    Application.put_env(:frontman_server, :workos_req_options, plug: {Req.Test, :workos_auth})
+
+    on_exit(fn ->
+      Application.put_env(:workos, WorkOS.Client, api_key: nil, client_id: nil)
+      Application.delete_env(:frontman_server, :workos_req_options)
+    end)
+
     %{user: user_fixture()}
+  end
+
+  defp workos_auth_response(provider, opts) do
+    user_id = Keyword.get(opts, :user_id, "user_#{System.unique_integer([:positive])}")
+    email = Keyword.get(opts, :email, "test#{System.unique_integer([:positive])}@example.com")
+
+    auth_method =
+      case provider do
+        "github" -> "GitHubOAuth"
+        "google" -> "GoogleOAuth"
+      end
+
+    response = %{
+      "user" => %{
+        "id" => user_id,
+        "email" => email,
+        "email_verified" => true,
+        "first_name" => "Test",
+        "last_name" => "User",
+        "profile_picture_url" => nil,
+        "created_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "updated_at" => DateTime.to_iso8601(DateTime.utc_now())
+      },
+      "access_token" => "wos_access_token",
+      "refresh_token" => "wos_refresh_token",
+      "authentication_method" => auth_method
+    }
+
+    case Keyword.get(opts, :oauth_tokens) do
+      nil -> response
+      tokens -> Map.put(response, "oauth_tokens", tokens)
+    end
   end
 
   describe "GET /auth/callback - access_denied" do
@@ -73,6 +120,93 @@ defmodule FrontmanServerWeb.OAuthControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "You must re-authenticate to access this page."
+    end
+  end
+
+  describe "GET /auth/callback - GitHub OAuth with tokens" do
+    test "stores GitHub OAuth token on successful login", %{conn: conn} do
+      github_tokens = %{
+        "access_token" => "gho_github_access_123",
+        "refresh_token" => "ghr_github_refresh_456",
+        "expires_at" => DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), 3600, :second)),
+        "scopes" => ["repo", "read:user"]
+      }
+
+      response = workos_auth_response("github", oauth_tokens: github_tokens)
+
+      Req.Test.stub(:workos_auth, fn conn ->
+        Req.Test.json(conn, response)
+      end)
+
+      conn = get(conn, ~p"/auth/callback", %{"code" => "test_github_code"})
+
+      assert redirected_to(conn) == ~p"/"
+
+      # Verify the token was persisted.
+      user =
+        FrontmanServer.Repo.get_by!(FrontmanServer.Accounts.User,
+          email: response["user"]["email"]
+        )
+
+      scope = Scope.for_user(user)
+      token = Providers.get_oauth_token(scope, "github")
+
+      assert token != nil
+      assert token.access_token == "gho_github_access_123"
+      assert token.refresh_token == "ghr_github_refresh_456"
+    end
+  end
+
+  describe "GET /auth/callback - Google OAuth with tokens" do
+    test "completes login without crashing when Google returns oauth_tokens", %{conn: conn} do
+      google_tokens = %{
+        "access_token" => "ya29_google_access_789",
+        "refresh_token" => "ggl_google_refresh_012",
+        "expires_at" => DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), 3600, :second)),
+        "scopes" => ["openid", "email", "profile"]
+      }
+
+      response = workos_auth_response("google", oauth_tokens: google_tokens)
+
+      Req.Test.stub(:workos_auth, fn conn ->
+        Req.Test.json(conn, response)
+      end)
+
+      conn = get(conn, ~p"/auth/callback", %{"code" => "test_google_code"})
+
+      # Login must succeed — not crash with FunctionClauseError.
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Welcome!"
+    end
+
+    test "does not store Google tokens in the oauth_tokens table", %{conn: conn} do
+      google_tokens = %{
+        "access_token" => "ya29_google_access_789",
+        "refresh_token" => "ggl_google_refresh_012",
+        "expires_at" => DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), 3600, :second)),
+        "scopes" => ["openid", "email", "profile"]
+      }
+
+      response = workos_auth_response("google", oauth_tokens: google_tokens)
+
+      Req.Test.stub(:workos_auth, fn conn ->
+        Req.Test.json(conn, response)
+      end)
+
+      conn = get(conn, ~p"/auth/callback", %{"code" => "test_google_code"})
+
+      assert redirected_to(conn) == ~p"/"
+
+      user =
+        FrontmanServer.Repo.get_by!(FrontmanServer.Accounts.User,
+          email: response["user"]["email"]
+        )
+
+      scope = Scope.for_user(user)
+
+      # Google tokens must NOT be stored as any provider.
+      assert Providers.get_oauth_token(scope, "google") == nil
+      assert Providers.get_oauth_token(scope, "github") == nil
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
@@ -1,9 +1,6 @@
 defmodule FrontmanServerWeb.OAuthControllerTest do
   use FrontmanServerWeb.ConnCase, async: true
 
-  alias FrontmanServer.Accounts.Scope
-  alias FrontmanServer.Providers
-
   import FrontmanServer.Test.Fixtures.Accounts
 
   setup do
@@ -42,30 +39,6 @@ defmodule FrontmanServerWeb.OAuthControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "You must re-authenticate to access this page."
-    end
-  end
-
-  describe "GitHub OAuth token storage" do
-    test "stores and retrieves GitHub OAuth token via Providers", %{user: user} do
-      scope = Scope.for_user(user)
-
-      expires_at =
-        DateTime.utc_now()
-        |> DateTime.add(28_800, :second)
-        |> DateTime.truncate(:second)
-
-      assert {:ok, _token} =
-               Providers.save_oauth_connection(
-                 scope,
-                 "github",
-                 "gho_test_token",
-                 "ghr_test_refresh",
-                 expires_at,
-                 %{"scopes" => ["repo"]}
-               )
-
-      assert {:ok, "gho_test_token"} =
-               Providers.get_valid_oauth_token(scope, "github")
     end
   end
 

--- a/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/controllers/oauth_controller_test.exs
@@ -1,6 +1,9 @@
 defmodule FrontmanServerWeb.OAuthControllerTest do
   use FrontmanServerWeb.ConnCase, async: true
 
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers
+
   import FrontmanServer.Test.Fixtures.Accounts
 
   setup do
@@ -39,6 +42,30 @@ defmodule FrontmanServerWeb.OAuthControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "You must re-authenticate to access this page."
+    end
+  end
+
+  describe "GitHub OAuth token storage" do
+    test "stores and retrieves GitHub OAuth token via Providers", %{user: user} do
+      scope = Scope.for_user(user)
+
+      expires_at =
+        DateTime.utc_now()
+        |> DateTime.add(28_800, :second)
+        |> DateTime.truncate(:second)
+
+      assert {:ok, _token} =
+               Providers.save_oauth_connection(
+                 scope,
+                 "github",
+                 "gho_test_token",
+                 "ghr_test_refresh",
+                 expires_at,
+                 %{"scopes" => ["repo"]}
+               )
+
+      assert {:ok, "gho_test_token"} =
+               Providers.get_valid_oauth_token(scope, "github")
     end
   end
 

--- a/apps/frontman_server/test/support/fixtures/accounts.ex
+++ b/apps/frontman_server/test/support/fixtures/accounts.ex
@@ -106,10 +106,10 @@ defmodule FrontmanServer.Test.Fixtures.Accounts do
   end
 
   def identity_fixture(user, attrs \\ %{}) do
-    attrs = valid_identity_attributes(attrs) |> Map.put(:user_id, user.id)
+    attrs = valid_identity_attributes(attrs)
 
     {:ok, identity} =
-      %Accounts.UserIdentity{}
+      %Accounts.UserIdentity{user_id: user.id}
       |> Accounts.UserIdentity.changeset(attrs)
       |> FrontmanServer.Repo.insert()
 

--- a/bin/mix-exec
+++ b/bin/mix-exec
@@ -43,7 +43,7 @@ if [ -n "$BRANCH" ]; then
     if podman container inspect "$CONTAINER" &>/dev/null 2>&1; then
         CONTAINER_CWD="/workspaces/frontman/${APP_DIR}"
         exec podman exec -w "$CONTAINER_CWD" "$CONTAINER" \
-            bash -lc "eval \"\$(mise activate bash)\" && mix ${args[*]}"
+            bash -lc 'eval "$(mise activate bash)" && mix "$@"' -- "${args[@]}"
     fi
 fi
 

--- a/bin/mix-exec
+++ b/bin/mix-exec
@@ -1,0 +1,52 @@
+#!/bin/bash
+# mix-exec — Run mix commands locally or inside the containerized worktree.
+#
+# If a running worktree container exists for the current branch, routes
+# the command through it (with mise activated). Otherwise falls back to
+# running mix directly on the host.
+#
+# The first argument is the umbrella app directory (e.g. apps/frontman_server).
+# Remaining arguments are passed to mix. File paths prefixed with the app
+# directory are stripped so they resolve correctly from within the app.
+#
+# Usage:
+#   ./bin/mix-exec apps/frontman_server format --check-formatted apps/frontman_server/lib/foo.ex
+#   ./bin/mix-exec apps/swarm_ai credo --strict apps/swarm_ai/lib/bar.ex
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: ./bin/mix-exec <app_dir> <mix_subcommand> [args...]"
+    exit 1
+fi
+
+APP_DIR="$1"
+shift
+
+# Strip the app_dir prefix from any file path arguments so they resolve
+# correctly when mix runs from inside the app directory.
+args=()
+for arg in "$@"; do
+    args+=("${arg#"${APP_DIR}/"}")
+done
+
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+
+if [ -n "$BRANCH" ]; then
+    if command -v md5sum >/dev/null 2>&1; then
+        HASH=$(echo -n "$BRANCH" | md5sum | cut -c1-4)
+    else
+        HASH=$(echo -n "$BRANCH" | md5 | cut -c1-4)
+    fi
+    CONTAINER="worktree-${HASH}-dev"
+
+    if podman container inspect "$CONTAINER" &>/dev/null 2>&1; then
+        CONTAINER_CWD="/workspaces/frontman/${APP_DIR}"
+        exec podman exec -w "$CONTAINER_CWD" "$CONTAINER" \
+            bash -lc "eval \"\$(mise activate bash)\" && mix ${args[*]}"
+    fi
+fi
+
+# Fallback: run mix directly on the host
+cd "$APP_DIR"
+exec mix "${args[@]}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,24 +10,20 @@ pre-commit:
       run: npx rescript format --check {staged_files}
 
     elixir-format-server:
-      root: "apps/frontman_server/"
       glob: "apps/frontman_server/**/*.{ex,exs}"
-      run: mix format --check-formatted {staged_files}
+      run: bin/mix-exec apps/frontman_server format --check-formatted {staged_files}
 
     elixir-format-swarm:
-      root: "apps/swarm_ai/"
       glob: "apps/swarm_ai/**/*.{ex,exs}"
-      run: mix format --check-formatted {staged_files}
+      run: bin/mix-exec apps/swarm_ai format --check-formatted {staged_files}
 
     elixir-credo-server:
-      root: "apps/frontman_server/"
       glob: "apps/frontman_server/**/*.{ex,exs}"
-      run: mix credo --strict {staged_files}
+      run: bin/mix-exec apps/frontman_server credo --strict {staged_files}
 
     elixir-credo-swarm:
-      root: "apps/swarm_ai/"
       glob: "apps/swarm_ai/**/*.{ex,exs}"
-      run: mix credo --strict {staged_files}
+      run: bin/mix-exec apps/swarm_ai credo --strict {staged_files}
 
 pre-push:
   commands:


### PR DESCRIPTION
## Summary

- Extract `oauth_tokens` from WorkOS authentication response as a flat map with `:provider` merged in (or `nil`) — no nested tagged tuples
- Store GitHub provider access token (with `repo` scope) in `oauth_tokens` table on OAuth callback via `store_provider_token/2`
- Provider-specific `github_changeset/2` on `OAuthToken` — hard-sets provider via `put_change`, normalizes unix timestamps, relaxed validations for nullable refresh_token/expires_at
- Base `changeset/2` validates provider inclusion against known providers (`github`, `anthropic`, `chatgpt`) and requires all fields
- GitHub-specific `refresh_oauth_token/2` clauses — nil refresh_token = non-expiring (no `"none"` sentinel), nil expires_at when GitHub doesn't return expires_in (no fake TTL)
- Migration makes `refresh_token` and `expires_at` nullable for GitHub OAuth App tokens
- `expired?/1` nil guard: nil expiry = never expires
- Req.Test stubs for GitHub refresh endpoint and WorkOS HTTP calls
- Add `Projects.github_token/1` convenience function for downstream consumers

## Design Decisions

- **Provider-specific changesets** over standalone normalization functions — data coercion belongs in the changeset
- **No catch-all** on `store_provider_token/2` — unknown providers crash with `FunctionClauseError` (fail fast)
- **Honest nil** for non-expiring tokens — no synthetic 8-hour TTL, no `"none"` sentinel strings
- **`validate_inclusion`** for provider field — only known providers accepted, not arbitrary strings

## Test Plan

- [x] `WorkOS.extract_oauth_tokens/1` — plain map return, nil when absent, nil passthrough
- [x] `OAuthTokenStorageTest` — stores with full tokens, stores with nil refresh_token/expires_at
- [x] GitHub refresh — nil refresh_token returns existing token, successful refresh via Req.Test stub, error handling
- [x] `OAuthTokenTest` — provider inclusion validation, required fields
- [x] `Projects.github_token/1` — retrieves valid token, returns error when missing
- [x] Full test suite: 891 tests, 0 failures
- [x] Credo strict: no issues
- [x] Format check: all clean

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)