### PR TITLE
fix(frontman-core): harden tool-call path guardrails and diagnostics

### DIFF
--- a/.changeset/clean-path-helpers.md
+++ b/.changeset/clean-path-helpers.md
@@ -1,0 +1,8 @@
+---
+"@frontman-ai/frontman-core": patch
+"@frontman-ai/client": patch
+"@frontman-ai/astro": patch
+"@frontman-ai/nextjs": patch
+---
+
+Centralize path normalization and filename pattern matching to shared helpers across core and framework packages. This removes duplicate `toForwardSlashes` logic from client/Next.js/Astro path conversion and moves search/file matching logic into reusable frontman-core utilities, while adding focused regression tests for mixed separators and wildcard/case-insensitive pattern matching.

--- a/.changeset/harden-toolcall-path-guardrails.md
+++ b/.changeset/harden-toolcall-path-guardrails.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-core": patch
+---
+
+Harden tool-call path handling for discovery workflows by adding a per-source-root path hints cache, a zero-result guardrail between `search_files` and `read_file`, nearest-parent recovery for missing paths, and structured `search_files` backend error payloads (command, cwd, exit code, stderr, target path). Add T1-T4 taxonomy regression tests plus a replay test modeled on the 3addabc6 failure sequence.

--- a/apps/marketing/src/components/blocks/hero/HomeCTA.astro
+++ b/apps/marketing/src/components/blocks/hero/HomeCTA.astro
@@ -67,7 +67,7 @@ if ('modelContext' in navigator && typeof navigator.modelContext?.provideContext
 ---
 
 <section id="intro" class="hero-section bg-primary-500">
-	<script is:inline>{webMcpScript}</script>
+	<script is:inline set:html={webMcpScript} />
 	<div class="hero-section__bg">
 		<img src={gridNetBackground.src} alt="Decorative grid background pattern" class="hero-section__bg-image" width="1440" height="900" fetchpriority="high" />
 	</div>

--- a/apps/marketing/src/components/blocks/hero/HomeCTA.astro
+++ b/apps/marketing/src/components/blocks/hero/HomeCTA.astro
@@ -16,9 +16,58 @@ import videoPlaceholder from '../../../assets/video-placeholder.png'
 
 // YouTube video
 const youtubeVideoId = '-4GD1GYwH8Y'
+
+const webMcpScript = `
+if ('modelContext' in navigator && typeof navigator.modelContext?.provideContext === 'function') {
+  navigator.modelContext.provideContext({
+    tools: [
+      {
+        name: 'open_docs',
+        description: 'Open Frontman documentation.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: async () => {
+          window.location.href = '/docs/'
+          return { ok: true }
+        },
+      },
+      {
+        name: 'go_to_pricing',
+        description: 'Navigate to the Frontman pricing page.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: async () => {
+          window.location.href = '/pricing/'
+          return { ok: true }
+        },
+      },
+      {
+        name: 'jump_to_install',
+        description: 'Scroll to the install section on the homepage.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: async () => {
+          document.querySelector('#install')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          return { ok: true }
+        },
+      },
+    ],
+  })
+}
+`
 ---
 
 <section id="intro" class="hero-section bg-primary-500">
+	<script is:inline>{webMcpScript}</script>
 	<div class="hero-section__bg">
 		<img src={gridNetBackground.src} alt="Decorative grid background pattern" class="hero-section__bg-image" width="1440" height="900" fetchpriority="high" />
 	</div>

--- a/apps/marketing/src/pages/.well-known/agent-skills/index.json.ts
+++ b/apps/marketing/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from 'astro'
+import { createHash } from 'node:crypto'
+
+const siteUrl = new URL(import.meta.env.SITE)
+const origin = siteUrl.origin
+
+const skillDocs = [
+  {
+    name: 'marketing-site-navigation',
+    type: 'site-resource',
+    description: 'Discover the main Frontman marketing pages and documentation entry points.',
+    url: `${origin}/`,
+  },
+  {
+    name: 'docs',
+    type: 'documentation',
+    description: 'Read Frontman installation, integration, troubleshooting, and self-hosting docs.',
+    url: `${origin}/docs/`,
+  },
+  {
+    name: 'markdown-negotiation',
+    type: 'content-negotiation',
+    description: 'Request markdown responses for the homepage with Accept: text/markdown.',
+    url: `${origin}/`,
+  },
+  {
+    name: 'webmcp-site-tools',
+    type: 'browser-tools',
+    description: 'Use lightweight WebMCP tools for on-site navigation such as opening docs or jumping to install.',
+    url: `${origin}/`,
+  },
+]
+
+const skills = skillDocs.map((skill) => ({
+  ...skill,
+  sha256: createHash('sha256').update(JSON.stringify(skill)).digest('hex'),
+}))
+
+const index = {
+  $schema: 'https://agentskills.io/schemas/agent-skills-index-v0.2.0.json',
+  skills,
+}
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(index, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  })
+}

--- a/apps/marketing/src/pages/.well-known/api-catalog.ts
+++ b/apps/marketing/src/pages/.well-known/api-catalog.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from 'astro'
+
+const siteUrl = new URL(import.meta.env.SITE)
+const origin = siteUrl.origin
+
+const apiCatalog = {
+  linkset: [
+    {
+      anchor: `${origin}/`,
+      about: [
+        {
+          href: `${origin}/how-it-works/`,
+          type: 'text/html',
+          title: 'How Frontman works',
+        },
+      ],
+      'service-doc': [
+        {
+          href: `${origin}/docs/`,
+          type: 'text/html',
+          title: 'Frontman documentation',
+        },
+      ],
+      contact: [
+        {
+          href: `${origin}/contact/`,
+          type: 'text/html',
+          title: 'Contact Frontman',
+        },
+      ],
+      'version-history': [
+        {
+          href: `${origin}/changelog/`,
+          type: 'text/html',
+          title: 'Frontman changelog',
+        },
+      ],
+    },
+  ],
+}
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(apiCatalog, null, 2), {
+    headers: {
+      'Content-Type': 'application/linkset+json; charset=utf-8',
+    },
+  })
+}

--- a/apps/marketing/src/pages/.well-known/mcp/server-card.json.ts
+++ b/apps/marketing/src/pages/.well-known/mcp/server-card.json.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+export const GET: APIRoute = () => {
+  return new Response(null, { status: 404 })
+}

--- a/apps/marketing/src/pages/.well-known/oauth-protected-resource.ts
+++ b/apps/marketing/src/pages/.well-known/oauth-protected-resource.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+export const GET: APIRoute = () => {
+  return new Response(null, { status: 404 })
+}

--- a/apps/marketing/src/pages/.well-known/openid-configuration.ts
+++ b/apps/marketing/src/pages/.well-known/openid-configuration.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+export const GET: APIRoute = () => {
+  return new Response(null, { status: 404 })
+}

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -1,8 +1,6 @@
 ---
-// Components
-// - Layout
+import type { APIRoute } from 'astro'
 import Layout from '../layouts/Layout.astro'
-// - UI
 import Hero from '../components/blocks/hero/HomeCTA.astro'
 import FullContextSection from '../components/blocks/context/FullContextSection.astro'
 import FeatureHighlights from '../components/blocks/features/FeatureHighlights.astro'
@@ -12,6 +10,7 @@ import ComparisonTable from '../components/blocks/comparison/ComparisonTable.ast
 import InstallSteps from '../components/blocks/install/InstallSteps.astro'
 import HomeFAQ from '../components/blocks/FAQ/HomeFAQ.astro'
 import FinalCTA from '../components/blocks/CTA/FinalCTA.astro'
+import { agentLinkHeader, homeMarkdown, markdownTokenCount } from '../utils/agentDiscovery'
 
 // Data
 import faqData from '../data/json-files/faqData.json'
@@ -37,6 +36,20 @@ const faqJsonLd = {
 		}
 	}))
 }
+
+const acceptsMarkdown = Astro.request.headers.get('accept')?.includes('text/markdown') ?? false
+
+if (acceptsMarkdown) {
+	return new Response(homeMarkdown, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+			Link: agentLinkHeader,
+			'x-markdown-tokens': String(markdownTokenCount)
+		}
+	})
+}
+
+Astro.response.headers.set('Link', agentLinkHeader)
 ---
 
 <Layout title={SEO.title} description={SEO.description}>

--- a/apps/marketing/src/pages/robots.txt.ts
+++ b/apps/marketing/src/pages/robots.txt.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro'
 const robotsTxt = `
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 # AI crawlers — explicitly allowed so Frontman appears in AI-generated answers
 User-agent: GPTBot
@@ -42,3 +43,5 @@ export const GET: APIRoute = () => {
 		}
 	})
 }
+
+export const prerender = true

--- a/apps/marketing/src/utils/agentDiscovery.ts
+++ b/apps/marketing/src/utils/agentDiscovery.ts
@@ -1,0 +1,38 @@
+export const agentLinkHeader = [
+  '</docs/>; rel="service-doc"; title="Frontman documentation"',
+  '</how-it-works/>; rel="about"; title="How Frontman works"',
+  '</pricing/>; rel="pricing"; title="Frontman pricing"',
+  '</changelog/>; rel="version-history"; title="Frontman changelog"',
+  '</compare/>; rel="related"; title="AI coding tools comparison"',
+  '</contact/>; rel="contact"; title="Contact Frontman"',
+  '</.well-known/agent-skills/index.json>; rel="agent-skills"; title="Frontman agent skills index"',
+].join(', ')
+
+export const homeMarkdown = `# Frontman: Visual AI Agent for Your Running App
+
+Frontman lets you click any element in your live product, describe the change in plain English, and get real code edits.
+
+## Why agents can use this site
+
+- The site supports markdown responses for agents.
+- It links to Frontman documentation, pricing, changelog, comparisons, and contact resources.
+- It exposes lightweight browser tools for on-site navigation through WebMCP when supported.
+
+## Key resources
+
+- Documentation: [/docs/](/docs/)
+- Installation: [/docs/installation/](/docs/installation/)
+- How it works: [/how-it-works/](/how-it-works/)
+- Pricing: [/pricing/](/pricing/)
+- Changelog: [/changelog/](/changelog/)
+- Comparisons: [/compare/](/compare/)
+- Integrations: [/integrations/](/integrations/)
+- Contact: [/contact/](/contact/)
+- Agent skills index: [/.well-known/agent-skills/index.json](/.well-known/agent-skills/index.json)
+
+## Product summary
+
+Frontman is an AI agent that lives inside your framework's dev server as middleware. It sees the live DOM, component tree, CSS styles, routes, and server logs so it can make more accurate visual changes than file-only agents.
+`
+
+export const markdownTokenCount = homeMarkdown.split(/\s+/u).filter(Boolean).length

--- a/infra/local/caddy-regen.sh
+++ b/infra/local/caddy-regen.sh
@@ -52,8 +52,10 @@ else
         # Extract hash from pod name (worktree-HASH)
         HASH="${POD#worktree-}"
 
-        # Derive ports from hash (must match wt-pod-create)
-        BASE_PORT=$(( 16#${HASH} % 5000 + 10000 ))
+        # Derive ports from hash (must match bin/wt-pod-create)
+        # Base port range uses 5-port strides to avoid overlap:
+        # (0xHASH % 1000) * 5 + 10000
+        BASE_PORT=$(( (16#${HASH} % 1000) * 5 + 10000 ))
         PORT_PHOENIX=$((BASE_PORT))
         PORT_VITE=$((BASE_PORT + 1))
         PORT_NEXTJS=$((BASE_PORT + 2))

--- a/libs/client/src/Client__PathStringUtils.res
+++ b/libs/client/src/Client__PathStringUtils.res
@@ -1,0 +1,1 @@
+let toForwardSlashes = (path: string): string => path->String.replaceAll("\\", "/")

--- a/libs/client/src/Client__SourcePath.res
+++ b/libs/client/src/Client__SourcePath.res
@@ -1,6 +1,8 @@
 // Shared path utilities for framework source detection modules.
 // Used by Vue, Astro, and future framework detections to avoid duplication.
 
+module PathStringUtils = Client__PathStringUtils
+
 // Check if a file path is from node_modules (third-party component).
 // Components from node_modules are skipped during source detection since
 // the user cares about their own source code, not library internals.
@@ -14,7 +16,7 @@ let isNodeModulesPath = (filePath: string): bool => {
 //        "C:\\Users\\dev\\App.astro" -> "App.astro"
 let extractFilename = (filePath: string): string => {
   filePath
-  ->String.replaceAll("\\", "/")
+  ->PathStringUtils.toForwardSlashes
   ->String.split("/")
   ->Array.at(-1)
   // String.split always returns at least one element — crash if invariant breaks

--- a/libs/client/test/Client__PathStringUtils.test.res
+++ b/libs/client/test/Client__PathStringUtils.test.res
@@ -1,0 +1,23 @@
+open Vitest
+
+module PathStringUtils = Client__PathStringUtils
+
+describe("toForwardSlashes", _t => {
+  test("replaces Windows backslashes", t => {
+    t
+    ->expect(PathStringUtils.toForwardSlashes("src\\components\\Hero.vue"))
+    ->Expect.toBe("src/components/Hero.vue")
+  })
+
+  test("keeps POSIX paths unchanged", t => {
+    t
+    ->expect(PathStringUtils.toForwardSlashes("/src/components/Hero.vue"))
+    ->Expect.toBe("/src/components/Hero.vue")
+  })
+
+  test("handles mixed separators", t => {
+    t
+    ->expect(PathStringUtils.toForwardSlashes("C:\\Users\\dev/src\\views\\Home.vue"))
+    ->Expect.toBe("C:/Users/dev/src/views/Home.vue")
+  })
+})

--- a/libs/client/test/Client__SourcePath.test.res
+++ b/libs/client/test/Client__SourcePath.test.res
@@ -34,6 +34,12 @@ describe("extractFilename", () => {
     ->expect(SourcePath.extractFilename("C:\\project/src\\views/Home.vue"))
     ->Expect.toBe("Home.vue")
   })
+
+  test("handles repeated mixed separators", t => {
+    t
+    ->expect(SourcePath.extractFilename("C:\\Users\\dev/src\\components/Leaf.vue"))
+    ->Expect.toBe("Leaf.vue")
+  })
 })
 
 // ── isNodeModulesPath ──────────────────────────────────────────────────

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
@@ -5,6 +5,7 @@ module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanAiFrontmanCore.FrontmanCore__PathContext
+module PathStringUtils = FrontmanAiFrontmanCore.FrontmanCore__PathStringUtils
 
 let name = "get_client_pages"
 let visibleToAgent = true
@@ -56,15 +57,11 @@ let isDynamicSegment = (segment: string): bool => {
   analyzeDynamicSegment(segment) != Static
 }
 
-// Normalize path separators to forward slashes for cross-platform route conversion
-// Route paths are URL paths and always use forward slashes
-let toForwardSlashes = (path: string): string => path->String.replaceAll("\\", "/")
-
 // Convert file path to route path
 // Normalizes separators first since Path.join uses \ on Windows but routes need /
 let fileToRoute = (filePath: string): string => {
   filePath
-  ->toForwardSlashes
+  ->PathStringUtils.toForwardSlashes
   ->String.replaceRegExp(/\.(astro|md|mdx|html)$/, "")
   ->String.replaceRegExp(/\/index$/, "")
   ->(p => p == "" ? "/" : p)
@@ -125,7 +122,10 @@ let rec findPages = async (
         let routePath = fileToRoute(filePath)
         let filePathNoExt = filePath->String.replaceRegExp(/\.(astro|md|mdx|html)$/, "")
         // Normalize separators for cross-platform segment splitting
-        let segments = filePathNoExt->toForwardSlashes->String.split("/")
+        let segments =
+          filePathNoExt
+          ->PathStringUtils.toForwardSlashes
+          ->String.split("/")
         let hasDynamic = segments->Array.some(isDynamicSegment)
         let dynType = getMostSignificantDynamicType(segments)
         // Make path relative to sourceRoot so the agent can pass it

--- a/libs/frontman-core/README.md
+++ b/libs/frontman-core/README.md
@@ -26,6 +26,17 @@ Core server functionality shared across framework adapters, providing a composab
 - `SearchFiles` - File glob pattern matching
 - `LoadAgentInstructions` - Load agent configuration files
 
+## Tool-Call Path Guardrails
+
+Frontman Core applies path-recovery guardrails across `list_tree`, `search_files`, and `read_file` to reduce deterministic tool failures:
+
+- **Discovery before read**: `read_file` now blocks guessed missing paths and returns recovery guidance.
+- **Zero-result guardrail**: when `search_files` returns `totalResults = 0`, immediate guessed `read_file` retries for matching candidates are blocked.
+- **ENOENT recovery**: path-climb strategy finds the nearest existing parent, shows recovery context, and suggests discovered candidates.
+- **No semantic guessing**: responses prioritize discovered paths over inferred folder/name guesses.
+- **Structured search errors**: `search_files` backend failures include command, cwd, exit code, stderr, and target path.
+- **Path hints cache**: per-source-root anchors from successful discovery/read calls are reused for later recovery hints.
+
 ## Development
 
 Build the library:

--- a/libs/frontman-core/src/FrontmanCore__FilenamePattern.res
+++ b/libs/frontman-core/src/FrontmanCore__FilenamePattern.res
@@ -1,0 +1,26 @@
+// Case-insensitive filename matching used by search/listing guardrail helpers.
+// Supports a minimal glob-style wildcard `*` syntax.
+
+let matchesPattern = (~pattern: string, ~text: string): bool => {
+  let patternLower = pattern->String.toLowerCase
+  let textLower = text->String.toLowerCase
+
+  switch patternLower {
+  | "" => true
+  | p if p->String.includes("*") => {
+      let parts = p->String.split("*")
+      let partsLength = Array.length(parts)
+
+      parts->Array.reduceWithIndex(true, (matches, part, idx) =>
+        switch (matches, part) {
+        | (false, _) => false
+        | (_, "") => true
+        | _ if idx === 0 => textLower->String.startsWith(part)
+        | _ if idx === partsLength - 1 => textLower->String.endsWith(part)
+        | _ => textLower->String.includes(part)
+        }
+      )
+    }
+  | p => textLower->String.includes(p)
+  }
+}

--- a/libs/frontman-core/src/FrontmanCore__PathContext.res
+++ b/libs/frontman-core/src/FrontmanCore__PathContext.res
@@ -11,6 +11,7 @@
 
 module SafePath = FrontmanCore__SafePath
 module Path = FrontmanBindings.Path
+module PathStringUtils = FrontmanCore__PathStringUtils
 
 // ============================================
 // Types
@@ -55,7 +56,10 @@ let toRelativePath = (~sourceRoot: string, ~absolutePath: string): string => {
   }
 
   if absolutePath->String.startsWith(normalizedRoot) {
-    absolutePath->String.slice(~start=normalizedRoot->String.length, ~end=absolutePath->String.length)
+    absolutePath->String.slice(
+      ~start=normalizedRoot->String.length,
+      ~end=absolutePath->String.length,
+    )
   } else if absolutePath->String.startsWith(sourceRoot) {
     // Handle case where path matches exactly without trailing separator
     absolutePath->String.slice(~start=sourceRoot->String.length, ~end=absolutePath->String.length)
@@ -113,27 +117,27 @@ let resolveSearchDir = async (~sourceRoot: string, ~inputPath: option<string>): 
 // Path Confusion Detection
 // ============================================
 
-// Normalize path separators to forward slashes for cross-platform string operations
-let toForwardSlashes = (path: string): string => path->String.replaceAll("\\", "/")
-
 // Detect if agent might be confused about paths
 // e.g., asking for "web" when sourceRoot=/repo/web
 let detectPathConfusion = (~sourceRoot: string, ~requestedPath: string): option<string> => {
   // Normalize separators for consistent splitting on both Unix and Windows
   // Strip leading ./ or /
-  let normalizedPath = requestedPath
-    ->toForwardSlashes
-    ->String.replaceRegExp(%re("/^\.\//"), "")
-    ->String.replaceRegExp(%re("/^\//"), "")
+  let normalizedPath =
+    requestedPath
+    ->PathStringUtils.toForwardSlashes
+    ->String.replaceRegExp(/^\.\//, "")
+    ->String.replaceRegExp(/^\//, "")
 
   // Get first segment of requested path
   let firstSegment = normalizedPath->String.split("/")->Array.get(0)->Option.getOr("")
 
   // Check if first segment appears in sourceRoot path segments
-  let sourceSegments = sourceRoot->toForwardSlashes->String.split("/")
+  let sourceSegments = sourceRoot->PathStringUtils.toForwardSlashes->String.split("/")
 
   if firstSegment != "" && sourceSegments->Array.includes(firstSegment) {
-    Some(`Path '${requestedPath}' not found. The sourceRoot is '${sourceRoot}' which already includes '${firstSegment}/'. Try using '.' or a path relative to sourceRoot instead.`)
+    Some(
+      `Path '${requestedPath}' not found. The sourceRoot is '${sourceRoot}' which already includes '${firstSegment}/'. Try using '.' or a path relative to sourceRoot instead.`,
+    )
   } else {
     None
   }
@@ -163,7 +167,8 @@ let resolve = (~sourceRoot: string, ~inputPath: string): result<resolveResult, r
       resolvedPath,
       relativePath: toRelativePath(~sourceRoot, ~absolutePath=resolvedPath),
     })
-  | Error(msg) => Error({
+  | Error(msg) =>
+    Error({
       message: msg,
       hint: detectPathConfusion(~sourceRoot, ~requestedPath=inputPath),
       sourceRoot,

--- a/libs/frontman-core/src/FrontmanCore__PathRecovery.res
+++ b/libs/frontman-core/src/FrontmanCore__PathRecovery.res
@@ -1,0 +1,98 @@
+// Path-recovery helpers for resilient tool execution on missing paths.
+
+module Path = FrontmanBindings.Path
+module Fs = FrontmanBindings.Fs
+module FsUtils = FrontmanCore__FsUtils
+module PathContext = FrontmanCore__PathContext
+
+type recovery = {
+  nearestDir: string,
+  nearestDirRelative: string,
+  siblingEntries: array<string>,
+}
+
+let normalize = (path: string): string => Path.normalize(path)
+
+let rec nearestExistingDir = async (~sourceRoot: string, ~startPath: string): option<string> => {
+  let normalizedRoot = sourceRoot->normalize
+  let candidate = startPath->normalize
+
+  switch await FsUtils.dirExists(candidate) {
+  | true => Some(candidate)
+  | false =>
+    switch candidate == normalizedRoot {
+    | true =>
+      switch await FsUtils.dirExists(normalizedRoot) {
+      | true => Some(normalizedRoot)
+      | false => None
+      }
+    | false =>
+      let parent = candidate->Path.dirname->normalize
+
+      switch parent == candidate || !(parent->String.startsWith(normalizedRoot)) {
+      | true =>
+        switch await FsUtils.dirExists(normalizedRoot) {
+        | true => Some(normalizedRoot)
+        | false => None
+        }
+      | false => await nearestExistingDir(~sourceRoot=normalizedRoot, ~startPath=parent)
+      }
+    }
+  }
+}
+
+let sortStrings = (items: array<string>): array<string> => {
+  items->Array.toSorted((a, b) => {
+    switch String.compare(a, b) {
+    | n if n < 0.0 => -1.0
+    | n if n > 0.0 => 1.0
+    | _ => 0.0
+    }
+  })
+}
+
+let readSiblingEntries = async (~dirPath: string, ~limit: int=12): array<string> => {
+  try {
+    let entries = await Fs.Promises.readdir(dirPath)
+    let sorted = entries->sortStrings
+    let visible = sorted->Array.slice(~start=0, ~end=limit)
+
+    await visible
+    ->Array.map(async entryName => {
+      let entryPath = Path.join([dirPath, entryName])
+
+      try {
+        let stats = await Fs.Promises.stat(entryPath)
+        switch Fs.isDirectory(stats) {
+        | true => entryName ++ "/"
+        | false => entryName
+        }
+      } catch {
+      | _ => entryName
+      }
+    })
+    ->Promise.all
+  } catch {
+  | _ => []
+  }
+}
+
+let recoverMissingPath = async (
+  ~sourceRoot: string,
+  ~resolvedPath: string,
+  ~entryLimit: int=12,
+): option<recovery> => {
+  let startDir = resolvedPath->Path.dirname
+
+  switch await nearestExistingDir(~sourceRoot, ~startPath=startDir) {
+  | None => None
+  | Some(nearestDir) =>
+    let siblingEntries = await readSiblingEntries(~dirPath=nearestDir, ~limit=entryLimit)
+
+    Some({
+      nearestDir,
+      nearestDirRelative: PathContext.toRelativePath(~sourceRoot, ~absolutePath=nearestDir),
+      siblingEntries,
+    })
+  }
+}

--- a/libs/frontman-core/src/FrontmanCore__PathRecovery.res
+++ b/libs/frontman-core/src/FrontmanCore__PathRecovery.res
@@ -13,12 +13,27 @@ type recovery = {
 
 let normalize = (path: string): string => Path.normalize(path)
 
+let isUnderSourceRoot = (~candidate: string, ~sourceRoot: string): bool => {
+  switch sourceRoot {
+  | "/" => candidate->String.startsWith("/")
+  | root => candidate == root || candidate->String.startsWith(root ++ "/")
+  }
+}
+
 let rec nearestExistingDir = async (~sourceRoot: string, ~startPath: string): option<string> => {
   let normalizedRoot = sourceRoot->normalize
   let candidate = startPath->normalize
 
   switch await FsUtils.dirExists(candidate) {
-  | true => Some(candidate)
+  | true =>
+    switch isUnderSourceRoot(~candidate, ~sourceRoot=normalizedRoot) {
+    | true => Some(candidate)
+    | false =>
+      switch await FsUtils.dirExists(normalizedRoot) {
+      | true => Some(normalizedRoot)
+      | false => None
+      }
+    }
   | false =>
     switch candidate == normalizedRoot {
     | true =>
@@ -29,7 +44,8 @@ let rec nearestExistingDir = async (~sourceRoot: string, ~startPath: string): op
     | false =>
       let parent = candidate->Path.dirname->normalize
 
-      switch parent == candidate || !(parent->String.startsWith(normalizedRoot)) {
+      switch parent == candidate ||
+        !isUnderSourceRoot(~candidate=parent, ~sourceRoot=normalizedRoot) {
       | true =>
         switch await FsUtils.dirExists(normalizedRoot) {
         | true => Some(normalizedRoot)

--- a/libs/frontman-core/src/FrontmanCore__PathStringUtils.res
+++ b/libs/frontman-core/src/FrontmanCore__PathStringUtils.res
@@ -1,0 +1,1 @@
+let toForwardSlashes = (path: string): string => path->String.replaceAll("\\", "/")

--- a/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
@@ -6,6 +6,8 @@
 
 module Path = FrontmanBindings.Path
 module PathContext = FrontmanCore__PathContext
+module FilenamePattern = FrontmanCore__FilenamePattern
+module PathStringUtils = FrontmanCore__PathStringUtils
 
 type zeroSearch = {
   pattern: string,
@@ -37,8 +39,6 @@ let emptyState = (): state => {
   zeroSearches: [],
 }
 
-let normalizeSlashes = (path: string): string => path->String.replaceAll("\\", "/")
-
 let stripLeadingDotSlash = (path: string): string => {
   path->String.replaceRegExp(/^\.\//, "")
 }
@@ -48,7 +48,7 @@ let stripLeadingSlash = (path: string): string => {
 }
 
 let normalizePath = (path: string): string => {
-  let normalized = path->normalizeSlashes->stripLeadingDotSlash->stripLeadingSlash
+  let normalized = path->PathStringUtils.toForwardSlashes->stripLeadingDotSlash->stripLeadingSlash
 
   switch normalized {
   | "" => "."
@@ -105,31 +105,6 @@ let normalizeFileRelativeToSearchRoot = (
 
       normalizeRelativeToRoot(~sourceRoot, ~path=prefixedPath)
     }
-  }
-}
-
-// Same matching rules as search_files: case-insensitive + wildcard support.
-let patternMatchesFileName = (~pattern: string, ~fileName: string): bool => {
-  let patternLower = pattern->String.toLowerCase
-  let fileNameLower = fileName->String.toLowerCase
-
-  switch patternLower {
-  | "" => true
-  | p if p->String.includes("*") => {
-      let parts = p->String.split("*")
-      let partsLength = Array.length(parts)
-
-      parts->Array.reduceWithIndex(true, (matches, part, idx) =>
-        switch (matches, part) {
-        | (false, _) => false
-        | (_, "") => true
-        | _ if idx == 0 => fileNameLower->String.startsWith(part)
-        | _ if idx == partsLength - 1 => fileNameLower->String.endsWith(part)
-        | _ => fileNameLower->String.includes(part)
-        }
-      )
-    }
-  | p => fileNameLower->String.includes(p)
   }
 }
 
@@ -254,7 +229,7 @@ let findBlockingZeroSearch = (~sourceRoot: string, ~requestedRelativePath: strin
 
     state.zeroSearches->Array.find(z => {
       isFreshZeroSearch(~nowMs, z) &&
-      patternMatchesFileName(~pattern=z.pattern, ~fileName) &&
+      FilenamePattern.matchesPattern(~pattern=z.pattern, ~text=fileName) &&
       pathIsUnderSearchRoot(~requestedPath, ~searchRoot=z.searchRoot)
     })
   }

--- a/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
@@ -43,8 +43,12 @@ let stripLeadingDotSlash = (path: string): string => {
   path->String.replaceRegExp(/^\.\//, "")
 }
 
+let stripLeadingSlash = (path: string): string => {
+  path->String.replaceRegExp(/^\//, "")
+}
+
 let normalizePath = (path: string): string => {
-  let normalized = path->normalizeSlashes->stripLeadingDotSlash
+  let normalized = path->normalizeSlashes->stripLeadingDotSlash->stripLeadingSlash
 
   switch normalized {
   | "" => "."
@@ -87,6 +91,21 @@ let normalizeRelativeToRoot = (~sourceRoot: string, ~path: string): string => {
   }
 
   relative->normalizePath
+}
+
+let normalizeFileRelativeToSearchRoot = (
+  ~sourceRoot: string,
+  ~searchPath: string,
+  ~filePath: string,
+): string => {
+  switch Path.isAbsolute(filePath) {
+  | true => normalizeRelativeToRoot(~sourceRoot, ~path=filePath)
+  | false => {
+      let prefixedPath = Path.join([searchPath, filePath])
+
+      normalizeRelativeToRoot(~sourceRoot, ~path=prefixedPath)
+    }
+  }
 }
 
 // Same matching rules as search_files: case-insensitive + wildcard support.
@@ -151,7 +170,7 @@ let recordSearch = (
   let reduced = files->Array.reduce(
     ({nextAnchors: seededAnchors, nextKnownFiles: state.knownFiles}: searchReduce),
     (acc, filePath) => {
-      let normalizedFile = normalizeRelativeToRoot(~sourceRoot, ~path=filePath)
+      let normalizedFile = normalizeFileRelativeToSearchRoot(~sourceRoot, ~searchPath, ~filePath)
       let nextKnownFiles =
         acc.nextKnownFiles->addUniqueBounded(normalizedFile, ~maxItems=maxKnownFiles)
       let anchors =

--- a/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolPathHints.res
@@ -1,0 +1,250 @@
+// Shared per-sourceRoot path hints for tool-call guardrails.
+//
+// The cache stores high-confidence anchors discovered during a session
+// (list_tree/list_files/search_files/read_file) plus recent zero-result
+// search patterns so read_file can block deterministic guess-reads.
+
+module Path = FrontmanBindings.Path
+module PathContext = FrontmanCore__PathContext
+
+type zeroSearch = {
+  pattern: string,
+  searchRoot: string,
+  timestampMs: float,
+}
+
+type state = {
+  anchors: array<string>,
+  knownFiles: array<string>,
+  zeroSearches: array<zeroSearch>,
+}
+
+type searchReduce = {
+  nextAnchors: array<string>,
+  nextKnownFiles: array<string>,
+}
+
+let maxAnchors = 32
+let maxKnownFiles = 400
+let maxZeroSearches = 24
+let zeroSearchTtlMs = 5.0 *. 60.0 *. 1000.0
+
+let states: ref<Dict.t<state>> = ref(Dict.make())
+
+let emptyState = (): state => {
+  anchors: [],
+  knownFiles: [],
+  zeroSearches: [],
+}
+
+let normalizeSlashes = (path: string): string => path->String.replaceAll("\\", "/")
+
+let stripLeadingDotSlash = (path: string): string => {
+  path->String.replaceRegExp(/^\.\//, "")
+}
+
+let normalizePath = (path: string): string => {
+  let normalized = path->normalizeSlashes->stripLeadingDotSlash
+
+  switch normalized {
+  | "" => "."
+  | p if p->String.endsWith("/") => p->String.slice(~start=0, ~end=p->String.length - 1)
+  | p => p
+  }
+}
+
+let getState = (sourceRoot: string): state => {
+  switch states.contents->Dict.get(sourceRoot) {
+  | Some(existing) => existing
+  | None => emptyState()
+  }
+}
+
+let putState = (sourceRoot: string, nextState: state): unit => {
+  states.contents->Dict.set(sourceRoot, nextState)
+}
+
+let addUniqueBounded = (items: array<string>, value: string, ~maxItems: int): array<string> => {
+  let normalized = value->normalizePath
+
+  switch (normalized == "" || normalized == ".", items->Array.includes(normalized)) {
+  | (true, _) => items
+  | (_, true) => items
+  | _ =>
+    let withPrepended = Array.concat([normalized], items)
+
+    switch Array.length(withPrepended) > maxItems {
+    | true => withPrepended->Array.slice(~start=0, ~end=maxItems)
+    | false => withPrepended
+    }
+  }
+}
+
+let normalizeRelativeToRoot = (~sourceRoot: string, ~path: string): string => {
+  let relative = switch Path.isAbsolute(path) {
+  | true => PathContext.toRelativePath(~sourceRoot, ~absolutePath=path)
+  | false => path
+  }
+
+  relative->normalizePath
+}
+
+// Same matching rules as search_files: case-insensitive + wildcard support.
+let patternMatchesFileName = (~pattern: string, ~fileName: string): bool => {
+  let patternLower = pattern->String.toLowerCase
+  let fileNameLower = fileName->String.toLowerCase
+
+  switch patternLower {
+  | "" => true
+  | p if p->String.includes("*") => {
+      let parts = p->String.split("*")
+      let partsLength = Array.length(parts)
+
+      parts->Array.reduceWithIndex(true, (matches, part, idx) =>
+        switch (matches, part) {
+        | (false, _) => false
+        | (_, "") => true
+        | _ if idx == 0 => fileNameLower->String.startsWith(part)
+        | _ if idx == partsLength - 1 => fileNameLower->String.endsWith(part)
+        | _ => fileNameLower->String.includes(part)
+        }
+      )
+    }
+  | p => fileNameLower->String.includes(p)
+  }
+}
+
+let pathIsUnderSearchRoot = (~requestedPath: string, ~searchRoot: string): bool => {
+  switch searchRoot {
+  | "." => true
+  | root =>
+    let requestedDir = requestedPath->Path.dirname->normalizePath
+    requestedDir == root || requestedDir->String.startsWith(root ++ "/")
+  }
+}
+
+let removeZeroSearch = (
+  zeroSearches: array<zeroSearch>,
+  ~pattern: string,
+  ~searchRoot: string,
+): array<zeroSearch> => {
+  zeroSearches->Array.filter(z => !(z.pattern == pattern && z.searchRoot == searchRoot))
+}
+
+let isFreshZeroSearch = (~nowMs: float, zeroSearch: zeroSearch): bool => {
+  nowMs -. zeroSearch.timestampMs <= zeroSearchTtlMs
+}
+
+let recordSearch = (
+  ~sourceRoot: string,
+  ~searchPath: string,
+  ~pattern: string,
+  ~files: array<string>,
+  ~totalResults: int,
+): unit => {
+  let state = getState(sourceRoot)
+  let normalizedSearchRoot = normalizeRelativeToRoot(~sourceRoot, ~path=searchPath)
+  let nowMs = Date.now()
+
+  let seededAnchors = state.anchors->addUniqueBounded(normalizedSearchRoot, ~maxItems=maxAnchors)
+
+  let reduced = files->Array.reduce(
+    ({nextAnchors: seededAnchors, nextKnownFiles: state.knownFiles}: searchReduce),
+    (acc, filePath) => {
+      let normalizedFile = normalizeRelativeToRoot(~sourceRoot, ~path=filePath)
+      let nextKnownFiles =
+        acc.nextKnownFiles->addUniqueBounded(normalizedFile, ~maxItems=maxKnownFiles)
+      let anchors =
+        acc.nextAnchors->addUniqueBounded(
+          normalizedFile->Path.dirname->normalizePath,
+          ~maxItems=maxAnchors,
+        )
+
+      {nextAnchors: anchors, nextKnownFiles}
+    },
+  )
+
+  let cleanedZeroSearches =
+    state.zeroSearches
+    ->Array.filter(z => isFreshZeroSearch(~nowMs, z))
+    ->removeZeroSearch(~pattern, ~searchRoot=normalizedSearchRoot)
+
+  let zeroSearches = switch totalResults == 0 {
+  | true => {
+      let withPrepended = Array.concat(
+        [
+          {
+            pattern,
+            searchRoot: normalizedSearchRoot,
+            timestampMs: nowMs,
+          },
+        ],
+        cleanedZeroSearches,
+      )
+
+      switch Array.length(withPrepended) > maxZeroSearches {
+      | true => withPrepended->Array.slice(~start=0, ~end=maxZeroSearches)
+      | false => withPrepended
+      }
+    }
+  | false => cleanedZeroSearches
+  }
+
+  putState(
+    sourceRoot,
+    {
+      anchors: reduced.nextAnchors,
+      knownFiles: reduced.nextKnownFiles,
+      zeroSearches,
+    },
+  )
+}
+
+let recordReadSuccess = (~sourceRoot: string, ~relativePath: string): unit => {
+  let state = getState(sourceRoot)
+  let normalizedFile = normalizeRelativeToRoot(~sourceRoot, ~path=relativePath)
+  let knownFiles = state.knownFiles->addUniqueBounded(normalizedFile, ~maxItems=maxKnownFiles)
+  let anchors =
+    state.anchors->addUniqueBounded(
+      normalizedFile->Path.dirname->normalizePath,
+      ~maxItems=maxAnchors,
+    )
+
+  putState(sourceRoot, {...state, knownFiles, anchors})
+}
+
+let recordListAnchor = (~sourceRoot: string, ~path: string): unit => {
+  let state = getState(sourceRoot)
+  let normalizedPath = normalizeRelativeToRoot(~sourceRoot, ~path)
+  let anchors = state.anchors->addUniqueBounded(normalizedPath, ~maxItems=maxAnchors)
+
+  putState(sourceRoot, {...state, anchors})
+}
+
+let findBlockingZeroSearch = (~sourceRoot: string, ~requestedRelativePath: string): option<
+  zeroSearch,
+> => {
+  let state = getState(sourceRoot)
+  let requestedPath = requestedRelativePath->normalizePath
+  let nowMs = Date.now()
+
+  switch state.knownFiles->Array.includes(requestedPath) {
+  | true => None
+  | false =>
+    let fileName = requestedPath->Path.basename
+
+    state.zeroSearches->Array.find(z => {
+      isFreshZeroSearch(~nowMs, z) &&
+      patternMatchesFileName(~pattern=z.pattern, ~fileName) &&
+      pathIsUnderSearchRoot(~requestedPath, ~searchRoot=z.searchRoot)
+    })
+  }
+}
+
+let getAnchors = (~sourceRoot: string): array<string> => {
+  getState(sourceRoot).anchors
+}
+
+let clear = (): unit => {
+  states := Dict.make()
+}

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
@@ -5,6 +5,7 @@ module Fs = FrontmanBindings.Fs
 module ChildProcess = FrontmanCore__ChildProcess
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
+module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.listFiles
 let visibleToAgent = true
@@ -100,6 +101,8 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
           }
         })
         ->Promise.all
+
+        ToolPathHints.recordListAnchor(~sourceRoot=ctx.sourceRoot, ~path=relativePath)
 
         Ok(entriesWithStats)
       }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
@@ -9,6 +9,8 @@ module ChildProcess = FrontmanCore__ChildProcess
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 module FsUtils = FrontmanCore__FsUtils
+module PathRecovery = FrontmanCore__PathRecovery
+module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.listTree
 let visibleToAgent = true
@@ -44,14 +46,10 @@ type output = {
 
 // Sury schemas for parsing package.json fields
 @schema
-type packageJsonName = {
-  name?: string,
-}
+type packageJsonName = {name?: string}
 
 @schema
-type packageJsonWorkspacesObj = {
-  packages?: array<string>,
-}
+type packageJsonWorkspacesObj = {packages?: array<string>}
 
 // Directories to always skip in the tree output
 let noiseDirs = [
@@ -155,14 +153,15 @@ let getSortedChildren = (node: trieNode): array<sortedEntry> => {
   })
 }
 
-let renderTree = (
-  root: trieNode,
-  ~maxDepth: int,
-  ~workspacePaths: Dict.t<string>,
-): string => {
+let renderTree = (root: trieNode, ~maxDepth: int, ~workspacePaths: Dict.t<string>): string => {
   let lines: array<string> = []
 
-  let rec walk = (node: trieNode, ~prefix: string, ~currentDepth: int, ~parentPath: option<string>) => {
+  let rec walk = (
+    node: trieNode,
+    ~prefix: string,
+    ~currentDepth: int,
+    ~parentPath: option<string>,
+  ) => {
     switch currentDepth > maxDepth {
     | true => ()
     | false =>
@@ -211,7 +210,12 @@ let renderTree = (
 
         switch entry.isDir {
         | true =>
-          walk(entry.node, ~prefix=childPrefix, ~currentDepth=currentDepth + 1, ~parentPath=Some(entryRelPath))
+          walk(
+            entry.node,
+            ~prefix=childPrefix,
+            ~currentDepth=currentDepth + 1,
+            ~parentPath=Some(entryRelPath),
+          )
         | false => ()
         }
       })
@@ -246,8 +250,7 @@ let readJsonFile = async (path: string): result<JSON.t, string> => {
     Ok(JSON.parseOrThrow(content))
   } catch {
   | exn =>
-    let msg =
-      exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
     Error(`Failed to read/parse ${path}: ${msg}`)
   }
 }
@@ -307,17 +310,16 @@ let resolveWorkspaceGlobs = async (rootPath: string, globs: array<string>): arra
       let fullParent = Path.join([rootPath, parentDir])
       try {
         let entries = await Fs.Promises.readdir(fullParent)
-        let _ =
-          await entries
-          ->Array.map(async entry => {
-            let entryPath = Path.join([fullParent, entry])
-            let stats = await Fs.Promises.stat(entryPath)
-            switch Fs.isDirectory(stats) {
-            | true => results->Array.push(parentDir ++ "/" ++ entry)
-            | false => ()
-            }
-          })
-          ->Promise.all
+        let _ = await entries
+        ->Array.map(async entry => {
+          let entryPath = Path.join([fullParent, entry])
+          let stats = await Fs.Promises.stat(entryPath)
+          switch Fs.isDirectory(stats) {
+          | true => results->Array.push(parentDir ++ "/" ++ entry)
+          | false => ()
+          }
+        })
+        ->Promise.all
       } catch {
       | exn =>
         let msg =
@@ -353,9 +355,9 @@ let detectMonorepo = async (rootPath: string): monorepoInfo => {
   }
 
   // Detect monorepo type indicators
-    let hasTurbo = await FsUtils.pathExists(Path.join([rootPath, "turbo.json"]))
-    let hasNx = await FsUtils.pathExists(Path.join([rootPath, "nx.json"]))
-    let hasPnpmWorkspace = await FsUtils.pathExists(Path.join([rootPath, "pnpm-workspace.yaml"]))
+  let hasTurbo = await FsUtils.pathExists(Path.join([rootPath, "turbo.json"]))
+  let hasNx = await FsUtils.pathExists(Path.join([rootPath, "nx.json"]))
+  let hasPnpmWorkspace = await FsUtils.pathExists(Path.join([rootPath, "pnpm-workspace.yaml"]))
 
   // Determine monorepo type
   let monorepoType = switch (workspaceGlobs, hasTurbo, hasNx, hasPnpmWorkspace) {
@@ -413,7 +415,7 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
     try {
       // If the agent passed a file path, use its parent directory instead.
       // ListTree is directory-centric — a file path means "show the tree near this file".
-      let fullPath = try {
+      let initialPath = try {
         let stats = await Fs.Promises.stat(result.resolvedPath)
         switch Fs.isFile(stats) {
         | true => Path.dirname(result.resolvedPath)
@@ -423,37 +425,63 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
       | _ => result.resolvedPath
       }
 
-      // Get tracked files
-      let filesResult = await getTrackedFiles(~cwd=fullPath)
+      // Path-climb recovery: when the requested directory does not exist,
+      // climb to the nearest existing parent and continue discovery there.
+      let nearestDir = await PathRecovery.nearestExistingDir(
+        ~sourceRoot=ctx.sourceRoot,
+        ~startPath=initialPath,
+      )
 
-      let files = switch filesResult {
-      | Ok(f) => f
-      | Error(errMsg) =>
-        // Fallback: single-level readdir if not a git repo.
-        // Known limitation: produces a flat list (depth 1) regardless of the
-        // depth parameter because readdir returns filenames, not nested paths.
-        Console.warn(`ListTree: ${errMsg}, falling back to readdir`)
-        let entries = await Fs.Promises.readdir(fullPath)
-        entries
+      switch nearestDir {
+      | None => Error(`Failed to list tree for ${path}: no existing directory found`)
+      | Some(fullPath) =>
+        let requestedRecovered = Path.normalize(fullPath) != Path.normalize(initialPath)
+        let relativeFullPath = PathContext.toRelativePath(
+          ~sourceRoot=ctx.sourceRoot,
+          ~absolutePath=fullPath,
+        )
+
+        // Get tracked files
+        let filesResult = await getTrackedFiles(~cwd=fullPath)
+
+        let files = switch filesResult {
+        | Ok(f) => f
+        | Error(errMsg) =>
+          // Fallback: single-level readdir if not a git repo.
+          // Known limitation: produces a flat list (depth 1) regardless of the
+          // depth parameter because readdir returns filenames, not nested paths.
+          Console.warn(`ListTree: ${errMsg}, falling back to readdir`)
+          let entries = await Fs.Promises.readdir(fullPath)
+          entries
+        }
+
+        // Build trie
+        let trie = buildTrie(files)
+
+        // Detect monorepo (only at the resolved root)
+        let monoInfo = await detectMonorepo(fullPath)
+
+        // Build workspace path lookup for annotations
+        let workspacePaths = buildWorkspacePathLookup(monoInfo.workspaces)
+
+        // Render
+        let renderedTree = renderTree(trie, ~maxDepth, ~workspacePaths)
+
+        let tree = switch requestedRecovered {
+        | true =>
+          `[recovered] requested path "${path}" was not found. Showing nearest existing directory "${relativeFullPath}".\n` ++
+          renderedTree
+        | false => renderedTree
+        }
+
+        ToolPathHints.recordListAnchor(~sourceRoot=ctx.sourceRoot, ~path=relativeFullPath)
+
+        Ok({
+          tree,
+          workspaces: monoInfo.workspaces,
+          monorepoType: monoInfo.monorepoType,
+        })
       }
-
-      // Build trie
-      let trie = buildTrie(files)
-
-      // Detect monorepo (only at the resolved root)
-      let monoInfo = await detectMonorepo(fullPath)
-
-      // Build workspace path lookup for annotations
-      let workspacePaths = buildWorkspacePathLookup(monoInfo.workspaces)
-
-      // Render
-      let tree = renderTree(trie, ~maxDepth, ~workspacePaths)
-
-      Ok({
-        tree,
-        workspaces: monoInfo.workspaces,
-        monorepoType: monoInfo.monorepoType,
-      })
     } catch {
     | exn =>
       let msg =

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
@@ -1,8 +1,14 @@
 // Read file tool - reads file content with optional offset/limit
 
 module Fs = FrontmanBindings.Fs
+module Path = FrontmanBindings.Path
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
+module FsUtils = FrontmanCore__FsUtils
+module SearchFiles = FrontmanCore__Tool__SearchFiles
+module ListTree = FrontmanCore__Tool__ListTree
+module PathRecovery = FrontmanCore__PathRecovery
+module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.readFile
 let visibleToAgent = true
@@ -44,6 +50,170 @@ type output = {
   _context?: pathContext,
 }
 
+let sortStrings = (items: array<string>): array<string> => {
+  items->Array.toSorted((a, b) => {
+    switch String.compare(a, b) {
+    | n if n < 0.0 => -1.0
+    | n if n > 0.0 => 1.0
+    | _ => 0.0
+    }
+  })
+}
+
+let previewLines = (text: string, ~maxLines: int): string => {
+  let lines = text->String.split("\n")
+  let visible = lines->Array.slice(~start=0, ~end=maxLines)
+  let suffix = switch Array.length(lines) > maxLines {
+  | true => "\n..."
+  | false => ""
+  }
+
+  visible->Array.join("\n") ++ suffix
+}
+
+let readResolvedFile = async (
+  ~ctx: Tool.serverExecutionContext,
+  ~resolved: PathContext.resolveResult,
+  ~offset: int,
+  ~limit: int,
+): Tool.toolResult<output> => {
+  try {
+    let stats = await Fs.Promises.stat(resolved.resolvedPath)
+    let content = await Fs.Promises.readFile(resolved.resolvedPath)
+    let lines = content->String.split("\n")
+    let totalLines = lines->Array.length
+
+    let selectedLines = lines->Array.slice(~start=offset, ~end=offset + limit)
+    let selectedContent = selectedLines->Array.join("\n")
+    let hasMore = offset + limit < totalLines
+
+    // Track that this file was read (for edit_file safety)
+    FrontmanCore__FileTracker.recordRead(
+      resolved.resolvedPath,
+      ~offset,
+      ~limit,
+      ~totalLines,
+      ~mtimeMs=Fs.mtimeMs(stats),
+      ~size=Fs.size(stats),
+    )
+
+    ToolPathHints.recordReadSuccess(~sourceRoot=ctx.sourceRoot, ~relativePath=resolved.relativePath)
+
+    Ok({
+      content: selectedContent,
+      totalLines,
+      hasMore,
+      _context: {
+        sourceRoot: resolved.sourceRoot,
+        resolvedPath: resolved.resolvedPath,
+        relativePath: resolved.relativePath,
+      },
+    })
+  } catch {
+  | exn =>
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    Error(`Failed to read file ${resolved.relativePath}: ${msg}`)
+  }
+}
+
+let buildMissingPathError = async (
+  ~ctx: Tool.serverExecutionContext,
+  ~requestedPath: string,
+  ~resolved: PathContext.resolveResult,
+): string => {
+  let zeroSearch = ToolPathHints.findBlockingZeroSearch(
+    ~sourceRoot=ctx.sourceRoot,
+    ~requestedRelativePath=resolved.relativePath,
+  )
+
+  let zeroSearchMsg = switch zeroSearch {
+  | Some(z) =>
+    `Zero-result guardrail: search_files pattern "${z.pattern}" returned 0 results under "${z.searchRoot}". Blind read_file retries are blocked.`
+  | None => "Discovery-before-read guardrail: path is unknown and does not exist. Use discovery tools before retrying read_file."
+  }
+
+  let anchors = ToolPathHints.getAnchors(~sourceRoot=ctx.sourceRoot)->Array.slice(~start=0, ~end=6)
+
+  switch await PathRecovery.recoverMissingPath(
+    ~sourceRoot=ctx.sourceRoot,
+    ~resolvedPath=resolved.resolvedPath,
+  ) {
+  | None => {
+      let anchorsLine = switch anchors {
+      | [] => ""
+      | _ => "\nKnown anchors: " ++ anchors->sortStrings->Array.join(", ")
+      }
+
+      `File not found: ${requestedPath}
+Resolved path: ${resolved.relativePath}
+${zeroSearchMsg}${anchorsLine}
+
+Next steps:
+- broaden search_files pattern
+- run list_tree on a nearby parent directory
+- retry read_file only with a discovered path`
+    }
+
+  | Some(recovery) =>
+    let siblingPreview = switch recovery.siblingEntries {
+    | [] => "(none)"
+    | entries => entries->Array.join(", ")
+    }
+
+    let basename = resolved.relativePath->Path.basename
+
+    let candidateFiles = switch await SearchFiles.execute(
+      ctx,
+      {
+        pattern: basename,
+        path: ?Some(recovery.nearestDirRelative),
+        maxResults: ?Some(8),
+      },
+    ) {
+    | Ok(output) => output.files
+    | Error(_) => []
+    }
+
+    let candidatesLine = switch candidateFiles {
+    | [] => "Candidate files: (none)"
+    | files => "Candidate files: " ++ files->Array.join(", ")
+    }
+
+    let treePreview = switch await ListTree.execute(
+      ctx,
+      {
+        path: ?Some(recovery.nearestDirRelative),
+        depth: ?Some(2),
+      },
+    ) {
+    | Ok(output) => Some(output.tree->previewLines(~maxLines=20))
+    | Error(_) => None
+    }
+
+    let treeSection = switch treePreview {
+    | Some(tree) => "\nRecovered tree preview:\n" ++ tree
+    | None => ""
+    }
+
+    let anchorsLine = switch anchors {
+    | [] => ""
+    | _ => "\nKnown anchors: " ++ anchors->sortStrings->Array.join(", ")
+    }
+
+    `File not found: ${requestedPath}
+Resolved path: ${resolved.relativePath}
+${zeroSearchMsg}
+Nearest existing parent: ${recovery.nearestDirRelative}
+Parent entries: ${siblingPreview}
+${candidatesLine}${anchorsLine}${treeSection}
+
+Next steps:
+- broaden search_files pattern if candidates are empty
+- use list_tree/list_files around ${recovery.nearestDirRelative}
+- retry read_file only with a discovered path`
+  }
+}
+
 let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolResult<output> => {
   let offset = input.offset->Option.getOr(0)
   let limit = input.limit->Option.getOr(500)
@@ -51,41 +221,9 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolR
   switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
   | Error(err) => Error(PathContext.formatError(err))
   | Ok(result) =>
-    try {
-      let stats = await Fs.Promises.stat(result.resolvedPath)
-      let content = await Fs.Promises.readFile(result.resolvedPath)
-      let lines = content->String.split("\n")
-      let totalLines = lines->Array.length
-
-      let selectedLines = lines->Array.slice(~start=offset, ~end=offset + limit)
-      let selectedContent = selectedLines->Array.join("\n")
-      let hasMore = offset + limit < totalLines
-
-      // Track that this file was read (for edit_file safety)
-      FrontmanCore__FileTracker.recordRead(
-        result.resolvedPath,
-        ~offset,
-        ~limit,
-        ~totalLines,
-        ~mtimeMs=Fs.mtimeMs(stats),
-        ~size=Fs.size(stats),
-      )
-
-      Ok({
-        content: selectedContent,
-        totalLines,
-        hasMore,
-        _context: {
-          sourceRoot: result.sourceRoot,
-          resolvedPath: result.resolvedPath,
-          relativePath: result.relativePath,
-        },
-      })
-    } catch {
-    | exn =>
-      let msg =
-        exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
-      Error(`Failed to read file ${input.path}: ${msg}`)
+    switch await FsUtils.fileExists(result.resolvedPath) {
+    | true => await readResolvedFile(~ctx, ~resolved=result, ~offset, ~limit)
+    | false => Error(await buildMissingPathError(~ctx, ~requestedPath=input.path, ~resolved=result))
     }
   }
 }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -4,6 +4,8 @@ module Path = FrontmanBindings.Path
 module ChildProcess = FrontmanCore__ChildProcess
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
+module PathRecovery = FrontmanCore__PathRecovery
+module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.searchFiles
 let visibleToAgent = true
@@ -41,6 +43,16 @@ type output = {
   files: array<string>,
   totalResults: int,
   truncated: bool,
+}
+
+type backendError = {
+  backend: string,
+  command: string,
+  cwd: string,
+  exitCode: option<int>,
+  stderr: string,
+  message: string,
+  targetPath: string,
 }
 
 // Get ripgrep path from @vscode/ripgrep package
@@ -116,13 +128,68 @@ let filterAndPaginate = (lines: array<string>, ~pattern: string, ~maxResults: in
   }
 }
 
+let trimForError = (value: string): string => {
+  let trimmed = value->String.trim
+  switch trimmed == "" {
+  | true => "(empty)"
+  | false => trimmed
+  }
+}
+
+let formatExitCode = (code: option<int>): string => {
+  switch code {
+  | Some(value) => Int.toString(value)
+  | None => "none"
+  }
+}
+
+let makeBackendError = (
+  ~backend: string,
+  ~command: string,
+  ~cwd: string,
+  ~exitCode: option<int>,
+  ~stderr: string,
+  ~message: string,
+  ~targetPath: string,
+): backendError => {
+  {
+    backend,
+    command,
+    cwd,
+    exitCode,
+    stderr,
+    message,
+    targetPath,
+  }
+}
+
+let formatBackendError = (err: backendError): string => {
+  `search_files backend failure (${err.backend})
+command: ${err.command}
+cwd: ${err.cwd}
+exit_code: ${formatExitCode(err.exitCode)}
+stderr: ${trimForError(err.stderr)}
+message: ${trimForError(err.message)}
+target_path: ${err.targetPath}`
+}
+
+let formatFallbackError = (~firstError: backendError, ~secondError: backendError): string => {
+  `search_files failed in both backends.
+
+primary:
+${formatBackendError(firstError)}
+
+fallback:
+${formatBackendError(secondError)}`
+}
+
 // Execute ripgrep for file search using spawn (no shell)
 let executeRipgrep = async (
   ~rgPath: string,
   ~pattern: string,
   ~searchPath: string,
   ~maxResults: int,
-): result<output, string> => {
+): result<output, backendError> => {
   let args = buildRipgrepArgs(~searchPath)
 
   let result = await ChildProcess.spawnResult(rgPath, args)
@@ -135,18 +202,28 @@ let executeRipgrep = async (
   | Error({code: Some(1), _}) =>
     // Exit code 1 means no matches found
     Ok({files: [], totalResults: 0, truncated: false})
-  | Error({stderr}) => Error(`Ripgrep failed: ${stderr}`)
+  | Error({code, stderr, message, _}) =>
+    Error(
+      makeBackendError(
+        ~backend="ripgrep",
+        ~command=rgPath ++ " --files --hidden --no-ignore " ++ searchPath,
+        ~cwd=searchPath,
+        ~exitCode=code,
+        ~stderr,
+        ~message,
+        ~targetPath=searchPath,
+      ),
+    )
   }
 }
 
 // Execute git ls-files using spawn (no shell) and filter results in-process.
 // The old approach piped through `grep -i` via a shell string, which broke on
 // patterns containing spaces or special characters.
-let executeGitLsFiles = async (
-  ~pattern: string,
-  ~searchPath: string,
-  ~maxResults: int,
-): result<output, string> => {
+let executeGitLsFiles = async (~pattern: string, ~searchPath: string, ~maxResults: int): result<
+  output,
+  backendError,
+> => {
   let result = await ChildProcess.spawnResult("git", ["ls-files"], ~cwd=searchPath)
 
   switch result {
@@ -157,35 +234,77 @@ let executeGitLsFiles = async (
   | Error({code: Some(1), _}) =>
     // Exit code 1 means no matches found
     Ok({files: [], totalResults: 0, truncated: false})
-  | Error({stderr}) => Error(`Git ls-files failed: ${stderr}`)
+  | Error({code, stderr, message, _}) =>
+    Error(
+      makeBackendError(
+        ~backend="git",
+        ~command="git ls-files",
+        ~cwd=searchPath,
+        ~exitCode=code,
+        ~stderr,
+        ~message,
+        ~targetPath=searchPath,
+      ),
+    )
   }
 }
 
 let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.toolResult<output> => {
   // resolveSearchDir ensures we always get a directory, even if the agent
   // passes a file path (e.g. "src/Button.tsx" → "src/").
-  let searchPath = await PathContext.resolveSearchDir(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path)
+  let requestedSearchPath = await PathContext.resolveSearchDir(
+    ~sourceRoot=ctx.sourceRoot,
+    ~inputPath=input.path,
+  )
+
+  let searchPath = switch await PathRecovery.nearestExistingDir(
+    ~sourceRoot=ctx.sourceRoot,
+    ~startPath=requestedSearchPath,
+  ) {
+  | Some(existingDir) => existingDir
+  | None => ctx.sourceRoot
+  }
+
   let maxResults = input.maxResults->Option.getOr(20)
 
   // Try ripgrep first, fall back to git ls-files
-  switch getRipgrepPath() {
+  let result = switch getRipgrepPath() {
   | Some(rgPath) =>
-    let result = await executeRipgrep(
+    let ripgrepResult = await executeRipgrep(
       ~rgPath,
       ~pattern=input.pattern,
       ~searchPath,
       ~maxResults,
     )
 
-    switch result {
-    | Ok(_) => result
-    | Error(_) =>
+    switch ripgrepResult {
+    | Ok(output) => Ok(output)
+    | Error(ripgrepError) =>
       // Fallback to git ls-files
-      await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults)
+      switch await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults) {
+      | Ok(output) => Ok(output)
+      | Error(gitError) =>
+        Error(formatFallbackError(~firstError=ripgrepError, ~secondError=gitError))
+      }
     }
   | None =>
     // No ripgrep, use git ls-files
-    await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults)
+    switch await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults) {
+    | Ok(output) => Ok(output)
+    | Error(gitError) => Error(formatBackendError(gitError))
+    }
+  }
+
+  switch result {
+  | Ok(output) =>
+    ToolPathHints.recordSearch(
+      ~sourceRoot=ctx.sourceRoot,
+      ~searchPath,
+      ~pattern=input.pattern,
+      ~files=output.files,
+      ~totalResults=output.totalResults,
+    )
+    Ok(output)
+  | Error(_) as err => err
   }
 }
-

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -6,6 +6,7 @@ module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 module PathRecovery = FrontmanCore__PathRecovery
 module ToolPathHints = FrontmanCore__ToolPathHints
+module FilenamePattern = FrontmanCore__FilenamePattern
 
 let name = Tool.ToolNames.searchFiles
 let visibleToAgent = true
@@ -84,29 +85,8 @@ let buildRipgrepArgs = (~searchPath: string): array<string> => {
   args
 }
 
-// Check if a filename matches a pattern (case-insensitive, glob-like)
-let matchesPattern = (fileName: string, ~patternLower: string): bool => {
-  let fileNameLower = fileName->String.toLowerCase
-
-  switch patternLower {
-  | "" => true
-  | p if p->String.includes("*") => {
-      let parts = p->String.split("*")
-      let partsLength = Array.length(parts)
-
-      parts->Array.reduceWithIndex(true, (matches, part, idx) =>
-        switch (matches, part) {
-        | (false, _) => false
-        | (_, "") => true
-        | _ if idx === 0 => fileNameLower->String.startsWith(part)
-        | _ if idx === partsLength - 1 => fileNameLower->String.endsWith(part)
-        | _ => fileNameLower->String.includes(part)
-        }
-      )
-    }
-  | p => fileNameLower->String.includes(p)
-  }
-}
+let matchesPattern = (fileName: string, ~patternLower: string): bool =>
+  FilenamePattern.matchesPattern(~pattern=patternLower, ~text=fileName)
 
 // Filter file paths by pattern and paginate results.
 // Shared by both the ripgrep and git ls-files code paths.

--- a/libs/frontman-core/test/FrontmanCore__FilenamePattern.test.res
+++ b/libs/frontman-core/test/FrontmanCore__FilenamePattern.test.res
@@ -1,0 +1,50 @@
+// Tests for shared case-insensitive filename pattern matching.
+
+open Vitest
+
+module FilenamePattern = FrontmanCore__FilenamePattern
+
+describe("FilenamePattern.matchesPattern", _t => {
+  test("empty pattern matches everything", t => {
+    t->expect(FilenamePattern.matchesPattern(~pattern="", ~text="anything.js"))->Expect.toBe(true)
+  })
+
+  test("supports substring matching", t => {
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="config", ~text="config.json"))
+    ->Expect.toBe(true)
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="config", ~text="readme.md"))
+    ->Expect.toBe(false)
+  })
+
+  test("is case-insensitive", t => {
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="config", ~text="Config.json"))
+    ->Expect.toBe(true)
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="config", ~text="CONFIG.ts"))
+    ->Expect.toBe(true)
+  })
+
+  test("supports leading wildcard", t => {
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="*.test.ts", ~text="app.test.ts"))
+    ->Expect.toBe(true)
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="*.test.ts", ~text="test.js"))
+    ->Expect.toBe(false)
+  })
+
+  test("supports multiple wildcards", t => {
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="*.config.*", ~text="app.config.ts"))
+    ->Expect.toBe(true)
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="*.config.*", ~text="test.config.js"))
+    ->Expect.toBe(true)
+    t
+    ->expect(FilenamePattern.matchesPattern(~pattern="*.config.*", ~text="config.json"))
+    ->Expect.toBe(false)
+  })
+})

--- a/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
@@ -1,0 +1,218 @@
+// Regression coverage for tool-call path recovery guardrails (issue #887).
+
+open Vitest
+
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module ListTree = FrontmanCore__Tool__ListTree
+module SearchFiles = FrontmanCore__Tool__SearchFiles
+module ReadFile = FrontmanCore__Tool__ReadFile
+module ToolPathHints = FrontmanCore__ToolPathHints
+module Fs = FrontmanBindings.Fs
+module Path = FrontmanBindings.Path
+module ChildProcess = FrontmanCore__ChildProcess
+
+let tmpPrefix = "/tmp/path-guardrails-test-"
+
+let makeTmpDir = async () => {
+  let dir = tmpPrefix ++ Float.toString(Date.now())
+  let _ = await Fs.Promises.mkdir(dir, {recursive: true})
+  dir
+}
+
+let writeFile = async (dir: string, relativePath: string, content: string) => {
+  let fullPath = Path.join([dir, relativePath])
+  let parentDir = Path.dirname(fullPath)
+  let _ = await Fs.Promises.mkdir(parentDir, {recursive: true})
+  await Fs.Promises.writeFile(fullPath, content)
+}
+
+let initGitRepo = async (dir: string) => {
+  let _ = await ChildProcess.execWithOptions("git init", {cwd: dir})
+  let _ = await ChildProcess.execWithOptions("git add -A", {cwd: dir})
+}
+
+let cleanup = async (dir: string) => {
+  let _ = await ChildProcess.exec(`rm -rf ${dir}`)
+}
+
+let makeCtx = (dir: string): Tool.serverExecutionContext => {
+  projectRoot: dir,
+  sourceRoot: dir,
+}
+
+let makeFixture = async () => {
+  let dir = await makeTmpDir()
+
+  await writeFile(
+    dir,
+    "apps/marketing/src/content/docs/docs/getting-started/installation.md",
+    "# Installation\nStep 1",
+  )
+
+  await writeFile(dir, "apps/marketing/src/content/docs/docs/reference/api.md", "# API Reference")
+
+  await writeFile(dir, "libs/frontman-nextjs/src/index.ts", "export const nextjs = true")
+  await writeFile(dir, "libs/frontman-vite/src/index.ts", "export const vite = true")
+  await initGitRepo(dir)
+  dir
+}
+
+describe("Tool path guardrails", _t => {
+  testAsync("T1 invalid list_tree path recovers via nearest existing parent", async t => {
+    ToolPathHints.clear()
+    let dir = await makeFixture()
+
+    let result = await ListTree.execute(
+      makeCtx(dir),
+      {path: ?Some("apps/marketing/src/pages/docs")},
+    )
+
+    switch result {
+    | Ok(output) => {
+        t->expect(output.tree->String.includes("[recovered]"))->Expect.toBe(true)
+        t->expect(output.tree->String.includes("content/"))->Expect.toBe(true)
+      }
+    | Error(msg) => failwith(`Expected recovery output, got error: ${msg}`)
+    }
+
+    await cleanup(dir)
+  })
+
+  test("T2 search_files backend errors include structured diagnostics", t => {
+    let err: SearchFiles.backendError = {
+      backend: "git",
+      command: "git ls-files",
+      cwd: "/tmp/missing",
+      exitCode: Some(128),
+      stderr: "fatal: not a git repository",
+      message: "Process exited with code 128",
+      targetPath: "/tmp/missing",
+    }
+
+    let rendered = SearchFiles.formatBackendError(err)
+
+    t->expect(rendered->String.includes("command:"))->Expect.toBe(true)
+    t->expect(rendered->String.includes("cwd:"))->Expect.toBe(true)
+    t->expect(rendered->String.includes("exit_code:"))->Expect.toBe(true)
+    t->expect(rendered->String.includes("stderr:"))->Expect.toBe(true)
+    t->expect(rendered->String.includes("target_path:"))->Expect.toBe(true)
+  })
+
+  testAsync("T3 wrong subfolder guess returns recovery guidance instead of ENOENT", async t => {
+    ToolPathHints.clear()
+    let dir = await makeFixture()
+
+    let result = await ReadFile.execute(
+      makeCtx(dir),
+      {path: "apps/marketing/src/content/docs/docs/reference/installation.md"},
+    )
+
+    switch result {
+    | Ok(_) => failwith("Expected read_file to fail with recovery guidance")
+    | Error(msg) => {
+        t->expect(msg->String.includes("Nearest existing parent"))->Expect.toBe(true)
+        t->expect(msg->String.includes("Candidate files"))->Expect.toBe(true)
+        t->expect(msg->String.includes("installation.md"))->Expect.toBe(true)
+        t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+      }
+    }
+
+    await cleanup(dir)
+  })
+
+  testAsync("T4 zero-result guardrail blocks immediate guessed read_file", async t => {
+    ToolPathHints.clear()
+    let dir = await makeFixture()
+    let ctx = makeCtx(dir)
+
+    let searchResult = await SearchFiles.execute(
+      ctx,
+      {
+        pattern: "index.d.ts",
+        path: ?Some("libs/frontman-nextjs"),
+      },
+    )
+
+    switch searchResult {
+    | Ok(output) => t->expect(output.totalResults)->Expect.toBe(0)
+    | Error(msg) => failwith(`Expected zero-result search, got error: ${msg}`)
+    }
+
+    let readResult = await ReadFile.execute(ctx, {path: "libs/frontman-nextjs/index.d.ts"})
+
+    switch readResult {
+    | Ok(_) => failwith("Expected read_file to be blocked by guardrail")
+    | Error(msg) => {
+        t->expect(msg->String.includes("Zero-result guardrail"))->Expect.toBe(true)
+        t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+      }
+    }
+
+    await cleanup(dir)
+  })
+
+  testAsync("regression replay: 3addabc6-like sequence avoids avoidable ENOENTs", async t => {
+    ToolPathHints.clear()
+    let dir = await makeFixture()
+    let ctx = makeCtx(dir)
+
+    let treeResult = await ListTree.execute(ctx, {path: ?Some("apps/marketing/src/pages/docs")})
+
+    switch treeResult {
+    | Ok(output) => t->expect(output.tree->String.includes("[recovered]"))->Expect.toBe(true)
+    | Error(msg) => failwith(`list_tree recovery failed: ${msg}`)
+    }
+
+    let mislocatedRead = await ReadFile.execute(
+      ctx,
+      {path: "apps/marketing/src/content/docs/docs/reference/installation.md"},
+    )
+
+    switch mislocatedRead {
+    | Ok(_) => failwith("Expected mislocated read to return guidance")
+    | Error(msg) => t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+    }
+
+    let zeroA = await SearchFiles.execute(
+      ctx,
+      {pattern: "index.d.ts", path: ?Some("libs/frontman-nextjs")},
+    )
+
+    switch zeroA {
+    | Ok(output) => t->expect(output.totalResults)->Expect.toBe(0)
+    | Error(msg) => failwith(`search_files nextjs failed: ${msg}`)
+    }
+
+    let readA = await ReadFile.execute(ctx, {path: "libs/frontman-nextjs/index.d.ts"})
+
+    switch readA {
+    | Ok(_) => failwith("Expected guarded read error for nextjs")
+    | Error(msg) => {
+        t->expect(msg->String.includes("Zero-result guardrail"))->Expect.toBe(true)
+        t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+      }
+    }
+
+    let zeroB = await SearchFiles.execute(
+      ctx,
+      {pattern: "index.d.ts", path: ?Some("libs/frontman-vite")},
+    )
+
+    switch zeroB {
+    | Ok(output) => t->expect(output.totalResults)->Expect.toBe(0)
+    | Error(msg) => failwith(`search_files vite failed: ${msg}`)
+    }
+
+    let readB = await ReadFile.execute(ctx, {path: "libs/frontman-vite/index.d.ts"})
+
+    switch readB {
+    | Ok(_) => failwith("Expected guarded read error for vite")
+    | Error(msg) => {
+        t->expect(msg->String.includes("Zero-result guardrail"))->Expect.toBe(true)
+        t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+      }
+    }
+
+    await cleanup(dir)
+  })
+})

--- a/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
@@ -7,6 +7,7 @@ module ListTree = FrontmanCore__Tool__ListTree
 module SearchFiles = FrontmanCore__Tool__SearchFiles
 module ReadFile = FrontmanCore__Tool__ReadFile
 module ToolPathHints = FrontmanCore__ToolPathHints
+module PathRecovery = FrontmanCore__PathRecovery
 module Fs = FrontmanBindings.Fs
 module Path = FrontmanBindings.Path
 module ChildProcess = FrontmanCore__ChildProcess
@@ -145,6 +146,46 @@ describe("Tool path guardrails", _t => {
     | Error(msg) => {
         t->expect(msg->String.includes("Zero-result guardrail"))->Expect.toBe(true)
         t->expect(msg->String.includes("ENOENT"))->Expect.toBe(false)
+      }
+    }
+
+    await cleanup(dir)
+  })
+
+  test("T5 recordSearch normalizes non-absolute files under search path", t => {
+    ToolPathHints.clear()
+
+    let sourceRoot = "/tmp/root-test"
+    let expectedFile = "libs/frontman-nextjs/src/index.ts"
+
+    ToolPathHints.recordSearch(
+      ~sourceRoot,
+      ~searchPath=Path.join([sourceRoot, "libs", "frontman-nextjs"]),
+      ~pattern="index.ts",
+      ~files=["src/index.ts"],
+      ~totalResults=1,
+    )
+
+    let anchors = ToolPathHints.getAnchors(~sourceRoot)
+    t->expect(anchors->Array.includes("."))->Expect.toBe(false)
+    t->expect(anchors->Array.includes(expectedFile->Path.dirname))->Expect.toBe(true)
+  })
+
+  testAsync("T6 read_file-style recovery stays in source root", async t => {
+    ToolPathHints.clear()
+    let dir = await makeFixture()
+
+    let outsideCandidate = await PathRecovery.recoverMissingPath(
+      ~sourceRoot=dir,
+      ~resolvedPath=dir,
+      ~entryLimit=4,
+    )
+
+    switch outsideCandidate {
+    | None => failwith("Expected recovery result")
+    | Some(recovery) => {
+        t->expect(recovery.nearestDir)->Expect.toBe(dir)
+        t->expect(recovery.nearestDirRelative)->Expect.toBe("")
       }
     }
 

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
@@ -3,6 +3,7 @@
 module Path = FrontmanBindings.Path
 module Fs = FrontmanBindings.Fs
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module PathStringUtils = FrontmanAiFrontmanCore.FrontmanCore__PathStringUtils
 
 let name = "get_routes"
 let visibleToAgent = true
@@ -25,10 +26,6 @@ type route = {
 @schema
 type output = array<route>
 
-// Normalize path separators to forward slashes for cross-platform route conversion
-// Route paths are URL paths and always use forward slashes
-let toForwardSlashes = (path: string): string => path->String.replaceAll("\\", "/")
-
 // Check if a segment is dynamic (contains [ ])
 let isDynamicSegment = (segment: string): bool => {
   segment->String.startsWith("[") && segment->String.endsWith("]")
@@ -38,7 +35,7 @@ let isDynamicSegment = (segment: string): bool => {
 // Normalizes separators first since Path.join uses \ on Windows but routes need /
 let fileToRoute = (filePath: string): string => {
   filePath
-  ->toForwardSlashes
+  ->PathStringUtils.toForwardSlashes
   ->String.replaceRegExp(/\.(tsx?|jsx?|mdx?)$/, "")
   ->String.replaceRegExp(/\/page$/, "")
   ->String.replaceRegExp(/\/route$/, "")
@@ -77,7 +74,10 @@ let rec findRoutes = async (baseDir: string, currentPath: string, ~projectRoot: 
       ) {
         let routePath = fileToRoute(currentPath)
         let hasDynamic =
-          currentPath->toForwardSlashes->String.split("/")->Array.some(isDynamicSegment)
+          currentPath
+          ->PathStringUtils.toForwardSlashes
+          ->String.split("/")
+          ->Array.some(isDynamicSegment)
         [
           {
             path: routePath,


### PR DESCRIPTION
## Summary
- add shared path-hint caching and nearest-parent path recovery so tool calls stop guessing dead paths and recover from missing directories deterministically
- harden `read_file`, `search_files`, `list_tree`, and `list_files` with discovery-before-read and zero-result guardrails, plus structured backend failure diagnostics for `search_files`
- add regression coverage for taxonomy cases T1-T4 (including a 3addabc6-style replay) and document the guardrail behavior in `frontman-core` docs

## Testing
- `make test` (in `libs/frontman-core`)
- `make test` (in `libs/frontman-nextjs`)
- `make test` (in `libs/frontman-astro`)
- `make build` (in `libs/frontman-vite`)
- `yarn vitest run --passWithNoTests` (in `libs/frontman-vite`)
- `make rescript-build` (repo root)

## Issue
- Closes #887
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
