### PR TITLE
fix(marketing): add crawlable links to orphan hub pages

### DIFF
--- a/apps/marketing/src/components/scripts/LocalScripts.astro
+++ b/apps/marketing/src/components/scripts/LocalScripts.astro
@@ -10,6 +10,9 @@
 			if (submenu && link) {
 				link.addEventListener('click', function (event) {
 					if (!window.matchMedia('(max-width: 1023px)').matches) return
+					const isOpen = menuItem.classList.contains('open')
+					if (isOpen) return
+
 					event.preventDefault()
 					// Close other open submenus first
 					menuItems.forEach((otherItem) => {
@@ -19,9 +22,8 @@
 							if (otherLink) otherLink.setAttribute('aria-expanded', 'false')
 						}
 					})
-					menuItem.classList.toggle('open')
-					const isOpen = menuItem.classList.contains('open')
-					link.setAttribute('aria-expanded', isOpen ? 'true' : 'false')
+					menuItem.classList.add('open')
+					link.setAttribute('aria-expanded', 'true')
 				})
 			}
 		})
@@ -61,7 +63,16 @@
 
 			// Close mobile menu when a nav link is clicked
 			headerMenu.querySelectorAll('a').forEach((link) => {
-				link.addEventListener('click', () => closeMobileMenu())
+				link.addEventListener('click', () => {
+					const parentMenuItem = link.closest('.header__menu-item')
+					const isSubmenuParent =
+						window.matchMedia('(max-width: 1023px)').matches
+						&& link.classList.contains('header__menu-link')
+						&& parentMenuItem?.querySelector('.header__submenu')
+
+					if (isSubmenuParent) return
+					closeMobileMenu()
+				})
 			})
 		}
 

--- a/apps/marketing/src/components/ui/NavigationBar.astro
+++ b/apps/marketing/src/components/ui/NavigationBar.astro
@@ -62,16 +62,16 @@ function isActivePath(currentPath: string): boolean {
 									{item.name}
 								</a>
 							) : (
-								<button
-									type="button"
+								<a
+									href={item.link}
 									role="menuitem"
 									aria-haspopup="true"
 									aria-expanded="false"
-									class="header__menu-link"
+									class={`header__menu-link ${isActivePath(item.link) ? 'active' : ''}`}
 								>
 									{item.name}
 									<Icon name="chevron-down" class="header__menu-chevron" aria-hidden="true" />
-								</button>
+								</a>
 							)}
 							{item.submenu && (
 								<ul class="header__submenu">

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -64,6 +64,10 @@ export const footerNavigationData: FooterData = {
 					subCategoryLink: '/how-it-works/'
 				},
 				{
+					subCategory: 'Features',
+					subCategoryLink: '/features/'
+				},
+				{
 					subCategory: 'Pricing',
 					subCategoryLink: '/pricing/'
 				},
@@ -89,6 +93,10 @@ export const footerNavigationData: FooterData = {
 			category: 'Integrations',
 			subCategories: [
 				{
+					subCategory: 'All Integrations',
+					subCategoryLink: '/integrations/'
+				},
+				{
 					subCategory: 'Next.js',
 					subCategoryLink: '/integrations/nextjs/'
 				},
@@ -105,6 +113,10 @@ export const footerNavigationData: FooterData = {
 		{
 			category: 'Compare',
 			subCategories: [
+				{
+					subCategory: 'All Comparisons',
+					subCategoryLink: '/vs/'
+				},
 				{
 					subCategory: 'Frontman vs Cursor',
 					subCategoryLink: '/vs/cursor/'
@@ -138,6 +150,10 @@ export const footerNavigationData: FooterData = {
 				{
 					subCategory: 'Documentation',
 					subCategoryLink: '/docs/'
+				},
+				{
+					subCategory: 'Reference',
+					subCategoryLink: '/docs/reference/'
 				},
 				{
 					subCategory: 'GitHub',

--- a/apps/marketing/src/config/navigationBar.ts
+++ b/apps/marketing/src/config/navigationBar.ts
@@ -43,6 +43,7 @@ export const navigationBarData: NavData = {
 			name: 'Compare',
 			link: '/vs/',
 			submenu: [
+				{ name: 'All comparisons', link: '/vs/' },
 				{ name: 'vs Cursor', link: '/vs/cursor/' },
 				{ name: 'vs Copilot', link: '/vs/copilot/' },
 				{ name: 'vs Stagewise', link: '/vs/stagewise/' },
@@ -53,6 +54,7 @@ export const navigationBarData: NavData = {
 			name: 'Integrations',
 			link: '/integrations/',
 			submenu: [
+				{ name: 'All integrations', link: '/integrations/' },
 				{ name: 'Next.js', link: '/integrations/nextjs/' },
 				{ name: 'Astro', link: '/integrations/astro/' },
 				{ name: 'Vite', link: '/integrations/vite/' }

--- a/apps/marketing/src/content/docs/docs/index.md
+++ b/apps/marketing/src/content/docs/docs/index.md
@@ -47,4 +47,4 @@ Already running? Learn how to get the most out of it.
 For developers who want framework-specific detail or technical reference.
 
 - **[Integrations](/docs/integrations/astro/)** — Framework-specific guides (Astro, Next.js, Vite, WordPress)
-- **[Reference](/docs/reference/configuration/)** — Configuration options, environment variables, architecture, troubleshooting
+- **[Reference](/docs/reference/)** — Configuration options, environment variables, architecture, troubleshooting


### PR DESCRIPTION
## Summary
- make dropdown parent items for Compare and Integrations render as real links so `/vs/` and `/integrations/` are crawlable from global nav
- preserve mobile submenu UX by updating nav scripts to open submenu on first tap and avoid auto-closing the menu for submenu parent taps
- add direct footer/internal links to `/features/`, `/vs/`, `/integrations/`, and `/docs/reference/`, and update docs intro to point to `/docs/reference/`

## Testing
- `make build` (in `apps/marketing`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
