### PR TITLE
new task opens in current url

### DIFF
--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1365,9 +1365,10 @@ let next = (state: state, action) => {
     }
 
   | ClearCurrentTask =>
+    let previewUrl = Selectors.previewUrl(state)
     {
       ...state,
-      currentTask: Task.New(Task.makeNew(~previewUrl=getInitialUrl())),
+      currentTask: Task.New(Task.makeNew(~previewUrl)),
     }->StateReducer.update
 
   | UpdateTaskTitle({taskId, title}) =>

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -770,6 +770,19 @@ describe("Client State Reducer - Task Management Actions", () => {
     }
   })
 
+  test("ClearCurrentTask preserves current preview URL", t => {
+    let previewUrl = "http://localhost:3000/products/42?tab=details"
+    let state = TestHelpers.makeStateWithTask(~previewUrl)
+
+    let (nextState, _effects) = Reducer.next(state, ClearCurrentTask)
+
+    t->expect(Reducer.Selectors.previewUrl(nextState))->Expect.toBe(previewUrl)
+    switch nextState.currentTask {
+    | Task.New(_) => t->expect(true)->Expect.toBe(true)
+    | Task.Selected(_) => t->expect(false)->Expect.toBe(true)
+    }
+  })
+
   test("DeleteTask switches to New when deleting only task", t => {
     let task1 = Task.makeLoaded(
       ~id="task-1",


### PR DESCRIPTION
when working, you expect to open a new task and keep working.. but currently Frontman opens it in a new url

## Description

<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
