### PR TITLE
expand docs reference and centralize integration snippets

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -42,7 +42,11 @@ function validateDocsDescriptions() {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         files.push(...walkDir(full));
-      } else if (entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith("_")) {
+      } else if (
+        entry.isFile() &&
+        (entry.name.endsWith(".md") || entry.name.endsWith(".mdx")) &&
+        !entry.name.startsWith("_")
+      ) {
         files.push(full);
       }
     }

--- a/apps/marketing/src/components/docs/CodeFromFile.astro
+++ b/apps/marketing/src/components/docs/CodeFromFile.astro
@@ -1,0 +1,36 @@
+---
+import fs from 'node:fs';
+import path from 'node:path';
+import { Code } from 'astro:components';
+
+interface Props {
+  snippet: string;
+  lang?: string;
+}
+
+const { snippet, lang } = Astro.props;
+
+const snippetsRoot = path.resolve(process.cwd(), 'src/content/docs/snippets');
+const snippetPath = path.resolve(snippetsRoot, snippet);
+const relativeSnippetPath = path.relative(snippetsRoot, snippetPath);
+const inSnippetsRoot =
+  relativeSnippetPath !== '' &&
+  !relativeSnippetPath.startsWith('..') &&
+  !path.isAbsolute(relativeSnippetPath);
+
+if (!inSnippetsRoot) {
+  throw new Error(`Snippet path must stay inside src/content/docs/snippets: ${snippet}`);
+}
+
+const code = fs.readFileSync(snippetPath, 'utf-8').trimEnd();
+let inferredLang = path.extname(snippetPath).slice(1);
+if (inferredLang === 'txt') {
+  const nestedExtension = path.extname(snippetPath.slice(0, -4)).slice(1);
+  if (nestedExtension !== '') {
+    inferredLang = nestedExtension;
+  }
+}
+const language = lang ?? (inferredLang === '' ? 'text' : inferredLang);
+---
+
+<Code code={code} lang={language as any} />

--- a/apps/marketing/src/content/docs/docs/index.md
+++ b/apps/marketing/src/content/docs/docs/index.md
@@ -24,8 +24,8 @@ Start here if Frontman isn't running in your project yet.
 | Framework | Install command | Docs |
 |-----------|----------------|------|
 | **Astro** | `astro add @frontman-ai/astro` | [Astro integration →](/docs/integrations/astro/) |
-| **Next.js** | `npx @frontman-ai/nextjs init` | [Next.js integration →](/docs/integrations/nextjs/) |
-| **Vite** | `npm install @frontman-ai/vite` | [Vite integration →](/docs/integrations/vite/) |
+| **Next.js** | `npx @frontman-ai/nextjs install` | [Next.js integration →](/docs/integrations/nextjs/) |
+| **Vite** | `npx @frontman-ai/vite install` | [Vite integration →](/docs/integrations/vite/) |
 | **WordPress** | Standalone binary (beta) | [WordPress setup →](/docs/integrations/wordpress/) |
 
 Then continue with:

--- a/apps/marketing/src/content/docs/docs/installation.md
+++ b/apps/marketing/src/content/docs/docs/installation.md
@@ -16,7 +16,7 @@ Then follow the [Astro integration guide →](/docs/integrations/astro/)
 ## Next.js
 
 ```bash
-npx @frontman-ai/nextjs init
+npx @frontman-ai/nextjs install
 ```
 
 Then follow the [Next.js integration guide →](/docs/integrations/nextjs/)
@@ -24,7 +24,7 @@ Then follow the [Next.js integration guide →](/docs/integrations/nextjs/)
 ## Vite
 
 ```bash
-npm install @frontman-ai/vite
+npx @frontman-ai/vite install
 ```
 
 Then follow the [Vite integration guide →](/docs/integrations/vite/)
@@ -38,4 +38,3 @@ See the [WordPress setup guide →](/docs/integrations/wordpress/)
 ## Next steps
 
 1. **[API Keys & Providers](/docs/api-keys/)** — configure your AI model
-

--- a/apps/marketing/src/content/docs/docs/integrations/astro.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/astro.mdx
@@ -3,6 +3,8 @@ title: Astro
 description: Complete reference for the @frontman-ai/astro integration — installation, configuration options, dev server hooks, element source detection, and troubleshooting.
 ---
 
+import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
+
 ## Overview
 
 `@frontman-ai/astro` is an Astro integration that embeds the Frontman AI agent directly into your Astro dev server. It combines Astro integration lifecycle hooks with a Vite plugin chain, giving the AI access to your source files, dev server logs, and resolved route manifest.
@@ -30,20 +32,7 @@ npm install --save-dev @frontman-ai/astro
 
 Then register it in your config:
 
-```js
-import frontman from '@frontman-ai/astro';
-import path from 'node:path';
-
-const appRoot = path.resolve(import.meta.dirname);
-
-export default defineConfig({
-  integrations: [
-    frontman({
-      projectRoot: appRoot,
-    }),
-  ],
-});
-```
+<CodeFromFile snippet="astro/astro.config.ts.txt" />
 
 ## Configuration
 

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.md
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.md
@@ -69,12 +69,13 @@ const frontman = createMiddleware({
   projectRoot: process.cwd(),
 });
 
-export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
+export async function proxy(req: NextRequest): Promise<NextResponse> {
   if (
     req.nextUrl.pathname === '/frontman' ||
     req.nextUrl.pathname.startsWith('/frontman/')
   ) {
-    return frontman(req) ?? NextResponse.next();
+    const response = await frontman(req);
+    if (response) return response;
   }
   return NextResponse.next();
 }

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
@@ -3,6 +3,8 @@ title: Next.js
 description: Complete reference for the @frontman-ai/nextjs integration — installation, middleware setup, App Router vs Pages Router, OpenTelemetry instrumentation, and troubleshooting.
 ---
 
+import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
+
 ## Overview
 
 `@frontman-ai/nextjs` integrates the Frontman AI agent into your Next.js dev server via the Next.js middleware system. It intercepts requests to `/frontman/*`, giving the AI access to your source files, dev server logs, route manifest, and optionally OpenTelemetry spans covering HTTP requests and route render timing.
@@ -36,24 +38,7 @@ The integration API differs depending on your Next.js version.
 
 Create or update `middleware.ts` in your project root (or `src/middleware.ts`):
 
-```ts
-import { createMiddleware } from '@frontman-ai/nextjs';
-import { type NextRequest, NextResponse } from 'next/server';
-
-const frontman = createMiddleware({
-  projectRoot: process.cwd(),
-});
-
-export async function middleware(req: NextRequest) {
-  const response = await frontman(req);
-  if (response) return response;
-  return NextResponse.next();
-}
-
-export const config = {
-  matcher: ['/frontman', '/frontman/:path*'],
-};
-```
+<CodeFromFile snippet="nextjs/middleware.ts.txt" />
 
 The `matcher` is required. Without it, Next.js runs the middleware on every request, adding unnecessary overhead across your entire application.
 
@@ -61,25 +46,7 @@ The `matcher` is required. Without it, Next.js runs the middleware on every requ
 
 Next.js 16 introduced a dedicated proxy mechanism. Create `proxy.ts` in your project root:
 
-```ts
-import { createMiddleware } from '@frontman-ai/nextjs';
-import { type NextRequest, NextResponse } from 'next/server';
-
-const frontman = createMiddleware({
-  projectRoot: process.cwd(),
-});
-
-export async function proxy(req: NextRequest): Promise<NextResponse> {
-  if (
-    req.nextUrl.pathname === '/frontman' ||
-    req.nextUrl.pathname.startsWith('/frontman/')
-  ) {
-    const response = await frontman(req);
-    if (response) return response;
-  }
-  return NextResponse.next();
-}
-```
+<CodeFromFile snippet="nextjs/proxy.ts.txt" />
 
 ## Configuration
 

--- a/apps/marketing/src/content/docs/docs/integrations/vite.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/vite.mdx
@@ -3,6 +3,8 @@ title: Vite
 description: Complete reference for the @frontman-ai/vite plugin — installation, configuration, framework auto-detection, Vue SFC source mapping, SvelteKit support, and troubleshooting.
 ---
 
+import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
+
 ## Overview
 
 `@frontman-ai/vite` is a Vite plugin that embeds the Frontman AI agent in your Vite dev server. It auto-detects your framework — React, Vue, Svelte, or SolidJS — from the Vite plugin array and provides framework-appropriate runtime context to the AI.
@@ -30,16 +32,7 @@ npm install --save-dev @frontman-ai/vite
 
 Then add the plugin to your Vite config:
 
-```ts
-import { defineConfig } from 'vite';
-import { frontmanPlugin } from '@frontman-ai/vite';
-
-export default defineConfig({
-  plugins: [
-    frontmanPlugin(),
-  ],
-});
-```
+<CodeFromFile snippet="vite/vite.config.ts.txt" />
 
 ### Plugin ordering
 

--- a/apps/marketing/src/content/docs/docs/reference/architecture.md
+++ b/apps/marketing/src/content/docs/docs/reference/architecture.md
@@ -3,4 +3,235 @@ title: Architecture Overview
 description: How Frontman works under the hood — the agent loop, client-server-LLM flow, ACP/MCP protocols, and tool routing.
 ---
 
-Content coming soon.
+Frontman is a browser-based coding agent built as a distributed system. A single prompt can move through four environments during one turn:
+
+1. **The browser client** renders the chat UI, hosts the live preview iframe, and executes browser-side tools described in [Tool Capabilities](/docs/using/tool-capabilities/).
+2. **The Frontman server** orchestrates the agent loop, manages sessions, persists interactions, and routes tool calls.
+3. **The LLM provider** generates responses and decides when to call tools.
+4. **Your dev server** executes file and project-structure tools on the machine that owns the source code through the relevant [framework integration](/docs/reference/compatibility/).
+
+This page describes how those parts fit together and how data moves between them.
+
+## System purpose
+
+Frontman lets an LLM act on a real running application instead of operating only on text. The agent can inspect the rendered DOM, take screenshots, read source files, edit code, and verify the result against the live preview.
+
+The design constraint is deliberate: the Frontman server does **not** require direct access to your filesystem or browser. Browser inspection happens in the browser. File operations happen on your machine through the framework integration. The server coordinates the loop and persists the state discussed in [Persistence model](#persistence-model).
+
+## High-level architecture
+
+```text
+┌───────────────┐      WebSocket / ACP / MCP      ┌──────────────────┐
+│ Browser       │ ◄──────────────────────────────► │ Frontman Server  │
+│ - Chat UI     │                                  │ - Agent runtime  │
+│ - Live preview│                                  │ - Persistence    │
+│ - Browser tools                                  │ - Tool routing   │
+└──────┬────────┘                                  └────────┬─────────┘
+       │                                                      │
+       │ HTTP relay for file tools                            │ API call
+       ▼                                                      ▼
+┌──────────────────┐                                 ┌──────────────────┐
+│ Dev Server       │                                 │ LLM Provider     │
+│ - File reads     │                                 │ - Response text  │
+│ - File edits     │                                 │ - Tool calls     │
+│ - Project info   │                                 │ - Turn complete  │
+└──────────────────┘                                 └──────────────────┘
+```
+
+## Core runtime flow
+
+A prompt runs through a repeatable loop:
+
+1. The user sends a prompt from the browser.
+2. The server resolves the model and API key to use as described in [Models & Providers](/docs/reference/models/) and [API Keys & Providers](/docs/api-keys/).
+3. The server constructs the agent context: system instructions, history, tool definitions, and task state.
+4. The runtime submits that context to the LLM provider.
+5. The LLM either returns assistant text or requests one or more tool calls.
+6. The server executes server-side tools directly and relays browser or filesystem tools through the client.
+7. Tool results are fed back into the runtime.
+8. The loop continues until the LLM returns `turn_complete`.
+
+In practice, one user-visible response is usually a sequence of smaller steps: inspect, locate, edit, verify, report. The user-facing version of this flow is covered in [How the Agent Works](/docs/using/how-the-agent-works/).
+
+## End-to-end execution sequence
+
+```text
+Client                          Server                          LLM Provider
+  │                               │                               │
+  │── prompt (ACP over WS) ─────►│                               │
+  │                               │── build context ─────────────►│
+  │                               │◄── response + tool calls ─────│
+  │                               │                               │
+  │◄── MCP tool call─────────────│                               │
+  │── execute browser tool        │                               │
+  │   or relay file tool          │                               │
+  │── tool result ───────────────►│── feed result to runtime ───►│
+  │                               │◄── next response / complete ──│
+  │◄── streamed events───────────│                               │
+```
+
+The same control path applies whether the tool is a screenshot, a DOM read, or a file edit. What changes is where the tool runs.
+
+## Tool execution model
+
+Frontman splits tools by execution environment, which complements the user-facing tool overview in [Tool Capabilities](/docs/using/tool-capabilities/).
+
+| Tool category | Runs where | Examples | Why |
+| --- | --- | --- | --- |
+| Browser tools | Browser client, against the preview iframe | `take_screenshot`, `get_dom`, `search_text`, `interact_with_element`, `set_device_mode` | Only the browser has direct access to the rendered page state |
+| Dev server tools | Your local framework integration | `read_file`, `write_file`, `edit_file`, `grep`, `list_tree` | Source files live on your machine, not on the Frontman server |
+| Server tools | Frontman server process | `todo_write`, `web_fetch` | These operate on server-side state or external network access |
+
+### File tool relay
+
+File tools do not execute on the Frontman server. They relay through the browser to the dev server that is running your application.
+
+```text
+Agent runtime ──MCP tool call──► Browser client ──HTTP──► Dev server plugin
+Agent runtime ◄─MCP tool result── Browser client ◄─────── Dev server plugin
+```
+
+This has a few direct consequences:
+
+- File tools require an active browser session.
+- The framework integration performs the actual filesystem I/O.
+- The server remains isolated from the local project filesystem.
+
+That boundary is one of the main security and deployment properties of the system. For deployment implications, see [Self-Hosting](/docs/reference/self-hosting/).
+
+## Persistence model
+
+Frontman persists agent activity as typed interactions in PostgreSQL before broadcasting them to connected clients.
+
+This persist-then-broadcast model matters for reliability:
+
+- If the browser disconnects, interaction history is not lost.
+- Reconnecting clients can reconstruct the full task state from the database.
+- The runtime can replay prior interaction history back into LLM message format when resuming work.
+
+The server stores domain events such as user messages, agent responses, tool calls, tool results, pauses, retries, and completion markers as structured JSONB records. The UI is therefore rendering persisted task history, not a transient in-memory transcript.
+
+## Server architecture
+
+The Phoenix application is responsible for orchestration, persistence, session management, and channel transport.
+
+### Main responsibilities
+
+- Accept ACP and MCP messages over WebSocket channels.
+- Resolve model/provider credentials.
+- Build agent execution context.
+- Submit work to the `SwarmAi.Runtime`.
+- Route tool calls to the correct execution environment.
+- Persist interactions and broadcast updates.
+- Expose authenticated HTTP endpoints for settings, OAuth, and token exchange.
+
+### Major server components
+
+| Component | Responsibility |
+| --- | --- |
+| `SwarmAi.Runtime` | Runs the agent loop and coordinates LLM interactions |
+| `TaskChannel` | Handles per-task prompt traffic, tool routing, and streamed updates |
+| `TasksChannel` | Handles task listing, creation, deletion, and session initialization |
+| `ToolCallRegistry` | Tracks pending client-executed tool calls and resolves waiting processes |
+| `SwarmDispatcher` | Persists interactions and broadcasts them through PubSub |
+| `Providers` | Resolves API keys, OAuth tokens, usage limits, and model catalog data |
+| `Repo` | Stores tasks, interactions, credentials, identities, and organizations |
+
+### Session and transport layer
+
+The wire protocol uses JSON-RPC 2.0 messages over Phoenix channels.
+
+- **ACP** handles session lifecycle and prompt exchange.
+- **MCP** handles tool registration, tool calls, and tool results.
+
+The split is intentional: ACP describes the conversation and task lifecycle, while MCP describes executable capabilities exposed to the agent. Configuration and deployment details that affect this transport layer are documented in [Configuration Options](/docs/reference/configuration/) and [Environment Variables](/docs/reference/env-vars/).
+
+## Client architecture
+
+The browser client has two jobs at the same time:
+
+1. Present the task UI to the user.
+2. Act as an execution host for browser tools and a relay for dev-server tools.
+
+For the user-facing side of this behavior, see [How the Agent Works](/docs/using/how-the-agent-works/), [Web Preview](/docs/using/web-preview/), and [The Question Flow](/docs/using/question-flow/).
+
+### Main client responsibilities
+
+- Render the chat transcript, plans, tool activity, and question UI.
+- Host the preview iframe used for DOM inspection and screenshots.
+- Maintain the WebSocket connection to the server.
+- Register browser-side MCP tools.
+- Relay file and project-inspection requests to the local dev server.
+
+### State model
+
+The client is built around a reducer-driven external store implemented in `libs/react-statestore`. Public reads go through selectors, and actions dispatch state transitions plus side effects.
+
+That split keeps the UI reactive while preserving a single state transition path for streamed updates, tool calls, questions, and task lifecycle events.
+
+## Protocol stack
+
+Frontman uses three layers that build on each other:
+
+1. **JSON-RPC 2.0** for the message envelope.
+2. **ACP** for task and session semantics.
+3. **MCP** for tool discovery and tool execution.
+
+A typical prompt therefore uses ACP for the user message, MCP for any tool calls generated during the turn, and JSON-RPC as the transport envelope for both.
+
+## Framework integrations
+
+The local dev server integration is how Frontman gains project awareness and filesystem access.
+
+Published integrations exist for Astro, Next.js, and Vite. Each integration injects the Frontman client into the running application, exposes HTTP endpoints or middleware for file tools, and provides framework-specific metadata where available.
+
+Examples:
+
+- **Astro** can expose source file annotations and dev-toolbar context.
+- **Next.js** can capture logs and instrument request flow.
+- **Vite** can adapt the same tool surface across multiple frontend frameworks.
+
+The integration layer is the bridge between the generic agent runtime and the specifics of an application's build system and file layout. See [Supported Frameworks](/docs/reference/compatibility/) for version support and [Configuration Options](/docs/reference/configuration/) for integration settings.
+
+## Reliability and failure handling
+
+Several architectural choices are there to keep task state coherent when things go wrong:
+
+- Interactions are persisted before broadcast.
+- Pending client-side tool calls are tracked in a registry rather than assumed to complete immediately.
+- Interactive tools can pause the agent instead of forcing a hard failure.
+- Reconnected clients can reload state from persisted interactions.
+
+This does not eliminate failure modes, but it prevents common ones from corrupting task history or silently dropping work.
+
+## Operational boundaries
+
+When debugging or extending Frontman, these boundaries matter most:
+
+1. **Browser boundary** — anything that needs the live DOM or visual output must run in the browser.
+2. **Filesystem boundary** — anything that touches project files must go through the local framework integration.
+3. **Server boundary** — orchestration, persistence, authentication, and runtime coordination stay on the server.
+4. **Provider boundary** — model behavior and tool selection originate with the external LLM provider.
+
+If a feature crosses one of those boundaries, the implementation usually needs explicit protocol support rather than a local-only change.
+
+## Monorepo layout
+
+The repository is organized as a monorepo with separate applications and shared libraries.
+
+- `apps/frontman_server/` contains the Phoenix backend.
+- `apps/marketing/` contains the Astro documentation and marketing site.
+- `apps/swarm_ai/` contains the runtime package used for agent execution.
+- `libs/client/` contains the ReScript React client.
+- `libs/frontman-core/` contains shared tool definitions and filesystem tool implementations.
+- `libs/frontman-protocol/` contains ACP/MCP types and schemas.
+- `libs/frontman-astro/`, `libs/frontman-nextjs/`, and `libs/frontman-vite/` contain framework integrations.
+
+This split keeps protocol types, client logic, runtime behavior, framework adapters, and the server deployable as separate units while still sharing a single source tree.
+
+## Related documentation
+
+- [How the Agent Works](/docs/using/how-the-agent-works/) for the user-facing explanation of the same loop.
+- [Tool Capabilities](/docs/using/tool-capabilities/) for the available tool surface.
+- [Configuration Options](/docs/reference/configuration/) for integration and runtime settings.
+- [Self-Hosting](/docs/reference/self-hosting/) for deployment architecture.

--- a/apps/marketing/src/content/docs/docs/reference/compatibility.md
+++ b/apps/marketing/src/content/docs/docs/reference/compatibility.md
@@ -1,6 +1,190 @@
 ---
 title: Supported Frameworks
-description: Framework and runtime version compatibility matrix for Frontman — Astro, Next.js, Vite, Node.js, and browser support.
+description: What Frontman supports today across Next.js, Astro, Vite-based apps, and WordPress, including requirements, limits, and what each integration exposes to the agent.
 ---
 
-Content coming soon.
+Frontman has two compatibility layers:
+
+1. **The browser UI and agent runtime** — the same Frontman interface and hosted orchestration server.
+2. **The local integration** — the package or plugin that exposes your project to the agent through framework-specific tools.
+
+Compatibility depends on the local integration. Frontman does not attach directly to arbitrary applications. It works when a supported integration is installed and the app is running in development mode.
+
+If you want the end-to-end execution model behind that split, read [How the Agent Works](/docs/using/how-the-agent-works/) and [Architecture Overview](/docs/reference/architecture/).
+
+## Compatibility summary
+
+| Platform | Package / integration | Status | Minimum versions | What Frontman can access |
+|----------|------------------------|--------|------------------|--------------------------|
+| Next.js | `@frontman-ai/nextjs` | Supported | Next.js 13.2+, Node.js 18+ | Files, route manifest, dev logs, optional OpenTelemetry spans |
+| Astro | `@frontman-ai/astro` | Supported | Astro 5.x or 6.x, Node.js 18+ | Files, resolved routes, dev logs, Astro source annotations |
+| Vite-based apps | `@frontman-ai/vite` | Supported | Vite 5.x or 6.x, Node.js 18+ | Files, dev logs, framework-aware client context |
+| WordPress | Frontman WordPress plugin | Beta | WordPress 6.0+, PHP 7.4+ | Site content and settings through WordPress tools, limited file inspection |
+
+## How compatibility works
+
+Frontman uses a split architecture:
+
+- The **browser-side client** exposes preview-aware tools such as screenshots, DOM inspection, text search, and element interaction.
+- The **framework integration** exposes project-local tools such as file reads, file edits, route discovery, and dev server logs.
+- The **Frontman server** orchestrates the agent loop, calls the LLM, and routes tool calls between the browser and the local integration.
+
+That architecture is why support is integration-specific. The hosted server is the same across frameworks, but each local integration decides which tools exist, how routes are discovered, and what source metadata can be recovered.
+
+For the full request/tool flow, see [Architecture Overview](/docs/reference/architecture/).
+
+## Supported integrations
+
+### Next.js
+
+`@frontman-ai/nextjs` integrates through Next.js middleware or proxy entrypoints, depending on your Next.js version.
+
+**Supported versions**
+- Next.js 13.2 or later
+- Node.js 18 or later
+
+**What the integration provides**
+- File access within `projectRoot` / `sourceRoot`
+- `get_routes` for App Router and Pages Router discovery
+- `get_logs` for console output, build output, and uncaught errors
+- Optional OpenTelemetry instrumentation for request and render spans
+
+See [Tool Capabilities](/docs/using/tool-capabilities/) for the shared file, log, and browser tools that work alongside these Next.js-specific capabilities.
+
+**Notes**
+- Frontman runs in development only.
+- App Router and Pages Router can coexist in the same project.
+- The integration works with both Webpack and Turbopack because it hooks at the middleware layer, not the bundler layer.
+
+See [Next.js integration](/docs/integrations/nextjs/).
+
+### Astro
+
+`@frontman-ai/astro` integrates through Astro lifecycle hooks and the underlying Vite dev server.
+
+**Supported versions**
+- Astro 5.x or 6.x
+- Node.js 18 or later
+
+**What the integration provides**
+- File access within `projectRoot` / `sourceRoot`
+- `get_client_pages` for Astro route discovery
+- `get_logs` for Astro and Vite dev output
+- Source mapping through Astro dev-toolbar annotations and content-file metadata
+
+**Notes**
+- On Astro 5+, route discovery uses the resolved route manifest, which includes content collections, redirects, API endpoints, and integration-injected routes.
+- On older behavior paths, filesystem scanning is less complete. Current documentation and support target Astro 5+.
+- Accurate element-to-file mapping depends on Astro dev toolbar annotations being available.
+
+See [Astro integration](/docs/integrations/astro/).
+
+### Vite-based applications
+
+`@frontman-ai/vite` supports applications that run on a standard Vite dev server.
+
+**Supported versions**
+- Vite 5.x or 6.x
+- Node.js 18 or later
+
+**What the integration provides**
+- File access within `projectRoot` / `sourceRoot`
+- `get_logs` for Vite console, build, and error output
+- Framework-aware client context when supported framework plugins are detected
+- Vue SFC source mapping through a dev-only source plugin
+
+**Supported framework families on Vite**
+- React
+- Vue
+- Svelte
+- SolidJS
+- Vanilla JavaScript / TypeScript
+- Other Vite-based apps that do not require framework-specific server hooks
+
+**Notes**
+- Vite compatibility is based on the dev server and plugin chain. If your project runs on Vite, Frontman can attach through the Vite integration even when the framework itself is not listed separately.
+- Framework-specific introspection is strongest for projects whose Vite plugin is explicitly detected.
+- SvelteKit works through its Vite dev server path.
+
+See [Vite integration](/docs/integrations/vite/).
+
+### WordPress
+
+The Frontman WordPress plugin is separate from the JavaScript framework integrations.
+
+**Supported versions**
+- WordPress 6.0 or later
+- PHP 7.4 or later
+- Administrator access
+
+**What the integration provides**
+- Post, page, block, menu, widget, template, and settings tools
+- A live preview inside the site itself
+- Read-only inspection of theme and plugin files
+- Managed child-theme editing for supported block-theme setups
+
+**Notes**
+- WordPress support is currently beta.
+- Direct arbitrary file writes are not available. File creation and editing are limited to the Frontman-managed child theme.
+- Supported workflows differ from the code-first integrations because the primary surface is WordPress content and configuration, not a local codebase.
+
+See [WordPress integration](/docs/integrations/wordpress/).
+
+## What is not supported
+
+### Unsupported local runtimes
+
+Frontman does not currently provide first-party integrations for:
+
+- plain Webpack dev servers
+- Parcel
+- Create React App without Vite migration
+- Remix as a standalone integration
+- Nuxt as a standalone integration
+- Gatsby
+- arbitrary static HTML sites without a supported dev server/plugin
+
+A framework may still be usable if it runs through a supported integration path. For example, a framework built on Vite can work through `@frontman-ai/vite` even if Frontman does not document that framework separately. Start with [Installation](/docs/installation/) if you need the package-level setup path.
+
+### Production environments
+
+Frontman integrations are development tools. They do not support attaching to production builds or preview deployments as a general workflow.
+
+In practice, that means:
+- Astro support applies to `astro dev`, not `astro build` or `astro preview`
+- Vite support applies to `vite dev`, not `vite build` or `vite preview`
+- Next.js support applies to local development entrypoints, not production middleware in deployed environments
+
+### Access outside the integration boundary
+
+Even on supported frameworks, Frontman is limited to what the integration exposes:
+
+- file tools are scoped to the configured project root
+- browser tools only see the embedded preview, not other tabs or devtools
+- there is no shell or terminal access
+- private-network `web_fetch` targets are blocked
+
+See [Limitations & Workarounds](/docs/using/limitations/) for the operational constraints that apply across all supported frameworks.
+
+## Choosing the right integration
+
+If you are deciding which package to install:
+
+1. **Use `@frontman-ai/nextjs`** for Next.js applications.
+2. **Use `@frontman-ai/astro`** for Astro applications.
+3. **Use `@frontman-ai/vite`** for React, Vue, Svelte, SolidJS, SvelteKit, or other apps whose local development server is Vite.
+4. **Use the WordPress plugin** for WordPress sites.
+
+If your project is in a monorepo, set `sourceRoot` to the repository root so file tools can reach the files you expect. See [Configuration Options](/docs/reference/configuration/) for the exact settings on each integration.
+
+## Practical compatibility guidance
+
+Before relying on Frontman for day-to-day work, verify these conditions:
+
+1. The app runs on a supported local integration.
+2. The dev server is running, and `/frontman` loads successfully.
+3. The relevant files are inside the configured `sourceRoot`.
+4. The page you want to edit is reachable in the preview without unsupported auth flows or cross-origin boundaries.
+5. Your framework-specific features are available through the integration path you chose.
+
+If one of those conditions is false, the issue is usually integration scope rather than agent behavior. When the failure mode is environmental rather than compatibility-related, continue with [Troubleshooting](/docs/reference/troubleshooting/).

--- a/apps/marketing/src/content/docs/docs/reference/configuration.md
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.md
@@ -304,7 +304,7 @@ const frontman = createMiddleware({
   host: 'api.frontman.sh',
 });
 
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const response = await frontman(req);
   if (response) return response;
   return NextResponse.next();

--- a/apps/marketing/src/content/docs/docs/reference/configuration.md
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.md
@@ -1,6 +1,465 @@
 ---
 title: Configuration Options
-description: All configuration options for Frontman across Astro, Next.js, Vite, and standalone — with types, defaults, and descriptions.
+description: Frontman configuration reference for Astro, Next.js, and Vite — every option, default value, environment override, and example setup.
 ---
 
-Content coming soon.
+Frontman lets you run an AI agent against your local app without giving the Frontman server direct access to your filesystem. The browser client connects to the Frontman server for the agent loop, and your framework integration exposes local tools like file reads, file edits, screenshots, logs, and route inspection.
+
+This page documents every supported configuration option for the official **Astro**, **Next.js**, and **Vite** integrations, including defaults, examples, and environment-variable overrides.
+
+## How Frontman configuration works
+
+All Frontman integrations configure the same core pieces:
+
+- **Where the Frontman UI is mounted** in your app, via `basePath`
+- **Which Frontman server the browser client connects to**, via `host`
+- **Which local directory should be treated as your project root**, via `projectRoot`
+- **How file paths should be resolved in monorepos**, via `sourceRoot`
+- **Which client bundle and stylesheet to load**, via `clientUrl` and `clientCssUrl`
+- **Whether to render the UI in light or dark mode**, via `isLightTheme`
+
+In practice, most projects only need `host` for remote development or `projectRoot` / `sourceRoot` for monorepos. The rest of the options are mainly for custom deployments, self-hosting, or advanced embedding.
+
+## Shared options across integrations
+
+These options exist in all three official integrations unless otherwise noted.
+
+| Option | Type | Default | What it does |
+|---|---|---|---|
+| `host` | `string` | `FRONTMAN_HOST` or `api.frontman.sh` | Frontman server host used by the browser client for WebSocket/API connections |
+| `basePath` | `string` | `"frontman"` | Mount path for the Frontman UI and dev-server tool routes |
+| `projectRoot` | `string` | `PROJECT_ROOT`, `PWD`, or `"."` | Root directory of the app Frontman should treat as the project |
+| `sourceRoot` | `string` | `projectRoot` | Root used to resolve source file paths, especially useful in monorepos |
+| `serverName` | `string` | Framework-specific | Name returned in tool metadata |
+| `serverVersion` | `string` | Package version | Version returned in tool metadata |
+| `clientUrl` | `string` | Auto-generated | URL of the Frontman browser client bundle |
+| `clientCssUrl` | `string` or `undefined` | Production CSS URL in prod, omitted in dev | URL of the Frontman client stylesheet |
+| `entrypointUrl` | `string` or `undefined` | `undefined` | Optional custom entrypoint URL for advanced deployments |
+| `isLightTheme` | `boolean` | `false` | Renders Frontman in light theme instead of dark |
+
+### Defaults and environment-variable behavior
+
+Frontman uses a few simple rules across integrations:
+
+1. **`FRONTMAN_HOST` overrides the default server host** if you do not pass `host` directly.
+2. **`PROJECT_ROOT` overrides auto-detected root resolution** if you do not pass `projectRoot` directly.
+3. **`FRONTMAN_CLIENT_URL` overrides the generated client bundle URL** if you do not pass `clientUrl` directly.
+4. **`sourceRoot` defaults to `projectRoot`** when omitted.
+5. **Non-production hosts are treated as dev mode** in Astro and Vite, and in Next.js unless you explicitly override `isDev`.
+
+## `host`
+
+`host` controls which Frontman server the browser client connects to.
+
+**Type:** `string`  
+**Default:** `FRONTMAN_HOST` or `api.frontman.sh`
+
+Use this when you want your local app to talk to:
+
+- the hosted Frontman server: `api.frontman.sh`
+- a local Frontman server during development
+- a self-hosted Frontman deployment inside your company network
+
+### Example
+
+```ts
+host: 'api.frontman.sh'
+```
+
+```ts
+host: 'frontman.local:4000'
+```
+
+In Vite and Next.js, host values are normalized, so these resolve to the same thing:
+
+```ts
+host: 'api.frontman.sh'
+host: 'https://api.frontman.sh'
+host: 'https://api.frontman.sh:443'
+```
+
+### Why it matters
+
+When you open `/frontman`, the integration serves the Frontman UI shell. That UI then loads the browser client bundle and opens a connection back to the Frontman server you configured here. If `host` is wrong, the UI may render but the agent loop will fail to connect.
+
+## `basePath`
+
+`basePath` changes where Frontman is mounted in your app.
+
+**Type:** `string`  
+**Default:** `"frontman"`
+
+By default, Frontman lives at:
+
+- Astro: `/frontman/`
+- Next.js: `/frontman`
+- Vite: `/frontman`
+
+### Example
+
+```ts
+basePath: 'devtools/frontman'
+```
+
+That would move the UI to `/devtools/frontman` and the related tool endpoints under the same prefix.
+
+### Notes
+
+- Astro normalizes leading and trailing slashes, so `'/frontman/'` becomes `frontman`.
+- If your app already uses `/frontman` for another route, change this.
+- In Next.js, make sure your `matcher` also covers the custom path if you wire middleware manually.
+
+## `projectRoot`
+
+`projectRoot` tells Frontman which directory should be treated as the root of the project.
+
+**Type:** `string`  
+**Default:** `PROJECT_ROOT`, then `PWD`, then `"."`
+
+This matters for file-based tools such as reading files, editing files, searching, and route discovery.
+
+### Example
+
+```ts
+projectRoot: import.meta.dirname
+```
+
+```ts
+projectRoot: process.cwd()
+```
+
+### When to set it
+
+Set `projectRoot` explicitly when:
+
+- your dev server is started from a wrapper directory
+- your framework config lives outside the actual app root
+- you're in a workspace or monorepo and want to avoid accidental path ambiguity
+
+## `sourceRoot`
+
+`sourceRoot` defines the root used when resolving source file locations back to real files.
+
+**Type:** `string`  
+**Default:** `projectRoot`
+
+This is especially important in monorepos. Your framework app might live in `apps/web`, but source references may need to resolve relative to the monorepo root.
+
+### Example
+
+```ts
+projectRoot: '/repo/apps/web',
+sourceRoot: '/repo'
+```
+
+### When to set it
+
+Set `sourceRoot` when:
+
+- your app runs from a subdirectory inside a monorepo
+- source-location metadata points to paths outside the app folder
+- Frontman can see the page but struggles to map visible elements back to the right files
+
+## `serverName`
+
+`serverName` changes the integration name returned in tool responses.
+
+**Type:** `string`  
+**Default:** framework-specific
+
+Defaults:
+
+- Astro: `frontman-astro`
+- Next.js: `frontman-nextjs`
+- Vite: `frontman-vite`
+
+Most users should leave this alone. It mainly helps when debugging custom setups or running multiple tool servers.
+
+## `serverVersion`
+
+`serverVersion` controls the version string returned in tool metadata.
+
+**Type:** `string`  
+**Default:** the installed package version
+
+You usually do not need this unless you're testing a custom build or want explicit metadata in a self-hosted environment.
+
+## `clientUrl`
+
+`clientUrl` overrides the URL of the Frontman browser client bundle.
+
+**Type:** `string`  
+**Default:** generated from environment and dev/prod mode
+
+By default, Frontman generates a client bundle URL automatically and appends the query parameters the browser client needs, including:
+
+- `host=<your-configured-host>`
+- `clientName=astro|nextjs|vite`
+
+### When to set it
+
+Override `clientUrl` when:
+
+- you're testing a local Frontman client build
+- you're self-hosting the client assets
+- you're debugging a custom browser bundle
+
+### Example
+
+```ts
+clientUrl: 'https://app.frontman.sh/frontman.es.js'
+```
+
+If you override this manually in Next.js, the URL **must include** a `host` query parameter. Astro and Vite will inject missing query parameters for you; Next.js throws if `host` is missing.
+
+## `clientCssUrl`
+
+`clientCssUrl` overrides the stylesheet URL used by the Frontman UI.
+
+**Type:** `string`  
+**Default:** production CSS asset in production, omitted in dev
+
+In local dev mode, integrations generally skip the hosted CSS because the dev client handles styling differently. In production-like setups, they use the hosted CSS asset unless you override it.
+
+### When to set it
+
+Set this only if you are:
+
+- self-hosting Frontman client assets
+- testing a custom client stylesheet
+- pinning asset delivery to your own CDN
+
+## `entrypointUrl`
+
+`entrypointUrl` provides an optional custom entrypoint URL for advanced deployments.
+
+**Type:** `string`  
+**Default:** `undefined`
+
+This option exists in the integration configs but is not something most Frontman users need. If you're not building a custom deployment flow or wiring Frontman into non-standard infrastructure, leave it unset.
+
+## `isLightTheme`
+
+`isLightTheme` switches the Frontman UI from the default dark theme to a light theme.
+
+**Type:** `boolean`  
+**Default:** `false`
+
+### Example
+
+```ts
+isLightTheme: true
+```
+
+Useful when you're embedding Frontman into internal tools that already use a light interface and you want the UI to feel less bolted on with duct tape and spite.
+
+## Astro configuration
+
+Use the Astro integration in `astro.config.mjs` or `astro.config.ts`.
+
+```ts
+import { defineConfig } from 'astro/config';
+import frontman from '@frontman-ai/astro';
+
+export default defineConfig({
+  integrations: [
+    frontman({
+      projectRoot: import.meta.dirname,
+    }),
+  ],
+});
+```
+
+### Astro-specific notes
+
+- Frontman only runs in **dev mode**.
+- It registers an Astro dev toolbar app for element selection.
+- It uses Astro source annotations so the agent can map visible elements back to `.astro` files.
+- Astro strips leading and trailing slashes from `basePath` and falls back to `frontman` if you pass an empty string.
+
+### Astro options reference
+
+| Option | Type | Default |
+|---|---|---|
+| `projectRoot` | `string` | `PROJECT_ROOT`, `PWD`, or `"."` |
+| `sourceRoot` | `string` | `projectRoot` |
+| `basePath` | `string` | `"frontman"` |
+| `serverName` | `string` | `"frontman-astro"` |
+| `serverVersion` | `string` | installed package version |
+| `host` | `string` | `FRONTMAN_HOST` or `api.frontman.sh` |
+| `clientUrl` | `string` | generated automatically |
+| `clientCssUrl` | `string \/ undefined` | hosted CSS in prod mode |
+| `entrypointUrl` | `string \/ undefined` | `undefined` |
+| `isLightTheme` | `boolean` | `false` |
+
+## Next.js configuration
+
+Use the Next.js integration in `middleware.ts` for Next.js 15 or `proxy.ts` for Next.js 16+.
+
+```ts
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  host: 'api.frontman.sh',
+});
+
+export async function middleware(req: NextRequest) {
+  const response = await frontman(req);
+  if (response) return response;
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/frontman', '/frontman/:path*'],
+};
+```
+
+### Next.js-specific notes
+
+- Next.js exposes an explicit `isDev` override in addition to the shared options.
+- Host values are normalized, so full URLs and bare hostnames are both accepted.
+- If you override `clientUrl`, it must include a `host` query parameter or Frontman throws immediately.
+- OpenTelemetry setup is separate from config and is recommended if you want richer logs and request traces.
+
+### Next.js options reference
+
+| Option | Type | Default |
+|---|---|---|
+| `isDev` | `boolean` | inferred from `host` |
+| `basePath` | `string` | `"frontman"` |
+| `serverName` | `string` | `"frontman-nextjs"` |
+| `serverVersion` | `string` | installed package version |
+| `host` | `string` | `FRONTMAN_HOST` or `api.frontman.sh` |
+| `clientUrl` | `string` | generated automatically |
+| `clientCssUrl` | `string \/ undefined` | hosted CSS in prod mode |
+| `entrypointUrl` | `string \/ undefined` | `undefined` |
+| `isLightTheme` | `boolean` | `false` |
+| `projectRoot` | `string` | `PROJECT_ROOT`, `PWD`, or `"."` |
+| `sourceRoot` | `string` | `projectRoot` |
+
+## Vite configuration
+
+Use the Vite plugin inside `vite.config.ts`.
+
+```ts
+import { defineConfig } from 'vite';
+import { frontmanPlugin } from '@frontman-ai/vite';
+
+export default defineConfig({
+  plugins: [
+    frontmanPlugin({
+      host: 'api.frontman.sh',
+    }),
+  ],
+});
+```
+
+### Vite-specific notes
+
+- Vite exposes an explicit `isDev` override in addition to the shared options.
+- Host values are normalized before use.
+- The plugin mounts middleware inside the Vite dev server and exposes Frontman routes under `basePath`.
+- Vite is the most flexible option when you want Frontman in React, Vue, Svelte, Solid, or vanilla projects.
+
+### Vite options reference
+
+| Option | Type | Default |
+|---|---|---|
+| `isDev` | `boolean` | inferred from `host` |
+| `projectRoot` | `string` | `PROJECT_ROOT`, `PWD`, or `"."` |
+| `sourceRoot` | `string` | `projectRoot` |
+| `basePath` | `string` | `"frontman"` |
+| `serverName` | `string` | `"frontman-vite"` |
+| `serverVersion` | `string` | installed package version |
+| `host` | `string` | `FRONTMAN_HOST` or `api.frontman.sh` |
+| `clientUrl` | `string` | generated automatically |
+| `clientCssUrl` | `string \/ undefined` | hosted CSS in prod mode |
+| `entrypointUrl` | `string \/ undefined` | `undefined` |
+| `isLightTheme` | `boolean` | `false` |
+
+## Environment variables
+
+Frontman supports these environment variables across integrations:
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `FRONTMAN_HOST` | Astro, Next.js, Vite | Default Frontman server host when `host` is not passed explicitly |
+| `PROJECT_ROOT` | Astro, Next.js, Vite | Default project root when `projectRoot` is omitted |
+| `FRONTMAN_CLIENT_URL` | Astro, Next.js, Vite | Overrides the generated browser client bundle URL |
+
+### Example `.env`
+
+```bash
+FRONTMAN_HOST=frontman.local:4000
+PROJECT_ROOT=/Users/you/code/acme-web
+FRONTMAN_CLIENT_URL=http://localhost:5174/frontman.es.js
+```
+
+## Common configuration patterns
+
+### Local app + hosted Frontman
+
+This is the default setup for most users.
+
+```ts
+frontman({
+  projectRoot: import.meta.dirname,
+})
+```
+
+### Monorepo app
+
+Use this when the app lives in a subdirectory but you want source resolution from the repo root.
+
+```ts
+frontmanPlugin({
+  projectRoot: '/repo/apps/web',
+  sourceRoot: '/repo',
+})
+```
+
+### Self-hosted Frontman server
+
+Point the browser client at your own server.
+
+```ts
+createMiddleware({
+  host: 'frontman.internal.example.com',
+})
+```
+
+### Custom route prefix
+
+Mount Frontman under an internal tools path.
+
+```ts
+frontman({
+  basePath: 'internal/frontman',
+})
+```
+
+## Configuration troubleshooting
+
+### Frontman UI loads, but the agent cannot connect
+
+Check `host` first. The most common failure is serving the UI from your app successfully but pointing the client at the wrong Frontman server.
+
+### File tools are reading the wrong paths
+
+Check `projectRoot` and `sourceRoot`. In monorepos, `sourceRoot` is usually the fix.
+
+### Custom `clientUrl` works in Astro or Vite but fails in Next.js
+
+Next.js validates that `clientUrl` includes a `host` query parameter. Add one explicitly.
+
+### `/frontman` returns 404 after changing `basePath`
+
+Update the route you visit in the browser, and in Next.js make sure your middleware or proxy matcher includes the new path.
+
+## Related pages
+
+- **[Architecture Overview](/docs/reference/architecture/)** — how the agent loop, browser client, and framework tools work together
+- **[Environment Variables](/docs/reference/env-vars/)** — server-side and client-side environment reference
+- **[Supported Frameworks](/docs/reference/compatibility/)** — compatibility matrix for Astro, Next.js, Vite, Node.js, and browsers
+- **[How the Agent Works](/docs/using/how-the-agent-works/)** — conceptual overview of the end-to-end flow

--- a/apps/marketing/src/content/docs/docs/reference/configuration.md
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.md
@@ -294,17 +294,19 @@ export default defineConfig({
 
 ## Next.js configuration
 
-Use the Next.js integration in `middleware.ts` for Next.js 15 or `proxy.ts` for Next.js 16+.
+Use the Next.js integration in `middleware.ts` for Next.js 13-15 or `proxy.ts` for Next.js 16+.
+
+### Next.js 13-15 (`middleware.ts`)
 
 ```ts
 import { createMiddleware } from '@frontman-ai/nextjs';
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 const frontman = createMiddleware({
   host: 'api.frontman.sh',
 });
 
-export async function proxy(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   const response = await frontman(req);
   if (response) return response;
   return NextResponse.next();
@@ -313,6 +315,27 @@ export async function proxy(req: NextRequest) {
 export const config = {
   matcher: ['/frontman', '/frontman/:path*'],
 };
+```
+
+### Next.js 16+ (`proxy.ts`)
+
+```ts
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  host: 'api.frontman.sh',
+});
+
+export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
+  if (
+    req.nextUrl.pathname === '/frontman' ||
+    req.nextUrl.pathname.startsWith('/frontman/')
+  ) {
+    return frontman(req) ?? NextResponse.next();
+  }
+  return NextResponse.next();
+}
 ```
 
 ### Next.js-specific notes

--- a/apps/marketing/src/content/docs/docs/reference/configuration.md
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.md
@@ -327,12 +327,13 @@ const frontman = createMiddleware({
   host: 'api.frontman.sh',
 });
 
-export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
+export async function proxy(req: NextRequest): Promise<NextResponse> {
   if (
     req.nextUrl.pathname === '/frontman' ||
     req.nextUrl.pathname.startsWith('/frontman/')
   ) {
-    return frontman(req) ?? NextResponse.next();
+    const response = await frontman(req);
+    if (response) return response;
   }
   return NextResponse.next();
 }

--- a/apps/marketing/src/content/docs/docs/reference/configuration.mdx
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.mdx
@@ -3,6 +3,8 @@ title: Configuration Options
 description: Frontman configuration reference for Astro, Next.js, and Vite — every option, default value, environment override, and example setup.
 ---
 
+import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
+
 Frontman lets you run an AI agent against your local app without giving the Frontman server direct access to your filesystem. The browser client connects to the Frontman server for the agent loop, and your framework integration exposes local tools like file reads, file edits, screenshots, logs, and route inspection.
 
 This page documents every supported configuration option for the official **Astro**, **Next.js**, and **Vite** integrations, including defaults, examples, and environment-variable overrides.
@@ -257,18 +259,7 @@ Useful when you're embedding Frontman into internal tools that already use a lig
 
 Use the Astro integration in `astro.config.mjs` or `astro.config.ts`.
 
-```ts
-import { defineConfig } from 'astro/config';
-import frontman from '@frontman-ai/astro';
-
-export default defineConfig({
-  integrations: [
-    frontman({
-      projectRoot: import.meta.dirname,
-    }),
-  ],
-});
-```
+<CodeFromFile snippet="astro/astro.config.ts.txt" />
 
 ### Astro-specific notes
 
@@ -298,46 +289,11 @@ Use the Next.js integration in `middleware.ts` for Next.js 13-15 or `proxy.ts` f
 
 ### Next.js 13-15 (`middleware.ts`)
 
-```ts
-import { createMiddleware } from '@frontman-ai/nextjs';
-import { type NextRequest, NextResponse } from 'next/server';
-
-const frontman = createMiddleware({
-  host: 'api.frontman.sh',
-});
-
-export async function middleware(req: NextRequest) {
-  const response = await frontman(req);
-  if (response) return response;
-  return NextResponse.next();
-}
-
-export const config = {
-  matcher: ['/frontman', '/frontman/:path*'],
-};
-```
+<CodeFromFile snippet="nextjs/middleware.ts.txt" />
 
 ### Next.js 16+ (`proxy.ts`)
 
-```ts
-import { createMiddleware } from '@frontman-ai/nextjs';
-import { type NextRequest, NextResponse } from 'next/server';
-
-const frontman = createMiddleware({
-  host: 'api.frontman.sh',
-});
-
-export async function proxy(req: NextRequest): Promise<NextResponse> {
-  if (
-    req.nextUrl.pathname === '/frontman' ||
-    req.nextUrl.pathname.startsWith('/frontman/')
-  ) {
-    const response = await frontman(req);
-    if (response) return response;
-  }
-  return NextResponse.next();
-}
-```
+<CodeFromFile snippet="nextjs/proxy.ts.txt" />
 
 ### Next.js-specific notes
 
@@ -366,18 +322,7 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
 
 Use the Vite plugin inside `vite.config.ts`.
 
-```ts
-import { defineConfig } from 'vite';
-import { frontmanPlugin } from '@frontman-ai/vite';
-
-export default defineConfig({
-  plugins: [
-    frontmanPlugin({
-      host: 'api.frontman.sh',
-    }),
-  ],
-});
-```
+<CodeFromFile snippet="vite/vite.config.ts.txt" />
 
 ### Vite-specific notes
 

--- a/apps/marketing/src/content/docs/snippets/astro/astro.config.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/astro/astro.config.ts.txt
@@ -1,0 +1,10 @@
+import { defineConfig } from 'astro/config';
+import frontman from '@frontman-ai/astro';
+
+export default defineConfig({
+  integrations: [
+    frontman({
+      projectRoot: import.meta.dirname,
+    }),
+  ],
+});

--- a/apps/marketing/src/content/docs/snippets/nextjs/middleware.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/nextjs/middleware.ts.txt
@@ -1,0 +1,17 @@
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  projectRoot: process.cwd(),
+});
+
+export async function middleware(req: NextRequest) {
+  const response = await frontman(req);
+  if (response) return response;
+  return NextResponse.next();
+}
+
+export const config = {
+  runtime: 'nodejs',
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/'],
+};

--- a/apps/marketing/src/content/docs/snippets/nextjs/proxy.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/nextjs/proxy.ts.txt
@@ -1,0 +1,17 @@
+import { createMiddleware } from '@frontman-ai/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const frontman = createMiddleware({
+  projectRoot: process.cwd(),
+});
+
+export async function proxy(req: NextRequest): Promise<NextResponse> {
+  const response = await frontman(req);
+  if (response) return response;
+  return NextResponse.next();
+}
+
+export const config = {
+  runtime: 'nodejs',
+  matcher: ['/frontman', '/frontman/:path*', '/:path*/frontman', '/:path*/frontman/'],
+};

--- a/apps/marketing/src/content/docs/snippets/vite/vite.config.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/vite/vite.config.ts.txt
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import { frontmanPlugin } from '@frontman-ai/vite';
+
+export default defineConfig({
+  plugins: [
+    frontmanPlugin(),
+  ],
+});


### PR DESCRIPTION
## Description

This PR expands and fixes the marketing docs, then removes duplicated integration setup snippets by embedding canonical snippet files across docs pages.

## What changed

- Added/expanded missing reference docs content for:
  - `apps/marketing/src/content/docs/docs/reference/architecture.md`
  - `apps/marketing/src/content/docs/docs/reference/compatibility.md`
- Fixed Next.js docs examples to match current behavior:
  - Split/clarified Next.js 13-15 (`middleware.ts`) vs 16+ (`proxy.ts`) examples
  - Fixed proxy fallback flow to `await frontman(req)` and return `NextResponse.next()` only when unhandled
- Centralized website snippets (Astro-only, no external sync script):
  - Added `apps/marketing/src/components/docs/CodeFromFile.astro`
  - Added canonical snippet files under `apps/marketing/src/content/docs/snippets/`
  - Converted docs pages to MDX and embedded snippets instead of duplicating code blocks
- Updated stale install commands in docs overview/install pages:
  - `npx @frontman-ai/nextjs install`
  - `npx @frontman-ai/vite install`

## Validation

- `make build` in `apps/marketing` passes locally
- No unresolved review threads on this PR

## Notes

- Scope is website docs only (marketing site).
- Package READMEs are intentionally not part of this PR.