### PR TITLE
refactor(codex): route ChatGPT OAuth through openai_codex

### DIFF
--- a/apps/frontman_server/lib/frontman_server/providers/codex.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/codex.ex
@@ -13,11 +13,10 @@ defmodule FrontmanServer.Providers.Codex do
   Requests to this endpoint require:
 
     * The `/responses` suffix stripped to get the `base_url`
-    * An optional `ChatGPT-Account-Id` header
+    * Optional `chatgpt_account_id` passed to ReqLLM
     * `max_tokens` removed (Codex ignores it)
-    * `provider_options: [store: false]`
-    * The wire protocol forced to `"openai_responses"`
     * Model alias normalisation (`codex-5.3` → `gpt-5.3-codex`)
+    * Provider namespace normalisation (`openai:*` → `openai_codex:*`)
     * Model synthesis for entries not yet in LLMDB
 
   Used by `ResolvedKey.to_llm_args/2` to transform connection config when
@@ -32,74 +31,59 @@ defmodule FrontmanServer.Providers.Codex do
   Normalises the ChatGPT Codex model alias.
 
   The ChatGPT UI sends `"openai:codex-5.3"` but the actual LLMDB / API
-  model id is `"openai:gpt-5.3-codex"`.
+  model id is `"openai_codex:gpt-5.3-codex"`.
 
   ## Examples
 
       iex> Codex.normalize_model("openai:codex-5.3")
-      "openai:gpt-5.3-codex"
+      "openai_codex:gpt-5.3-codex"
 
       iex> Codex.normalize_model("openai:gpt-5.2-codex")
-      "openai:gpt-5.2-codex"
+      "openai_codex:gpt-5.2-codex"
   """
   @spec normalize_model(String.t()) :: String.t()
   def normalize_model("openai:codex-5.3") do
-    Logger.debug("Normalizing openai:codex-5.3 → openai:gpt-5.3-codex for Codex endpoint")
-    "openai:gpt-5.3-codex"
+    Logger.debug("Normalizing openai:codex-5.3 → openai_codex:gpt-5.3-codex")
+    "openai_codex:gpt-5.3-codex"
   end
+
+  def normalize_model("openai:" <> model_id), do: "openai_codex:" <> model_id
 
   def normalize_model(model) when is_binary(model), do: model
 
   @doc """
-  Forces the wire protocol to `"openai_responses"` on an LLMDB model struct.
-
-  The Codex endpoint only speaks the OpenAI Responses API, so we patch
-  `model.extra.wire.protocol` regardless of what LLMDB declares.
-  """
-  @spec force_responses_protocol(map()) :: map()
-  def force_responses_protocol(model) do
-    extra = model.extra || %{}
-    wire = Map.get(extra, :wire, %{})
-    patched_extra = Map.put(extra, :wire, Map.put(wire, :protocol, "openai_responses"))
-    %{model | extra: patched_extra}
-  end
-
-  @doc """
-  Builds an LLMDB-compatible model spec for a Codex model string that
-  isn't catalogued in LLMDB yet.
-
-  Clones `gpt-5.2-codex` (which *is* catalogued) and swaps the model id.
-  Falls back to the raw model string when even the base entry is missing.
+  Builds an explicit model spec for an OpenAI Codex model string that
+  is not yet catalogued in LLMDB.
   """
   @spec synthesize_model(String.t()) :: map() | String.t()
-  def synthesize_model("openai:gpt-5.3-codex") do
-    case ReqLLM.model("openai:gpt-5.2-codex") do
-      {:ok, base} ->
-        %{force_responses_protocol(base) | id: "gpt-5.3-codex", model: "gpt-5.3-codex"}
-
-      {:error, _} ->
-        "openai:gpt-5.3-codex"
-    end
+  def synthesize_model("openai_codex:" <> model_id) do
+    %{
+      provider: :openai_codex,
+      id: model_id,
+      model: model_id,
+      provider_model_id: model_id,
+      extra: %{wire: %{protocol: "openai_codex_responses"}}
+    }
   end
 
   def synthesize_model(model_string) when is_binary(model_string), do: model_string
 
   @doc """
-  Resolves a Codex model string to an LLMDB struct with the Responses
-  protocol forced, synthesising a spec when the model isn't catalogued.
+  Resolves an OpenAI Codex model string to an LLMDB struct, synthesising
+  a spec when the model isn't catalogued.
 
   This is the high-level entry point — call it instead of chaining
-  `ReqLLM.model` + `force_responses_protocol` + `synthesize_model` manually.
+  `ReqLLM.model` + `synthesize_model` manually.
 
   ## Examples
 
-      iex> Codex.resolve_model("openai:gpt-5.2-codex")
-      # => %LLMDB.Model{..., extra: %{wire: %{protocol: "openai_responses"}}}
+      iex> Codex.resolve_model("openai_codex:gpt-5.2-codex")
+      # => %LLMDB.Model{provider: :openai_codex, ...}
   """
   @spec resolve_model(String.t()) :: map() | String.t()
   def resolve_model(model_string) when is_binary(model_string) do
     case ReqLLM.model(model_string) do
-      {:ok, model} -> force_responses_protocol(model)
+      {:ok, model} -> model
       {:error, _} -> synthesize_model(model_string)
     end
   end
@@ -121,40 +105,25 @@ defmodule FrontmanServer.Providers.Codex do
   end
 
   @doc """
-  Builds Codex account headers for a request.
-
-  Returns `[{"ChatGPT-Account-Id", id}]` when the account id is a
-  non-empty binary, `[]` otherwise.
-  """
-  @spec account_headers(String.t() | nil) :: [{String.t(), String.t()}]
-  def account_headers(account_id) when is_binary(account_id) and account_id != "" do
-    [{"ChatGPT-Account-Id", account_id}]
-  end
-
-  def account_headers(_), do: []
-
-  @doc """
   Patches a keyword list of ReqLLM options for the Codex endpoint.
 
   Applies:
     * `base_url` derived from `endpoint`
-    * `req_http_options` headers with optional account id
+    * Optional `chatgpt_account_id`
     * Removes `max_tokens`
-    * Adds `provider_options: [store: false]`
   """
   @spec patch_llm_opts(keyword(), String.t(), String.t() | nil) :: keyword()
   def patch_llm_opts(opts, endpoint, account_id) when is_binary(endpoint) do
-    headers = account_headers(account_id)
-
     opts
     |> Keyword.put(:base_url, base_url(endpoint))
-    |> put_req_http_headers(headers)
     |> Keyword.delete(:max_tokens)
-    |> Keyword.update(:provider_options, [store: false], &Keyword.put(&1, :store, false))
+    |> maybe_put_chatgpt_account_id(account_id)
   end
 
-  defp put_req_http_headers(opts, []), do: opts
+  defp maybe_put_chatgpt_account_id(opts, account_id)
+       when is_binary(account_id) and account_id != "" do
+    Keyword.put(opts, :chatgpt_account_id, account_id)
+  end
 
-  defp put_req_http_headers(opts, headers),
-    do: Keyword.put(opts, :req_http_options, headers: headers)
+  defp maybe_put_chatgpt_account_id(opts, _), do: opts
 end

--- a/apps/frontman_server/lib/frontman_server/providers/resolved_key.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/resolved_key.ex
@@ -82,7 +82,7 @@ defmodule FrontmanServer.Providers.ResolvedKey do
   provider-specific wiring internally:
 
     * For Codex (ChatGPT OAuth): normalizes the model alias, patches the
-      base URL and headers, forces the Responses API protocol
+      base URL and routes through the `openai_codex` provider
     * For all providers: sets `api_key` (or `auth_mode` + `access_token` for OAuth), `requires_mcp_prefix`,
       and `identity_override`
 

--- a/apps/frontman_server/test/frontman_server/providers/codex_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/codex_test.exs
@@ -3,25 +3,33 @@ defmodule FrontmanServer.Providers.CodexTest do
 
   alias FrontmanServer.Providers.Codex
 
-  describe "force_responses_protocol/1" do
-    test "handles nil extra without crashing" do
-      model = %{extra: nil}
-      result = Codex.force_responses_protocol(model)
-      assert result.extra.wire.protocol == "openai_responses"
+  describe "normalize_model/1" do
+    test "normalizes codex alias to openai_codex model" do
+      assert Codex.normalize_model("openai:codex-5.3") == "openai_codex:gpt-5.3-codex"
     end
 
-    test "handles missing wire key without crashing" do
-      model = %{extra: %{}}
-      result = Codex.force_responses_protocol(model)
-      assert result.extra.wire.protocol == "openai_responses"
+    test "rewrites openai namespace to openai_codex" do
+      assert Codex.normalize_model("openai:gpt-5.2-codex") == "openai_codex:gpt-5.2-codex"
     end
 
-    test "preserves other extra fields" do
-      model = %{extra: %{something: "else", wire: %{protocol: "old", other: true}}}
-      result = Codex.force_responses_protocol(model)
-      assert result.extra.something == "else"
-      assert result.extra.wire.other == true
-      assert result.extra.wire.protocol == "openai_responses"
+    test "keeps openai_codex models unchanged" do
+      assert Codex.normalize_model("openai_codex:gpt-5.3-codex") == "openai_codex:gpt-5.3-codex"
+    end
+  end
+
+  describe "resolve_model/1" do
+    test "returns catalogued openai_codex model" do
+      result = Codex.resolve_model("openai_codex:gpt-5.3-codex")
+      assert %{provider: :openai_codex, id: "gpt-5.3-codex"} = result
+    end
+
+    test "synthesizes explicit model spec when model is uncatalogued" do
+      result = Codex.resolve_model("openai_codex:gpt-9.9-codex")
+
+      assert %{provider: :openai_codex, id: "gpt-9.9-codex"} = result
+      assert result.model == "gpt-9.9-codex"
+      assert result.provider_model_id == "gpt-9.9-codex"
+      assert get_in(result.extra, [:wire, :protocol]) == "openai_codex_responses"
     end
   end
 
@@ -33,30 +41,18 @@ defmodule FrontmanServer.Providers.CodexTest do
         Codex.patch_llm_opts(opts, "https://chatgpt.com/backend-api/codex/responses", "acc-456")
 
       assert Keyword.get(result, :base_url) == "https://chatgpt.com/backend-api/codex"
-
-      assert Keyword.get(result, :req_http_options) ==
-               [headers: [{"ChatGPT-Account-Id", "acc-456"}]]
-
+      assert Keyword.get(result, :chatgpt_account_id) == "acc-456"
       refute Keyword.has_key?(result, :max_tokens)
-      assert Keyword.get(result, :provider_options) == [store: false]
+      refute Keyword.has_key?(result, :provider_options)
+      refute Keyword.has_key?(result, :req_http_options)
       assert Keyword.get(result, :api_key) == "sk-123"
     end
 
-    test "merges store: false into existing provider_options" do
-      opts = [provider_options: [other: true]]
+    test "does not set chatgpt_account_id when missing" do
+      opts = [api_key: "sk-123", max_tokens: 16_384]
       result = Codex.patch_llm_opts(opts, "https://example.com/responses", nil)
 
-      assert Keyword.get(result, :provider_options) == [store: false, other: true]
-    end
-
-    test "overwrites existing req_http_options when account header is present" do
-      opts = [req_http_options: [headers: [{"X-Trace-Id", "trace-1"}], receive_timeout: 1_000]]
-
-      result = Codex.patch_llm_opts(opts, "https://example.com/responses", "acc-999")
-
-      assert Keyword.get(result, :req_http_options) == [
-               headers: [{"ChatGPT-Account-Id", "acc-999"}]
-             ]
+      refute Keyword.has_key?(result, :chatgpt_account_id)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/providers/resolved_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/resolved_key_test.exs
@@ -62,7 +62,7 @@ defmodule FrontmanServer.Providers.ResolvedKeyTest do
   end
 
   describe "to_llm_args/2 for Codex (ChatGPT OAuth)" do
-    test "patches base_url, headers, strips max_tokens, forces store:false" do
+    test "routes through openai_codex, patches base_url, and strips max_tokens" do
       key =
         resolved_key_fixture("openai",
           api_key: "chatgpt-access-token",
@@ -72,17 +72,22 @@ defmodule FrontmanServer.Providers.ResolvedKeyTest do
       {model_spec, llm_opts} = ResolvedKey.to_llm_args(key, max_tokens: 16_384)
 
       case model_spec do
-        %{id: id} -> assert id == "gpt-5.3-codex"
-        string when is_binary(string) -> assert string =~ "codex"
+        %{provider: provider, id: id} ->
+          assert provider == :openai_codex
+          assert id == "gpt-5.3-codex"
+
+        string when is_binary(string) ->
+          assert string == "openai_codex:gpt-5.3-codex"
       end
 
       assert llm_opts[:base_url] == "https://chatgpt.com/backend-api/codex"
-      assert llm_opts[:req_http_options] == [headers: [{"ChatGPT-Account-Id", "acc-789"}]]
-      assert llm_opts[:provider_options] == [store: false]
+      assert llm_opts[:chatgpt_account_id] == "acc-789"
       assert llm_opts[:access_token] == "chatgpt-access-token"
       assert llm_opts[:auth_mode] == :oauth
       refute Keyword.has_key?(llm_opts, :api_key)
       refute Keyword.has_key?(llm_opts, :max_tokens)
+      refute Keyword.has_key?(llm_opts, :provider_options)
+      refute Keyword.has_key?(llm_opts, :req_http_options)
     end
 
     test "normalizes codex-5.3 alias before resolution" do
@@ -91,8 +96,12 @@ defmodule FrontmanServer.Providers.ResolvedKeyTest do
       {model_spec, _llm_opts} = ResolvedKey.to_llm_args(key)
 
       case model_spec do
-        %{id: id} -> assert id == "gpt-5.3-codex"
-        string when is_binary(string) -> assert string == "openai:gpt-5.3-codex"
+        %{provider: provider, id: id} ->
+          assert provider == :openai_codex
+          assert id == "gpt-5.3-codex"
+
+        string when is_binary(string) ->
+          assert string == "openai_codex:gpt-5.3-codex"
       end
     end
 
@@ -101,7 +110,7 @@ defmodule FrontmanServer.Providers.ResolvedKeyTest do
 
       {_model_spec, llm_opts} = ResolvedKey.to_llm_args(key)
 
-      refute Keyword.has_key?(llm_opts, :req_http_options)
+      refute Keyword.has_key?(llm_opts, :chatgpt_account_id)
     end
   end
 


### PR DESCRIPTION
## Summary
- route ChatGPT OAuth Codex traffic through `openai_codex:*` model specs instead of forcing OpenAI Responses protocol on `openai:*`
- remove frontman-side Codex request hacks (`provider_options: [store: false]`, manual `ChatGPT-Account-Id` request headers) and pass `chatgpt_account_id` directly to ReqLLM
- update Codex + resolved-key tests to assert the upstream-aligned contract and openai_codex model resolution behavior

## Testing
- `mix test test/frontman_server/providers/codex_test.exs test/frontman_server/providers/resolved_key_test.exs`
- `mix test test/frontman_server/providers/`
- `mix test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
