### PR TITLE
fix(frontman_server): classify raised ReqLLM stream errors

### DIFF
--- a/apps/frontman_server/lib/frontman_server/accounts/user.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user.ex
@@ -12,6 +12,8 @@ defmodule FrontmanServer.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "users" do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
@@ -234,13 +234,9 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
     nil
   end
 
-  # Stream-level provider/API error chunk emitted by ReqLLM.
-  # The raise propagates through Response.from_stream → Task crash →
-  # death watcher → {:agent_error, message} → TaskChannel → client ErrorBanner.
-  #
-  # ReqLLM StreamChunk error shape: %{type: :error, text: message, metadata: %{error: original}}
-  # where `original` is typically a ReqLLM.Error.API.Request with :status and :reason fields.
-  # We classify by HTTP status to produce user-friendly messages.
+  # Legacy compatibility path for ReqLLM builds that emit :error chunks.
+  # Current ReqLLM versions raise ReqLLM.Error.API.Stream instead; those are
+  # classified in ExecutionEvent.classify_error/1.
   defp to_swarm_chunk(
          %{type: :error, text: text, metadata: %{error: original}},
          _requires_mcp_prefix?

--- a/apps/frontman_server/lib/frontman_server/tasks/execution_event.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution_event.ex
@@ -66,6 +66,18 @@ defmodule FrontmanServer.Tasks.ExecutionEvent do
   @spec classify_error(term()) :: {String.t(), String.t(), boolean()}
   def classify_error(%LLMError{message: msg, category: cat, retryable: r}), do: {msg, cat, r}
 
+  def classify_error(%ReqLLM.Error.API.Stream{cause: %ReqLLM.Error.API.Request{} = cause}) do
+    classify_reqllm_request(cause.status, cause.reason)
+  end
+
+  def classify_error(%ReqLLM.Error.API.Stream{reason: reason}) when is_binary(reason) do
+    classify_reqllm_request(nil, reason)
+  end
+
+  def classify_error(%ReqLLM.Error.API.Request{status: status, reason: reason}) do
+    classify_reqllm_request(status, reason)
+  end
+
   def classify_error(%StreamStallTimeout.Error{}) do
     {"The AI provider stopped responding mid-reply. " <>
        "This usually happens when the provider is temporarily overloaded. " <>
@@ -98,6 +110,52 @@ defmodule FrontmanServer.Tasks.ExecutionEvent do
 
   def classify_error(reason) when is_binary(reason), do: {reason, "unknown", false}
   def classify_error(reason), do: {inspect(reason), "unknown", false}
+
+  defp classify_reqllm_request(status, _reason) when status in [401, 403] do
+    {"Authentication failed — your API key may be invalid or expired (HTTP #{status})", "auth",
+     false}
+  end
+
+  defp classify_reqllm_request(400, reason) when is_binary(reason) do
+    {"Bad request — the provider rejected the request: #{reason}", "unknown", false}
+  end
+
+  defp classify_reqllm_request(400, _reason) do
+    {"Bad request — the provider rejected the request.", "unknown", false}
+  end
+
+  defp classify_reqllm_request(402, _reason) do
+    {"Payment required — your account balance is insufficient or billing is not configured (HTTP 402)",
+     "billing", false}
+  end
+
+  defp classify_reqllm_request(413, _reason) do
+    {"Payload too large — the request exceeded the provider's size limit. Try reducing image size or message length (HTTP 413)",
+     "payload_too_large", false}
+  end
+
+  defp classify_reqllm_request(429, _reason) do
+    {"Rate limited — the provider is throttling requests. Please try again shortly.",
+     "rate_limit", true}
+  end
+
+  defp classify_reqllm_request(status, _reason) when is_integer(status) and status >= 500 do
+    {"Provider error — the LLM service returned an internal error (HTTP #{status}). Please try again.",
+     "overload", true}
+  end
+
+  defp classify_reqllm_request(status, reason)
+       when is_integer(status) and is_binary(reason) do
+    {"LLM error (HTTP #{status}): #{reason}", "unknown", false}
+  end
+
+  defp classify_reqllm_request(_status, reason) when is_binary(reason) do
+    {"LLM stream error: #{reason}", "unknown", false}
+  end
+
+  defp classify_reqllm_request(_status, _reason) do
+    {"LLM stream error", "unknown", false}
+  end
 
   # Translates internal error reasons into user-friendly messages.
   defp humanize_error(reason) do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
@@ -2,27 +2,21 @@ defmodule FrontmanServer.Tasks.Execution.LLMClientTest do
   use ExUnit.Case, async: true
 
   alias FrontmanServer.Tasks.Execution.LLMClient
+  alias ReqLLM.Error.API.{Request, Stream}
 
-  describe "ReqLLM error chunk contract" do
-    test "ReqLLM.StreamChunk.error/1 creates an :error type chunk" do
-      chunk = ReqLLM.StreamChunk.error("image exceeds the maximum allowed size")
-
-      assert chunk.type == :error
-      assert chunk.text == "image exceeds the maximum allowed size"
-      assert chunk.metadata == %{}
-    end
-
-    test "ReqLLM.StreamChunk.error/2 preserves metadata" do
-      chunk =
-        ReqLLM.StreamChunk.error("HTTP 400: Request too large", %{
+  describe "ReqLLM stream exception contract" do
+    test "ReqLLM.Error.API.Stream carries ReqLLM.Error.API.Request as cause" do
+      request_error =
+        Request.exception(
           status: 400,
-          provider: :anthropic
-        })
+          reason: "image exceeds the maximum allowed size"
+        )
 
-      assert chunk.type == :error
-      assert chunk.text == "HTTP 400: Request too large"
-      assert chunk.metadata.status == 400
-      assert chunk.metadata.provider == :anthropic
+      stream_error = Stream.exception(reason: "Stream failed", cause: request_error)
+
+      assert %Request{} = stream_error.cause
+      assert stream_error.cause.status == 400
+      assert stream_error.cause.reason == "image exceeds the maximum allowed size"
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
@@ -4,11 +4,31 @@ defmodule FrontmanServer.Tasks.ExecutionClassifyErrorTest do
   alias FrontmanServer.Tasks.Execution.LLMError
   alias FrontmanServer.Tasks.ExecutionEvent
   alias FrontmanServer.Tasks.StreamStallTimeout
+  alias ReqLLM.Error.API.{Request, Stream}
 
   describe "classify_error/1" do
     test "LLMError passes through message, category, retryable" do
       err = %LLMError{message: "Rate limited", category: "rate_limit", retryable: true}
       assert {"Rate limited", "rate_limit", true} = ExecutionEvent.classify_error(err)
+    end
+
+    test "ReqLLM request error 429 is classified as retryable rate limit" do
+      err = Request.exception(status: 429, reason: "Too many requests")
+      {msg, "rate_limit", true} = ExecutionEvent.classify_error(err)
+      assert String.contains?(msg, "Rate limited")
+    end
+
+    test "ReqLLM stream error with request cause 413 is classified as payload too large" do
+      request_error =
+        Request.exception(
+          status: 413,
+          reason: "image exceeds the maximum allowed size"
+        )
+
+      err = Stream.exception(reason: "Stream failed", cause: request_error)
+
+      {msg, "payload_too_large", false} = ExecutionEvent.classify_error(err)
+      assert String.contains?(msg, "Payload too large")
     end
 
     test "StreamStallTimeout.Error returns overload, retryable" do


### PR DESCRIPTION
## Summary
- classify `ReqLLM.Error.API.Stream` and `ReqLLM.Error.API.Request` in `ExecutionEvent.classify_error/1` so raised stream failures keep Frontman's existing user-facing error categories and retryability behavior
- keep `:error` chunk handling in `LLMClient` as a legacy compatibility path while documenting that current ReqLLM versions raise stream exceptions
- update tests to assert the stream-exception contract and add coverage for request/stream error classification paths

## Validation
- mix test test/frontman_server/tasks/execution/llm_client_test.exs test/frontman_server/tasks/execution_classify_error_test.exs
- mix test test/frontman_server/tasks/execution/error_propagation_test.exs
- mix test test/frontman_server/tasks/execution_classify_test.exs test/frontman_server/tasks/execution_classify_error_test.exs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
