### PR TITLE
feat(sandbox): implement Provider behaviour and Microsandbox CLI client

### DIFF
--- a/apps/frontman_server/lib/frontman_server/sandbox/command_runner.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/command_runner.ex
@@ -1,0 +1,13 @@
+defmodule FrontmanServer.Sandbox.CommandRunner do
+  @moduledoc """
+  Behaviour for executing system commands.
+
+  Abstracts `System.cmd/3` so the Microsandbox provider can be tested
+  without shelling out to real processes. Same pattern as `GitHubClient`
+  for GitHub API calls.
+  """
+
+  @type result :: {output :: String.t(), exit_code :: non_neg_integer()}
+
+  @callback run(command :: String.t(), args :: [String.t()], opts :: keyword()) :: result()
+end

--- a/apps/frontman_server/lib/frontman_server/sandbox/command_runner/system.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/command_runner/system.ex
@@ -1,0 +1,10 @@
+defmodule FrontmanServer.Sandbox.CommandRunner.System do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Sandbox.CommandRunner
+
+  @impl true
+  def run(command, args, opts) do
+    System.cmd(command, args, opts)
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/sandbox/environment_spec.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/environment_spec.ex
@@ -1,19 +1,64 @@
 defmodule FrontmanServer.Sandbox.EnvironmentSpec do
   @moduledoc """
-  The parsed contents of a repo's devcontainer.json.
+  Input to Provider.create/1 — everything needed to provision a sandbox VM.
 
-  Stored as JSONB on the project. Consumed by the provisioning
-  pipeline to build a VM image via envbuilder.
+  Validated at the boundary via NimbleOptions. Ephemeral — only used at
+  creation time. After that the provider ref string is sufficient for
+  all operations.
   """
 
-  @derive Jason.Encoder
-  defstruct [:contents]
+  @enforce_keys [:name, :image, :devcontainer]
+  defstruct [:name, :image, :devcontainer, env: %{}]
 
-  @type t :: %__MODULE__{contents: map()}
+  @type t :: %__MODULE__{
+          name: String.t(),
+          image: String.t(),
+          devcontainer: map(),
+          env: %{String.t() => String.t()}
+        }
 
-  @spec new(map()) :: {:ok, t()} | {:error, :empty_devcontainer}
-  def new(contents) when is_map(contents) and map_size(contents) > 0,
-    do: {:ok, %__MODULE__{contents: contents}}
+  @schema [
+    name: [
+      type: :string,
+      required: true,
+      doc: "Human-readable sandbox name (e.g., \"issue-123\")."
+    ],
+    image: [
+      type: :string,
+      required: true,
+      doc: "OCI image reference for the VM base."
+    ],
+    devcontainer: [
+      type: {:map, :string, :any},
+      required: true,
+      doc: "Raw parsed devcontainer.json — passed through to msb."
+    ],
+    env: [
+      type: {:map, :string, :string},
+      default: %{},
+      doc: "Environment variables for the VM. Caller merges all vars before constructing."
+    ]
+  ]
 
-  def new(_), do: {:error, :empty_devcontainer}
+  @spec new(keyword()) :: {:ok, t()} | {:error, NimbleOptions.ValidationError.t()}
+  def new(opts) when is_list(opts) do
+    case NimbleOptions.validate(opts, @schema) do
+      {:ok, validated} ->
+        spec = struct!(__MODULE__, validated)
+
+        case validate_name(spec) do
+          :ok -> {:ok, spec}
+          {:error, _} = error -> error
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp validate_name(%__MODULE__{name: name}) when byte_size(name) == 0 do
+    {:error, %NimbleOptions.ValidationError{key: :name, message: "must be a non-empty string"}}
+  end
+
+  defp validate_name(%__MODULE__{}), do: :ok
 end

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider.ex
@@ -1,0 +1,77 @@
+defmodule FrontmanServer.Sandbox.Provider do
+  @moduledoc """
+  Contract for sandbox infrastructure providers.
+
+  A Provider is a stateless client adapter — each callback is an independent
+  request to the underlying VM manager. No GenServer, no local process state.
+  The provider ref is a string ID that the VM manager uses to identify the
+  sandbox.
+
+  Process management (supervision, heartbeat, state machine) lives in the
+  Orchestrator (#834), not here.
+
+  ## Runtime Resolution
+
+  The Orchestrator resolves the provider implementation at runtime:
+
+      provider = Application.get_env(:frontman_server, :sandbox_provider, Microsandbox)
+      provider.create(env_spec)
+
+  This allows swapping providers per environment (test mock, local CLI, future
+  remote API) without changing Orchestrator code.
+  """
+
+  @type provider_ref :: String.t()
+
+  @type exec_result :: %{
+          exit_code: integer(),
+          stdout: String.t(),
+          stderr: String.t()
+        }
+
+  @type sandbox_metrics :: %{
+          status: String.t(),
+          cpu_percent: float(),
+          memory_bytes: integer()
+        }
+
+  @type env_spec :: FrontmanServer.Sandbox.EnvironmentSpec.t()
+
+  @doc """
+  Create and start a VM from an environment spec.
+
+  Returns the provider ref string used to identify this sandbox in all
+  subsequent calls. The VM should be running and reachable when this returns.
+  """
+  @callback create(env_spec()) :: {:ok, provider_ref()} | {:error, term()}
+
+  @doc """
+  Execute a command inside the sandbox.
+
+  Accepts `:timeout_ms` in opts — caller decides based on the command.
+  """
+  @callback exec(
+              provider_ref(),
+              command :: String.t(),
+              args :: [String.t()],
+              opts :: keyword()
+            ) :: {:ok, exec_result()} | {:error, term()}
+
+  @doc """
+  Poll sandbox health and resource usage.
+
+  Returns running status and resource metrics. Does NOT return vm_ip —
+  the Orchestrator discovers that via `exec(ref, "hostname", ["-I"], [])`
+  after creation.
+  """
+  @callback metrics(provider_ref()) :: {:ok, sandbox_metrics()} | {:error, term()}
+
+  @doc "Stop the sandbox VM. Preserves filesystem and named volumes."
+  @callback stop(provider_ref()) :: :ok | {:error, term()}
+
+  @doc "Resume a previously stopped sandbox."
+  @callback start(provider_ref()) :: :ok | {:error, term()}
+
+  @doc "Destroy the sandbox and all its resources."
+  @callback destroy(provider_ref()) :: :ok | {:error, term()}
+end

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -92,6 +92,36 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
     end
   end
 
+  # --- Microsandbox-specific file operations (not Provider callbacks) ---
+
+  @doc "Read a file from inside the sandbox VM via `cat`."
+  @spec read_file(String.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def read_file(ref, path, opts \\ [])
+      when is_binary(ref) and is_binary(path) do
+    case exec(ref, "cat", [path], opts) do
+      {:ok, %{exit_code: 0, stdout: content}} -> {:ok, content}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Write a file inside the sandbox VM via base64 decode.
+
+  Content is base64-encoded and piped through `base64 -d` to avoid
+  shell escaping issues.
+  """
+  @spec write_file(String.t(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def write_file(ref, path, content, opts \\ [])
+      when is_binary(ref) and is_binary(path) and is_binary(content) do
+    encoded = Base.encode64(content)
+    command = "echo '#{encoded}' | base64 -d > #{path}"
+
+    case exec(ref, "bash", ["-c", command], opts) do
+      {:ok, %{exit_code: 0}} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
   # --- Internal ---
 
   defp msb(args, caller_opts, internal_opts) do

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -1,0 +1,82 @@
+defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
+  @moduledoc """
+  CLI wrapper for the `msb` (microsandbox) command.
+
+  Translates Provider callbacks into `msb` CLI invocations via a
+  `CommandRunner` behaviour. Stateless — each function call is an
+  independent shell command. microsandbox manages VM lifecycle; this
+  module is purely a client adapter.
+  """
+
+  @behaviour FrontmanServer.Sandbox.Provider
+
+  alias FrontmanServer.Sandbox.CommandRunner
+
+  @default_timeout_ms 30_000
+  @create_timeout_ms 180_000
+
+  # --- Provider callbacks ---
+
+  @impl true
+  def create(%FrontmanServer.Sandbox.EnvironmentSpec{} = spec, opts \\ []) do
+    args =
+      ["run", "--name", spec.name, "--image", spec.image] ++
+        env_flags(spec.env) ++
+        devcontainer_flags(spec.devcontainer)
+
+    case msb(args, opts, timeout: @create_timeout_ms) do
+      {:ok, _output} -> {:ok, spec.name}
+      {:error, _} = error -> error
+    end
+  end
+
+  @impl true
+  def exec(_ref, _command, _args, _opts), do: {:error, :not_implemented}
+
+  @impl true
+  def metrics(_ref), do: {:error, :not_implemented}
+
+  @impl true
+  def stop(_ref), do: {:error, :not_implemented}
+
+  @impl true
+  def start(_ref), do: {:error, :not_implemented}
+
+  @impl true
+  def destroy(_ref), do: {:error, :not_implemented}
+
+  # --- Internal ---
+
+  defp msb(args, caller_opts, internal_opts) do
+    timeout = Keyword.get(internal_opts, :timeout, @default_timeout_ms)
+    runner = Keyword.get(caller_opts, :command_runner, default_runner())
+
+    case runner.run("msb", args, stderr_to_stdout: true, timeout: timeout) do
+      {output, 0} -> {:ok, output}
+      {output, code} -> {:error, {:cmd_failed, code, output}}
+    end
+  end
+
+  defp env_flags(env) when map_size(env) == 0, do: []
+
+  defp env_flags(env) do
+    Enum.flat_map(env, fn {k, v} -> ["--env", "#{k}=#{v}"] end)
+  end
+
+  defp devcontainer_flags(dc) when map_size(dc) == 0, do: []
+
+  defp devcontainer_flags(dc) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "msb-devcontainer-#{System.unique_integer([:positive])}.json"
+      )
+
+    File.write!(path, Jason.encode!(dc))
+    ["--config", path]
+  end
+
+  defp default_runner do
+    Application.get_env(:frontman_server, :command_runner, CommandRunner.System)
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -26,15 +26,14 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
         env_flags(spec.env) ++
         dc_flags
 
-    result =
+    try do
       case msb(args, opts, timeout: @create_timeout_ms) do
         {:ok, _output} -> {:ok, spec.name}
         {:error, _} = error -> error
       end
-
-    if dc_temp_path, do: File.rm(dc_temp_path)
-
-    result
+    after
+      if dc_temp_path, do: File.rm(dc_temp_path)
+    end
   end
 
   @impl true

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -31,10 +31,39 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
   end
 
   @impl true
-  def exec(_ref, _command, _args, _opts), do: {:error, :not_implemented}
+  def exec(ref, command, args, opts)
+      when is_binary(ref) and is_binary(command) and is_list(args) do
+    {caller_opts, exec_opts} = extract_caller_opts(opts)
+    timeout = Keyword.get(exec_opts, :timeout_ms, @default_timeout_ms)
+
+    msb_args = ["exec", ref, "--" | [command | args]]
+
+    case msb(msb_args, caller_opts, timeout: timeout) do
+      {:ok, output} ->
+        {:ok, %{exit_code: 0, stdout: output, stderr: ""}}
+
+      {:error, _} = error ->
+        error
+    end
+  end
 
   @impl true
-  def metrics(_ref), do: {:error, :not_implemented}
+  def metrics(ref, opts \\ []) when is_binary(ref) do
+    with {:ok, output} <- msb(["list", "--json"], opts, []),
+         {:ok, entries} when is_list(entries) <- Jason.decode(output),
+         entry when not is_nil(entry) <- Enum.find(entries, &(&1["name"] == ref)) do
+      {:ok,
+       %{
+         status: Map.get(entry, "status", "unknown"),
+         cpu_percent: Map.get(entry, "cpu_percent", 0.0),
+         memory_bytes: Map.get(entry, "memory_bytes", 0)
+       }}
+    else
+      nil -> {:error, :not_found}
+      {:error, _} = error -> error
+      _ -> {:error, :invalid_json}
+    end
+  end
 
   @impl true
   def stop(_ref), do: {:error, :not_implemented}
@@ -55,6 +84,10 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
       {output, 0} -> {:ok, output}
       {output, code} -> {:error, {:cmd_failed, code, output}}
     end
+  end
+
+  defp extract_caller_opts(opts) do
+    Keyword.split(opts, [:command_runner])
   end
 
   defp env_flags(env) when map_size(env) == 0, do: []

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -66,13 +66,31 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
   end
 
   @impl true
-  def stop(_ref), do: {:error, :not_implemented}
+  def stop(ref, opts \\ []) when is_binary(ref) do
+    case msb(["stop", ref], opts, []) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
 
   @impl true
-  def start(_ref), do: {:error, :not_implemented}
+  def start(ref, opts \\ []) when is_binary(ref) do
+    case msb(["start", ref], opts, []) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
 
   @impl true
-  def destroy(_ref), do: {:error, :not_implemented}
+  def destroy(ref, opts \\ []) when is_binary(ref) do
+    # Stop first (tolerate "already stopped" errors), then remove.
+    _ = msb(["stop", ref], opts, [])
+
+    case msb(["remove", ref], opts, []) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
 
   # --- Internal ---
 

--- a/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/provider/microsandbox.ex
@@ -19,15 +19,22 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
 
   @impl true
   def create(%FrontmanServer.Sandbox.EnvironmentSpec{} = spec, opts \\ []) do
+    {dc_flags, dc_temp_path} = devcontainer_flags(spec.devcontainer)
+
     args =
       ["run", "--name", spec.name, "--image", spec.image] ++
         env_flags(spec.env) ++
-        devcontainer_flags(spec.devcontainer)
+        dc_flags
 
-    case msb(args, opts, timeout: @create_timeout_ms) do
-      {:ok, _output} -> {:ok, spec.name}
-      {:error, _} = error -> error
-    end
+    result =
+      case msb(args, opts, timeout: @create_timeout_ms) do
+        {:ok, _output} -> {:ok, spec.name}
+        {:error, _} = error -> error
+      end
+
+    if dc_temp_path, do: File.rm(dc_temp_path)
+
+    result
   end
 
   @impl true
@@ -42,8 +49,8 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
       {:ok, output} ->
         {:ok, %{exit_code: 0, stdout: output, stderr: ""}}
 
-      {:error, _} = error ->
-        error
+      {:error, {:cmd_failed, code, output}} ->
+        {:ok, %{exit_code: code, stdout: output, stderr: ""}}
     end
   end
 
@@ -100,7 +107,7 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
       when is_binary(ref) and is_binary(path) do
     case exec(ref, "cat", [path], opts) do
       {:ok, %{exit_code: 0, stdout: content}} -> {:ok, content}
-      {:error, _} = error -> error
+      {:ok, %{exit_code: code, stdout: output}} -> {:error, {:cmd_failed, code, output}}
     end
   end
 
@@ -114,11 +121,15 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
   def write_file(ref, path, content, opts \\ [])
       when is_binary(ref) and is_binary(path) and is_binary(content) do
     encoded = Base.encode64(content)
-    command = "echo '#{encoded}' | base64 -d > #{path}"
 
-    case exec(ref, "bash", ["-c", command], opts) do
+    case exec(
+           ref,
+           "bash",
+           ["-c", ~S(printf '%s' "$1" | base64 -d > "$2"), "_", encoded, path],
+           opts
+         ) do
       {:ok, %{exit_code: 0}} -> :ok
-      {:error, _} = error -> error
+      {:ok, %{exit_code: code, stdout: output}} -> {:error, {:cmd_failed, code, output}}
     end
   end
 
@@ -144,7 +155,7 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
     Enum.flat_map(env, fn {k, v} -> ["--env", "#{k}=#{v}"] end)
   end
 
-  defp devcontainer_flags(dc) when map_size(dc) == 0, do: []
+  defp devcontainer_flags(dc) when map_size(dc) == 0, do: {[], nil}
 
   defp devcontainer_flags(dc) do
     path =
@@ -154,7 +165,7 @@ defmodule FrontmanServer.Sandbox.Provider.Microsandbox do
       )
 
     File.write!(path, Jason.encode!(dc))
-    ["--config", path]
+    {["--config", path], path}
   end
 
   defp default_runner do

--- a/apps/frontman_server/lib/frontman_server/sandbox/repo_analyzer.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/repo_analyzer.ex
@@ -3,9 +3,9 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzer do
   Entry point for environment detection.
 
   Given a GitHub repo and token, fetches the repo's devcontainer.json
-  and returns it as an EnvironmentSpec. If no devcontainer.json is
-  found, returns a structured error rather than generating one — MVP
-  scope only.
+  and returns it as a parsed map. If no devcontainer.json is found,
+  returns a structured error rather than generating one — MVP scope
+  only.
   """
 
   alias FrontmanServer.Sandbox.GitHubClient

--- a/apps/frontman_server/lib/frontman_server/sandbox/repo_analyzer.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/repo_analyzer.ex
@@ -8,7 +8,7 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzer do
   scope only.
   """
 
-  alias FrontmanServer.Sandbox.{EnvironmentSpec, GitHubClient}
+  alias FrontmanServer.Sandbox.GitHubClient
 
   @devcontainer_paths [
     ".devcontainer/devcontainer.json",
@@ -17,7 +17,7 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzer do
   ]
 
   @spec analyze(String.t(), String.t(), keyword()) ::
-          {:ok, EnvironmentSpec.t()}
+          {:ok, map()}
           | {:error,
              :no_devcontainer
              | :invalid_json
@@ -41,7 +41,7 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzer do
          {:ok, path} <- find_devcontainer(tree),
          {:ok, content} <- client.get_file(owner, repo, path, token),
          {:ok, map} <- decode_json(content) do
-      EnvironmentSpec.new(map)
+      validate_devcontainer(map)
     else
       {:error, {:http_error, 401, _}} -> {:error, :unauthorized}
       {:error, {:http_error, 404, _}} -> {:error, :not_found}
@@ -62,6 +62,8 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzer do
       path -> {:ok, path}
     end
   end
+
+  defp validate_devcontainer(map) when is_map(map), do: {:ok, map}
 
   defp decode_json(content) do
     case Jason.decode(content) do

--- a/apps/frontman_server/mix.exs
+++ b/apps/frontman_server/mix.exs
@@ -98,6 +98,7 @@ defmodule FrontmanServer.MixProject do
       {:dns_cluster, "~> 0.2.0"},
       {:bandit, "~> 1.5"},
       {:typedstruct, "~> 0.5"},
+      {:nimble_options, "~> 1.1"},
       {:zoi, "~> 0.14"},
       {:dotenvy, "~> 1.1"},
       # Sentry error tracking

--- a/apps/frontman_server/test/frontman_server/sandbox/environment_spec_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/environment_spec_test.exs
@@ -4,25 +4,84 @@ defmodule FrontmanServer.Sandbox.EnvironmentSpecTest do
   alias FrontmanServer.Sandbox.EnvironmentSpec
 
   describe "new/1" do
-    test "returns {:ok, struct} for a non-empty map" do
-      contents = %{"image" => "ubuntu"}
+    test "returns {:ok, spec} with valid required fields" do
+      assert {:ok, spec} =
+               EnvironmentSpec.new(
+                 name: "issue-123",
+                 image: "ghcr.io/frontman-ai/frontman-dev:latest",
+                 devcontainer: %{"postCreateCommand" => "mix setup"}
+               )
 
-      assert {:ok, %EnvironmentSpec{contents: ^contents}} = EnvironmentSpec.new(contents)
+      assert spec.name == "issue-123"
+      assert spec.image == "ghcr.io/frontman-ai/frontman-dev:latest"
+      assert spec.devcontainer == %{"postCreateCommand" => "mix setup"}
+      assert spec.env == %{}
     end
 
-    test "returns {:error, :empty_devcontainer} for an empty map" do
-      assert {:error, :empty_devcontainer} = EnvironmentSpec.new(%{})
+    test "returns {:ok, spec} with all fields including env" do
+      assert {:ok, spec} =
+               EnvironmentSpec.new(
+                 name: "issue-123",
+                 image: "ghcr.io/frontman-ai/frontman-dev:latest",
+                 devcontainer: %{"forwardPorts" => [4000, 5173]},
+                 env: %{"GITHUB_TOKEN" => "ghp_abc123"}
+               )
+
+      assert spec.env == %{"GITHUB_TOKEN" => "ghp_abc123"}
     end
 
-    test "returns {:error, :empty_devcontainer} for nil" do
-      assert {:error, :empty_devcontainer} = EnvironmentSpec.new(nil)
+    test "accepts empty devcontainer map" do
+      assert {:ok, spec} =
+               EnvironmentSpec.new(
+                 name: "test",
+                 image: "ubuntu:24.04",
+                 devcontainer: %{}
+               )
+
+      assert spec.devcontainer == %{}
     end
 
-    test "struct serializes to JSON via Jason" do
-      {:ok, spec} = EnvironmentSpec.new(%{"image" => "ubuntu"})
+    test "returns {:error, _} when name is missing" do
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               EnvironmentSpec.new(
+                 image: "ubuntu:24.04",
+                 devcontainer: %{}
+               )
+    end
 
-      assert {:ok, json} = Jason.encode(spec)
-      assert json =~ "ubuntu"
+    test "returns {:error, _} when image is missing" do
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               EnvironmentSpec.new(
+                 name: "test",
+                 devcontainer: %{}
+               )
+    end
+
+    test "returns {:error, _} when devcontainer is missing" do
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               EnvironmentSpec.new(
+                 name: "test",
+                 image: "ubuntu:24.04"
+               )
+    end
+
+    test "returns {:error, _} when name is empty string" do
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               EnvironmentSpec.new(
+                 name: "",
+                 image: "ubuntu:24.04",
+                 devcontainer: %{"runtime" => "node20"}
+               )
+    end
+
+    test "returns {:error, _} when env values are not strings" do
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               EnvironmentSpec.new(
+                 name: "test",
+                 image: "ubuntu:24.04",
+                 devcontainer: %{"runtime" => "node20"},
+                 env: %{"PORT" => 3000}
+               )
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_integration_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_integration_test.exs
@@ -1,0 +1,66 @@
+defmodule FrontmanServer.Sandbox.Provider.MicrosandboxIntegrationTest do
+  @moduledoc """
+  Integration tests for the Microsandbox provider against a real `msb` CLI.
+
+  These tests are excluded by default. Run with:
+
+      mix test --include integration
+
+  Requires `msb` to be installed and working on the host.
+  """
+
+  use ExUnit.Case
+
+  @moduletag :integration
+
+  alias FrontmanServer.Sandbox.EnvironmentSpec
+  alias FrontmanServer.Sandbox.Provider.Microsandbox
+
+  defp test_env_spec do
+    {:ok, spec} =
+      EnvironmentSpec.new(
+        name: "integration-test-#{System.unique_integer([:positive])}",
+        image: "ubuntu:24.04",
+        devcontainer: %{},
+        env: %{"SANDBOX_NAME" => "integration-test"}
+      )
+
+    spec
+  end
+
+  describe "full lifecycle" do
+    test "create → exec → write_file → read_file → metrics → stop → start → destroy" do
+      env_spec = test_env_spec()
+
+      # Create
+      assert {:ok, ref} = Microsandbox.create(env_spec)
+      assert is_binary(ref)
+
+      # Exec
+      assert {:ok, %{exit_code: 0, stdout: stdout}} =
+               Microsandbox.exec(ref, "echo", ["hello"], [])
+
+      assert String.contains?(stdout, "hello")
+
+      # Write file
+      assert :ok = Microsandbox.write_file(ref, "/tmp/test.txt", "integration test content")
+
+      # Read file
+      assert {:ok, content} = Microsandbox.read_file(ref, "/tmp/test.txt")
+      assert String.contains?(content, "integration test content")
+
+      # Metrics
+      assert {:ok, metrics} = Microsandbox.metrics(ref)
+      assert metrics.status == "running"
+
+      # Stop
+      assert :ok = Microsandbox.stop(ref)
+
+      # Start
+      assert :ok = Microsandbox.start(ref)
+
+      # Destroy
+      assert :ok = Microsandbox.destroy(ref)
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
@@ -74,4 +74,103 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
                Microsandbox.create(env_spec, microsandbox())
     end
   end
+
+  describe "exec/4" do
+    test "returns {:ok, exec_result} on success" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", args, _opts ->
+        assert args == ["exec", "sb-abc123", "--", "echo", "hello"]
+        {"hello\n", 0}
+      end)
+
+      assert {:ok, %{exit_code: 0, stdout: "hello\n", stderr: ""}} =
+               Microsandbox.exec("sb-abc123", "echo", ["hello"], microsandbox())
+    end
+
+    test "returns exec_result with non-zero exit code (command ran but failed)" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"test failed\n", 0}
+      end)
+
+      assert {:ok, %{exit_code: 0, stdout: "test failed\n"}} =
+               Microsandbox.exec("sb-abc123", "mix", ["test"], microsandbox())
+    end
+
+    test "passes timeout_ms from opts" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, opts ->
+        assert Keyword.get(opts, :timeout) == 300_000
+        {"", 0}
+      end)
+
+      assert {:ok, _} =
+               Microsandbox.exec(
+                 "sb-abc123",
+                 "mix",
+                 ["test"],
+                 microsandbox(timeout_ms: 300_000)
+               )
+    end
+
+    test "returns error when msb exec fails" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"Error: sandbox not found\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} =
+               Microsandbox.exec("sb-abc123", "false", [], microsandbox())
+    end
+  end
+
+  describe "metrics/1" do
+    test "returns {:ok, sandbox_metrics} on success" do
+      json_output =
+        Jason.encode!([
+          %{
+            "name" => "sb-abc123",
+            "status" => "running",
+            "cpu_percent" => 12.5,
+            "memory_bytes" => 268_435_456
+          },
+          %{
+            "name" => "other-sandbox",
+            "status" => "stopped",
+            "cpu_percent" => 0.0,
+            "memory_bytes" => 0
+          }
+        ])
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["list", "--json"], _opts ->
+        {json_output, 0}
+      end)
+
+      assert {:ok, metrics} = Microsandbox.metrics("sb-abc123", microsandbox())
+      assert metrics.status == "running"
+      assert metrics.cpu_percent == 12.5
+      assert metrics.memory_bytes == 268_435_456
+    end
+
+    test "returns error when sandbox not found in list" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["list", "--json"], _opts ->
+        {Jason.encode!([
+           %{"name" => "other", "status" => "running", "cpu_percent" => 0.0, "memory_bytes" => 0}
+         ]), 0}
+      end)
+
+      assert {:error, :not_found} = Microsandbox.metrics("sb-abc123", microsandbox())
+    end
+
+    test "returns error when msb list fails" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"Error: daemon unreachable\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} = Microsandbox.metrics("sb-abc123", microsandbox())
+    end
+  end
 end

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
@@ -173,4 +173,73 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
       assert {:error, {:cmd_failed, 1, _}} = Microsandbox.metrics("sb-abc123", microsandbox())
     end
   end
+
+  describe "stop/1" do
+    test "returns :ok on success" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["stop", "sb-abc123"], _opts ->
+        {"Sandbox sb-abc123 stopped\n", 0}
+      end)
+
+      assert :ok = Microsandbox.stop("sb-abc123", microsandbox())
+    end
+
+    test "returns error on failure" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["stop", "sb-abc123"], _opts ->
+        {"Error: not running\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} = Microsandbox.stop("sb-abc123", microsandbox())
+    end
+  end
+
+  describe "start/1" do
+    test "returns :ok on success" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["start", "sb-abc123"], _opts ->
+        {"Sandbox sb-abc123 started\n", 0}
+      end)
+
+      assert :ok = Microsandbox.start("sb-abc123", microsandbox())
+    end
+  end
+
+  describe "destroy/1" do
+    test "returns :ok when stop + remove both succeed" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["stop", "sb-abc123"], _opts ->
+        {"Stopped\n", 0}
+      end)
+      |> expect(:run, fn "msb", ["remove", "sb-abc123"], _opts ->
+        {"Removed\n", 0}
+      end)
+
+      assert :ok = Microsandbox.destroy("sb-abc123", microsandbox())
+    end
+
+    test "returns :ok when stop fails (already stopped) but remove succeeds" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["stop", "sb-abc123"], _opts ->
+        {"Error: not running\n", 1}
+      end)
+      |> expect(:run, fn "msb", ["remove", "sb-abc123"], _opts ->
+        {"Removed\n", 0}
+      end)
+
+      assert :ok = Microsandbox.destroy("sb-abc123", microsandbox())
+    end
+
+    test "returns error when remove fails" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["stop", "sb-abc123"], _opts ->
+        {"Stopped\n", 0}
+      end)
+      |> expect(:run, fn "msb", ["remove", "sb-abc123"], _opts ->
+        {"Error: sandbox not found\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} = Microsandbox.destroy("sb-abc123", microsandbox())
+    end
+  end
 end

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
@@ -242,4 +242,53 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
       assert {:error, {:cmd_failed, 1, _}} = Microsandbox.destroy("sb-abc123", microsandbox())
     end
   end
+
+  describe "read_file/2" do
+    test "returns {:ok, content} by executing cat inside the sandbox" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["exec", "sb-abc123", "--", "cat", "/app/README.md"], _opts ->
+        {"# Hello\n", 0}
+      end)
+
+      assert {:ok, "# Hello\n"} =
+               Microsandbox.read_file("sb-abc123", "/app/README.md", microsandbox())
+    end
+
+    test "returns error when file not found" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"cat: /app/nope.txt: No such file or directory\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} =
+               Microsandbox.read_file("sb-abc123", "/app/nope.txt", microsandbox())
+    end
+  end
+
+  describe "write_file/3" do
+    test "returns :ok by writing base64-decoded content inside the sandbox" do
+      content = "hello world"
+      expected_b64 = Base.encode64(content)
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", ["exec", "sb-abc123", "--", "bash", "-c", command], _opts ->
+        assert String.contains?(command, expected_b64)
+        assert String.contains?(command, "/app/hello.txt")
+        {"", 0}
+      end)
+
+      assert :ok =
+               Microsandbox.write_file("sb-abc123", "/app/hello.txt", content, microsandbox())
+    end
+
+    test "returns error on failure" do
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"Error: permission denied\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, _}} =
+               Microsandbox.write_file("sb-abc123", "/etc/passwd", "nope", microsandbox())
+    end
+  end
 end

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
@@ -62,6 +62,43 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
       assert {:ok, "test-sandbox"} = Microsandbox.create(spec, microsandbox())
     end
 
+    test "cleans up devcontainer temp file after msb returns" do
+      env_spec = valid_env_spec()
+      test_pid = self()
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", args, _opts ->
+        config_idx = Enum.find_index(args, &(&1 == "--config"))
+        config_path = Enum.at(args, config_idx + 1)
+        assert File.exists?(config_path), "temp file should exist during msb call"
+        send(test_pid, {:config_path, config_path})
+        {"Sandbox test-sandbox is running\n", 0}
+      end)
+
+      assert {:ok, "test-sandbox"} = Microsandbox.create(env_spec, microsandbox())
+
+      assert_receive {:config_path, config_path}
+      refute File.exists?(config_path), "temp file should be cleaned up after create returns"
+    end
+
+    test "cleans up devcontainer temp file even when msb fails" do
+      env_spec = valid_env_spec()
+      test_pid = self()
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", args, _opts ->
+        config_idx = Enum.find_index(args, &(&1 == "--config"))
+        config_path = Enum.at(args, config_idx + 1)
+        send(test_pid, {:config_path, config_path})
+        {"Error: image not found\n", 1}
+      end)
+
+      assert {:error, _} = Microsandbox.create(env_spec, microsandbox())
+
+      assert_receive {:config_path, config_path}
+      refute File.exists?(config_path), "temp file should be cleaned up even on failure"
+    end
+
     test "returns error when msb run fails" do
       env_spec = valid_env_spec()
 
@@ -87,13 +124,13 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
                Microsandbox.exec("sb-abc123", "echo", ["hello"], microsandbox())
     end
 
-    test "returns exec_result with non-zero exit code (command ran but failed)" do
+    test "returns {:ok, exec_result} with non-zero exit code when command fails inside sandbox" do
       MockCommandRunner
       |> expect(:run, fn "msb", _args, _opts ->
-        {"test failed\n", 0}
+        {"test failed\n", 1}
       end)
 
-      assert {:ok, %{exit_code: 0, stdout: "test failed\n"}} =
+      assert {:ok, %{exit_code: 1, stdout: "test failed\n", stderr: ""}} =
                Microsandbox.exec("sb-abc123", "mix", ["test"], microsandbox())
     end
 
@@ -113,13 +150,13 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
                )
     end
 
-    test "returns error when msb exec fails" do
+    test "returns non-zero exit code from inner command as {:ok, exec_result}" do
       MockCommandRunner
       |> expect(:run, fn "msb", _args, _opts ->
         {"Error: sandbox not found\n", 1}
       end)
 
-      assert {:error, {:cmd_failed, 1, _}} =
+      assert {:ok, %{exit_code: 1, stdout: "Error: sandbox not found\n", stderr: ""}} =
                Microsandbox.exec("sb-abc123", "false", [], microsandbox())
     end
   end
@@ -271,14 +308,68 @@ defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
       expected_b64 = Base.encode64(content)
 
       MockCommandRunner
-      |> expect(:run, fn "msb", ["exec", "sb-abc123", "--", "bash", "-c", command], _opts ->
-        assert String.contains?(command, expected_b64)
-        assert String.contains?(command, "/app/hello.txt")
+      |> expect(:run, fn "msb",
+                         ["exec", "sb-abc123", "--", "bash", "-c", _cmd, "_", encoded, path_arg],
+                         _opts ->
+        assert encoded == expected_b64
+        assert path_arg == "/app/hello.txt"
         {"", 0}
       end)
 
       assert :ok =
                Microsandbox.write_file("sb-abc123", "/app/hello.txt", content, microsandbox())
+    end
+
+    test "path is passed as positional arg, never interpolated in shell command" do
+      malicious_path = "/tmp/foo; rm -rf /"
+      content = "safe"
+
+      MockCommandRunner
+      |> expect(:run, fn "msb",
+                         [
+                           "exec",
+                           "sb-abc123",
+                           "--",
+                           "bash",
+                           "-c",
+                           command,
+                           "_",
+                           _encoded,
+                           path_arg
+                         ],
+                         _opts ->
+        # Shell template must NOT contain the path
+        refute String.contains?(command, malicious_path)
+        # Path arrives as a separate argv element
+        assert path_arg == malicious_path
+        {"", 0}
+      end)
+
+      assert :ok =
+               Microsandbox.write_file("sb-abc123", malicious_path, content, microsandbox())
+    end
+
+    test "shell metacharacters in path cannot be interpreted" do
+      paths = [
+        "/tmp/$(whoami)/file",
+        "/tmp/`id`/file",
+        "/tmp/foo | cat /etc/shadow",
+        "/tmp/foo\nrm -rf /"
+      ]
+
+      for path <- paths do
+        MockCommandRunner
+        |> expect(:run, fn "msb",
+                           ["exec", _ref, "--", "bash", "-c", cmd, "_", _encoded, path_arg],
+                           _opts ->
+          refute String.contains?(cmd, path)
+          assert path_arg == path
+          {"", 0}
+        end)
+
+        assert :ok =
+                 Microsandbox.write_file("sb-abc123", path, "x", microsandbox())
+      end
     end
 
     test "returns error on failure" do

--- a/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/provider/microsandbox_test.exs
@@ -1,0 +1,77 @@
+defmodule FrontmanServer.Sandbox.Provider.MicrosandboxTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias FrontmanServer.Sandbox.EnvironmentSpec
+  alias FrontmanServer.Sandbox.Provider.Microsandbox
+
+  setup :verify_on_exit!
+
+  defp valid_env_spec do
+    {:ok, spec} =
+      EnvironmentSpec.new(
+        name: "test-sandbox",
+        image: "ubuntu:24.04",
+        devcontainer: %{"postCreateCommand" => "echo ready"}
+      )
+
+    spec
+  end
+
+  defp microsandbox(opts \\ []) do
+    Keyword.put_new(opts, :command_runner, MockCommandRunner)
+  end
+
+  describe "create/1" do
+    test "returns {:ok, name} when msb run succeeds" do
+      env_spec = valid_env_spec()
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", args, _opts ->
+        assert "run" in args
+        assert "--name" in args
+        assert "test-sandbox" in args
+        assert "--image" in args
+        assert "ubuntu:24.04" in args
+        {"Sandbox test-sandbox is running\n", 0}
+      end)
+
+      assert {:ok, "test-sandbox"} = Microsandbox.create(env_spec, microsandbox())
+    end
+
+    test "passes env vars as --env flags" do
+      {:ok, spec} =
+        EnvironmentSpec.new(
+          name: "test-sandbox",
+          image: "ubuntu:24.04",
+          devcontainer: %{},
+          env: %{"FOO" => "bar", "BAZ" => "qux"}
+        )
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", args, _opts ->
+        env_args =
+          Enum.filter(args, &String.starts_with?(&1, "FOO=")) ++
+            Enum.filter(args, &String.starts_with?(&1, "BAZ="))
+
+        assert env_args != [] or "--env" in args
+        {"Sandbox test-sandbox is running\n", 0}
+      end)
+
+      assert {:ok, "test-sandbox"} = Microsandbox.create(spec, microsandbox())
+    end
+
+    test "returns error when msb run fails" do
+      env_spec = valid_env_spec()
+
+      MockCommandRunner
+      |> expect(:run, fn "msb", _args, _opts ->
+        {"Error: image not found\n", 1}
+      end)
+
+      assert {:error, {:cmd_failed, 1, "Error: image not found\n"}} =
+               Microsandbox.create(env_spec, microsandbox())
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/sandbox/repo_analyzer_test.exs
+++ b/apps/frontman_server/test/frontman_server/sandbox/repo_analyzer_test.exs
@@ -3,7 +3,7 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzerTest do
 
   import Mox
 
-  alias FrontmanServer.Sandbox.{EnvironmentSpec, RepoAnalyzer}
+  alias FrontmanServer.Sandbox.RepoAnalyzer
 
   setup :verify_on_exit!
 
@@ -36,24 +36,21 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzerTest do
       stub_tree([".devcontainer/devcontainer.json", "README.md"])
       stub_file(".devcontainer/devcontainer.json", @devcontainer_json)
 
-      assert {:ok,
-              %EnvironmentSpec{
-                contents: %{"image" => "mcr.microsoft.com/devcontainers/base:ubuntu"}
-              }} = analyze()
+      assert {:ok, %{"image" => "mcr.microsoft.com/devcontainers/base:ubuntu"}} = analyze()
     end
 
     test "finds .devcontainer.json at root" do
       stub_tree([".devcontainer.json", "README.md"])
       stub_file(".devcontainer.json", @devcontainer_json)
 
-      assert {:ok, %EnvironmentSpec{}} = analyze()
+      assert {:ok, %{}} = analyze()
     end
 
     test "finds devcontainer.json at root" do
       stub_tree(["src/main.ex", "devcontainer.json"])
       stub_file("devcontainer.json", @devcontainer_json)
 
-      assert {:ok, %EnvironmentSpec{}} = analyze()
+      assert {:ok, %{}} = analyze()
     end
   end
 
@@ -62,7 +59,7 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzerTest do
       stub_tree([".devcontainer/devcontainer.json", ".devcontainer.json"])
       stub_file(".devcontainer/devcontainer.json", @devcontainer_json)
 
-      assert {:ok, %EnvironmentSpec{}} = analyze()
+      assert {:ok, %{}} = analyze()
     end
   end
 
@@ -80,11 +77,11 @@ defmodule FrontmanServer.Sandbox.RepoAnalyzerTest do
       assert {:error, :invalid_json} = analyze()
     end
 
-    test "empty devcontainer map returns :empty_devcontainer" do
+    test "empty devcontainer map is accepted" do
       stub_tree([".devcontainer/devcontainer.json"])
       stub_file(".devcontainer/devcontainer.json", "{}")
 
-      assert {:error, :empty_devcontainer} = analyze()
+      assert {:ok, %{}} = analyze()
     end
 
     test "401 from get_tree returns :unauthorized" do

--- a/apps/frontman_server/test/support/mocks.ex
+++ b/apps/frontman_server/test/support/mocks.ex
@@ -1,1 +1,2 @@
 Mox.defmock(MockGitHubClient, for: FrontmanServer.Sandbox.GitHubClient)
+Mox.defmock(MockCommandRunner, for: FrontmanServer.Sandbox.CommandRunner)

--- a/apps/frontman_server/test/support/mocks.ex
+++ b/apps/frontman_server/test/support/mocks.ex
@@ -1,2 +1,3 @@
 Mox.defmock(MockGitHubClient, for: FrontmanServer.Sandbox.GitHubClient)
 Mox.defmock(MockCommandRunner, for: FrontmanServer.Sandbox.CommandRunner)
+Mox.defmock(MockSandboxProvider, for: FrontmanServer.Sandbox.Provider)

--- a/apps/frontman_server/test/test_helper.exs
+++ b/apps/frontman_server/test/test_helper.exs
@@ -4,5 +4,6 @@ Logger.put_module_level(ReqLLM.Streaming, :none)
 Logger.put_module_level(ReqLLM.StreamServer, :none)
 Logger.put_module_level(ReqLLM.StreamResponse.MetadataHandle, :none)
 
+ExUnit.configure(exclude: [:integration])
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(FrontmanServer.Repo, :manual)


### PR DESCRIPTION
## Summary

- Define `Sandbox.Provider` behaviour with 6 stateless callbacks (`create`, `exec`, `metrics`, `stop`, `start`, `destroy`) for sandbox infrastructure providers
- Implement `Sandbox.Provider.Microsandbox` CLI client wrapping the `msb` binary via a `CommandRunner` behaviour for testability
- Replace thin `EnvironmentSpec` contents wrapper with NimbleOptions-validated struct (`name`, `image`, `devcontainer`, `env`); empty devcontainer maps now valid per spec
- Decouple `RepoAnalyzer` — returns `{:ok, map()}` instead of `{:ok, EnvironmentSpec.t()}`
- Add `read_file/2` and `write_file/3` Microsandbox-specific file operations built on `exec`
- Add `MockSandboxProvider` + `MockCommandRunner` mocks for downstream Orchestrator tests (#834)

## Design Decisions

- Provider is stateless — no GenServer, no process state. Each callback is an independent CLI call. Process management lives in the Orchestrator (#834)
- CLI integration via `msb` (not HTTP/JSON-RPC) — microsandbox doesn't expose a daemon API
- VM IP discovered via `exec("hostname", ["-I"])`, not metrics — msb metrics don't include IP
- No host port exposure — Phoenix proxies to VM IP directly
- Provider is project-agnostic — only injects `SANDBOX_ID`/`SANDBOX_NAME`, no framework-specific vars

## Test Plan

- [x] 20 unit tests for Microsandbox client (all callbacks + file ops) via MockCommandRunner
- [x] 8 tests for NimbleOptions-validated EnvironmentSpec
- [x] 12 RepoAnalyzer tests updated for `{:ok, map()}` return type
- [x] Integration test skeleton tagged `:integration` (excluded by default)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 904 tests, 0 failures
- [x] `mix credo --strict` — no issues
- [x] `mix dialyzer` — passed

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
