### PR TITLE
feat(auth): include signup framework in Discord signup alerts

### DIFF
--- a/.changeset/add-signup-framework-to-discord-notify.md
+++ b/.changeset/add-signup-framework-to-discord-notify.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Append the detected framework to auth-required login redirects and thread it through OAuth signup so new-user Discord notifications include the framework used at signup.

--- a/apps/frontman_server/lib/frontman_server/accounts.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts.ex
@@ -351,10 +351,21 @@ defmodule FrontmanServer.Accounts do
     to: WorkOS,
     as: :get_authorization_url
 
-  defdelegate authenticate_with_oauth(code), to: WorkOS, as: :authenticate_with_code
+  def authenticate_with_oauth(code, signup_framework \\ nil) do
+    WorkOS.authenticate_with_code(code, signup_framework)
+  end
 
-  defdelegate authenticate_with_email_verification(code, pending_authentication_token),
-    to: WorkOS
+  def authenticate_with_email_verification(
+        code,
+        pending_authentication_token,
+        signup_framework \\ nil
+      ) do
+    WorkOS.authenticate_with_email_verification(
+      code,
+      pending_authentication_token,
+      signup_framework
+    )
+  end
 
   defdelegate link_oauth_provider(user, code), to: WorkOS, as: :link_provider
   defdelegate unlink_oauth_provider(user, provider), to: WorkOS, as: :unlink_provider

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -74,10 +74,10 @@ defmodule FrontmanServer.Accounts.WorkOS do
   Note: We use a raw HTTP call instead of the SDK to capture the full error
   response, including `pending_authentication_token` for email verification.
   """
-  def authenticate_with_code(code) do
+  def authenticate_with_code(code, signup_framework \\ nil) do
     with {:ok, auth_response} <- authenticate_with_code_raw(code),
          {:ok, profile} <- extract_profile(auth_response) do
-      find_or_create_user_from_oauth(profile)
+      find_or_create_user_from_oauth(profile, signup_framework)
     end
   end
 
@@ -88,7 +88,11 @@ defmodule FrontmanServer.Accounts.WorkOS do
   receives a verification code via email, which is then submitted along with
   the pending authentication token to complete the flow.
   """
-  def authenticate_with_email_verification(code, pending_authentication_token) do
+  def authenticate_with_email_verification(
+        code,
+        pending_authentication_token,
+        signup_framework \\ nil
+      ) do
     require Logger
 
     body = %{
@@ -103,7 +107,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         with {:ok, auth_response} <- parse_auth_response(response_body),
              {:ok, profile} <- extract_profile(auth_response) do
-          find_or_create_user_from_oauth(profile)
+          find_or_create_user_from_oauth(profile, signup_framework)
         end
 
       {:ok, %Req.Response{status: status, body: error_body}} ->
@@ -197,11 +201,11 @@ defmodule FrontmanServer.Accounts.WorkOS do
     end
   end
 
-  defp find_or_create_user_from_oauth(profile) do
+  defp find_or_create_user_from_oauth(profile, signup_framework) do
     identity = get_identity_by_provider_id(profile.provider, profile.provider_id)
     existing_user = get_user_by_email(profile.provider_email)
 
-    multi = build_oauth_multi(identity, existing_user, profile)
+    multi = build_oauth_multi(identity, existing_user, profile, signup_framework)
 
     case Repo.transaction(multi) do
       {:ok, %{user: user}} -> {:ok, user}
@@ -211,10 +215,10 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
   # Suppress Dialyzer false positive: Ecto.Multi.new/0 returns a struct with
   # opaque MapSet internals that Dialyzer flags as call_without_opaque.
-  @dialyzer {:nowarn_function, build_oauth_multi: 3}
+  @dialyzer {:nowarn_function, build_oauth_multi: 4}
 
   # Returning user with existing identity — touch timestamps, no welcome email.
-  defp build_oauth_multi(%UserIdentity{} = identity, _existing_user, _profile) do
+  defp build_oauth_multi(%UserIdentity{} = identity, _existing_user, _profile, _signup_framework) do
     now = DateTime.utc_now(:second)
 
     Multi.new()
@@ -226,7 +230,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   end
 
   # Existing user by email but no identity for this provider — link identity.
-  defp build_oauth_multi(nil, %User{} = user, profile) do
+  defp build_oauth_multi(nil, %User{} = user, profile, _signup_framework) do
     now = DateTime.utc_now(:second)
 
     Multi.new()
@@ -235,7 +239,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   end
 
   # Brand-new user — create user + identity + enqueue welcome email.
-  defp build_oauth_multi(nil, nil, profile) do
+  defp build_oauth_multi(nil, nil, profile, signup_framework) do
     Multi.new()
     |> Multi.insert(
       :user,
@@ -254,9 +258,12 @@ defmodule FrontmanServer.Accounts.WorkOS do
       SyncResendContact.new(%{user_id: user.id})
     end)
     |> Oban.insert(:notify_discord, fn %{user: user} ->
-      NotifyDiscordNewUser.new(%{user_id: user.id})
+      NotifyDiscordNewUser.new(notify_discord_args(user.id, signup_framework))
     end)
   end
+
+  defp notify_discord_args(user_id, nil), do: %{user_id: user_id}
+  defp notify_discord_args(user_id, framework), do: %{user_id: user_id, framework: framework}
 
   defp build_identity_changeset(user, profile) do
     %UserIdentity{}

--- a/apps/frontman_server/lib/frontman_server/workers/notify_discord_new_user.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/notify_discord_new_user.ex
@@ -24,11 +24,11 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+  def perform(%Oban.Job{args: %{"user_id" => user_id} = args}) do
     if enabled?() do
       case Accounts.get_user(user_id) do
         %User{} = user ->
-          post_to_discord(user)
+          post_to_discord(user, args["framework"])
 
         nil ->
           :discard
@@ -43,7 +43,7 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
     Application.get_env(:frontman_server, __MODULE__)[:enabled] == true
   end
 
-  defp post_to_discord(user) do
+  defp post_to_discord(user, framework) do
     webhook_url = Application.fetch_env!(:frontman_server, :discord_new_users_webhook_url)
 
     body = %{
@@ -53,7 +53,8 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
           color: 0x57F287,
           fields: [
             %{name: "Name", value: user.name || "—", inline: true},
-            %{name: "Email", value: user.email || "—", inline: true}
+            %{name: "Email", value: user.email || "—", inline: true},
+            %{name: "Framework", value: framework_display_name(framework), inline: true}
           ],
           timestamp: DateTime.to_iso8601(user.inserted_at)
         }
@@ -78,4 +79,13 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
   defp req_options do
     Application.get_env(:frontman_server, :notify_discord_req_options, [])
   end
+
+  defp framework_display_name("nextjs"), do: "Next.js"
+  defp framework_display_name("vite"), do: "Vite"
+  defp framework_display_name("astro"), do: "Astro"
+  defp framework_display_name("wordpress"), do: "WordPress"
+  defp framework_display_name(nil), do: "—"
+  defp framework_display_name(""), do: "—"
+  defp framework_display_name(framework) when is_binary(framework), do: framework
+  defp framework_display_name(_), do: "—"
 end

--- a/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/oauth_controller.ex
@@ -24,7 +24,9 @@ defmodule FrontmanServerWeb.OAuthController do
   def callback(conn, %{"code" => code}) do
     require Logger
 
-    case Accounts.authenticate_with_oauth(code) do
+    signup_framework = get_session(conn, :signup_framework)
+
+    case Accounts.authenticate_with_oauth(code, signup_framework) do
       {:ok, user} ->
         conn
         |> put_flash(:info, "Welcome!")
@@ -81,13 +83,14 @@ defmodule FrontmanServerWeb.OAuthController do
 
   def verify_email(conn, %{"code" => code}) do
     token = get_session(conn, :pending_auth_token)
+    signup_framework = get_session(conn, :signup_framework)
 
     if is_nil(token) do
       conn
       |> put_flash(:error, "No pending verification. Please sign in again.")
       |> redirect(to: ~p"/users/log-in")
     else
-      case Accounts.authenticate_with_email_verification(code, token) do
+      case Accounts.authenticate_with_email_verification(code, token, signup_framework) do
         {:ok, user} ->
           conn
           |> delete_session(:pending_auth_token)

--- a/apps/frontman_server/lib/frontman_server_web/controllers/user_session_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/user_session_controller.ex
@@ -17,10 +17,9 @@ defmodule FrontmanServerWeb.UserSessionController do
     # Store return_to from query param (for cross-origin redirects like /frontman).
     # Validated by redirect_to_return_path/2 in UserAuth before any redirect happens.
     conn =
-      case params["return_to"] do
-        nil -> conn
-        return_to -> put_session(conn, :user_return_to, return_to)
-      end
+      conn
+      |> maybe_put_user_return_to(params["return_to"])
+      |> maybe_put_signup_framework(params["framework"])
 
     render(conn, :new, form: form)
   end
@@ -108,5 +107,37 @@ defmodule FrontmanServerWeb.UserSessionController do
     conn
     |> put_flash(:info, "Logged out successfully.")
     |> UserAuth.log_out_user(params["return_to"])
+  end
+
+  defp maybe_put_user_return_to(conn, nil), do: conn
+
+  defp maybe_put_user_return_to(conn, return_to) when is_binary(return_to) do
+    put_session(conn, :user_return_to, return_to)
+  end
+
+  defp maybe_put_user_return_to(conn, _), do: conn
+
+  defp maybe_put_signup_framework(conn, framework) when is_binary(framework) do
+    case normalize_signup_framework(framework) do
+      {:ok, normalized} -> put_session(conn, :signup_framework, normalized)
+      :error -> delete_session(conn, :signup_framework)
+    end
+  end
+
+  defp maybe_put_signup_framework(conn, _), do: delete_session(conn, :signup_framework)
+
+  defp normalize_signup_framework("Next.js"), do: {:ok, "nextjs"}
+  defp normalize_signup_framework("Vite"), do: {:ok, "vite"}
+  defp normalize_signup_framework("Astro"), do: {:ok, "astro"}
+  defp normalize_signup_framework("WordPress"), do: {:ok, "wordpress"}
+
+  defp normalize_signup_framework(framework) do
+    case framework |> String.downcase() |> String.replace(~r/[^a-z]/, "") do
+      "nextjs" -> {:ok, "nextjs"}
+      "vite" -> {:ok, "vite"}
+      "astro" -> {:ok, "astro"}
+      "wordpress" -> {:ok, "wordpress"}
+      _ -> :error
+    end
   end
 end

--- a/apps/frontman_server/lib/frontman_server_web/controllers/user_session_controller.ex
+++ b/apps/frontman_server/lib/frontman_server_web/controllers/user_session_controller.ex
@@ -126,18 +126,9 @@ defmodule FrontmanServerWeb.UserSessionController do
 
   defp maybe_put_signup_framework(conn, _), do: delete_session(conn, :signup_framework)
 
-  defp normalize_signup_framework("Next.js"), do: {:ok, "nextjs"}
-  defp normalize_signup_framework("Vite"), do: {:ok, "vite"}
-  defp normalize_signup_framework("Astro"), do: {:ok, "astro"}
-  defp normalize_signup_framework("WordPress"), do: {:ok, "wordpress"}
-
-  defp normalize_signup_framework(framework) do
-    case framework |> String.downcase() |> String.replace(~r/[^a-z]/, "") do
-      "nextjs" -> {:ok, "nextjs"}
-      "vite" -> {:ok, "vite"}
-      "astro" -> {:ok, "astro"}
-      "wordpress" -> {:ok, "wordpress"}
-      _ -> :error
-    end
-  end
+  defp normalize_signup_framework("nextjs"), do: {:ok, "nextjs"}
+  defp normalize_signup_framework("vite"), do: {:ok, "vite"}
+  defp normalize_signup_framework("astro"), do: {:ok, "astro"}
+  defp normalize_signup_framework("wordpress"), do: {:ok, "wordpress"}
+  defp normalize_signup_framework(_), do: :error
 end

--- a/apps/frontman_server/test/frontman_server/workers/notify_discord_new_user_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/notify_discord_new_user_test.exs
@@ -18,7 +18,7 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUserTest do
   end
 
   describe "perform/1" do
-    test "posts new-user embed to the configured Discord webhook" do
+    test "posts new-user embed with framework to the configured Discord webhook" do
       user = Accounts.user_fixture(%{name: "Ada Lovelace", email: "ada@example.com"})
 
       Req.Test.stub(:discord_webhook, fn conn ->
@@ -32,6 +32,25 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUserTest do
         fields = Map.new(embed["fields"], &{&1["name"], &1["value"]})
         assert fields["Name"] == "Ada Lovelace"
         assert fields["Email"] == "ada@example.com"
+        assert fields["Framework"] == "Next.js"
+
+        Req.Test.json(conn, %{ok: true})
+      end)
+
+      assert :ok = perform_job(NotifyDiscordNewUser, %{user_id: user.id, framework: "nextjs"})
+    end
+
+    test "falls back to em dash when framework is missing" do
+      user = Accounts.user_fixture(%{name: "Grace Hopper", email: "grace@example.com"})
+
+      Req.Test.stub(:discord_webhook, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        [embed] = payload["embeds"]
+        fields = Map.new(embed["fields"], &{&1["name"], &1["value"]})
+
+        assert fields["Framework"] == "—"
 
         Req.Test.json(conn, %{ok: true})
       end)

--- a/apps/frontman_server/test/frontman_server_web/controllers/user_session_controller_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/controllers/user_session_controller_test.exs
@@ -18,10 +18,19 @@ defmodule FrontmanServerWeb.UserSessionControllerTest do
       assert response =~ "Continue with Google"
     end
 
-    test "stores normalized signup framework in session", %{conn: conn} do
-      conn = get(conn, ~p"/users/log-in?#{%{"framework" => "Next.js"}}")
+    test "stores canonical signup framework in session", %{conn: conn} do
+      conn = get(conn, ~p"/users/log-in?#{%{"framework" => "nextjs"}}")
 
       assert get_session(conn, :signup_framework) == "nextjs"
+    end
+
+    test "rejects non-canonical signup framework labels", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{signup_framework: "nextjs"})
+        |> get(~p"/users/log-in?#{%{"framework" => "Next.js"}}")
+
+      refute get_session(conn, :signup_framework)
     end
 
     test "clears signup framework when value is invalid", %{conn: conn} do

--- a/apps/frontman_server/test/frontman_server_web/controllers/user_session_controller_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/controllers/user_session_controller_test.exs
@@ -18,6 +18,30 @@ defmodule FrontmanServerWeb.UserSessionControllerTest do
       assert response =~ "Continue with Google"
     end
 
+    test "stores normalized signup framework in session", %{conn: conn} do
+      conn = get(conn, ~p"/users/log-in?#{%{"framework" => "Next.js"}}")
+
+      assert get_session(conn, :signup_framework) == "nextjs"
+    end
+
+    test "clears signup framework when value is invalid", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{signup_framework: "nextjs"})
+        |> get(~p"/users/log-in?#{%{"framework" => "totally-unknown"}}")
+
+      refute get_session(conn, :signup_framework)
+    end
+
+    test "clears signup framework when param is missing", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{signup_framework: "nextjs"})
+        |> get(~p"/users/log-in")
+
+      refute get_session(conn, :signup_framework)
+    end
+
     test "redirects to home when already logged in", %{conn: conn, user: user} do
       # The login route has redirect_if_user_is_authenticated plug,
       # so authenticated users are redirected away from the login page

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -29,11 +29,13 @@ type initConfig = {
 }
 
 // Connection states
+type authRequiredPayload = {loginUrl: string}
+
 type acpState =
   | ACPDisconnected
   | ACPConnecting
   | ACPConnected(ACP.connection)
-  | ACPAuthRequired({loginUrl: string})
+  | ACPAuthRequired(authRequiredPayload)
   | ACPError(string)
 
 type relayState =
@@ -65,12 +67,10 @@ type state = {
 @schema
 type clientInfoMeta = {framework: option<string>}
 
+@val external encodeURIComponent: string => string = "encodeURIComponent"
+
 let frameworkFromClientInfoMeta = (meta: JSON.t): option<string> =>
-  try {
-    S.parseOrThrow(meta, clientInfoMetaSchema).framework
-  } catch {
-  | _ => None
-  }
+  S.parseOrThrow(meta, clientInfoMetaSchema).framework
 
 // Initialization payload - includes pre-created instances
 type initPayload = {
@@ -84,6 +84,7 @@ type action =
   | Initialize(initPayload)
   | ACPConnectStart
   | ACPConnectSuccess(ACP.connection)
+  | ACPAuthRequiredReceived(authRequiredPayload)
   | ACPConnectError(string)
   | RelayInstanceCreated(Relay.t)
   | RelayConnectStart
@@ -172,6 +173,7 @@ type effect =
       taskId: string,
       onComplete: result<unit, string> => unit,
     })
+  | NotifyDeleteSessionRejected({onComplete: result<unit, string> => unit, reason: string})
   | CleanupSessionEffect({session: ACP.session})
 
 let initialState: state = {
@@ -189,15 +191,28 @@ module Selectors = {
   let getSession = (state: state): option<ACP.session> => {
     switch state.session {
     | SessionActive(s) => Some(s)
-    | _ => None
+    | NoSession | SessionCreating | SessionError(_) => None
     }
   }
 
   let canCreateSession = (state: state): bool => {
-    switch (state.acp, state.relay, state.mcpServer, state.session) {
-    | (ACPConnected(_), RelayConnected, Some(_), NoSession) => true
-    | _ => false
+    let acpReady = switch state.acp {
+    | ACPConnected(_) => true
+    | ACPDisconnected | ACPConnecting | ACPAuthRequired(_) | ACPError(_) => false
     }
+    let relayReady = switch state.relay {
+    | RelayConnected => true
+    | RelayDisconnected | RelayConnecting | RelayError(_) => false
+    }
+    let mcpReady = switch state.mcpServer {
+    | Some(_) => true
+    | None => false
+    }
+    let hasNoSession = switch state.session {
+    | NoSession => true
+    | SessionCreating | SessionActive(_) | SessionError(_) => false
+    }
+    acpReady && relayReady && mcpReady && hasNoSession
   }
 
   // Derive user-facing connection state
@@ -232,7 +247,7 @@ module Selectors = {
   let getAuthRedirectUrl = (state: state): option<string> => {
     switch state.acp {
     | ACPAuthRequired({loginUrl}) => Some(loginUrl)
-    | _ => None
+    | ACPDisconnected | ACPConnecting | ACPConnected(_) | ACPError(_) => None
     }
   }
 
@@ -299,6 +314,11 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
   | ({acp: ACPConnecting}, ACPConnectSuccess(conn)) => (
       {...state, acp: ACPConnected(conn)},
       [LogInfo("ACP connected"), FetchSessionsEffect(conn)],
+    )
+
+  | ({acp: ACPConnecting}, ACPAuthRequiredReceived({loginUrl})) => (
+      {...state, acp: ACPAuthRequired({loginUrl: loginUrl})},
+      [LogInfo("ACP auth required")],
     )
 
   | ({acp: ACPConnecting}, ACPConnectError(msg)) => (
@@ -471,10 +491,13 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
       [DeleteSessionEffect({connection: conn, taskId, onComplete})],
     )
 
-  | (_, DeleteSession({onComplete, _})) => {
-      onComplete(Error("Not connected"))
-      (state, [])
-    }
+  | (_, DeleteSession({onComplete, _})) => (
+      state,
+      [
+        NotifyDeleteSessionRejected({onComplete, reason: "Not connected"}),
+        LogError("Cannot delete session: not connected"),
+      ],
+    )
 
   // === Clear Session (for starting new task) ===
   | ({session: SessionActive(oldSession)}, ClearSession) => (
@@ -497,7 +520,7 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
     }
     let acpEffects = switch state.acp {
     | ACPConnected(conn) => [DisconnectACP(conn)]
-    | _ => []
+    | ACPDisconnected | ACPConnecting | ACPAuthRequired(_) | ACPError(_) => []
     }
     (
       {...initialState, initialAuthBehavior: state.initialAuthBehavior},
@@ -505,40 +528,82 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
     )
 
   // === Invalid transitions ===
-  | (_, Initialize(_)) => (state, [LogError("Invalid: already initialized")])
+  | (_, Initialize(_)) => (state, [LogInfo("Initialize ignored: already initialized")])
 
   | (
       {acp: ACPConnecting | ACPConnected(_) | ACPAuthRequired(_) | ACPError(_)},
       ACPConnectStart,
-    ) => (state, [LogError("Invalid: ACP connect already in progress or completed")])
+    ) => (state, [LogInfo("ACPConnectStart ignored: ACP not disconnected")])
 
   | (
       {acp: ACPDisconnected | ACPConnected(_) | ACPAuthRequired(_) | ACPError(_)},
       ACPConnectSuccess(_),
-    ) => (state, [LogError("Invalid: unexpected ACP connect success")])
+    ) => (state, [LogInfo("ACPConnectSuccess ignored")])
+
+  | (
+      {acp: ACPDisconnected | ACPConnected(_) | ACPAuthRequired(_) | ACPError(_)},
+      ACPAuthRequiredReceived(_),
+    ) => (state, [LogInfo("ACPAuthRequiredReceived ignored")])
+
+  | (
+      {acp: ACPDisconnected | ACPConnected(_) | ACPAuthRequired(_) | ACPError(_)},
+      ACPConnectError(_),
+    ) => (state, [LogInfo("ACPConnectError ignored")])
+
+  | ({relayInstance: Some(_)}, RelayInstanceCreated(_)) => (
+      state,
+      [LogInfo("RelayInstanceCreated ignored: already exists")],
+    )
 
   | ({relay: RelayConnecting | RelayConnected | RelayError(_)}, RelayConnectStart) => (
       state,
-      [LogError("Invalid: Relay connect already in progress or completed")],
+      [LogInfo("RelayConnectStart ignored: relay not disconnected")],
+    )
+
+  | ({relay: RelayDisconnected, relayInstance: None}, RelayConnectStart) => (
+      state,
+      [LogError("RelayConnectStart rejected: no relay instance")],
+    )
+
+  | ({relay: RelayDisconnected | RelayConnected | RelayError(_)}, RelayConnectSuccess) => (
+      state,
+      [LogInfo("RelayConnectSuccess ignored")],
+    )
+
+  | ({relay: RelayDisconnected | RelayConnected | RelayError(_)}, RelayConnectError(_)) => (
+      state,
+      [LogInfo("RelayConnectError ignored")],
+    )
+
+  | ({mcpServer: Some(_)}, MCPServerCreated(_)) => (
+      state,
+      [LogInfo("MCPServerCreated ignored: already exists")],
     )
 
   | (
       {acp: ACPDisconnected | ACPConnecting | ACPAuthRequired(_) | ACPError(_)},
       SessionCreateStart,
-    ) => (state, [LogError("Cannot create session: ACP not connected")])
+    ) => (state, [LogError("SessionCreateStart rejected: ACP not connected")])
 
   | ({mcpServer: None}, SessionCreateStart) => (
       state,
-      [LogError("Cannot create session: MCPServer not ready")],
+      [LogError("SessionCreateStart rejected: MCPServer not ready")],
     )
 
   | ({session: SessionCreating | SessionActive(_) | SessionError(_)}, SessionCreateStart) => (
       state,
-      [LogError("Cannot create session: session already exists")],
+      [LogError("SessionCreateStart rejected: session already exists")],
     )
 
-  // Ignore other invalid transitions silently
-  | _ => (state, [])
+  | ({session: NoSession | SessionActive(_) | SessionError(_)}, SessionCreateError(_)) => (
+      state,
+      [LogInfo("SessionCreateError ignored")],
+    )
+
+  | (
+      {isSendingPrompt: true, session: NoSession | SessionCreating | SessionError(_)},
+      CancelPrompt,
+    ) => (state, [LogError("CancelPrompt rejected: no active session")])
   }
 }
 
@@ -571,6 +636,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
   | LogInfo(msg) => Log.info(msg)
   | DisconnectRelay(relay) => Relay.disconnect(relay)
   | DisconnectACP(_) => ()
+  | NotifyDeleteSessionRejected({onComplete, reason}) => onComplete(Error(reason))
   | AbortConnections(controller) =>
     Log.info("Aborting in-flight connections")
     WebAPI.AbortController.abort(controller)
@@ -581,12 +647,11 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
       | Ok(conn) => dispatch(ACPConnectSuccess(conn))
       | Error(err) =>
         // Don't dispatch error for aborted connections - component is unmounting
-        if signal.aborted {
-          Log.info("ACP connection aborted (cleanup)")
-        } else {
+        switch signal.aborted {
+        | true => Log.info("ACP connection aborted (cleanup)")
+        | false =>
           switch err {
           | ACP.AuthRequired({loginUrl}) =>
-            let encodeURIComponent: string => string = %raw(`encodeURIComponent`)
             let currentUrl = WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href
             let returnTo = encodeURIComponent(currentUrl)
             let framework = config.clientInfo._meta->Option.flatMap(frameworkFromClientInfoMeta)
@@ -596,15 +661,14 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
             | None => ""
             }
 
-            let separator = if String.includes(loginUrl, "?") {
-              "&"
-            } else {
-              "?"
+            let separator = switch String.includes(loginUrl, "?") {
+            | true => "&"
+            | false => "?"
             }
             let fullUrl = `${loginUrl}${separator}return_to=${returnTo}${frameworkParam}`
             switch initialAuthBehavior {
             | Client__FtueState.ShowWelcomeModal =>
-              dispatch(ACPConnectError(`auth_required:${fullUrl}`))
+              dispatch(ACPAuthRequiredReceived({loginUrl: fullUrl}))
             | Client__FtueState.RedirectToLogin =>
               WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.assign(fullUrl)
             }
@@ -717,7 +781,8 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
     }) =>
     let activateSession = async () => {
       let mcpServerInterface = MCPServer.toInterface(mcpServer)
-      let result = if needsHistory {
+      let result = switch needsHistory {
+      | true =>
         let loadResult = await ACP.loadSession(
           connection,
           taskId,
@@ -732,7 +797,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
           Ok(session)
         | Error(e) => Error(e)
         }
-      } else {
+      | false =>
         await ACP.joinSession(
           connection,
           taskId,
@@ -755,10 +820,13 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
     }
 
     switch state.session {
-    | SessionActive({sessionId}) if sessionId == taskId => onComplete(Ok())
     | SessionActive(oldSession) =>
-      cleanupSession(oldSession)
-      activateSession()->ignore
+      switch oldSession.sessionId == taskId {
+      | true => onComplete(Ok())
+      | false =>
+        cleanupSession(oldSession)
+        activateSession()->ignore
+      }
     | NoSession | SessionCreating | SessionError(_) => activateSession()->ignore
     }
 

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -62,6 +62,16 @@ type state = {
   abortController: option<WebAPI.EventAPI.abortController>,
 }
 
+@schema
+type clientInfoMeta = {framework: option<string>}
+
+let frameworkFromClientInfoMeta = (meta: JSON.t): option<string> =>
+  try {
+    S.parseOrThrow(meta, clientInfoMetaSchema).framework
+  } catch {
+  | _ => None
+  }
+
 // Initialization payload - includes pre-created instances
 type initPayload = {
   config: initConfig,
@@ -579,13 +589,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
             let encodeURIComponent: string => string = %raw(`encodeURIComponent`)
             let currentUrl = WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href
             let returnTo = encodeURIComponent(currentUrl)
-            let framework = config.clientInfo._meta->Option.flatMap(meta => {
-              meta
-              ->JSON.Decode.object
-              ->Option.flatMap(obj =>
-                obj->Dict.get("framework")->Option.flatMap(JSON.Decode.string)
-              )
-            })
+            let framework = config.clientInfo._meta->Option.flatMap(frameworkFromClientInfoMeta)
 
             let frameworkParam = switch framework {
             | Some(framework) => `&framework=${encodeURIComponent(framework)}`

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -579,7 +579,25 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
             let encodeURIComponent: string => string = %raw(`encodeURIComponent`)
             let currentUrl = WebAPI.Global.window->WebAPI.Window.location->WebAPI.Location.href
             let returnTo = encodeURIComponent(currentUrl)
-            let fullUrl = `${loginUrl}?return_to=${returnTo}`
+            let framework = config.clientInfo._meta->Option.flatMap(meta => {
+              meta
+              ->JSON.Decode.object
+              ->Option.flatMap(obj =>
+                obj->Dict.get("framework")->Option.flatMap(JSON.Decode.string)
+              )
+            })
+
+            let frameworkParam = switch framework {
+            | Some(framework) => `&framework=${encodeURIComponent(framework)}`
+            | None => ""
+            }
+
+            let separator = if String.includes(loginUrl, "?") {
+              "&"
+            } else {
+              "?"
+            }
+            let fullUrl = `${loginUrl}${separator}return_to=${returnTo}${frameworkParam}`
             switch initialAuthBehavior {
             | Client__FtueState.ShowWelcomeModal =>
               dispatch(ACPConnectError(`auth_required:${fullUrl}`))

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -433,16 +433,7 @@ module Provider = {
       dispatch(DeleteSession({taskId, onComplete}))
     }, [dispatch])
 
-    // Submit a late tool result via the ACP session channel.
-    // Extract auth redirect URL from ACP error state (encoded as "auth_required:<url>")
-    let authRedirectUrl = switch state.acp {
-    | Reducer.ACPError(msg) =>
-      switch String.startsWith(msg, "auth_required:") {
-      | true => Some(String.slice(msg, ~start=14, ~end=String.length(msg)))
-      | false => None
-      }
-    | _ => None
-    }
+    let authRedirectUrl = Reducer.Selectors.getAuthRedirectUrl(state)
 
     let contextValue: contextValue = {
       connectionState: Reducer.Selectors.getConnectionStatus(state),

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -72,13 +72,13 @@ describe("Connection Reducer", () => {
     )
 
     test(
-      "rejects ACPConnectStart when already connecting",
+      "ignores ACPConnectStart when already connecting",
       t => {
         let state = {...Reducer.initialState, acp: ACPConnecting}
         let (nextState, effects) = Reducer.reduce(state, ACPConnectStart)
 
         t->expect(nextState.acp)->Expect.toBe(Reducer.ACPConnecting)
-        t->expect(hasLogError(effects))->Expect.toBe(true)
+        t->expect(hasLogInfo(effects))->Expect.toBe(true)
       },
     )
   })
@@ -118,7 +118,7 @@ describe("Connection Reducer", () => {
     )
 
     test(
-      "Initialize rejects when already initialized",
+      "Initialize ignores when already initialized",
       t => {
         let mockRelay = Obj.magic({"id": "relay-1"})
         let mockServer = Obj.magic({"tools": []})
@@ -139,7 +139,7 @@ describe("Connection Reducer", () => {
           Initialize({config: mockConfig, relay: mockRelay, mcpServer: mockServer}),
         )
 
-        t->expect(hasLogError(effects))->Expect.toBe(true)
+        t->expect(hasLogInfo(effects))->Expect.toBe(true)
       },
     )
   })
@@ -164,9 +164,10 @@ describe("Connection Reducer", () => {
       t => {
         let (nextState, effects) = Reducer.reduce(Reducer.initialState, RelayConnectStart)
 
-        // Should be ignored - no relay instance
+        // Should be rejected - no relay instance
         t->expect(nextState.relay)->Expect.toBe(Reducer.RelayDisconnected)
-        t->expect(effects->Array.length)->Expect.toBe(0)
+        t->expect(effects->Array.length)->Expect.toBe(1)
+        t->expect(hasLogError(effects))->Expect.toBe(true)
       },
     )
 


### PR DESCRIPTION
## Summary
- Append the detected framework to auth-required login redirects so OAuth signup flow can carry framework context.
- Normalize/store the signup framework in session and thread it through OAuth callback + verify-email authentication paths.
- Enqueue Discord signup notifications with framework metadata and render a `Framework` field in the Discord embed.
- Add regression tests for login framework session handling and Discord worker payload, plus a changeset.

## Testing
- `cd libs/client && make test`
- `cd apps/frontman_server && mix test test/frontman_server_web/controllers/user_session_controller_test.exs test/frontman_server/workers/notify_discord_new_user_test.exs test/frontman_server_web/controllers/oauth_controller_test.exs`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
