### PR TITLE
feat(sandbox): route backend tools into task sandboxes

### DIFF
--- a/apps/frontman_server/config/dev.exs
+++ b/apps/frontman_server/config/dev.exs
@@ -16,6 +16,22 @@ config :frontman_server,
         System.get_env("PHX_URL_PORT") || if(System.get_env("E2E"), do: "4002", else: "4000")
       ),
     upstream_host: "127.0.0.1"
+  ],
+  sandbox_mvp: [
+    enabled: System.get_env("SANDBOX_MVP_ENABLED") in ["1", "true", "TRUE"],
+    image: System.get_env("SANDBOX_MVP_IMAGE") || "ghcr.io/frontman-ai/frontman-dev:latest",
+    project_root: System.get_env("SANDBOX_MVP_PROJECT_ROOT") || "/workspace/frontman",
+    repo_url:
+      System.get_env("SANDBOX_MVP_REPO_URL") || "https://github.com/frontman-ai/frontman.git",
+    repo_ref: System.get_env("SANDBOX_MVP_REPO_REF") || "main",
+    app_dir: System.get_env("SANDBOX_MVP_APP_DIR") || "apps/frontman_server",
+    install_command: System.get_env("SANDBOX_MVP_INSTALL_COMMAND") || "mix deps.get",
+    start_command: System.get_env("SANDBOX_MVP_START_COMMAND") || "mix phx.server",
+    app_port: String.to_integer(System.get_env("SANDBOX_MVP_APP_PORT") || "4000"),
+    health_path: System.get_env("SANDBOX_MVP_HEALTH_PATH") || "/health/ready",
+    wait_timeout_ms: String.to_integer(System.get_env("SANDBOX_MVP_WAIT_TIMEOUT_MS") || "600000"),
+    poll_interval_ms: String.to_integer(System.get_env("SANDBOX_MVP_POLL_INTERVAL_MS") || "1000"),
+    step_timeout_ms: String.to_integer(System.get_env("SANDBOX_MVP_STEP_TIMEOUT_MS") || "180000")
   ]
 
 # Configure your database

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -174,6 +174,17 @@ if config_env() == :prod do
   preview_base_host = System.get_env("PREVIEW_BASE_HOST") || "preview.frontman.sh"
   auth_cookie_domain = System.get_env("AUTH_COOKIE_DOMAIN") || ".frontman.sh"
   app_login_host = System.get_env("APP_LOGIN_HOST") || host
+  sandbox_mvp_enabled = System.get_env("SANDBOX_MVP_ENABLED") in ["1", "true", "TRUE"]
+  sandbox_mvp_app_port = String.to_integer(System.get_env("SANDBOX_MVP_APP_PORT") || "4000")
+
+  sandbox_mvp_wait_timeout_ms =
+    String.to_integer(System.get_env("SANDBOX_MVP_WAIT_TIMEOUT_MS") || "600000")
+
+  sandbox_mvp_poll_interval_ms =
+    String.to_integer(System.get_env("SANDBOX_MVP_POLL_INTERVAL_MS") || "1000")
+
+  sandbox_mvp_step_timeout_ms =
+    String.to_integer(System.get_env("SANDBOX_MVP_STEP_TIMEOUT_MS") || "180000")
 
   app_login_port =
     case System.get_env("APP_LOGIN_PORT") do
@@ -190,6 +201,22 @@ if config_env() == :prod do
       app_login_scheme: "https",
       app_login_port: app_login_port,
       upstream_host: "127.0.0.1"
+    ],
+    sandbox_mvp: [
+      enabled: sandbox_mvp_enabled,
+      image: System.get_env("SANDBOX_MVP_IMAGE") || "ghcr.io/frontman-ai/frontman-dev:latest",
+      project_root: System.get_env("SANDBOX_MVP_PROJECT_ROOT") || "/workspace/frontman",
+      repo_url:
+        System.get_env("SANDBOX_MVP_REPO_URL") || "https://github.com/frontman-ai/frontman.git",
+      repo_ref: System.get_env("SANDBOX_MVP_REPO_REF") || "main",
+      app_dir: System.get_env("SANDBOX_MVP_APP_DIR") || "apps/frontman_server",
+      install_command: System.get_env("SANDBOX_MVP_INSTALL_COMMAND") || "mix deps.get",
+      start_command: System.get_env("SANDBOX_MVP_START_COMMAND") || "mix phx.server",
+      app_port: sandbox_mvp_app_port,
+      health_path: System.get_env("SANDBOX_MVP_HEALTH_PATH") || "/health/ready",
+      wait_timeout_ms: sandbox_mvp_wait_timeout_ms,
+      poll_interval_ms: sandbox_mvp_poll_interval_ms,
+      step_timeout_ms: sandbox_mvp_step_timeout_ms
     ]
 
   config :frontman_server, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -33,6 +33,21 @@ config :frontman_server,
     app_login_scheme: "http",
     app_login_port: 4002,
     upstream_host: "127.0.0.1"
+  ],
+  sandbox_mvp: [
+    enabled: false,
+    image: "ghcr.io/frontman-ai/frontman-dev:latest",
+    project_root: "/workspace/frontman",
+    repo_url: "https://github.com/frontman-ai/frontman.git",
+    repo_ref: "main",
+    app_dir: "apps/frontman_server",
+    install_command: "mix deps.get",
+    start_command: "mix phx.server",
+    app_port: 4000,
+    health_path: "/health/ready",
+    wait_timeout_ms: 60_000,
+    poll_interval_ms: 100,
+    step_timeout_ms: 30_000
   ]
 
 # In test we don't send emails

--- a/apps/frontman_server/lib/frontman_server/sandbox/orchestrator.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/orchestrator.ex
@@ -39,10 +39,36 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     :bootstrap_config
   ]
 
+  @type orchestrator_status :: :provisioning | :running
+
+  @type t :: %__MODULE__{
+          sandbox_id: String.t(),
+          provider_ref: String.t() | nil,
+          status: orchestrator_status(),
+          heartbeat_ref: reference() | nil,
+          provision_timer_ref: reference() | nil,
+          provider: module(),
+          heartbeat_interval_ms: pos_integer(),
+          provision_timeout_ms: pos_integer(),
+          environment_spec: EnvironmentSpec.t() | nil,
+          task_supervisor: term(),
+          setup_task_ref: reference() | nil,
+          bootstrap_config: map()
+        }
+
+  @type callback_reply ::
+          {:reply, term(), t()}
+          | {:noreply, t()}
+          | {:stop, :normal, term(), t()}
+
+  @type callback_noreply ::
+          {:noreply, t()}
+          | {:stop, :normal, t()}
+
   # --- Client API ---
 
   @spec start_link(keyword()) :: GenServer.on_start()
-  def start_link(opts) do
+  def start_link(opts) when is_list(opts) do
     sandbox_id = Keyword.fetch!(opts, :sandbox_id)
 
     GenServer.start_link(__MODULE__, opts,
@@ -52,7 +78,8 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
 
   @spec exec(String.t(), String.t(), [String.t()], keyword()) ::
           {:ok, map()} | {:error, term()}
-  def exec(sandbox_id, command, args, opts \\ []) do
+  def exec(sandbox_id, command, args, opts \\ [])
+      when is_binary(sandbox_id) and is_binary(command) and is_list(args) and is_list(opts) do
     call_timeout = exec_call_timeout(opts)
 
     case safe_call(sandbox_id, {:exec, command, args, opts}, call_timeout) do
@@ -63,7 +90,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   @spec stop(String.t()) :: :ok | {:error, term()}
-  def stop(sandbox_id) do
+  def stop(sandbox_id) when is_binary(sandbox_id) do
     case safe_call(sandbox_id, :stop) do
       {:ok, result} -> result
       {:error, :not_found} -> {:error, :not_found}
@@ -72,7 +99,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   @spec destroy(String.t()) :: :ok | {:error, term()}
-  def destroy(sandbox_id) do
+  def destroy(sandbox_id) when is_binary(sandbox_id) do
     case safe_call(sandbox_id, :destroy) do
       {:ok, result} -> result
       {:error, :not_found} -> {:error, :not_found}
@@ -81,7 +108,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   @spec status(String.t()) :: {:ok, atom()} | {:error, :not_found | :timeout | term()}
-  def status(sandbox_id) do
+  def status(sandbox_id) when is_binary(sandbox_id) do
     case safe_call(sandbox_id, :status) do
       {:ok, result} -> result
       {:error, :not_found} -> {:error, :not_found}
@@ -89,14 +116,15 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     end
   end
 
-  defp via(sandbox_id) do
+  defp via(sandbox_id) when is_binary(sandbox_id) do
     {:via, Registry, {FrontmanServer.Sandbox.Registry, sandbox_id}}
   end
 
   # --- Server Callbacks ---
 
+  @spec init(keyword()) :: {:ok, t(), {:continue, :provision}} | {:stop, :normal}
   @impl true
-  def init(opts) do
+  def init(opts) when is_list(opts) do
     sandbox_id = Keyword.fetch!(opts, :sandbox_id)
     provider = Keyword.get(opts, :provider, default_provider())
     task_supervisor = Keyword.get(opts, :task_supervisor, FrontmanServer.Sandbox.TaskSupervisor)
@@ -126,11 +154,12 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
       {:error, reason} ->
         Logger.error("[Orchestrator] invalid env_spec for #{sandbox_id}: #{inspect(reason)}")
 
-        update_db_status(sandbox_id, :error)
+        persist_status(sandbox_id, :error)
         {:stop, :normal}
     end
   end
 
+  @spec handle_continue(:provision, t()) :: callback_noreply()
   @impl true
   def handle_continue(:provision, state) do
     with {:ok, routing} <- build_port_routing(state.environment_spec),
@@ -164,10 +193,11 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
 
         {:error, reason} ->
           Logger.error(
-            "[Orchestrator] failed to start setup task for #{state.sandbox_id}: #{inspect(reason)}"
+            "[Orchestrator] failed to start setup task for #{state.sandbox_id}: " <>
+              inspect(reason)
           )
 
-          update_db_status(state.sandbox_id, :error)
+          persist_status(state.sandbox_id, :error)
           {:stop, :normal, state}
       end
     else
@@ -176,11 +206,12 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
           "[Orchestrator] provider.create failed for #{state.sandbox_id}: #{inspect(reason)}"
         )
 
-        update_db_status(state.sandbox_id, :error)
+        persist_status(state.sandbox_id, :error)
         {:stop, :normal, state}
     end
   end
 
+  @spec handle_call(term(), GenServer.from(), t()) :: callback_reply()
   @impl true
   def handle_call({:exec, command, args, opts}, from, %{status: :running} = state) do
     case start_exec_task(state.task_supervisor, fn ->
@@ -188,7 +219,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
            GenServer.reply(from, result)
          end) do
       {:ok, _pid} ->
-        touch_last_active(state.sandbox_id)
+        touch_last_active_and_log(state.sandbox_id)
         {:noreply, state}
 
       {:error, reason} ->
@@ -203,8 +234,13 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   def handle_call(:stop, _from, state) do
     case state.provider.stop(state.provider_ref) do
       :ok ->
-        update_db_status(state.sandbox_id, :stopped)
-        {:stop, :normal, :ok, state}
+        case persist_status(state.sandbox_id, :stopped) do
+          :ok ->
+            {:stop, :normal, :ok, state}
+
+          {:error, reason} ->
+            {:stop, :normal, {:error, {:status_persist_failed, reason}}, state}
+        end
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -214,12 +250,13 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   def handle_call(:destroy, _from, state) do
     case state.provider.destroy(state.provider_ref) do
       :ok ->
-        case Repo.get(SandboxSchema, state.sandbox_id) do
-          nil -> :ok
-          sandbox -> Repo.delete(sandbox)
-        end
+        case delete_sandbox_record(state.sandbox_id) do
+          :ok ->
+            {:stop, :normal, :ok, state}
 
-        {:stop, :normal, :ok, state}
+          {:error, reason} ->
+            {:stop, :normal, {:error, {:delete_failed, reason}}, state}
+        end
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -230,10 +267,11 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     {:reply, {:ok, state.status}, state}
   end
 
+  @spec handle_info(term(), t()) :: callback_noreply()
   @impl true
   def handle_info({ref, :ok}, %{setup_task_ref: ref} = state) do
     Process.demonitor(ref, [:flush])
-    maybe_transition_to_running(%{state | setup_task_ref: nil})
+    transition_to_running_or_reschedule(%{state | setup_task_ref: nil})
   end
 
   def handle_info({ref, {:error, reason}}, %{setup_task_ref: ref} = state) do
@@ -243,7 +281,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
       "[Orchestrator] setup sequence failed for #{state.sandbox_id}: #{inspect(reason)}"
     )
 
-    update_db_status(state.sandbox_id, :error)
+    persist_status(state.sandbox_id, :error)
     {:stop, :normal, %{state | setup_task_ref: nil}}
   end
 
@@ -254,24 +292,54 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{setup_task_ref: ref} = state) do
     Logger.error("[Orchestrator] setup task crashed for #{state.sandbox_id}: #{inspect(reason)}")
 
-    update_db_status(state.sandbox_id, :error)
+    persist_status(state.sandbox_id, :error)
     {:stop, :normal, %{state | setup_task_ref: nil}}
   end
 
-  def handle_info({_ref, :ok}, state), do: {:noreply, state}
-  def handle_info({_ref, {:error, _reason}}, state), do: {:noreply, state}
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
+  def handle_info({ref, :ok}, state) when is_reference(ref) do
+    Logger.debug("[Orchestrator] ignoring unrelated task success for ref=#{inspect(ref)}")
+    {:noreply, state}
+  end
+
+  def handle_info({ref, {:error, reason}}, state) when is_reference(ref) do
+    Logger.warning(
+      "[Orchestrator] ignoring unrelated task error for ref=#{inspect(ref)}: #{inspect(reason)}"
+    )
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) when is_reference(ref) do
+    Logger.debug(
+      "[Orchestrator] ignoring unrelated task DOWN for ref=#{inspect(ref)}: #{inspect(reason)}"
+    )
+
+    {:noreply, state}
+  end
 
   def handle_info(:heartbeat, %{status: :provisioning} = state) do
     case state.provider.metrics(state.provider_ref) do
       {:ok, %{running: true}} ->
-        maybe_transition_to_running(state)
+        transition_to_running_or_reschedule(state)
 
       {:ok, %{running: false}} ->
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
         {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
 
-      _ ->
+      {:error, reason} ->
+        Logger.warning(
+          "[Orchestrator] heartbeat metrics failed for #{state.sandbox_id}: #{inspect(reason)}"
+        )
+
+        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+        {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+
+      {:ok, metrics} ->
+        Logger.warning(
+          "[Orchestrator] invalid heartbeat metrics for #{state.sandbox_id}: " <>
+            inspect(metrics)
+        )
+
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
         {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
     end
@@ -285,10 +353,23 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
 
       {:ok, %{running: false}} ->
         Logger.error("[Orchestrator] VM crashed for #{state.sandbox_id}")
-        update_db_status(state.sandbox_id, :error)
+        persist_status(state.sandbox_id, :error)
         {:stop, :normal, state}
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        Logger.warning(
+          "[Orchestrator] heartbeat metrics failed for #{state.sandbox_id}: #{inspect(reason)}"
+        )
+
+        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+        {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+
+      {:ok, metrics} ->
+        Logger.warning(
+          "[Orchestrator] invalid heartbeat metrics for #{state.sandbox_id}: " <>
+            inspect(metrics)
+        )
+
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
         {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
     end
@@ -296,7 +377,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
 
   def handle_info(:provision_timeout, %{status: :provisioning} = state) do
     Logger.error("[Orchestrator] provisioning timed out for #{state.sandbox_id}")
-    update_db_status(state.sandbox_id, :error)
+    persist_status(state.sandbox_id, :error)
     {:stop, :normal, state}
   end
 
@@ -304,6 +385,12 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     {:noreply, state}
   end
 
+  def handle_info(message, state) do
+    Logger.warning("[Orchestrator] unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  @spec terminate(term(), t()) :: :ok
   @impl true
   def terminate(reason, state) do
     if state.heartbeat_ref, do: Process.cancel_timer(state.heartbeat_ref)
@@ -311,7 +398,8 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     if state.setup_task_ref, do: Process.demonitor(state.setup_task_ref, [:flush])
 
     Logger.info(
-      "[Orchestrator] terminating #{state.sandbox_id} (status=#{state.status}, reason=#{inspect(reason)})"
+      "[Orchestrator] terminating #{state.sandbox_id} " <>
+        "(status=#{state.status}, reason=#{inspect(reason)})"
     )
 
     :ok
@@ -332,30 +420,26 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     :exit, reason -> {:error, reason}
   end
 
-  defp maybe_transition_to_running(%{setup_task_ref: setup_task_ref} = state)
+  defp transition_to_running_or_reschedule(%{setup_task_ref: setup_task_ref} = state)
        when not is_nil(setup_task_ref) do
     heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
     {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
   end
 
-  defp maybe_transition_to_running(state) do
+  defp transition_to_running_or_reschedule(state) do
     case state.provider.metrics(state.provider_ref) do
       {:ok, %{running: true}} ->
         if state.provision_timer_ref, do: Process.cancel_timer(state.provision_timer_ref)
 
-        case update_db_status(state.sandbox_id, :running) do
-          {:ok, _sandbox} ->
+        case persist_status(state.sandbox_id, :running) do
+          :ok ->
             heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
 
             {:noreply,
              %{state | status: :running, provision_timer_ref: nil, heartbeat_ref: heartbeat_ref}}
 
-          {:error, reason} ->
-            Logger.error(
-              "[Orchestrator] failed to persist running status for #{state.sandbox_id}: #{inspect(reason)}"
-            )
-
-            update_db_status(state.sandbox_id, :error)
+          {:error, _reason} ->
+            persist_status(state.sandbox_id, :error)
             {:stop, :normal, state}
         end
 
@@ -363,7 +447,20 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
         {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        Logger.warning(
+          "[Orchestrator] transition metrics failed for #{state.sandbox_id}: #{inspect(reason)}"
+        )
+
+        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+        {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+
+      {:ok, metrics} ->
+        Logger.warning(
+          "[Orchestrator] invalid transition metrics for #{state.sandbox_id}: " <>
+            inspect(metrics)
+        )
+
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
         {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
     end
@@ -442,10 +539,16 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   defp run_start_command(provider, provider_ref, app_root, config, timeout_ms) do
+    stop_existing_process_script =
+      "if [ -f /tmp/frontman-app.pid ]; then " <>
+        "kill $(cat /tmp/frontman-app.pid) >/dev/null 2>&1 || true; " <>
+        "fi"
+
     script =
       "cd " <>
         shell_escape(app_root) <>
-        " && if [ -f /tmp/frontman-app.pid ]; then kill $(cat /tmp/frontman-app.pid) >/dev/null 2>&1 || true; fi" <>
+        " && " <>
+        stop_existing_process_script <>
         " && nohup " <>
         config.start_command <>
         " >/tmp/frontman-app.log 2>&1 & echo $! > /tmp/frontman-app.pid"
@@ -475,8 +578,13 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
         :ok
 
       {:ok, %{exit_code: exit_code, stdout: stdout, stderr: stderr}} ->
-        {:error,
-         {step, %{exit_code: exit_code, stdout: String.trim(stdout), stderr: String.trim(stderr)}}}
+        command_result = %{
+          exit_code: exit_code,
+          stdout: String.trim(stdout),
+          stderr: String.trim(stderr)
+        }
+
+        {:error, {step, command_result}}
 
       {:error, reason} ->
         {:error, {step, reason}}
@@ -521,15 +629,72 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     end
   end
 
-  defp touch_last_active(sandbox_id) do
+  defp persist_status(sandbox_id, new_status) do
+    case update_db_status(sandbox_id, new_status) do
+      {:ok, _sandbox} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "[Orchestrator] failed to persist #{new_status} status for #{sandbox_id}: " <>
+            inspect(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp delete_sandbox_record(sandbox_id) do
     case Repo.get(SandboxSchema, sandbox_id) do
       nil ->
         :ok
 
       sandbox ->
-        sandbox
-        |> SandboxSchema.touch_changeset()
-        |> Repo.update()
+        case Repo.delete(sandbox) do
+          {:ok, _sandbox} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.error(
+              "[Orchestrator] failed to delete sandbox #{sandbox_id}: #{inspect(reason)}"
+            )
+
+            {:error, reason}
+        end
+    end
+  end
+
+  defp touch_last_active_and_log(sandbox_id) do
+    case touch_last_active(sandbox_id) do
+      :ok ->
+        :ok
+
+      {:error, :not_found} ->
+        Logger.debug("[Orchestrator] sandbox missing when touching activity: #{sandbox_id}")
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[Orchestrator] failed to touch last active for #{sandbox_id}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  defp touch_last_active(sandbox_id) do
+    case Repo.get(SandboxSchema, sandbox_id) do
+      nil ->
+        {:error, :not_found}
+
+      sandbox ->
+        case sandbox |> SandboxSchema.touch_changeset() |> Repo.update() do
+          {:ok, _sandbox} ->
+            :ok
+
+          {:error, reason} ->
+            {:error, reason}
+        end
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/sandbox/orchestrator.ex
+++ b/apps/frontman_server/lib/frontman_server/sandbox/orchestrator.ex
@@ -34,7 +34,9 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
     :heartbeat_interval_ms,
     :provision_timeout_ms,
     :environment_spec,
-    :task_supervisor
+    :task_supervisor,
+    :setup_task_ref,
+    :bootstrap_config
   ]
 
   # --- Client API ---
@@ -113,7 +115,8 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
       status: :provisioning,
       heartbeat_interval_ms: heartbeat_interval_ms,
       provision_timeout_ms: provision_timeout_ms,
-      task_supervisor: task_supervisor
+      task_supervisor: task_supervisor,
+      bootstrap_config: sandbox_bootstrap_config()
     }
 
     case EnvironmentSpec.from_map(sandbox.env_spec) do
@@ -148,13 +151,25 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
 
       heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
 
-      {:noreply,
-       %{
-         state
-         | provider_ref: provider_ref,
-           heartbeat_ref: heartbeat_ref,
-           provision_timer_ref: provision_timer_ref
-       }}
+      case start_setup_task(state, provider_ref) do
+        {:ok, setup_task_ref} ->
+          {:noreply,
+           %{
+             state
+             | provider_ref: provider_ref,
+               heartbeat_ref: heartbeat_ref,
+               provision_timer_ref: provision_timer_ref,
+               setup_task_ref: setup_task_ref
+           }}
+
+        {:error, reason} ->
+          Logger.error(
+            "[Orchestrator] failed to start setup task for #{state.sandbox_id}: #{inspect(reason)}"
+          )
+
+          update_db_status(state.sandbox_id, :error)
+          {:stop, :normal, state}
+      end
     else
       {:error, reason} ->
         Logger.error(
@@ -216,15 +231,41 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   @impl true
+  def handle_info({ref, :ok}, %{setup_task_ref: ref} = state) do
+    Process.demonitor(ref, [:flush])
+    maybe_transition_to_running(%{state | setup_task_ref: nil})
+  end
+
+  def handle_info({ref, {:error, reason}}, %{setup_task_ref: ref} = state) do
+    Process.demonitor(ref, [:flush])
+
+    Logger.error(
+      "[Orchestrator] setup sequence failed for #{state.sandbox_id}: #{inspect(reason)}"
+    )
+
+    update_db_status(state.sandbox_id, :error)
+    {:stop, :normal, %{state | setup_task_ref: nil}}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, :normal}, %{setup_task_ref: ref} = state) do
+    {:noreply, %{state | setup_task_ref: nil}}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{setup_task_ref: ref} = state) do
+    Logger.error("[Orchestrator] setup task crashed for #{state.sandbox_id}: #{inspect(reason)}")
+
+    update_db_status(state.sandbox_id, :error)
+    {:stop, :normal, %{state | setup_task_ref: nil}}
+  end
+
+  def handle_info({_ref, :ok}, state), do: {:noreply, state}
+  def handle_info({_ref, {:error, _reason}}, state), do: {:noreply, state}
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
+
   def handle_info(:heartbeat, %{status: :provisioning} = state) do
     case state.provider.metrics(state.provider_ref) do
       {:ok, %{running: true}} ->
-        if state.provision_timer_ref, do: Process.cancel_timer(state.provision_timer_ref)
-        update_db_status(state.sandbox_id, :running)
-        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
-
-        {:noreply,
-         %{state | status: :running, provision_timer_ref: nil, heartbeat_ref: heartbeat_ref}}
+        maybe_transition_to_running(state)
 
       {:ok, %{running: false}} ->
         heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
@@ -267,6 +308,7 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   def terminate(reason, state) do
     if state.heartbeat_ref, do: Process.cancel_timer(state.heartbeat_ref)
     if state.provision_timer_ref, do: Process.cancel_timer(state.provision_timer_ref)
+    if state.setup_task_ref, do: Process.demonitor(state.setup_task_ref, [:flush])
 
     Logger.info(
       "[Orchestrator] terminating #{state.sandbox_id} (status=#{state.status}, reason=#{inspect(reason)})"
@@ -276,6 +318,191 @@ defmodule FrontmanServer.Sandbox.Orchestrator do
   end
 
   # --- Private Helpers ---
+
+  defp start_setup_task(%{bootstrap_config: %{enabled: false}}, _provider_ref), do: {:ok, nil}
+
+  defp start_setup_task(state, provider_ref) do
+    task =
+      Task.Supervisor.async_nolink(state.task_supervisor, fn ->
+        run_setup_sequence(state.provider, provider_ref, state.bootstrap_config)
+      end)
+
+    {:ok, task.ref}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  defp maybe_transition_to_running(%{setup_task_ref: setup_task_ref} = state)
+       when not is_nil(setup_task_ref) do
+    heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+    {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+  end
+
+  defp maybe_transition_to_running(state) do
+    case state.provider.metrics(state.provider_ref) do
+      {:ok, %{running: true}} ->
+        if state.provision_timer_ref, do: Process.cancel_timer(state.provision_timer_ref)
+
+        case update_db_status(state.sandbox_id, :running) do
+          {:ok, _sandbox} ->
+            heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+
+            {:noreply,
+             %{state | status: :running, provision_timer_ref: nil, heartbeat_ref: heartbeat_ref}}
+
+          {:error, reason} ->
+            Logger.error(
+              "[Orchestrator] failed to persist running status for #{state.sandbox_id}: #{inspect(reason)}"
+            )
+
+            update_db_status(state.sandbox_id, :error)
+            {:stop, :normal, state}
+        end
+
+      {:ok, %{running: false}} ->
+        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+        {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+
+      {:error, _reason} ->
+        heartbeat_ref = schedule_heartbeat(state.heartbeat_interval_ms)
+        {:noreply, %{state | heartbeat_ref: heartbeat_ref}}
+    end
+  end
+
+  defp run_setup_sequence(_provider, _provider_ref, %{enabled: false}), do: :ok
+
+  defp run_setup_sequence(provider, provider_ref, config) do
+    step_timeout_ms = Map.fetch!(config, :step_timeout_ms)
+    project_root = Map.fetch!(config, :project_root)
+    app_dir = Map.fetch!(config, :app_dir)
+
+    app_root = Path.join(project_root, app_dir)
+
+    with :ok <- wait_for_vm_running(provider, provider_ref, step_timeout_ms),
+         :ok <- sync_repo(provider, provider_ref, config, step_timeout_ms),
+         :ok <- run_install_command(provider, provider_ref, app_root, config, step_timeout_ms),
+         :ok <- run_start_command(provider, provider_ref, app_root, config, step_timeout_ms) do
+      wait_for_health(provider, provider_ref, config, step_timeout_ms)
+    end
+  end
+
+  defp wait_for_vm_running(provider, provider_ref, timeout_ms) do
+    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
+    wait_for_vm_running_until(provider, provider_ref, deadline_ms)
+  end
+
+  defp wait_for_vm_running_until(provider, provider_ref, deadline_ms) do
+    case provider.metrics(provider_ref) do
+      {:ok, %{running: true}} ->
+        :ok
+
+      _other ->
+        now_ms = System.monotonic_time(:millisecond)
+
+        case now_ms >= deadline_ms do
+          true ->
+            {:error, {:wait_for_vm_running, :timeout}}
+
+          false ->
+            Process.sleep(1_000)
+            wait_for_vm_running_until(provider, provider_ref, deadline_ms)
+        end
+    end
+  end
+
+  defp sync_repo(provider, provider_ref, config, timeout_ms) do
+    script =
+      "if [ -d " <>
+        shell_escape(Path.join(config.project_root, ".git")) <>
+        " ]; then " <>
+        "git -C " <>
+        shell_escape(config.project_root) <>
+        " fetch --depth 1 origin " <>
+        shell_escape(config.repo_ref) <>
+        " && git -C " <>
+        shell_escape(config.project_root) <>
+        " checkout -f FETCH_HEAD; " <>
+        "else " <>
+        "rm -rf " <>
+        shell_escape(config.project_root) <>
+        " && git clone --depth 1 --branch " <>
+        shell_escape(config.repo_ref) <>
+        " " <>
+        shell_escape(config.repo_url) <>
+        " " <>
+        shell_escape(config.project_root) <>
+        "; fi"
+
+    run_setup_step(provider, provider_ref, :sync_repo, script, timeout_ms)
+  end
+
+  defp run_install_command(provider, provider_ref, app_root, config, timeout_ms) do
+    script = "cd " <> shell_escape(app_root) <> " && " <> config.install_command
+    run_setup_step(provider, provider_ref, :install_dependencies, script, timeout_ms)
+  end
+
+  defp run_start_command(provider, provider_ref, app_root, config, timeout_ms) do
+    script =
+      "cd " <>
+        shell_escape(app_root) <>
+        " && if [ -f /tmp/frontman-app.pid ]; then kill $(cat /tmp/frontman-app.pid) >/dev/null 2>&1 || true; fi" <>
+        " && nohup " <>
+        config.start_command <>
+        " >/tmp/frontman-app.log 2>&1 & echo $! > /tmp/frontman-app.pid"
+
+    run_setup_step(provider, provider_ref, :start_application, script, timeout_ms)
+  end
+
+  defp wait_for_health(provider, provider_ref, config, timeout_ms) do
+    health_url =
+      "http://127.0.0.1:" <> Integer.to_string(config.app_port) <> to_string(config.health_path)
+
+    script =
+      "for i in $(seq 1 60); do " <>
+        "curl -fsS " <>
+        shell_escape(health_url) <>
+        " >/dev/null 2>&1 && exit 0; " <>
+        "sleep 2; " <>
+        "done; " <>
+        "echo healthcheck_failed; exit 1"
+
+    run_setup_step(provider, provider_ref, :wait_for_health, script, timeout_ms)
+  end
+
+  defp run_setup_step(provider, provider_ref, step, script, timeout_ms) do
+    case provider.exec(provider_ref, "bash", ["-lc", script], timeout_ms: timeout_ms) do
+      {:ok, %{exit_code: 0}} ->
+        :ok
+
+      {:ok, %{exit_code: exit_code, stdout: stdout, stderr: stderr}} ->
+        {:error,
+         {step, %{exit_code: exit_code, stdout: String.trim(stdout), stderr: String.trim(stderr)}}}
+
+      {:error, reason} ->
+        {:error, {step, reason}}
+    end
+  end
+
+  defp sandbox_bootstrap_config do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+
+    %{
+      enabled: Keyword.get(config, :enabled, false),
+      repo_url: Keyword.get(config, :repo_url, "https://github.com/frontman-ai/frontman.git"),
+      repo_ref: Keyword.get(config, :repo_ref, "main"),
+      project_root: Keyword.get(config, :project_root, "/workspace/frontman"),
+      app_dir: Keyword.get(config, :app_dir, "apps/frontman_server"),
+      install_command: Keyword.get(config, :install_command, "mix deps.get"),
+      start_command: Keyword.get(config, :start_command, "mix phx.server"),
+      app_port: Keyword.get(config, :app_port, 4000),
+      health_path: Keyword.get(config, :health_path, "/health/ready"),
+      step_timeout_ms: Keyword.get(config, :step_timeout_ms, 180_000)
+    }
+  end
+
+  defp shell_escape(value) when is_binary(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
 
   defp schedule_heartbeat(interval_ms) do
     Process.send_after(self(), :heartbeat, interval_ms)

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -31,6 +31,8 @@ defmodule FrontmanServer.Tasks do
   alias FrontmanServer.Workers.GenerateTitle
   alias ReqLLM.ToolCall
 
+  @execution_start_table :frontman_tasks_execution_start_locks
+
   # --- Authorization Helpers ---
 
   @spec get_task_by_id(Scope.t(), String.t()) :: {:ok, TaskSchema.t()} | {:error, :not_found}
@@ -268,7 +270,7 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp guard_not_running(scope, task_id) do
-    if Execution.running?(scope, task_id), do: {:error, :already_running}, else: :ok
+    if execution_active?(scope, task_id), do: {:error, :already_running}, else: :ok
   end
 
   @doc """
@@ -430,27 +432,94 @@ defmodule FrontmanServer.Tasks do
   """
   @spec maybe_start_execution(Scope.t(), String.t(), list(), keyword()) :: :ok | :already_running
   def maybe_start_execution(scope, task_id, tools, opts) do
-    if Execution.running?(scope, task_id) do
+    if execution_active?(scope, task_id) do
       :already_running
     else
-      {:ok, task} = get_task(scope, task_id)
+      case Execution.sandbox_mvp_enabled?() do
+        true ->
+          maybe_start_execution_async(scope, task_id, tools, opts)
 
-      case Execution.run(scope, task, Keyword.merge([tools: tools], opts)) do
-        {:ok, _pid_or_already_running} ->
-          :ok
-
-        {:error, reason} ->
-          # Broadcast as :execution_start_error so TaskChannel can handle it.
-          # This is NOT a swarm_event (the agent never started), so we use a
-          # separate message shape to avoid double-wrapping.
-          Phoenix.PubSub.broadcast(
-            FrontmanServer.PubSub,
-            topic(task_id),
-            {:execution_start_error, Execution.error_message(scope, reason)}
-          )
-
-          :ok
+        false ->
+          maybe_start_execution_sync(scope, task_id, tools, opts)
       end
+    end
+  end
+
+  defp maybe_start_execution_async(scope, task_id, tools, opts) do
+    case mark_execution_starting(task_id) do
+      :ok ->
+        {:ok, _pid} =
+          Elixir.Task.start(fn ->
+            try do
+              maybe_start_execution_sync(scope, task_id, tools, opts)
+            after
+              clear_execution_starting(task_id)
+            end
+          end)
+
+        :ok
+
+      :already_starting ->
+        :already_running
+    end
+  end
+
+  defp maybe_start_execution_sync(scope, task_id, tools, opts) do
+    {:ok, task} = get_task(scope, task_id)
+
+    case Execution.run(scope, task, Keyword.merge([tools: tools], opts)) do
+      {:ok, _pid_or_already_running} ->
+        :ok
+
+      {:error, reason} ->
+        # Broadcast as :execution_start_error so TaskChannel can handle it.
+        # This is NOT a swarm_event (the agent never started), so we use a
+        # separate message shape to avoid double-wrapping.
+        Phoenix.PubSub.broadcast(
+          FrontmanServer.PubSub,
+          topic(task_id),
+          {:execution_start_error, Execution.error_message(scope, reason)}
+        )
+
+        :ok
+    end
+  end
+
+  defp execution_active?(scope, task_id) do
+    Execution.running?(scope, task_id) or execution_starting?(task_id)
+  end
+
+  defp mark_execution_starting(task_id) do
+    table = ensure_execution_start_table()
+
+    case :ets.insert_new(table, {task_id}) do
+      true -> :ok
+      false -> :already_starting
+    end
+  end
+
+  defp execution_starting?(task_id) do
+    table = ensure_execution_start_table()
+    :ets.member(table, task_id)
+  end
+
+  defp clear_execution_starting(task_id) do
+    table = ensure_execution_start_table()
+    :ets.delete(table, task_id)
+    :ok
+  end
+
+  defp ensure_execution_start_table do
+    case :ets.whereis(@execution_start_table) do
+      :undefined ->
+        try do
+          :ets.new(@execution_start_table, [:named_table, :public, :set, read_concurrency: true])
+        rescue
+          ArgumentError -> @execution_start_table
+        end
+
+      table ->
+        table
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -408,6 +408,9 @@ defmodule FrontmanServer.Tasks.Execution do
           :error ->
             {:error, :sandbox_provisioning_failed}
 
+          :stopped ->
+            {:error, :sandbox_stopped}
+
           _status ->
             continue_waiting(scope, sandbox_id, deadline_ms, poll_interval_ms)
         end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -27,6 +27,7 @@ defmodule FrontmanServer.Tasks.Execution do
   alias FrontmanServer.Observability.TelemetryEvents
   alias FrontmanServer.Providers
   alias FrontmanServer.Providers.{Model, Registry, ResolvedKey}
+  alias FrontmanServer.Sandboxes
   alias FrontmanServer.Tasks.Execution.{Framework, RootAgent, ToolExecutor}
   alias FrontmanServer.Tasks.{Interaction, Task}
   alias FrontmanServer.Tools
@@ -48,6 +49,13 @@ defmodule FrontmanServer.Tasks.Execution do
   @spec running?(Scope.t(), String.t()) :: boolean()
   def running?(%Scope{}, task_id) do
     SwarmAi.Runtime.running?(FrontmanServer.AgentRuntime, task_id)
+  end
+
+  @doc "Returns true when sandbox MVP bootstrap is enabled."
+  @spec sandbox_mvp_enabled?() :: boolean()
+  def sandbox_mvp_enabled? do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :enabled, false)
   end
 
   @doc """
@@ -72,30 +80,41 @@ defmodule FrontmanServer.Tasks.Execution do
   def run(%Scope{} = scope, %Task{} = task, opts \\ []) do
     tools = Keyword.get(opts, :tools, [])
     model = opts |> Keyword.get(:model) |> Model.resolve_string()
+    task_id = task.task_id
 
     # Resolve API key at the domain layer (earliest point)
     case Providers.prepare_api_key(scope, model) do
       {:ok, api_key_info} ->
-        task_id = task.task_id
-        agent = build_agent(task, tools, opts, api_key_info)
+        case ensure_sandbox(scope, task, opts) do
+          {:ok, sandbox} ->
+            agent = build_agent(task, tools, opts, api_key_info)
 
-        messages =
-          task.interactions
-          |> Interaction.to_llm_messages()
-          |> Enum.map(&to_swarm_message/1)
-          |> maybe_constrain_images(api_key_info.provider)
+            messages =
+              task.interactions
+              |> Interaction.to_llm_messages()
+              |> Enum.map(&to_swarm_message/1)
+              |> maybe_constrain_images(api_key_info.provider)
 
-        mcp_tool_defs = Keyword.get(opts, :mcp_tool_defs, [])
+            mcp_tool_defs = Keyword.get(opts, :mcp_tool_defs, [])
 
-        backend_tool_modules =
-          Keyword.get(opts, :backend_tool_modules, Tools.backend_tool_modules())
+            backend_tool_modules =
+              Keyword.get(
+                opts,
+                :backend_tool_modules,
+                Tools.backend_tool_modules(sandbox: sandbox)
+              )
 
-        submit_to_runtime(scope, agent, task_id, messages,
-          api_key_info: api_key_info,
-          mcp_tool_defs: mcp_tool_defs,
-          backend_tool_modules: backend_tool_modules,
-          interaction_id: Keyword.get(opts, :interaction_id)
-        )
+            submit_to_runtime(scope, agent, task_id, messages,
+              api_key_info: api_key_info,
+              mcp_tool_defs: mcp_tool_defs,
+              backend_tool_modules: backend_tool_modules,
+              interaction_id: Keyword.get(opts, :interaction_id),
+              sandbox: sandbox
+            )
+
+          {:error, reason} ->
+            {:error, reason}
+        end
 
       {:error, reason} ->
         {:error, reason}
@@ -143,7 +162,8 @@ defmodule FrontmanServer.Tasks.Execution do
         backend_tool_modules: backend_tool_modules,
         mcp_tools: mcp_tools,
         mcp_tool_defs: mcp_tool_defs,
-        llm_opts: llm_opts
+        llm_opts: llm_opts,
+        sandbox: Keyword.get(opts, :sandbox)
       )
 
     # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
@@ -328,6 +348,113 @@ defmodule FrontmanServer.Tasks.Execution do
         arguments: ReqLLM.ToolCall.args_json(tc)
       }
     end)
+  end
+
+  # --- Sandbox bootstrap ---
+
+  defp ensure_sandbox(%Scope{} = scope, %Task{} = task, opts) do
+    case sandbox_mvp_enabled?() do
+      false ->
+        {:ok, nil}
+
+      true ->
+        wait_timeout_ms = Keyword.get(opts, :sandbox_wait_timeout_ms, sandbox_wait_timeout_ms())
+
+        case get_or_start_sandbox(scope, task.task_id, opts) do
+          {:ok, sandbox} ->
+            wait_for_sandbox_running(scope, sandbox.id, wait_timeout_ms)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp get_or_start_sandbox(%Scope{} = scope, task_id, opts) do
+    case Sandboxes.current_for_task(scope, task_id) do
+      {:ok, sandbox} ->
+        {:ok, sandbox}
+
+      {:error, :not_found} ->
+        env_spec = sandbox_env_spec(task_id)
+
+        create_opts =
+          [task_id: task_id]
+          |> maybe_put_provider_override(opts)
+
+        Sandboxes.provision_and_start(scope, env_spec, create_opts)
+    end
+  end
+
+  defp maybe_put_provider_override(opts, create_opts) do
+    case Keyword.fetch(opts, :sandbox_provider) do
+      {:ok, provider} -> Keyword.put(create_opts, :provider, provider)
+      :error -> create_opts
+    end
+  end
+
+  defp wait_for_sandbox_running(%Scope{} = scope, sandbox_id, timeout_ms) do
+    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
+    wait_for_sandbox_running(scope, sandbox_id, deadline_ms, sandbox_wait_interval_ms())
+  end
+
+  defp wait_for_sandbox_running(%Scope{} = scope, sandbox_id, deadline_ms, poll_interval_ms) do
+    case Sandboxes.get_sandbox(scope, sandbox_id) do
+      {:ok, sandbox} ->
+        case sandbox.status do
+          :running ->
+            {:ok, sandbox}
+
+          :error ->
+            {:error, :sandbox_provisioning_failed}
+
+          _status ->
+            continue_waiting(scope, sandbox_id, deadline_ms, poll_interval_ms)
+        end
+
+      {:error, :not_found} ->
+        {:error, :sandbox_not_found}
+    end
+  end
+
+  defp continue_waiting(scope, sandbox_id, deadline_ms, poll_interval_ms) do
+    now_ms = System.monotonic_time(:millisecond)
+
+    case now_ms >= deadline_ms do
+      true ->
+        {:error, :sandbox_provisioning_timeout}
+
+      false ->
+        Process.sleep(poll_interval_ms)
+        wait_for_sandbox_running(scope, sandbox_id, deadline_ms, poll_interval_ms)
+    end
+  end
+
+  defp sandbox_env_spec(task_id) do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+
+    app_port = Keyword.get(config, :app_port, 4000)
+
+    %{
+      "name" => sandbox_name(task_id),
+      "image" => Keyword.get(config, :image, "ghcr.io/frontman-ai/frontman-dev:latest"),
+      "devcontainer" => %{"forwardPorts" => [app_port]},
+      "env" => %{}
+    }
+  end
+
+  defp sandbox_name(task_id) when is_binary(task_id) do
+    "task-" <> String.slice(task_id, 0, 12)
+  end
+
+  defp sandbox_wait_timeout_ms do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :wait_timeout_ms, 600_000)
+  end
+
+  defp sandbox_wait_interval_ms do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :poll_interval_ms, 1_000)
   end
 
   @doc false

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -386,7 +386,7 @@ defmodule FrontmanServer.Tasks.Execution do
     end
   end
 
-  defp maybe_put_provider_override(opts, create_opts) do
+  defp maybe_put_provider_override(create_opts, opts) do
     case Keyword.fetch(opts, :sandbox_provider) do
       {:ok, provider} -> Keyword.put(create_opts, :provider, provider)
       :error -> create_opts

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -259,7 +259,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
         backend_tool_modules: Map.get(opts, :backend_tool_modules, []),
         mcp_tools: Map.get(opts, :mcp_tools, []),
         mcp_tool_defs: Map.get(opts, :mcp_tool_defs, []),
-        llm_opts: Map.get(opts, :llm_opts, [])
+        llm_opts: Map.get(opts, :llm_opts, []),
+        sandbox: Map.get(opts, :sandbox)
       )
 
     context_messages = Interaction.extract_markdown_messages(task.interactions)

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -211,7 +211,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
       backend_module_map: Map.new(backend_tool_modules, &{&1.name(), &1}),
       mcp_tools: Keyword.fetch!(opts, :mcp_tools),
       mcp_tool_defs: Keyword.fetch!(opts, :mcp_tool_defs),
-      llm_opts: Keyword.fetch!(opts, :llm_opts)
+      llm_opts: Keyword.fetch!(opts, :llm_opts),
+      sandbox: Keyword.get(opts, :sandbox)
     }
   end
 
@@ -255,10 +256,10 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     # Pass the executor itself so backend tools can spawn sub-agents.
     executor =
       make_executor(scope, task_id,
-        backend_tool_modules: opts.backend_tool_modules,
-        mcp_tools: opts.mcp_tools,
-        mcp_tool_defs: opts.mcp_tool_defs,
-        llm_opts: opts.llm_opts
+        backend_tool_modules: Map.get(opts, :backend_tool_modules, []),
+        mcp_tools: Map.get(opts, :mcp_tools, []),
+        mcp_tool_defs: Map.get(opts, :mcp_tool_defs, []),
+        llm_opts: Map.get(opts, :llm_opts, [])
       )
 
     context_messages = Interaction.extract_markdown_messages(task.interactions)
@@ -266,10 +267,11 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     context = %Backend.Context{
       scope: scope,
       task: task,
+      sandbox: Map.get(opts, :sandbox),
       tool_executor: executor,
-      mcp_tools: opts.mcp_tools,
+      mcp_tools: Map.get(opts, :mcp_tools, []),
       context_messages: context_messages,
-      llm_opts: opts.llm_opts
+      llm_opts: Map.get(opts, :llm_opts, [])
     }
 
     case parse_arguments(tool_call.name, tool_call.arguments) do

--- a/apps/frontman_server/lib/frontman_server/tools.ex
+++ b/apps/frontman_server/lib/frontman_server/tools.ex
@@ -12,24 +12,53 @@ defmodule FrontmanServer.Tools do
   alias FrontmanServer.Tools.Backend
   alias FrontmanServer.Tools.MCP
 
-  @backend_tools [
+  @base_backend_tools [
     FrontmanServer.Tools.TodoWrite,
     FrontmanServer.Tools.WebFetch
+  ]
+
+  @sandbox_backend_tools [
+    FrontmanServer.Tools.Sandbox.EditFile,
+    FrontmanServer.Tools.Sandbox.FileExists,
+    FrontmanServer.Tools.Sandbox.Grep,
+    FrontmanServer.Tools.Sandbox.ListFiles,
+    FrontmanServer.Tools.Sandbox.ListTree,
+    FrontmanServer.Tools.Sandbox.ReadFile,
+    FrontmanServer.Tools.Sandbox.SearchFiles,
+    FrontmanServer.Tools.Sandbox.WriteFile
   ]
 
   @todo_mutations [FrontmanServer.Tools.TodoWrite.name()]
 
   @spec backend_tool_modules() :: [module()]
-  def backend_tool_modules, do: @backend_tools
+  def backend_tool_modules, do: @base_backend_tools
+
+  @spec backend_tool_modules(keyword()) :: [module()]
+  def backend_tool_modules(opts) when is_list(opts) do
+    case Keyword.get(opts, :sandbox) do
+      nil -> @base_backend_tools
+      _sandbox -> @base_backend_tools ++ @sandbox_backend_tools
+    end
+  end
+
+  @spec sandbox_tool_modules() :: [module()]
+  def sandbox_tool_modules, do: @sandbox_backend_tools
 
   @spec backend_tools() :: [SwarmAi.Tool.t()]
   def backend_tools do
-    Enum.map(@backend_tools, &Backend.to_swarm_tool/1)
+    Enum.map(@base_backend_tools, &Backend.to_swarm_tool/1)
+  end
+
+  @spec backend_tools([module()]) :: [SwarmAi.Tool.t()]
+  def backend_tools(modules) when is_list(modules) do
+    Enum.map(modules, &Backend.to_swarm_tool/1)
   end
 
   @spec find_tool(String.t()) :: {:ok, module()} | :not_found
   def find_tool(tool_name) do
-    case Enum.find(@backend_tools, fn mod -> mod.name() == tool_name end) do
+    all_backend_tools = @base_backend_tools ++ @sandbox_backend_tools
+
+    case Enum.find(all_backend_tools, fn mod -> mod.name() == tool_name end) do
       nil -> :not_found
       mod -> {:ok, mod}
     end
@@ -43,9 +72,14 @@ defmodule FrontmanServer.Tools do
   """
   @spec execution_target(String.t()) :: :backend | :mcp
   def execution_target(tool_name) do
-    case find_tool(tool_name) do
-      {:ok, _module} -> :backend
-      :not_found -> :mcp
+    execution_target(tool_name, @base_backend_tools)
+  end
+
+  @spec execution_target(String.t(), [module()]) :: :backend | :mcp
+  def execution_target(tool_name, backend_modules) when is_list(backend_modules) do
+    case Enum.find(backend_modules, fn mod -> mod.name() == tool_name end) do
+      nil -> :mcp
+      _module -> :backend
     end
   end
 
@@ -62,9 +96,26 @@ defmodule FrontmanServer.Tools do
       mcp_tools |> Tools.prepare_for_task(task_id)
   """
   @spec prepare_for_task([FrontmanServer.Tools.MCP.t()], String.t()) :: [SwarmAi.Tool.t()]
-  def prepare_for_task(mcp_tools, _task_id) do
-    mcp_formatted = MCP.to_swarm_tools(mcp_tools)
-    backend = backend_tools()
+  def prepare_for_task(mcp_tools, task_id) do
+    prepare_for_task(mcp_tools, task_id, [])
+  end
+
+  @spec prepare_for_task([FrontmanServer.Tools.MCP.t()], String.t(), keyword()) :: [
+          SwarmAi.Tool.t()
+        ]
+  def prepare_for_task(mcp_tools, _task_id, opts) do
+    backend_tool_modules = Keyword.get(opts, :backend_tool_modules, @base_backend_tools)
+    backend = backend_tools(backend_tool_modules)
+
+    backend_tool_names =
+      backend_tool_modules
+      |> Enum.map(& &1.name())
+      |> MapSet.new()
+
+    mcp_formatted =
+      mcp_tools
+      |> Enum.reject(fn tool -> MapSet.member?(backend_tool_names, tool.name) end)
+      |> MCP.to_swarm_tools()
 
     backend ++ mcp_formatted
   end

--- a/apps/frontman_server/lib/frontman_server/tools/backend.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/backend.ex
@@ -31,6 +31,7 @@ defmodule FrontmanServer.Tools.Backend do
     use TypedStruct
 
     alias FrontmanServer.Accounts.Scope
+    alias FrontmanServer.Sandboxes.Sandbox
     alias FrontmanServer.Tasks.Task
 
     @type executor :: ([SwarmAi.ToolCall.t()] ->
@@ -39,6 +40,7 @@ defmodule FrontmanServer.Tools.Backend do
     typedstruct do
       field(:scope, Scope.t(), enforce: true)
       field(:task, Task.t(), enforce: true)
+      field(:sandbox, Sandbox.t() | nil, default: nil)
       field(:tool_executor, executor(), enforce: true)
       field(:mcp_tools, [SwarmAi.Tool.t()], default: [])
       field(:context_messages, [SwarmAi.Message.t()], default: [])

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/common.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/common.ex
@@ -1,0 +1,137 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.Common do
+  @moduledoc false
+
+  alias FrontmanServer.Sandboxes
+  alias FrontmanServer.Tools.Backend.Context
+
+  @spec sandbox_from_context(Context.t()) ::
+          {:ok, FrontmanServer.Sandboxes.Sandbox.t()} | {:error, String.t()}
+  def sandbox_from_context(%Context{sandbox: nil}) do
+    {:error, "Sandbox is not available for this task"}
+  end
+
+  def sandbox_from_context(%Context{sandbox: sandbox}), do: {:ok, sandbox}
+
+  @spec project_root() :: String.t()
+  def project_root do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :project_root, "/workspace/frontman")
+  end
+
+  @spec app_port() :: pos_integer()
+  def app_port do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :app_port, 4000)
+  end
+
+  @spec health_path() :: String.t()
+  def health_path do
+    config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    Keyword.get(config, :health_path, "/health/ready")
+  end
+
+  @spec resolve_relative_path(String.t()) ::
+          {:ok, %{absolute: String.t(), relative: String.t()}} | {:error, String.t()}
+  def resolve_relative_path(path) when is_binary(path) do
+    trimmed = String.trim(path)
+
+    cond do
+      trimmed == "" ->
+        {:error, "path is required"}
+
+      String.starts_with?(trimmed, "/") ->
+        {:error, "path must be relative to the sandbox project root"}
+
+      true ->
+        pieces = String.split(trimmed, "/", trim: true)
+
+        case Enum.any?(pieces, &(&1 == "..")) do
+          true ->
+            {:error, "path must not traverse parent directories"}
+
+          false ->
+            relative = Path.join(pieces)
+            absolute = Path.join(project_root(), relative)
+            {:ok, %{absolute: absolute, relative: relative}}
+        end
+    end
+  end
+
+  def resolve_relative_path(_), do: {:error, "path is required"}
+
+  @spec run(Context.t(), String.t(), [String.t()], keyword()) ::
+          {:ok, %{exit_code: integer(), stdout: String.t(), stderr: String.t()}}
+          | {:error, String.t()}
+  def run(%Context{} = context, command, args, opts \\ [])
+      when is_binary(command) and is_list(args) do
+    with {:ok, sandbox} <- sandbox_from_context(context),
+         {:ok, result} <- Sandboxes.exec(context.scope, sandbox.id, command, args, opts) do
+      {:ok, result}
+    else
+      {:error, reason} -> {:error, format_reason(reason)}
+    end
+  end
+
+  @spec run_strict(Context.t(), String.t(), [String.t()], keyword()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def run_strict(%Context{} = context, command, args, opts \\ [])
+      when is_binary(command) and is_list(args) do
+    case run(context, command, args, opts) do
+      {:ok, %{exit_code: 0, stdout: stdout}} ->
+        {:ok, stdout}
+
+      {:ok, %{exit_code: exit_code, stdout: stdout, stderr: stderr}} ->
+        {:error,
+         "Sandbox command failed: command=#{command} exit_code=#{exit_code} stdout=#{String.trim(stdout)} stderr=#{String.trim(stderr)}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec run_bash(Context.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def run_bash(%Context{} = context, script, opts \\ []) when is_binary(script) do
+    run_strict(context, "bash", ["-lc", script], opts)
+  end
+
+  @spec run_bash_capture(Context.t(), String.t(), keyword()) ::
+          {:ok, %{exit_code: integer(), stdout: String.t(), stderr: String.t()}}
+          | {:error, String.t()}
+  def run_bash_capture(%Context{} = context, script, opts \\ []) when is_binary(script) do
+    run(context, "bash", ["-lc", script], opts)
+  end
+
+  @spec write_file(Context.t(), String.t(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def write_file(%Context{} = context, absolute_path, content, opts \\ [])
+      when is_binary(absolute_path) and is_binary(content) do
+    encoded = Base.encode64(content)
+    dir = Path.dirname(absolute_path)
+
+    script =
+      "mkdir -p " <>
+        shell_escape(dir) <>
+        " && printf '%s' " <>
+        shell_escape(encoded) <>
+        " | base64 -d > " <>
+        shell_escape(absolute_path)
+
+    case run_bash(context, script, opts) do
+      {:ok, _stdout} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec shell_escape(String.t()) :: String.t()
+  def shell_escape(value) when is_binary(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/common.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/common.ex
@@ -46,7 +46,7 @@ defmodule FrontmanServer.Tools.Sandbox.Common do
         {:error, "path is required"}
 
       String.starts_with?(trimmed, "/") ->
-        {:error, "path must be relative to the sandbox project root"}
+        resolve_absolute_path(trimmed)
 
       true ->
         pieces = String.split(trimmed, "/", trim: true)
@@ -64,6 +64,22 @@ defmodule FrontmanServer.Tools.Sandbox.Common do
   end
 
   def resolve_relative_path(_), do: {:error, "path is required"}
+
+  defp resolve_absolute_path(path) do
+    root = project_root() |> Path.expand()
+    absolute = Path.expand(path)
+
+    cond do
+      absolute == root ->
+        {:ok, %{absolute: absolute, relative: "."}}
+
+      String.starts_with?(absolute, root <> "/") ->
+        {:ok, %{absolute: absolute, relative: Path.relative_to(absolute, root)}}
+
+      true ->
+        {:error, "path must be inside sandbox project root"}
+    end
+  end
 
   @spec run(Context.t(), String.t(), [String.t()], keyword()) ::
           {:ok, %{exit_code: integer(), stdout: String.t(), stderr: String.t()}}

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/edit_file.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/edit_file.ex
@@ -1,0 +1,104 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.EditFile do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "edit_file"
+
+  @impl true
+  def description do
+    "Edit a file by replacing oldText with newText. Set oldText to an empty string to create a new file."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "path" => %{"type" => "string"},
+        "oldText" => %{"type" => "string"},
+        "newText" => %{"type" => "string"},
+        "replaceAll" => %{"type" => "boolean", "default" => false}
+      },
+      "required" => ["path", "oldText", "newText"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 120_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    with {:ok, resolved} <- resolve_path(args),
+         {:ok, old_text} <- fetch_old_text(args),
+         {:ok, new_text} <- fetch_new_text(args),
+         :ok <- validate_text_change(old_text, new_text),
+         {:ok, current_content} <- read_existing_content(context, resolved.absolute, old_text),
+         {:ok, updated_content} <- apply_edit(current_content, old_text, new_text, args),
+         :ok <- Common.write_file(context, resolved.absolute, updated_content) do
+      {:ok,
+       %{
+         "message" => "Edit applied successfully.",
+         "_context" => %{
+           "sourceRoot" => Common.project_root(),
+           "resolvedPath" => resolved.absolute,
+           "relativePath" => resolved.relative
+         }
+       }}
+    end
+  end
+
+  defp resolve_path(%{"path" => path}), do: Common.resolve_relative_path(path)
+  defp resolve_path(_), do: {:error, "path is required"}
+
+  defp fetch_old_text(%{"oldText" => old_text}) when is_binary(old_text), do: {:ok, old_text}
+  defp fetch_old_text(_), do: {:error, "oldText is required"}
+
+  defp fetch_new_text(%{"newText" => new_text}) when is_binary(new_text), do: {:ok, new_text}
+  defp fetch_new_text(_), do: {:error, "newText is required"}
+
+  defp validate_text_change(old_text, new_text) do
+    case old_text == new_text do
+      true -> {:error, "oldText and newText must be different"}
+      false -> :ok
+    end
+  end
+
+  defp read_existing_content(_context, _absolute_path, ""), do: {:ok, ""}
+
+  defp read_existing_content(context, absolute_path, _old_text) do
+    Common.run_strict(context, "cat", [absolute_path])
+  end
+
+  defp apply_edit(_current_content, "", new_text, _args), do: {:ok, new_text}
+
+  defp apply_edit(current_content, old_text, new_text, args) do
+    replace_all = Map.get(args, "replaceAll", false) == true
+
+    case String.contains?(current_content, old_text) do
+      true ->
+        updated =
+          case replace_all do
+            true -> String.replace(current_content, old_text, new_text)
+            false -> String.replace(current_content, old_text, new_text, global: false)
+          end
+
+        {:ok, updated}
+
+      false ->
+        {:error, "oldText not found in file"}
+    end
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/file_exists.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/file_exists.ex
@@ -1,0 +1,53 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.FileExists do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "file_exists"
+
+  @impl true
+  def description, do: "Check whether a file or directory exists in the sandbox project."
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{"path" => %{"type" => "string"}},
+      "required" => ["path"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 30_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    with {:ok, resolved} <- resolve_path(args),
+         {:ok, result} <- Common.run_bash_capture(context, exists_script(resolved.absolute)) do
+      case result.exit_code do
+        0 -> {:ok, true}
+        1 -> {:ok, false}
+        _ -> {:error, "Failed to check file existence: #{String.trim(result.stdout)}"}
+      end
+    end
+  end
+
+  defp resolve_path(%{"path" => path}), do: Common.resolve_relative_path(path)
+  defp resolve_path(_), do: {:error, "path is required"}
+
+  defp exists_script(absolute_path) do
+    "[ -e " <> Common.shell_escape(absolute_path) <> " ]"
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/grep.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/grep.ex
@@ -1,0 +1,153 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.Grep do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "grep"
+
+  @impl true
+  def description do
+    "Search file contents in the sandbox project and return matching lines grouped by file."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "pattern" => %{"type" => "string"},
+        "path" => %{"type" => "string"},
+        "case_insensitive" => %{"type" => "boolean", "default" => false},
+        "literal" => %{"type" => "boolean", "default" => false},
+        "max_results" => %{"type" => "integer", "default" => 20}
+      },
+      "required" => ["pattern"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 120_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    pattern = Map.get(args, "pattern")
+    relative_path = Map.get(args, "path", ".")
+    max_results = parse_max_results(Map.get(args, "max_results"))
+    case_insensitive = Map.get(args, "case_insensitive", false) == true
+    literal = Map.get(args, "literal", false) == true
+
+    with {:ok, pattern} <- validate_pattern(pattern),
+         {:ok, resolved} <- resolve_path(relative_path),
+         {:ok, result} <- run_grep(context, resolved.absolute, pattern, case_insensitive, literal) do
+      formatted = format_results(result.stdout, max_results)
+      {:ok, formatted}
+    end
+  end
+
+  defp validate_pattern(pattern) when is_binary(pattern) and pattern != "", do: {:ok, pattern}
+  defp validate_pattern(_), do: {:error, "pattern is required"}
+
+  defp parse_max_results(value) when is_integer(value) and value > 0 and value <= 200, do: value
+  defp parse_max_results(_), do: 20
+
+  defp resolve_path("."), do: {:ok, %{absolute: Common.project_root(), relative: "."}}
+  defp resolve_path(path) when is_binary(path), do: Common.resolve_relative_path(path)
+  defp resolve_path(_path), do: {:error, "path must be a string"}
+
+  defp run_grep(context, absolute_path, pattern, case_insensitive, literal) do
+    flags =
+      []
+      |> maybe_add_flag(case_insensitive, "-i")
+      |> maybe_add_flag(literal, "-F")
+
+    command =
+      ["grep", "-RIn", "--binary-files=without-match", "--exclude-dir=.git"] ++
+        flags ++ ["--", pattern, absolute_path]
+
+    case Common.run(context, hd(command), tl(command), timeout_ms: timeout_ms()) do
+      {:ok, %{exit_code: 0} = result} ->
+        {:ok, result}
+
+      {:ok, %{exit_code: 1}} ->
+        {:ok, %{stdout: "", stderr: "", exit_code: 1}}
+
+      {:ok, %{exit_code: exit_code, stdout: stdout, stderr: stderr}} ->
+        {:error,
+         "grep failed: exit_code=#{exit_code} stdout=#{String.trim(stdout)} stderr=#{String.trim(stderr)}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp maybe_add_flag(flags, true, flag), do: flags ++ [flag]
+  defp maybe_add_flag(flags, false, _flag), do: flags
+
+  defp format_results("", _max_results) do
+    %{"files" => [], "totalMatches" => 0, "truncated" => false}
+  end
+
+  defp format_results(stdout, max_results) do
+    grouped =
+      stdout
+      |> String.split("\n", trim: true)
+      |> Enum.reduce(%{}, &accumulate_match/2)
+
+    files =
+      grouped
+      |> Enum.map(fn {path, matches} -> %{"path" => path, "matches" => matches} end)
+
+    total_matches =
+      files
+      |> Enum.map(fn file -> length(file["matches"]) end)
+      |> Enum.sum()
+
+    %{
+      "files" => Enum.take(files, max_results),
+      "totalMatches" => total_matches,
+      "truncated" => length(files) > max_results
+    }
+  end
+
+  defp accumulate_match(line, acc) do
+    case parse_line(line) do
+      {:ok, file_path, line_num, line_text} ->
+        add_grouped_match(acc, file_path, line_num, line_text)
+
+      :error ->
+        acc
+    end
+  end
+
+  defp add_grouped_match(acc, file_path, line_num, line_text) do
+    entry = %{"lineNum" => line_num, "lineText" => line_text}
+    Map.update(acc, file_path, [entry], &append_entry(&1, entry))
+  end
+
+  defp append_entry(entries, entry), do: entries ++ [entry]
+
+  defp parse_line(line) do
+    case String.split(line, ":", parts: 3) do
+      [file_path, line_num, line_text] ->
+        case Integer.parse(line_num) do
+          {value, ""} -> {:ok, file_path, value, line_text}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/list_files.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/list_files.ex
@@ -1,0 +1,104 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.ListFiles do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "list_files"
+
+  @impl true
+  def description do
+    "List immediate contents of a directory in the sandbox project."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{"path" => %{"type" => "string"}}
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 60_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    relative_path = Map.get(args, "path", ".")
+
+    with {:ok, resolved} <- resolve_path(relative_path),
+         {:ok, stdout} <-
+           Common.run_bash(context, list_script(resolved.absolute), timeout_ms: timeout_ms()) do
+      entries =
+        stdout
+        |> String.split("\n", trim: true)
+        |> Enum.map(&parse_line(&1, resolved.relative))
+
+      {:ok, entries}
+    end
+  end
+
+  defp resolve_path("."), do: {:ok, %{absolute: Common.project_root(), relative: "."}}
+  defp resolve_path(path) when is_binary(path), do: Common.resolve_relative_path(path)
+  defp resolve_path(_path), do: {:error, "path must be a string"}
+
+  defp list_script(absolute_path) do
+    quoted = Common.shell_escape(absolute_path)
+
+    ~S"""
+      if [ -f __QUOTED_PATH__ ]; then target=$(dirname __QUOTED_PATH__); else target=__QUOTED_PATH__; fi;
+      for entry in "$target"/* "$target"/.*; do
+        [ -e "$entry" ] || continue;
+        name=$(basename "$entry");
+        [ "$name" = '.' ] && continue;
+        [ "$name" = '..' ] && continue;
+        if [ -d "$entry" ]; then kind=d; else kind=f; fi;
+        printf '%s\t%s\n' "$name" "$kind";
+      done
+    """
+    |> String.replace("__QUOTED_PATH__", quoted)
+    |> String.trim()
+  end
+
+  defp parse_line(line, base_relative) do
+    case String.split(line, "\t", parts: 2) do
+      [name, "d"] ->
+        %{
+          "name" => name,
+          "path" => join_relative(base_relative, name),
+          "isFile" => false,
+          "isDirectory" => true
+        }
+
+      [name, _] ->
+        %{
+          "name" => name,
+          "path" => join_relative(base_relative, name),
+          "isFile" => true,
+          "isDirectory" => false
+        }
+
+      _ ->
+        %{
+          "name" => line,
+          "path" => join_relative(base_relative, line),
+          "isFile" => true,
+          "isDirectory" => false
+        }
+    end
+  end
+
+  defp join_relative(".", name), do: name
+  defp join_relative(base, name), do: Path.join(base, name)
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/list_tree.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/list_tree.ex
@@ -1,0 +1,93 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.ListTree do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "list_tree"
+
+  @impl true
+  def description do
+    "Return a recursive directory tree rooted at the sandbox project or a given subdirectory."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "path" => %{"type" => "string"},
+        "depth" => %{"type" => "integer", "default" => 3}
+      }
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 90_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    relative_path = Map.get(args, "path", ".")
+
+    with {:ok, resolved} <- resolve_path(relative_path),
+         {:ok, depth} <- parse_depth(Map.get(args, "depth")),
+         {:ok, stdout} <-
+           Common.run_bash(context, tree_script(resolved.absolute, depth),
+             timeout_ms: timeout_ms()
+           ) do
+      tree_lines =
+        stdout
+        |> String.split("\n", trim: true)
+        |> Enum.map(&decorate_tree_line/1)
+
+      tree = ["." | tree_lines] |> Enum.join("\n")
+
+      {:ok,
+       %{
+         "tree" => tree,
+         "workspaces" => [],
+         "monorepoType" => nil
+       }}
+    end
+  end
+
+  defp resolve_path("."), do: {:ok, %{absolute: Common.project_root(), relative: "."}}
+  defp resolve_path(path) when is_binary(path), do: Common.resolve_relative_path(path)
+  defp resolve_path(_path), do: {:error, "path must be a string"}
+
+  defp parse_depth(nil), do: {:ok, 3}
+
+  defp parse_depth(depth) when is_integer(depth) and depth > 0 and depth <= 10,
+    do: {:ok, depth}
+
+  defp parse_depth(_), do: {:error, "depth must be an integer between 1 and 10"}
+
+  defp tree_script(absolute_path, depth) do
+    escaped_path = Common.shell_escape(absolute_path)
+
+    "find " <>
+      escaped_path <>
+      " -mindepth 1 -maxdepth " <>
+      Integer.to_string(depth) <>
+      " -printf '%P\t%y\n' | sort"
+  end
+
+  defp decorate_tree_line(line) do
+    case String.split(line, "\t", parts: 2) do
+      [path, "d"] -> "|- " <> path <> "/"
+      [path, _] -> "|- " <> path
+      _ -> "|- " <> line
+    end
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/read_file.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/read_file.ex
@@ -1,0 +1,87 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.ReadFile do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "read_file"
+
+  @impl true
+  def description do
+    "Read a file from the sandbox project. Returns content with line metadata for pagination."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "path" => %{"type" => "string"},
+        "offset" => %{"type" => "integer", "default" => 0},
+        "limit" => %{"type" => "integer", "default" => 500}
+      },
+      "required" => ["path"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 120_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    with {:ok, resolved} <- resolve_path(args),
+         {:ok, file_content} <- Common.run_strict(context, "cat", [resolved.absolute]) do
+      offset = parse_non_negative_int(Map.get(args, "offset"), 0)
+      limit = clamp_limit(Map.get(args, "limit"), 500)
+
+      lines = String.split(file_content, "\n", trim: false)
+      total_lines = length(lines)
+
+      selected_lines =
+        lines
+        |> Enum.drop(offset)
+        |> Enum.take(limit)
+
+      has_more = offset + limit < total_lines
+
+      {:ok,
+       %{
+         "content" => Enum.join(selected_lines, "\n"),
+         "totalLines" => total_lines,
+         "hasMore" => has_more,
+         "_context" => %{
+           "sourceRoot" => Common.project_root(),
+           "resolvedPath" => resolved.absolute,
+           "relativePath" => resolved.relative
+         }
+       }}
+    end
+  end
+
+  defp resolve_path(%{"path" => path}), do: Common.resolve_relative_path(path)
+  defp resolve_path(_), do: {:error, "path is required"}
+
+  defp parse_non_negative_int(nil, default), do: default
+
+  defp parse_non_negative_int(value, _default) when is_integer(value) and value >= 0,
+    do: value
+
+  defp parse_non_negative_int(_value, default), do: default
+
+  defp clamp_limit(nil, default), do: default
+  defp clamp_limit(value, _default) when is_integer(value) and value < 1, do: 1
+  defp clamp_limit(value, _default) when is_integer(value) and value > 2_000, do: 2_000
+  defp clamp_limit(value, _default) when is_integer(value), do: value
+  defp clamp_limit(_value, default), do: default
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/search_files.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/search_files.ex
@@ -1,0 +1,105 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.SearchFiles do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "search_files"
+
+  @impl true
+  def description do
+    "Search for files by filename pattern in the sandbox project."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "pattern" => %{"type" => "string"},
+        "path" => %{"type" => "string"},
+        "max_results" => %{"type" => "integer", "default" => 20}
+      },
+      "required" => ["pattern"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 90_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    pattern = Map.get(args, "pattern")
+    max_results = parse_max_results(Map.get(args, "max_results"))
+    relative_path = Map.get(args, "path", ".")
+
+    with {:ok, pattern} <- validate_pattern(pattern),
+         {:ok, resolved} <- resolve_path(relative_path),
+         {:ok, stdout} <-
+           Common.run_bash(context, search_script(resolved.absolute), timeout_ms: timeout_ms()) do
+      matches =
+        stdout
+        |> String.split("\n", trim: true)
+        |> Enum.filter(&matches_pattern?(Path.basename(&1), pattern))
+
+      total_results = length(matches)
+      files = Enum.take(matches, max_results)
+
+      {:ok,
+       %{
+         "files" => files,
+         "totalResults" => total_results,
+         "truncated" => total_results > max_results
+       }}
+    end
+  end
+
+  defp validate_pattern(pattern) when is_binary(pattern) and pattern != "", do: {:ok, pattern}
+  defp validate_pattern(_), do: {:error, "pattern is required"}
+
+  defp parse_max_results(value) when is_integer(value) and value > 0 and value <= 200, do: value
+  defp parse_max_results(_), do: 20
+
+  defp resolve_path("."), do: {:ok, %{absolute: Common.project_root(), relative: "."}}
+  defp resolve_path(path) when is_binary(path), do: Common.resolve_relative_path(path)
+  defp resolve_path(_path), do: {:error, "path must be a string"}
+
+  defp search_script(absolute_path) do
+    "find " <> Common.shell_escape(absolute_path) <> " -type f -printf '%P\n'"
+  end
+
+  defp matches_pattern?(filename, pattern) do
+    normalized_pattern = String.downcase(pattern)
+    normalized_filename = String.downcase(filename)
+
+    case wildcard_pattern?(normalized_pattern) do
+      true -> wildcard_match?(normalized_filename, normalized_pattern)
+      false -> String.contains?(normalized_filename, normalized_pattern)
+    end
+  end
+
+  defp wildcard_pattern?(pattern) do
+    String.contains?(pattern, ["*", "?"])
+  end
+
+  defp wildcard_match?(filename, pattern) do
+    regex =
+      pattern
+      |> Regex.escape()
+      |> String.replace("\\*", ".*")
+      |> String.replace("\\?", ".")
+
+    Regex.match?(Regex.compile!("^" <> regex <> "$"), filename)
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tools/sandbox/write_file.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/sandbox/write_file.ex
@@ -1,0 +1,61 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 -- see LICENSE for details.
+# Additional terms apply -- see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.Sandbox.WriteFile do
+  @moduledoc false
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  @impl true
+  def name, do: "write_file"
+
+  @impl true
+  def description do
+    "Write text content to a file in the sandbox project, creating parent directories as needed."
+  end
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "path" => %{"type" => "string"},
+        "content" => %{"type" => "string"}
+      },
+      "required" => ["path", "content"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 120_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, context) do
+    with {:ok, resolved} <- resolve_path(args),
+         {:ok, content} <- fetch_content(args),
+         :ok <- Common.write_file(context, resolved.absolute, content) do
+      {:ok,
+       %{
+         "_context" => %{
+           "sourceRoot" => Common.project_root(),
+           "resolvedPath" => resolved.absolute,
+           "relativePath" => resolved.relative
+         }
+       }}
+    end
+  end
+
+  defp resolve_path(%{"path" => path}), do: Common.resolve_relative_path(path)
+  defp resolve_path(_), do: {:error, "path is required"}
+
+  defp fetch_content(%{"content" => content}) when is_binary(content), do: {:ok, content}
+  defp fetch_content(_), do: {:error, "content is required"}
+end

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -682,6 +682,14 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   def handle_info({:interaction, %Tasks.Interaction.ToolCall{} = tool_call}, socket) do
     task_id = socket.assigns.task_id
+    last_execution_opts = socket.assigns[:last_execution_opts] || []
+
+    backend_tool_modules =
+      Keyword.get(
+        last_execution_opts,
+        :backend_tool_modules,
+        backend_tool_modules_for_execution()
+      )
 
     # Only send tool_call_create if we haven't already announced this tool call
     # via the streaming :tool_call_start event (which fires earlier during LLM streaming).
@@ -713,7 +721,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     push(socket, @acp_message, args_notification)
 
-    case Tools.execution_target(tool_call.tool_name) do
+    case Tools.execution_target(tool_call.tool_name, backend_tool_modules) do
       :backend ->
         # Backend tools are executed by ToolExecutor in the agent loop.
         # The channel just notifies the UI (already done above).

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -255,12 +255,17 @@ defmodule FrontmanServerWeb.TaskChannel do
       end
 
     mcp_tools = socket.assigns[:mcp_tools] || []
-    all_tools = mcp_tools |> Tools.prepare_for_task(task_id)
+    backend_tool_modules = backend_tool_modules_for_execution()
+
+    all_tools =
+      mcp_tools
+      |> Tools.prepare_for_task(task_id, backend_tool_modules: backend_tool_modules)
 
     opts =
       build_execution_opts(socket,
         model: model,
-        mcp_tool_defs: mcp_tools
+        mcp_tool_defs: mcp_tools,
+        backend_tool_modules: backend_tool_modules
       )
 
     Tasks.maybe_start_execution(scope, task_id, all_tools, opts)
@@ -523,12 +528,17 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
 
     # Prepare tools (domain service)
-    all_tools = mcp_tools |> Tools.prepare_for_task(task_id)
+    backend_tool_modules = backend_tool_modules_for_execution()
+
+    all_tools =
+      mcp_tools
+      |> Tools.prepare_for_task(task_id, backend_tool_modules: backend_tool_modules)
 
     opts =
       build_execution_opts(socket,
         model: model,
-        mcp_tool_defs: mcp_tools
+        mcp_tool_defs: mcp_tools,
+        backend_tool_modules: backend_tool_modules
       )
 
     case Tasks.submit_user_message(scope, task_id, prompt.content, all_tools, opts) do
@@ -576,6 +586,13 @@ defmodule FrontmanServerWeb.TaskChannel do
     case socket.assigns[:agent_override] do
       nil -> base_opts
       agent -> [{:agent, agent} | base_opts]
+    end
+  end
+
+  defp backend_tool_modules_for_execution do
+    case Execution.sandbox_mvp_enabled?() do
+      true -> Tools.backend_tool_modules(sandbox: %{})
+      false -> Tools.backend_tool_modules()
     end
   end
 
@@ -755,7 +772,14 @@ defmodule FrontmanServerWeb.TaskChannel do
       task_id = socket.assigns.task_id
       opts = socket.assigns[:last_execution_opts] || []
       mcp_tools = socket.assigns[:mcp_tools] || []
-      all_tools = mcp_tools |> Tools.prepare_for_task(task_id)
+
+      backend_tool_modules =
+        Keyword.get(opts, :backend_tool_modules, Tools.backend_tool_modules())
+
+      all_tools =
+        mcp_tools
+        |> Tools.prepare_for_task(task_id, backend_tool_modules: backend_tool_modules)
+
       Tasks.maybe_start_execution(scope, task_id, all_tools, opts)
     end
 
@@ -801,7 +825,14 @@ defmodule FrontmanServerWeb.TaskChannel do
       Tasks.add_agent_retry(scope, task_id, retried_error_id)
       opts = socket.assigns[:last_execution_opts] || []
       mcp_tools = socket.assigns[:mcp_tools] || []
-      all_tools = mcp_tools |> Tools.prepare_for_task(task_id)
+
+      backend_tool_modules =
+        Keyword.get(opts, :backend_tool_modules, Tools.backend_tool_modules())
+
+      all_tools =
+        mcp_tools
+        |> Tools.prepare_for_task(task_id, backend_tool_modules: backend_tool_modules)
+
       Tasks.maybe_start_execution(scope, task_id, all_tools, opts)
     end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -32,6 +32,42 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     end
   end
 
+  # A backend tool that inspects nested executor opts for sandbox propagation.
+  defmodule SubAgentSandboxProbeTool do
+    @behaviour Backend
+
+    def name, do: "sub_agent_sandbox_probe_tool"
+    def description, do: "Inspects nested executor sandbox opts"
+    def parameter_schema, do: %{"type" => "object", "properties" => %{}}
+    def timeout_ms, do: 30_000
+    def on_timeout, do: :error
+
+    def execute(_args, context) do
+      nested_tool_call = %SwarmAi.ToolCall{
+        id: "nested_#{System.unique_integer([:positive])}",
+        name: "pause_on_timeout_tool",
+        arguments: "{}"
+      }
+
+      [execution] = context.tool_executor.([nested_tool_call])
+
+      case execution do
+        %SwarmAi.ToolExecution.Sync{
+          run:
+            {FrontmanServer.Tasks.Execution.ToolExecutor, :run_backend_tool,
+             [_scope, _module, _task_id, exec_opts]}
+        } ->
+          case Map.get(exec_opts, :sandbox) do
+            nil -> {:error, "nested executor missing sandbox"}
+            _sandbox -> {:ok, "nested executor has sandbox"}
+          end
+
+        _other ->
+          {:error, "unexpected nested execution shape"}
+      end
+    end
+  end
+
   # A backend tool that declares on_timeout: :pause_agent.
   defmodule PauseOnTimeoutTool do
     @behaviour Backend
@@ -89,6 +125,44 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       result = ToolExecutor.run_backend_tool(scope, SubAgentTool, task_id, exec_opts, tool_call)
 
       # SubAgentTool calls context.tool_executor.([]) and returns {:ok, "executor is callable"}.
+      assert %SwarmAi.ToolResult{is_error: false} = result
+    end
+
+    @tag :capture_log
+    test "sub-agent executor preserves sandbox in nested execution opts", %{
+      scope: scope,
+      task_id: task_id,
+      llm_opts: llm_opts
+    } do
+      sandbox = %{id: "sandbox-#{System.unique_integer([:positive])}"}
+
+      exec_opts = %{
+        backend_tool_modules: [SubAgentSandboxProbeTool, PauseOnTimeoutTool],
+        backend_module_map: %{
+          SubAgentSandboxProbeTool.name() => SubAgentSandboxProbeTool,
+          PauseOnTimeoutTool.name() => PauseOnTimeoutTool
+        },
+        mcp_tools: [],
+        mcp_tool_defs: [],
+        llm_opts: llm_opts,
+        sandbox: sandbox
+      }
+
+      tool_call = %SwarmAi.ToolCall{
+        id: "tc_#{System.unique_integer([:positive])}",
+        name: SubAgentSandboxProbeTool.name(),
+        arguments: "{}"
+      }
+
+      result =
+        ToolExecutor.run_backend_tool(
+          scope,
+          SubAgentSandboxProbeTool,
+          task_id,
+          exec_opts,
+          tool_call
+        )
+
       assert %SwarmAi.ToolResult{is_error: false} = result
     end
   end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -19,8 +19,11 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Sandboxes
   alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Execution
   alias FrontmanServer.Tasks.{ExecutionEvent, Interaction}
+  alias FrontmanServer.Test.Support.Sandbox.IntegrationProvider
   alias FrontmanServer.Tools.MCP
   alias FrontmanServer.Workers.GenerateTitle
 
@@ -91,6 +94,32 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     {:ok, socket: socket}
   end
 
+  defp setup_sandbox_mvp_enabled(_context) do
+    original_config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+
+    sandbox_mvp_config =
+      original_config
+      |> Keyword.put(:enabled, true)
+      |> Keyword.put(:wait_timeout_ms, 50)
+      |> Keyword.put(:poll_interval_ms, 10)
+
+    Application.put_env(:frontman_server, :sandbox_mvp, sandbox_mvp_config)
+    IntegrationProvider.reset!()
+
+    on_exit(fn ->
+      Application.put_env(:frontman_server, :sandbox_mvp, original_config)
+      IntegrationProvider.reset!()
+
+      DynamicSupervisor.which_children(FrontmanServer.Sandbox.DynamicSupervisor)
+      |> Enum.each(fn
+        {_, pid, _, _} when is_pid(pid) -> Process.exit(pid, :kill)
+        _ -> :ok
+      end)
+    end)
+
+    :ok
+  end
+
   # -- Cancel (low-level) ----------------------------------------------------
 
   describe "cancel_execution/2 (registry-level)" do
@@ -116,6 +145,32 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert :ok = Tasks.cancel_execution(%Scope{}, task_id)
 
       assert_receive {:DOWN, ^ref, :process, ^agent_pid, :cancelled}, 1_000
+    end
+  end
+
+  describe "sandbox bootstrap invariants" do
+    setup [:setup_sandbox, :setup_user, :setup_task_only, :setup_sandbox_mvp_enabled]
+
+    test "creating a new sandbox preserves task_id and provider override", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      {:ok, task} = Tasks.get_task(scope, task_id)
+      agent = test_agent(%MockLLM{response: "hello", delay_ms: 5_000}, "SandboxBootstrapAgent")
+
+      assert {:ok, _pid} =
+               Execution.run(scope, task,
+                 agent: agent,
+                 sandbox_provider: IntegrationProvider,
+                 sandbox_wait_timeout_ms: 50
+               )
+
+      assert {:ok, sandbox} = Sandboxes.current_for_task(scope, task_id)
+      assert sandbox.task_id == task_id
+      assert sandbox.status == :running
+      assert String.starts_with?(sandbox.provider_ref, "integration-task-")
+
+      assert :ok = Tasks.cancel_execution(scope, task_id)
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -13,15 +13,18 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
+  import FrontmanServer.Test.Fixtures.Sandboxes, only: [valid_env_spec: 0]
 
   import FrontmanServer.Test.Fixtures.Tools,
     only: [question_args: 0, question_mcp_tool_defs: 0, todo_args: 0]
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Repo
+  alias FrontmanServer.Sandbox.EnvironmentSpec
   alias FrontmanServer.Sandboxes
   alias FrontmanServer.Tasks
-  alias FrontmanServer.Tasks.Execution
+  alias FrontmanServer.Tasks.{Execution, TaskSchema}
   alias FrontmanServer.Tasks.{ExecutionEvent, Interaction}
   alias FrontmanServer.Test.Support.Sandbox.IntegrationProvider
   alias FrontmanServer.Tools.MCP
@@ -64,6 +67,30 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
         on_timeout: :error
       }
     ]
+  end
+
+  defmodule StuckProvisionProvider do
+    @behaviour FrontmanServer.Sandbox.Provider
+
+    @impl true
+    def create(%EnvironmentSpec{} = spec, _opts) do
+      {:ok, "stuck-#{spec.name}-#{System.unique_integer([:positive])}"}
+    end
+
+    @impl true
+    def exec(_ref, _command, _args, _opts), do: {:error, :not_ready}
+
+    @impl true
+    def metrics(_ref), do: {:ok, %{running: false}}
+
+    @impl true
+    def stop(_ref), do: :ok
+
+    @impl true
+    def start(_ref), do: :ok
+
+    @impl true
+    def destroy(_ref), do: :ok
   end
 
   defp setup_sandbox(_context) do
@@ -149,7 +176,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   end
 
   describe "sandbox bootstrap invariants" do
-    setup [:setup_sandbox, :setup_user, :setup_task_only, :setup_sandbox_mvp_enabled]
+    setup [:setup_sandbox, :setup_user, :setup_task, :setup_sandbox_mvp_enabled]
 
     test "creating a new sandbox preserves task_id and provider override", %{
       task_id: task_id,
@@ -171,6 +198,63 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert String.starts_with?(sandbox.provider_ref, "integration-task-")
 
       assert :ok = Tasks.cancel_execution(scope, task_id)
+    end
+
+    test "submit_user_message returns quickly while sandbox provisioning is pending", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      agent =
+        test_agent(
+          %MockLLM{response: "hello", delay_ms: 5_000},
+          "SandboxProvisioningPendingAgent"
+        )
+
+      started_at = System.monotonic_time(:millisecond)
+
+      assert {:ok, _interaction} =
+               Tasks.submit_user_message(scope, task_id, user_content("Hello"), [],
+                 agent: agent,
+                 sandbox_provider: StuckProvisionProvider,
+                 sandbox_wait_timeout_ms: 350
+               )
+
+      elapsed_ms = System.monotonic_time(:millisecond) - started_at
+      assert elapsed_ms < 200
+
+      assert_receive {:execution_start_error, ":sandbox_provisioning_timeout"}, 1_000
+    end
+
+    test "returns sandbox_stopped immediately instead of waiting for timeout", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      {:ok, task} = Tasks.get_task(scope, task_id)
+      task_schema = Repo.get!(TaskSchema, task_id)
+
+      env_spec =
+        valid_env_spec()
+        |> Map.put("name", "sandbox-stopped-#{System.unique_integer([:positive])}")
+
+      {:ok, sandbox} = Sandboxes.provision_for_task(scope, task_schema, env_spec)
+
+      {:ok, _pid} =
+        Task.start(fn ->
+          Process.sleep(20)
+          {:ok, _sandbox} = Sandboxes.suspend(scope, sandbox.id)
+        end)
+
+      agent = test_agent(%MockLLM{response: "hello"}, "SandboxStoppedAgent")
+      started_at = System.monotonic_time(:millisecond)
+
+      assert {:error, :sandbox_stopped} =
+               Execution.run(scope, task,
+                 agent: agent,
+                 sandbox_wait_timeout_ms: 500
+               )
+
+      elapsed_ms = System.monotonic_time(:millisecond) - started_at
+      assert elapsed_ms < 300
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tools/sandbox/common_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/sandbox/common_test.exs
@@ -1,0 +1,41 @@
+defmodule FrontmanServer.Tools.Sandbox.CommonTest do
+  use ExUnit.Case, async: true
+
+  alias FrontmanServer.Tools.Sandbox.Common
+
+  describe "resolve_relative_path/1" do
+    test "resolves relative project paths" do
+      root = Common.project_root()
+
+      assert {:ok, %{absolute: absolute, relative: "apps/frontman_server/mix.exs"}} =
+               Common.resolve_relative_path("apps/frontman_server/mix.exs")
+
+      assert absolute == Path.join(root, "apps/frontman_server/mix.exs")
+    end
+
+    test "accepts absolute paths under project root" do
+      root = Common.project_root()
+      absolute_path = Path.join(root, "apps/frontman_server/mix.exs")
+
+      assert {:ok, %{absolute: ^absolute_path, relative: "apps/frontman_server/mix.exs"}} =
+               Common.resolve_relative_path(absolute_path)
+    end
+
+    test "accepts project root absolute path" do
+      root = Common.project_root() |> Path.expand()
+
+      assert {:ok, %{absolute: ^root, relative: "."}} =
+               Common.resolve_relative_path(root)
+    end
+
+    test "rejects absolute paths outside project root" do
+      assert {:error, "path must be inside sandbox project root"} =
+               Common.resolve_relative_path("/tmp/outside-root.txt")
+    end
+
+    test "rejects relative parent traversal" do
+      assert {:error, "path must not traverse parent directories"} =
+               Common.resolve_relative_path("../secrets.txt")
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -7,6 +7,7 @@ defmodule FrontmanServer.ToolsTest do
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tools
   alias FrontmanServer.Tools.Backend.Context
+  alias FrontmanServer.Tools.MCP
   alias FrontmanServer.Tools.TodoWrite
 
   setup do
@@ -67,6 +68,35 @@ defmodule FrontmanServer.ToolsTest do
       assert Tools.execution_target("unknown_tool") == :mcp
       assert Tools.execution_target("question") == :mcp
       assert Tools.execution_target("") == :mcp
+    end
+  end
+
+  describe "backend_tool_modules/1" do
+    test "includes sandbox tools when sandbox is provided" do
+      modules = Tools.backend_tool_modules(sandbox: %{id: "sandbox-1"})
+      names = Enum.map(modules, & &1.name())
+
+      assert "todo_write" in names
+      assert "web_fetch" in names
+      assert "read_file" in names
+      assert "write_file" in names
+    end
+  end
+
+  describe "prepare_for_task/3" do
+    test "deduplicates MCP tools that conflict with backend names", %{task_id: task_id} do
+      conflicting_mcp = %MCP{
+        name: "web_fetch",
+        description: "conflicting tool",
+        input_schema: %{"type" => "object", "properties" => %{}},
+        timeout_ms: 60_000,
+        on_timeout: :error
+      }
+
+      tools = Tools.prepare_for_task([conflicting_mcp], task_id)
+      web_fetch_count = tools |> Enum.count(&(&1.name == "web_fetch"))
+
+      assert web_fetch_count == 1
     end
   end
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_sandbox_provisioning_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_sandbox_provisioning_test.exs
@@ -1,0 +1,88 @@
+defmodule FrontmanServerWeb.TaskChannelSandboxProvisioningTest do
+  use FrontmanServerWeb.ChannelCase, async: false
+
+  alias FrontmanServer.Sandbox.EnvironmentSpec
+
+  @moduletag :capture_log
+
+  defmodule StuckProvisionProvider do
+    @behaviour FrontmanServer.Sandbox.Provider
+
+    @impl true
+    def create(%EnvironmentSpec{} = spec, _opts) do
+      {:ok, "stuck-#{spec.name}-#{System.unique_integer([:positive])}"}
+    end
+
+    @impl true
+    def exec(_ref, _command, _args, _opts), do: {:error, :not_ready}
+
+    @impl true
+    def metrics(_ref), do: {:ok, %{running: false}}
+
+    @impl true
+    def stop(_ref), do: :ok
+
+    @impl true
+    def start(_ref), do: :ok
+
+    @impl true
+    def destroy(_ref), do: :ok
+  end
+
+  setup do
+    original_mvp_config = Application.get_env(:frontman_server, :sandbox_mvp, [])
+    original_provider = Application.get_env(:frontman_server, :sandbox_provider)
+
+    sandbox_mvp_config =
+      original_mvp_config
+      |> Keyword.put(:enabled, true)
+      |> Keyword.put(:wait_timeout_ms, 400)
+      |> Keyword.put(:poll_interval_ms, 20)
+
+    Application.put_env(:frontman_server, :sandbox_mvp, sandbox_mvp_config)
+    Application.put_env(:frontman_server, :sandbox_provider, StuckProvisionProvider)
+
+    on_exit(fn ->
+      Application.put_env(:frontman_server, :sandbox_mvp, original_mvp_config)
+
+      case original_provider do
+        nil -> Application.delete_env(:frontman_server, :sandbox_provider)
+        provider -> Application.put_env(:frontman_server, :sandbox_provider, provider)
+      end
+
+      DynamicSupervisor.which_children(FrontmanServer.Sandbox.DynamicSupervisor)
+      |> Enum.each(fn
+        {_, pid, _, _} when is_pid(pid) -> Process.exit(pid, :kill)
+        _ -> :ok
+      end)
+    end)
+
+    :ok
+  end
+
+  test "channel remains responsive while sandbox provisioning is pending", %{scope: scope} do
+    {socket, _task_id} = join_task_channel(scope)
+    complete_mcp_handshake(socket)
+
+    push(socket, "acp:message", build_prompt_request(id: 1, text: "Start"))
+
+    ref =
+      push(
+        socket,
+        "acp:message",
+        build_acp_request("unknown/method", 2, %{})
+      )
+
+    assert_reply(ref, :ok, %{"acp:message" => %{"id" => 2, "error" => %{"code" => -32_601}}}, 150)
+
+    assert_push(
+      "acp:message",
+      %{
+        "params" => %{
+          "update" => %{"sessionUpdate" => "error", "message" => ":sandbox_provisioning_timeout"}
+        }
+      },
+      2_000
+    )
+  end
+end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1029,6 +1029,64 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
   end
 
+  describe "interaction tool routing" do
+    setup %{scope: scope} do
+      {socket, task_id} = join_task_channel(scope)
+      complete_mcp_handshake(socket)
+      {:ok, socket: socket, task_id: task_id}
+    end
+
+    test "uses backend_tool_modules from last_execution_opts for routing", %{socket: socket} do
+      :sys.replace_state(socket.channel_pid, fn channel_socket ->
+        Phoenix.Socket.assign(
+          channel_socket,
+          :last_execution_opts,
+          backend_tool_modules: [FrontmanServer.Tools.Sandbox.ReadFile]
+        )
+      end)
+
+      tool_call_id = "call_backend_#{:rand.uniform(1_000_000)}"
+      tc = tool_call(tool_call_id, "read_file", %{"target_file" => "README.md"})
+
+      send(socket.channel_pid, {:interaction, tc})
+      :sys.get_state(socket.channel_pid)
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call",
+            "toolCallId" => ^tool_call_id
+          }
+        }
+      })
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call_update",
+            "toolCallId" => ^tool_call_id,
+            "status" => "pending"
+          }
+        }
+      })
+
+      refute_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "tool_call_update",
+            "toolCallId" => ^tool_call_id,
+            "status" => "in_progress"
+          }
+        }
+      })
+
+      refute_push("mcp:message", %{
+        "method" => "tools/call",
+        "params" => %{"name" => "read_file"}
+      })
+    end
+  end
+
   describe "reconnect re-executes unresolved tool calls" do
     setup %{scope: scope} do
       task_id = task_fixture(scope)


### PR DESCRIPTION
## Summary
- provision and wait for a task sandbox before execution when `sandbox_mvp` is enabled, and thread sandbox context through `Execution` + `ToolExecutor`
- add sandbox backend tool modules (`read_file`, `write_file`, `edit_file`, `file_exists`, `list_files`, `list_tree`, `search_files`, `grep`) and register them so they run server-side instead of being routed to MCP
- add sandbox bootstrap flow in `Sandbox.Orchestrator` (repo sync, dependency install, app start, health check) and wire sandbox-aware tool selection in `TaskChannel` retry/start paths
- add `sandbox_mvp` config wiring in `dev`, `test`, and `runtime` config files, plus tool registry tests for sandbox module inclusion and MCP/backend dedupe

## Testing
- `mix test test/frontman_server/tools_test.exs`
- `mix test test/frontman_server/sandboxes_orchestrator_integration_test.exs`
- `mix test test/frontman_server/tasks/execution/tool_executor_test.exs`
- `mix test test/frontman_server/tasks/execution_test.exs test/frontman_server_web/channels/task_channel_test.exs`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
