### PR TITLE
fix(marketing): expand reference index and noindex guides stub

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -198,6 +198,8 @@ export default defineConfig({
       // Exclude integration redirect pages — they 301 to /docs/integrations/*,
       // which are already in the sitemap.
       if (/(?<!\/docs)\/integrations\/(astro|nextjs|vite)\/?$/.test(item.url)) return undefined;
+      // Exclude noindexed stub pages that exist only for sidebar navigation.
+      if (/\/docs\/guides\/?$/.test(item.url)) return undefined;
 
       // Use the real pubDate for blog and release posts; fall back to
       // build date for everything else.

--- a/apps/marketing/src/content/docs/docs/guides/index.md
+++ b/apps/marketing/src/content/docs/docs/guides/index.md
@@ -1,6 +1,11 @@
 ---
 title: Guides
 description: Guides for working with Frontman — see the Using Frontman section for detailed workflows.
+head:
+  - tag: meta
+    attrs:
+      name: robots
+      content: noindex,nofollow
 ---
 
 This section has moved. See [Using Frontman](/docs/using/how-the-agent-works/) for guides and workflows.

--- a/apps/marketing/src/content/docs/docs/reference/index.md
+++ b/apps/marketing/src/content/docs/docs/reference/index.md
@@ -1,6 +1,30 @@
 ---
 title: Reference
-description: Reference documentation for Frontman — see specific reference pages for configuration, environment variables, and more.
+description: Technical reference for Frontman — configuration options, environment variables, architecture internals, supported models, framework compatibility, self-hosting, and troubleshooting.
 ---
 
-This is a section index. See the specific reference pages in the sidebar.
+The reference section covers everything under the hood: how Frontman is structured, how to configure it, and what to do when something goes wrong. If you're looking for step-by-step workflows, head to [Using Frontman](/docs/using/how-the-agent-works/) instead.
+
+## Configuration & environment
+
+Frontman ships with sensible defaults, but most projects need at least a few tweaks. The **[Configuration Options](/docs/reference/configuration/)** page documents every option available across Astro, Next.js, Vite, and standalone setups — with types, defaults, and descriptions. For secrets and server-side settings, **[Environment Variables](/docs/reference/env-vars/)** lists every variable the client and server recognize.
+
+## Architecture & internals
+
+**[Architecture Overview](/docs/reference/architecture/)** walks through the agent loop end-to-end: how a prompt becomes a screenshot, how the server queries MCP tools, and how edits flow back to your dev server. Understanding this flow helps when you're debugging unexpected behavior or contributing to the codebase.
+
+## Models & providers
+
+Frontman connects to multiple AI providers — OpenRouter, Anthropic, OpenAI, Google, and xAI — each with different authentication methods and model catalogs. The **[Models & Providers](/docs/reference/models/)** page lists every supported model, its ID, and how to authenticate. If you're choosing between providers or configuring a bring-your-own-key setup, start there.
+
+## Framework compatibility
+
+Not sure if your runtime or framework version is supported? The **[Supported Frameworks](/docs/reference/compatibility/)** page has the compatibility matrix for Astro, Next.js, Vite, Node.js, and browser versions.
+
+## Self-hosting
+
+Most users don't need to self-host — the client libraries are open source and run entirely in your browser. But if you need data sovereignty, air-gapped deployments, or custom server modifications, the **[Self-Hosting](/docs/reference/self-hosting/)** guide covers architecture, requirements, and deployment options.
+
+## Troubleshooting
+
+When things break, check **[Troubleshooting](/docs/reference/troubleshooting/)** for fixes to common issues: the UI not loading, agent timeouts, tool failures, and WebSocket connection problems.


### PR DESCRIPTION
## Summary

- **`/docs/reference/`** — Expanded from a ~15-word stub to a 280+ word landing page that summarizes each child page (configuration, env vars, architecture, models, compatibility, self-hosting, troubleshooting) with internal links
- **`/docs/guides/`** — Added `noindex,nofollow` meta tag via Starlight `head` frontmatter and excluded from sitemap, since the content has moved to `/docs/using/`
- Sitemap exclusion added in `astro.config.mjs` alongside existing exclusion patterns

Closes #867

## Test plan

- [ ] Build marketing site and verify `/docs/reference/` renders the expanded content
- [ ] Verify `/docs/guides/` page source contains `<meta name="robots" content="noindex,nofollow">`
- [ ] Verify `/docs/guides/` does not appear in the generated sitemap XML
- [ ] Check all internal links on the reference page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
