### PR TITLE
fix(web_fetch): reject non-text content types and guard JSONB persistence

### DIFF
--- a/apps/frontman_server/lib/frontman_server/changeset_sanitizer.ex
+++ b/apps/frontman_server/lib/frontman_server/changeset_sanitizer.ex
@@ -42,4 +42,25 @@ defmodule FrontmanServer.ChangesetSanitizer do
   defp do_strip(value) when is_list(value), do: Enum.map(value, &do_strip/1)
 
   defp do_strip(value), do: value
+
+  @doc """
+  Validates that the given field is JSON-encodable.
+
+  JSONB columns crash Postgrex with `Jason.EncodeError` when a value contains
+  raw binary data (e.g. PNG bytes from an HTTP response). This catches the
+  problem at the changeset level with a clear error instead of a DB crash.
+  """
+  @spec validate_json_encodable(Ecto.Changeset.t(), atom()) :: Ecto.Changeset.t()
+  def validate_json_encodable(changeset, field) do
+    case get_change(changeset, field) do
+      nil ->
+        changeset
+
+      value ->
+        case Jason.encode(value) do
+          {:ok, _} -> changeset
+          {:error, _} -> add_error(changeset, field, "contains data that is not JSON-encodable")
+        end
+    end
+  end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -296,8 +296,26 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   end
 
   defp handle_backend_outcome({:returned, {:ok, value}}, scope, tool_call, task_id) do
-    Tasks.add_tool_result(scope, task_id, tool_call_ref(tool_call), value, false)
-    {:ok, encode_result(value)}
+    case Tasks.add_tool_result(scope, task_id, tool_call_ref(tool_call), value, false) do
+      {:ok, _interaction, _executor_status} ->
+        {:ok, encode_result(value)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        reason =
+          "Tool result not JSON-serializable: #{inspect(changeset.errors)}. Tool: #{tool_call.name}"
+
+        Logger.error("ToolExecutor: #{reason}")
+        report_tool_sentry("tool_persist_error", tool_call, task_id, reason)
+        Tasks.add_tool_result(scope, task_id, tool_call_ref(tool_call), reason, true)
+        {:error, reason}
+
+      {:error, reason} ->
+        Logger.error(
+          "ToolExecutor: Failed to persist tool result for #{tool_call.name}: #{inspect(reason)}"
+        )
+
+        {:error, inspect(reason)}
+    end
   end
 
   defp handle_backend_outcome({:returned, {:error, reason}}, scope, tool_call, task_id) do

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -55,6 +55,7 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
     |> cast(attrs, [:task_id, :type, :data, :sequence])
     |> validate_required([:task_id, :type, :data, :sequence])
     |> strip_null_bytes(:data)
+    |> validate_json_encodable(:data)
     |> validate_inclusion(:type, Interaction.known_type_strings())
     |> foreign_key_constraint(:task_id)
     |> unique_constraint([:task_id, :data],

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -79,13 +79,10 @@ defmodule FrontmanServer.Tools.WebFetch do
       offset = clamp(Map.get(args, "offset", 0), 0, :infinity)
       limit = clamp(Map.get(args, "limit", 500), 1, 2000)
 
-      case fetch(url) do
-        {:ok, content_type, body} ->
-          markdown = convert_to_markdown(body, content_type)
-          paginate(markdown, url, content_type, offset, limit)
-
-        {:error, reason} ->
-          {:error, reason}
+      with {:ok, content_type, body} <- fetch(url),
+           :ok <- require_text_content(content_type) do
+        markdown = convert_to_markdown(body, content_type)
+        paginate(markdown, url, content_type, offset, limit)
       end
     end
   end
@@ -214,6 +211,23 @@ defmodule FrontmanServer.Tools.WebFetch do
     case Map.get(headers, "content-type") do
       [value | _] -> value
       nil -> "text/html"
+    end
+  end
+
+  # -- Content-type guard ------------------------------------------------------
+
+  @text_prefixes ["text/", "application/json", "application/xml", "application/javascript"]
+
+  defp require_text_content(content_type) do
+    ct = String.downcase(content_type)
+
+    case Enum.any?(@text_prefixes, &String.contains?(ct, &1)) do
+      true ->
+        :ok
+
+      false ->
+        {:error,
+         "Cannot fetch non-text content (#{content_type}). This tool only supports text-based URLs."}
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/changeset_sanitizer_test.exs
+++ b/apps/frontman_server/test/frontman_server/changeset_sanitizer_test.exs
@@ -71,4 +71,40 @@ defmodule FrontmanServer.ChangesetSanitizerTest do
       assert result["nothing"] == nil
     end
   end
+
+  describe "validate_json_encodable/2" do
+    test "passes for a JSON-safe map" do
+      cs = changeset(%{data: %{"key" => "value", "num" => 42}}) |> validate_json_encodable(:data)
+      assert cs.valid?
+    end
+
+    test "fails for a map containing raw binary data" do
+      # PNG header bytes — not valid UTF-8
+      cs =
+        changeset(%{data: %{"content" => <<137, 80, 78, 71, 13, 10, 26, 10>>}})
+        |> validate_json_encodable(:data)
+
+      refute cs.valid?
+      assert {"contains data that is not JSON-encodable", []} in errors_on(cs, :data)
+    end
+
+    test "no-ops when field has no change" do
+      cs = changeset(%{}) |> validate_json_encodable(:data)
+      assert cs.valid?
+    end
+
+    test "passes for nested maps with valid data" do
+      cs =
+        changeset(%{data: %{"nested" => %{"list" => [1, "two", true]}}})
+        |> validate_json_encodable(:data)
+
+      assert cs.valid?
+    end
+  end
+
+  defp errors_on(changeset, field) do
+    for {msg, opts} <- Keyword.get_values(changeset.errors, field) do
+      {msg, opts}
+    end
+  end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -224,6 +224,49 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     end
   end
 
+  describe "run_backend_tool/5 — non-JSON-serializable result" do
+    defmodule BinaryResultTool do
+      @behaviour Backend
+
+      def name, do: "binary_result_tool"
+      def description, do: "Returns raw binary that breaks JSON encoding"
+      def parameter_schema, do: %{"type" => "object", "properties" => %{}}
+      def timeout_ms, do: 30_000
+      def on_timeout, do: :error
+
+      # Simulates a tool returning raw PNG bytes
+      def execute(_args, _context), do: {:ok, %{"content" => <<137, 80, 78, 71, 13, 10, 26, 10>>}}
+    end
+
+    @tag :capture_log
+    test "converts non-JSON-serializable result to error instead of crashing", %{
+      scope: scope,
+      task_id: task_id,
+      llm_opts: llm_opts
+    } do
+      exec_opts = %{
+        backend_tool_modules: [BinaryResultTool],
+        backend_module_map: %{BinaryResultTool.name() => BinaryResultTool},
+        mcp_tools: [],
+        mcp_tool_defs: [],
+        llm_opts: llm_opts
+      }
+
+      tool_call = %SwarmAi.ToolCall{
+        id: "tc_#{System.unique_integer([:positive])}",
+        name: BinaryResultTool.name(),
+        arguments: "{}"
+      }
+
+      result =
+        ToolExecutor.run_backend_tool(scope, BinaryResultTool, task_id, exec_opts, tool_call)
+
+      assert %SwarmAi.ToolResult{is_error: true} = result
+      assert [%SwarmAi.Message.ContentPart{type: :text, text: text}] = result.content
+      assert text =~ "JSON"
+    end
+  end
+
   describe "make_executor/3 — returns single function" do
     test "returns a function, not a tuple", %{scope: scope, task_id: task_id, llm_opts: llm_opts} do
       result =

--- a/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
@@ -320,6 +320,68 @@ defmodule FrontmanServer.Tools.WebFetchTest do
     end
   end
 
+  describe "execute/2 — non-text content rejection" do
+    test "rejects image/png responses", %{context: ctx} do
+      # PNG header bytes
+      stub_resp(200, "image/png", <<137, 80, 78, 71, 13, 10, 26, 10>>)
+
+      assert {:error, msg} = execute("https://example.com/logo.png", ctx)
+      assert msg =~ "non-text"
+      assert msg =~ "image/png"
+    end
+
+    test "rejects image/jpeg responses", %{context: ctx} do
+      stub_resp(200, "image/jpeg", <<255, 216, 255, 224>>)
+
+      assert {:error, msg} = execute("https://example.com/photo.jpg", ctx)
+      assert msg =~ "non-text"
+    end
+
+    test "rejects application/octet-stream responses", %{context: ctx} do
+      stub_resp(200, "application/octet-stream", <<0, 1, 2, 3>>)
+
+      assert {:error, msg} = execute("https://example.com/file.bin", ctx)
+      assert msg =~ "non-text"
+    end
+
+    test "rejects application/pdf responses", %{context: ctx} do
+      stub_resp(200, "application/pdf", "%PDF-1.4 binary content")
+
+      assert {:error, msg} = execute("https://example.com/doc.pdf", ctx)
+      assert msg =~ "non-text"
+    end
+
+    test "allows text/html responses", %{context: ctx} do
+      stub_resp(200, "text/html", "<h1>Hello</h1>")
+
+      assert {:ok, _} = execute("https://example.com/page", ctx)
+    end
+
+    test "allows text/plain responses", %{context: ctx} do
+      stub_resp(200, "text/plain", "Hello")
+
+      assert {:ok, _} = execute("https://example.com/text", ctx)
+    end
+
+    test "allows application/json responses", %{context: ctx} do
+      stub_resp(200, "application/json", ~s({"key": "value"}))
+
+      assert {:ok, _} = execute("https://example.com/api", ctx)
+    end
+
+    test "allows application/xml responses", %{context: ctx} do
+      stub_resp(200, "application/xml", "<root>data</root>")
+
+      assert {:ok, _} = execute("https://example.com/feed.xml", ctx)
+    end
+
+    test "allows application/javascript responses", %{context: ctx} do
+      stub_resp(200, "application/javascript", "console.log('hi')")
+
+      assert {:ok, _} = execute("https://example.com/script.js", ctx)
+    end
+  end
+
   describe "execute/2 — Cloudflare retry" do
     test "retries with honest UA on Cloudflare challenge", %{context: ctx} do
       call_count = :counters.new(1, [:atomics])


### PR DESCRIPTION
## Summary

- **Layer 1 — `web_fetch.ex`**: Rejects non-text content types (`image/png`, `application/pdf`, `application/octet-stream`, etc.) early in `execute/2`, returning a descriptive error to the LLM instead of passing raw binary bytes through to JSONB persistence
- **Layer 2 — changeset validation**: Adds `validate_json_encodable/2` to `ChangesetSanitizer` and wires it into `InteractionSchema.create_changeset/2` — catches any non-JSON-serializable data at the persistence boundary before it crashes Postgrex
- **Layer 2 — `tool_executor.ex`**: `handle_backend_outcome` now handles `{:error, changeset}` from `add_tool_result` instead of ignoring the return value, converting persistence failures into error tool results

Fixes #881 (ELIXIR-5K)

## Test plan

- [ ] `mix test test/frontman_server/tools/web_fetch_test.exs` — 9 new tests for content-type rejection (PNG, JPEG, octet-stream, PDF rejected; HTML, plain, JSON, XML, JS allowed)
- [ ] `mix test test/frontman_server/changeset_sanitizer_test.exs` — 4 new tests for `validate_json_encodable/2` (valid maps pass, binary data fails, no-op on nil, nested maps pass)
- [ ] `mix test test/frontman_server/tasks/execution/tool_executor_test.exs` — 1 new test for `BinaryResultTool` returning PNG bytes gets converted to error result instead of crashing
- [ ] Full suite: 854 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
