### PR TITLE
fix: make ParallelExecutor the single timeout authority (#760)

### DIFF
--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -49,8 +49,6 @@ defmodule FrontmanServer.Application do
       {SwarmAi.Runtime,
        name: FrontmanServer.AgentRuntime,
        event_dispatcher: {FrontmanServer.Tasks.SwarmDispatcher, :dispatch, []}},
-      # Registry for MCP tool call result routing (separate from agent execution tracking)
-      {Registry, keys: :unique, name: FrontmanServer.ToolCallRegistry},
       # Oban background job processing (email delivery, contact sync, etc.)
       {Oban, Application.fetch_env!(:frontman_server, Oban)},
       # Start to serve requests, typically the last entry

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -414,28 +414,27 @@ defmodule FrontmanServer.Tasks do
   @doc """
   Creates and appends a ToolResult interaction.
 
-  Routes the result to the waiting executor so the agent can continue.
+  Persists the tool result in the interaction history. Process routing
+  (delivering the result to a waiting executor) is handled separately
+  by the caller via `SwarmAi.Runtime.deliver_tool_result/5`.
+
   Duplicate tool results for the same tool_call_id are prevented by a
   unique partial index on the interactions table.
-
-  Returns `{:ok, interaction, :notified}` when a live executor received the result,
-  `{:ok, interaction, :no_executor}` when no executor was waiting (e.g., server restart).
   """
   @spec add_tool_result(Accounts.scope(), String.t(), map(), term(), boolean()) ::
-          {:ok, Interaction.ToolResult.t(), :notified | :no_executor}
+          {:ok, Interaction.ToolResult.t()}
           | {:error, :not_found | Ecto.Changeset.t()}
   def add_tool_result(
         scope,
         task_id,
-        %{id: tool_call_id, name: _} = tool_call_data,
+        %{id: _tool_call_id, name: _} = tool_call_data,
         result,
         is_error \\ false
       ) do
     with {:ok, schema} <- get_task_by_id(scope, task_id),
          interaction = Interaction.ToolResult.new(tool_call_data, result, is_error),
          {:ok, interaction} <- append_interaction(schema, interaction) do
-      executor_status = Execution.notify_tool_result(scope, tool_call_id, result, is_error)
-      {:ok, interaction, executor_status}
+      {:ok, interaction}
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -161,7 +161,7 @@ defmodule FrontmanServer.Tasks.Execution do
               message_key: tc.id,
               on_timeout:
                 {AgentStrategy, :handle_timeout_mfa, [strategy_state, tool_def.on_timeout]},
-              process_result: nil
+              process_result: {AgentStrategy, :make_mcp_tool_result, [tc.name]}
             }
         end
       end)

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -128,14 +128,43 @@ defmodule FrontmanServer.Tasks.Execution do
       llm_opts: llm_opts
     ]
 
-    # Initialize the AgentStrategy and build a tool_executor closure.
-    # Runtime.run/5 accepts `tool_executor:` (a closure), not `strategy:`.
-    # This bridges the new behaviour to the existing runtime interface.
-    # When Runtime is updated to accept `strategy:` natively, this
-    # adapter code can be removed.
     {:ok, strategy_state} = AgentStrategy.init(strategy_opts)
+    tool_executor = build_tool_executor(strategy_state)
 
-    tool_executor = fn tool_calls ->
+    # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
+    # in event handlers — the agent may complete before this line returns.
+    TelemetryEvents.task_start(task_id)
+
+    interaction_id = Keyword.get(opts, :interaction_id)
+
+    case SwarmAi.Runtime.run(FrontmanServer.AgentRuntime, task_id, agent, messages,
+           metadata: %{
+             task_id: task_id,
+             resolved_key: resolved_key,
+             scope: scope,
+             interaction_id: interaction_id
+           },
+           tool_executor: tool_executor
+         ) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, :already_running} ->
+        TelemetryEvents.task_stop(task_id)
+        {:ok, :already_running}
+
+      error ->
+        TelemetryEvents.task_stop(task_id)
+        error
+    end
+  end
+
+  # Bridges AgentStrategy to the existing Runtime tool_executor interface.
+  # Runtime.run/5 accepts `tool_executor:` (a closure that maps tool calls
+  # to ToolExecution structs), not `strategy:` natively. When Runtime is
+  # updated to accept `strategy:` directly, this adapter can be removed.
+  defp build_tool_executor(strategy_state) do
+    fn tool_calls ->
       Enum.map(tool_calls, fn tc ->
         tc = SwarmAi.ToolCall.strip_null_arguments(tc)
 
@@ -165,33 +194,6 @@ defmodule FrontmanServer.Tasks.Execution do
             }
         end
       end)
-    end
-
-    # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
-    # in event handlers — the agent may complete before this line returns.
-    TelemetryEvents.task_start(task_id)
-
-    interaction_id = Keyword.get(opts, :interaction_id)
-
-    case SwarmAi.Runtime.run(FrontmanServer.AgentRuntime, task_id, agent, messages,
-           metadata: %{
-             task_id: task_id,
-             resolved_key: resolved_key,
-             scope: scope,
-             interaction_id: interaction_id
-           },
-           tool_executor: tool_executor
-         ) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      {:error, :already_running} ->
-        TelemetryEvents.task_stop(task_id)
-        {:ok, :already_running}
-
-      error ->
-        TelemetryEvents.task_stop(task_id)
-        error
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -128,6 +128,45 @@ defmodule FrontmanServer.Tasks.Execution do
       llm_opts: llm_opts
     ]
 
+    # Initialize the AgentStrategy and build a tool_executor closure.
+    # Runtime.run/5 accepts `tool_executor:` (a closure), not `strategy:`.
+    # This bridges the new behaviour to the existing runtime interface.
+    # When Runtime is updated to accept `strategy:` natively, this
+    # adapter code can be removed.
+    {:ok, strategy_state} = AgentStrategy.init(strategy_opts)
+
+    tool_executor = fn tool_calls ->
+      Enum.map(tool_calls, fn tc ->
+        tc = SwarmAi.ToolCall.strip_null_arguments(tc)
+
+        case Map.fetch(strategy_state.backend_module_map, tc.name) do
+          {:ok, module} ->
+            %SwarmAi.ToolExecution.Sync{
+              tool_call: tc,
+              timeout_ms: module.timeout_ms(),
+              on_timeout_policy: module.on_timeout(),
+              run: {AgentStrategy, :run_backend_tool_mfa, [strategy_state, module]},
+              on_timeout:
+                {AgentStrategy, :handle_timeout_mfa, [strategy_state, module.on_timeout()]}
+            }
+
+          :error ->
+            tool_def = find_mcp_tool_def!(tc.name, strategy_state)
+
+            %SwarmAi.ToolExecution.Await{
+              tool_call: tc,
+              timeout_ms: tool_def.timeout_ms,
+              on_timeout_policy: tool_def.on_timeout,
+              start: {AgentStrategy, :start_mcp_tool_mfa, [strategy_state]},
+              message_key: tc.id,
+              on_timeout:
+                {AgentStrategy, :handle_timeout_mfa, [strategy_state, tool_def.on_timeout]},
+              process_result: nil
+            }
+        end
+      end)
+    end
+
     # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
     # in event handlers — the agent may complete before this line returns.
     TelemetryEvents.task_start(task_id)
@@ -141,7 +180,7 @@ defmodule FrontmanServer.Tasks.Execution do
              scope: scope,
              interaction_id: interaction_id
            },
-           strategy: {AgentStrategy, strategy_opts}
+           tool_executor: tool_executor
          ) do
       {:ok, pid} ->
         {:ok, pid}
@@ -154,6 +193,12 @@ defmodule FrontmanServer.Tasks.Execution do
         TelemetryEvents.task_stop(task_id)
         error
     end
+  end
+
+  defp find_mcp_tool_def!(tool_name, strategy_state) do
+    Enum.find(strategy_state.mcp_tool_defs, &(&1.name == tool_name)) ||
+      Enum.find(strategy_state.mcp_tools, &(&1.name == tool_name)) ||
+      raise "Unknown tool: #{tool_name}. Not in backend_module_map, mcp_tool_defs, or mcp_tools."
   end
 
   defp maybe_enable_prompt_cache(opts, "anthropic"),
@@ -232,9 +277,6 @@ defmodule FrontmanServer.Tasks.Execution do
   end
 
   defp constrain_image_part(part, _max), do: part
-
-  defp encode_result_for_swarm(value) when is_binary(value), do: value
-  defp encode_result_for_swarm(value), do: Jason.encode!(value)
 
   # --- SwarmAi Message Conversion ---
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -28,7 +28,7 @@ defmodule FrontmanServer.Tasks.Execution do
   alias FrontmanServer.Observability.TelemetryEvents
   alias FrontmanServer.Providers
   alias FrontmanServer.Providers.ResolvedKey
-  alias FrontmanServer.Tasks.Execution.{Framework, RootAgent, ToolExecutor}
+  alias FrontmanServer.Tasks.Execution.{AgentStrategy, Framework, RootAgent}
   alias FrontmanServer.Tasks.{Interaction, Task}
   alias FrontmanServer.Tools
   alias SwarmAi.Message
@@ -103,28 +103,6 @@ defmodule FrontmanServer.Tasks.Execution do
     end
   end
 
-  @doc """
-  Notifies that a tool result has arrived.
-
-  Routes the result to the blocking executor via Registry metadata.
-  Called by the Tasks facade after persisting the tool result interaction.
-  Returns `:notified` when the result was delivered to a live executor,
-  `:no_executor` when no executor was waiting (e.g., server restarted).
-  """
-  @spec notify_tool_result(Accounts.scope(), String.t(), term(), boolean()) ::
-          :notified | :no_executor
-  def notify_tool_result(%Scope{}, tool_call_id, result, is_error) do
-    case Elixir.Registry.lookup(FrontmanServer.ToolCallRegistry, {:tool_call, tool_call_id}) do
-      [{_pid, %{caller_pid: caller}}] ->
-        encoded = encode_result_for_swarm(result)
-        send(caller, {:tool_result, tool_call_id, encoded, is_error})
-        :notified
-
-      [] ->
-        :no_executor
-    end
-  end
-
   # --- Private ---
 
   # Dialyzer warning suppressed: protocol dispatch on Agent can't be statically proven.
@@ -140,13 +118,15 @@ defmodule FrontmanServer.Tasks.Execution do
       [api_key: resolved_key.api_key, model: resolved_key.model]
       |> maybe_enable_prompt_cache(resolved_key.provider)
 
-    tool_executor =
-      ToolExecutor.make_executor(scope, task_id,
-        backend_tool_modules: backend_tool_modules,
-        mcp_tools: mcp_tools,
-        mcp_tool_defs: mcp_tool_defs,
-        llm_opts: llm_opts
-      )
+    strategy_opts = [
+      scope: scope,
+      task_id: task_id,
+      runtime: FrontmanServer.AgentRuntime,
+      backend_tool_modules: backend_tool_modules,
+      mcp_tools: mcp_tools,
+      mcp_tool_defs: mcp_tool_defs,
+      llm_opts: llm_opts
+    ]
 
     # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
     # in event handlers — the agent may complete before this line returns.
@@ -161,7 +141,7 @@ defmodule FrontmanServer.Tasks.Execution do
              scope: scope,
              interaction_id: interaction_id
            },
-           tool_executor: tool_executor
+           strategy: {AgentStrategy, strategy_opts}
          ) do
       {:ok, pid} ->
         {:ok, pid}

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -391,6 +391,16 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
     timeout_msg = "Tool #{tool_call.name} timed out"
     Logger.error("AgentStrategy: #{timeout_msg}")
 
+    Sentry.capture_message("Tool timeout",
+      level: :error,
+      tags: %{error_type: "tool_timeout"},
+      extra: %{
+        tool_name: tool_call.name,
+        tool_call_id: tool_call.id,
+        task_id: state.task_id
+      }
+    )
+
     Tasks.add_tool_result(
       state.scope,
       state.task_id,

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -1,0 +1,412 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
+  @moduledoc """
+  Frontman's `ExecutionStrategy` implementation.
+
+  Replaces the former `ToolExecutor` closure-based approach with a plain struct
+  implementing the `SwarmAi.ExecutionStrategy` behaviour. Fully testable in
+  isolation without standing up the Swarm runtime.
+
+  ## Backend tools
+
+  Each backend tool is executed synchronously via its module's `execute/2`
+  callback inside the supervised task that `ParallelExecutor` spawns.
+
+  ## MCP tools
+
+  MCP tools block via `SwarmAi.Runtime.await_tool_result/3` until the browser
+  client delivers the result through `SwarmAi.Runtime.deliver_tool_result/5`.
+  """
+
+  @behaviour SwarmAi.ExecutionStrategy
+
+  require Logger
+
+  alias FrontmanServer.Accounts
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Image
+  alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Interaction
+  alias FrontmanServer.Tools.Backend
+  alias SwarmAi.Message.ContentPart
+
+  defstruct [
+    :scope,
+    :task_id,
+    :runtime,
+    :backend_module_map,
+    :backend_tool_modules,
+    :mcp_tool_defs,
+    :mcp_tools,
+    :llm_opts
+  ]
+
+  # --- ExecutionStrategy callbacks ---
+
+  @impl SwarmAi.ExecutionStrategy
+  def init(opts) do
+    backend_tool_modules = Keyword.fetch!(opts, :backend_tool_modules)
+
+    state = %__MODULE__{
+      scope: Keyword.fetch!(opts, :scope),
+      task_id: Keyword.fetch!(opts, :task_id),
+      runtime: Keyword.fetch!(opts, :runtime),
+      backend_tool_modules: backend_tool_modules,
+      backend_module_map: Map.new(backend_tool_modules, &{&1.name(), &1}),
+      mcp_tool_defs: Keyword.fetch!(opts, :mcp_tool_defs),
+      mcp_tools: Keyword.fetch!(opts, :mcp_tools),
+      llm_opts: Keyword.fetch!(opts, :llm_opts)
+    }
+
+    {:ok, state}
+  end
+
+  @impl SwarmAi.ExecutionStrategy
+  def execute_tool(state, tool_call) do
+    tool_call = SwarmAi.ToolCall.strip_null_arguments(tool_call)
+
+    result =
+      case Map.fetch(state.backend_module_map, tool_call.name) do
+        {:ok, module} ->
+          execute_backend_tool(state, module, tool_call)
+
+        :error ->
+          execute_mcp_tool(state, tool_call)
+      end
+
+    {result, state}
+  end
+
+  @impl SwarmAi.ExecutionStrategy
+  def on_deadline(state, tool_call) do
+    policy =
+      case Map.get(state.backend_module_map, tool_call.name) do
+        nil -> find_mcp_policy(tool_call.name, state)
+        module -> map_timeout_policy(module.on_timeout())
+      end
+
+    {policy, state}
+  end
+
+  # --- Backend Tool Execution ---
+
+  defp execute_backend_tool(state, module, tool_call) do
+    Logger.info("AgentStrategy: Executing backend tool #{tool_call.name}")
+
+    # Re-fetch task to get latest interactions
+    {:ok, task} = Tasks.get_task(state.scope, state.task_id)
+
+    context_messages = Interaction.extract_markdown_messages(task.interactions)
+
+    context = %Backend.Context{
+      scope: state.scope,
+      task: task,
+      tool_executor: build_legacy_executor(state),
+      mcp_tools: state.mcp_tools,
+      context_messages: context_messages,
+      llm_opts: state.llm_opts
+    }
+
+    case parse_arguments(tool_call.name, tool_call.arguments) do
+      {:error, reason} ->
+        Tasks.add_tool_result(
+          state.scope,
+          state.task_id,
+          tool_call_ref(tool_call),
+          reason,
+          true
+        )
+
+        SwarmAi.ToolResult.make(tool_call.id, to_string(reason), true)
+
+      {:ok, args} ->
+        run_backend_tool(state, module, args, context, tool_call)
+    end
+  end
+
+  defp run_backend_tool(state, module, args, context, tool_call) do
+    outcome =
+      try do
+        {:returned, module.execute(args, context)}
+      catch
+        kind, reason -> {:crashed, {kind, reason}}
+      end
+
+    handle_backend_outcome(outcome, state, tool_call)
+  end
+
+  defp handle_backend_outcome({:returned, {:ok, value}}, state, tool_call) do
+    case Tasks.add_tool_result(state.scope, state.task_id, tool_call_ref(tool_call), value, false) do
+      {:ok, _interaction} ->
+        result = maybe_enrich_with_images(tool_call.name, {:ok, encode_result(value)})
+        {:ok, content} = result
+        SwarmAi.ToolResult.make(tool_call.id, content, false)
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        reason =
+          "Tool result not JSON-serializable: #{inspect(changeset.errors)}. Tool: #{tool_call.name}"
+
+        Logger.error("AgentStrategy: #{reason}")
+        report_tool_sentry("tool_persist_error", tool_call, state.task_id, reason)
+        Tasks.add_tool_result(state.scope, state.task_id, tool_call_ref(tool_call), reason, true)
+        SwarmAi.ToolResult.make(tool_call.id, reason, true)
+
+      {:error, reason} ->
+        Logger.error(
+          "AgentStrategy: Failed to persist tool result for #{tool_call.name}: #{inspect(reason)}"
+        )
+
+        SwarmAi.ToolResult.make(tool_call.id, inspect(reason), true)
+    end
+  end
+
+  defp handle_backend_outcome({:returned, {:error, reason}}, state, tool_call) do
+    Logger.error("AgentStrategy: Backend tool #{tool_call.name} returned error: #{inspect(reason)}")
+    report_tool_sentry("tool_soft_error", tool_call, state.task_id, inspect(reason))
+    Tasks.add_tool_result(state.scope, state.task_id, tool_call_ref(tool_call), reason, true)
+    SwarmAi.ToolResult.make(tool_call.id, to_string(reason), true)
+  end
+
+  defp handle_backend_outcome({:crashed, reason}, state, tool_call) do
+    reason_str = inspect(reason)
+    Logger.error("AgentStrategy: Backend tool #{tool_call.name} crashed: #{reason_str}")
+    report_tool_sentry("tool_crash", tool_call, state.task_id, reason_str)
+    Tasks.add_tool_result(state.scope, state.task_id, tool_call_ref(tool_call), reason_str, true)
+    SwarmAi.ToolResult.make(tool_call.id, reason_str, true)
+  end
+
+  # --- MCP Tool Execution ---
+
+  defp execute_mcp_tool(state, tool_call) do
+    Logger.info("AgentStrategy: Routing to MCP tool #{tool_call.name}")
+
+    # Publish tool call to client BEFORE blocking — so the client knows to execute it
+    publish_mcp_tool_call(state.scope, state.task_id, tool_call)
+
+    # Block until deliver_tool_result sends the result
+    case SwarmAi.Runtime.await_tool_result(state.runtime, tool_call.id) do
+      {:ok, content, is_error} ->
+        result = maybe_enrich_with_images(tool_call.name, {:ok, content})
+        {:ok, enriched} = result
+        SwarmAi.ToolResult.make(tool_call.id, enriched, is_error)
+
+      {:error, :timeout} ->
+        SwarmAi.ToolResult.make(tool_call.id, "Tool result delivery timed out", true)
+    end
+  end
+
+  defp publish_mcp_tool_call(%Scope{} = scope, task_id, tool_call) do
+    reqllm_tc = ReqLLM.ToolCall.new(tool_call.id, tool_call.name, tool_call.arguments)
+
+    case Tasks.add_tool_call(scope, task_id, reqllm_tc) do
+      {:ok, _interaction} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "AgentStrategy: Failed to publish MCP tool call #{tool_call.id}: #{inspect(reason)}"
+        )
+
+        raise "Failed to publish MCP tool call: #{inspect(reason)}"
+    end
+  end
+
+  # --- Helpers ---
+
+  defp find_mcp_policy(tool_name, state) do
+    found =
+      Enum.find(state.mcp_tool_defs, &(&1.name == tool_name)) ||
+        Enum.find(state.mcp_tools, &(&1.name == tool_name))
+
+    case found do
+      %{on_timeout: :pause_agent} -> :pause
+      _ -> :error
+    end
+  end
+
+  defp map_timeout_policy(:pause_agent), do: :pause
+  defp map_timeout_policy(_), do: :error
+
+  defp tool_call_ref(tool_call), do: %{id: tool_call.id, name: tool_call.name}
+
+  # Build a legacy executor function for Backend.Context.tool_executor
+  # (used by backend tools that spawn sub-agents)
+  defp build_legacy_executor(state) do
+    fn tool_calls ->
+      Enum.map(tool_calls, fn tc ->
+        tc = SwarmAi.ToolCall.strip_null_arguments(tc)
+
+        case Map.fetch(state.backend_module_map, tc.name) do
+          {:ok, module} ->
+            %SwarmAi.ToolExecution.Sync{
+              tool_call: tc,
+              timeout_ms: module.timeout_ms(),
+              on_timeout_policy: module.on_timeout(),
+              run: {__MODULE__, :run_backend_tool_mfa, [state, module]},
+              on_timeout: {__MODULE__, :handle_timeout_mfa, [state, module.on_timeout()]}
+            }
+
+          :error ->
+            tool_def = find_mcp_tool_def!(tc.name, state)
+
+            %SwarmAi.ToolExecution.Await{
+              tool_call: tc,
+              timeout_ms: tool_def.timeout_ms,
+              on_timeout_policy: tool_def.on_timeout,
+              start: {__MODULE__, :start_mcp_tool_mfa, [state]},
+              message_key: tc.id,
+              on_timeout: {__MODULE__, :handle_timeout_mfa, [state, tool_def.on_timeout]},
+              process_result: nil
+            }
+        end
+      end)
+    end
+  end
+
+  defp find_mcp_tool_def!(tool_name, state) do
+    Enum.find(state.mcp_tool_defs, &(&1.name == tool_name)) ||
+      Enum.find(state.mcp_tools, &(&1.name == tool_name)) ||
+      raise "Unknown tool: #{tool_name}. Not in backend_module_map, mcp_tool_defs, or mcp_tools."
+  end
+
+  defp parse_arguments(tool_name, arguments) when is_binary(arguments) do
+    case Jason.decode(arguments) do
+      {:ok, decoded} ->
+        {:ok, decoded}
+
+      {:error, decode_error} ->
+        reason =
+          "Failed to parse arguments for tool #{tool_name}: #{inspect(decode_error)}, raw: #{String.slice(arguments, 0, 500)}"
+
+        Logger.error("AgentStrategy: #{reason}")
+
+        Sentry.capture_message("Tool argument parse failure",
+          level: :error,
+          tags: %{error_type: "tool_parse_error", tool_name: tool_name},
+          extra: %{
+            tool_name: tool_name,
+            raw_arguments: String.slice(arguments, 0, 500),
+            decode_error: inspect(decode_error)
+          }
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp parse_arguments(_tool_name, arguments) when is_map(arguments), do: {:ok, arguments}
+  defp parse_arguments(_tool_name, _), do: {:ok, %{}}
+
+  defp encode_result(value) when is_binary(value), do: value
+  defp encode_result(value), do: Jason.encode!(value)
+
+  defp report_tool_sentry(error_type, tool_call, task_id, reason) do
+    Sentry.capture_message("Tool execution failed",
+      level: :error,
+      tags: %{error_type: error_type},
+      extra: %{
+        tool_name: tool_call.name,
+        tool_call_id: tool_call.id,
+        task_id: task_id,
+        reason: reason
+      }
+    )
+  end
+
+  # --- Image Enrichment ---
+
+  defp maybe_enrich_with_images(tool_name, {:ok, content} = result) when is_binary(content) do
+    case Image.image_tool_config(tool_name) do
+      nil ->
+        result
+
+      {image_field, _text_fields} ->
+        case extract_image_content(content, image_field) do
+          {:ok, content_parts} -> {:ok, content_parts}
+          :no_image -> result
+        end
+    end
+  end
+
+  defp maybe_enrich_with_images(_tool_name, result), do: result
+
+  defp extract_image_content(json_string, image_field) do
+    field_name = Atom.to_string(image_field)
+
+    with {:ok, decoded} when is_map(decoded) <- Jason.decode(json_string),
+         data_url when is_binary(data_url) <- Map.get(decoded, field_name),
+         {:ok, binary, mime} <- Image.decode_data_url(data_url) do
+      {:ok, [ContentPart.image(binary, mime)]}
+    else
+      {:error, _json_error} -> :no_image
+      {:ok, _not_a_map} -> :no_image
+      nil -> :no_image
+      _non_string_field -> :no_image
+    end
+  end
+
+  # --- MFA callbacks for legacy executor (sub-agent compatibility) ---
+
+  @doc false
+  def run_backend_tool_mfa(state, module, tool_call) do
+    execute_backend_tool(state, module, tool_call)
+  end
+
+  @doc false
+  def start_mcp_tool_mfa(state, tool_call) do
+    publish_mcp_tool_call(state.scope, state.task_id, tool_call)
+    :ok
+  end
+
+  @doc false
+  def handle_timeout_mfa(state, :error, tool_call, :triggered) do
+    timeout_msg = "Tool #{tool_call.name} timed out"
+    Logger.error("AgentStrategy: #{timeout_msg}")
+
+    Tasks.add_tool_result(
+      state.scope,
+      state.task_id,
+      %{id: tool_call.id, name: tool_call.name},
+      timeout_msg,
+      true
+    )
+
+    :ok
+  end
+
+  def handle_timeout_mfa(state, :error, tool_call, :cancelled) do
+    cancel_msg = "Tool #{tool_call.name} cancelled (sibling tool paused agent)"
+    Logger.info("AgentStrategy: #{cancel_msg}")
+
+    Tasks.add_tool_result(
+      state.scope,
+      state.task_id,
+      %{id: tool_call.id, name: tool_call.name},
+      cancel_msg,
+      true
+    )
+
+    :ok
+  end
+
+  def handle_timeout_mfa(_state, :pause_agent, _tool_call, :triggered), do: :ok
+
+  def handle_timeout_mfa(state, :pause_agent, tool_call, :cancelled) do
+    cancel_msg = "Tool #{tool_call.name} cancelled (sibling tool paused agent)"
+
+    Tasks.add_tool_result(
+      state.scope,
+      state.task_id,
+      %{id: tool_call.id, name: tool_call.name},
+      cancel_msg,
+      true
+    )
+
+    :ok
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -261,7 +261,7 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
               start: {__MODULE__, :start_mcp_tool_mfa, [state]},
               message_key: tc.id,
               on_timeout: {__MODULE__, :handle_timeout_mfa, [state, tool_def.on_timeout]},
-              process_result: nil
+              process_result: {__MODULE__, :make_mcp_tool_result, [tc.name]}
             }
         end
       end)
@@ -367,6 +367,14 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
 
     publish_mcp_tool_call(state.scope, state.task_id, tool_call)
     :ok
+  end
+
+  @doc false
+  @spec make_mcp_tool_result(String.t(), SwarmAi.ToolCall.t(), term(), boolean()) ::
+          SwarmAi.ToolResult.t()
+  def make_mcp_tool_result(tool_name, tool_call, content, is_error) do
+    {:ok, enriched} = maybe_enrich_with_images(tool_name, {:ok, content})
+    SwarmAi.ToolResult.make(tool_call.id, enriched, is_error)
   end
 
   @doc false

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -359,6 +359,12 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
 
   @doc false
   def start_mcp_tool_mfa(state, tool_call) do
+    # Register PE's pid in the Runtime's ToolRegistry BEFORE publishing.
+    # self() here = PE's pid (start MFA runs in PE's own process).
+    # This lets deliver_tool_result route {:tool_result, ...} back to PE.
+    tool_reg = SwarmAi.Runtime.tool_registry_name(state.runtime)
+    Registry.register(tool_reg, {:awaiting_result, tool_call.id}, %{})
+
     publish_mcp_tool_call(state.scope, state.task_id, tool_call)
     :ok
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -193,28 +193,19 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
     # NOW publish — client can respond at any time, we're already registered
     publish_mcp_tool_call(state.scope, state.task_id, tool_call)
 
-    # Block until deliver_tool_result sends {:tool_result, ...} to our mailbox
-    timeout = 600_000
-
-    result =
-      receive do
-        {:tool_result, tool_call_id, content, is_error}
-        when tool_call_id == tool_call.id ->
-          Registry.unregister(tool_reg, {:awaiting_result, tool_call.id})
-          {:ok, content, is_error}
-      after
-        timeout ->
-          Registry.unregister(tool_reg, {:awaiting_result, tool_call.id})
-          {:error, :timeout}
-      end
-
-    case result do
-      {:ok, content, is_error} ->
+    # Block until deliver_tool_result sends {:tool_result, ...} to our mailbox.
+    #
+    # NO internal timeout here — ParallelExecutor owns per-tool deadlines via
+    # Process.send_after + terminate_child. Having a second timeout here creates
+    # a race condition (#760). When PE kills this process on deadline, Registry
+    # auto-unregisters {:awaiting_result, tool_call.id} because the owning
+    # process exited — no manual cleanup needed.
+    receive do
+      {:tool_result, tool_call_id, content, is_error}
+      when tool_call_id == tool_call.id ->
+        Registry.unregister(tool_reg, {:awaiting_result, tool_call.id})
         {:ok, enriched} = maybe_enrich_with_images(tool_call.name, {:ok, content})
         SwarmAi.ToolResult.make(tool_call.id, enriched, is_error)
-
-      {:error, :timeout} ->
-        SwarmAi.ToolResult.make(tool_call.id, "Tool result delivery timed out", true)
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/agent_strategy.ex
@@ -185,14 +185,32 @@ defmodule FrontmanServer.Tasks.Execution.AgentStrategy do
   defp execute_mcp_tool(state, tool_call) do
     Logger.info("AgentStrategy: Routing to MCP tool #{tool_call.name}")
 
-    # Publish tool call to client BEFORE blocking — so the client knows to execute it
+    # Register BEFORE publishing to prevent a race where the client responds
+    # before we're listening. Same pattern as start_mcp_tool_mfa.
+    tool_reg = SwarmAi.Runtime.tool_registry_name(state.runtime)
+    {:ok, _} = Registry.register(tool_reg, {:awaiting_result, tool_call.id}, %{})
+
+    # NOW publish — client can respond at any time, we're already registered
     publish_mcp_tool_call(state.scope, state.task_id, tool_call)
 
-    # Block until deliver_tool_result sends the result
-    case SwarmAi.Runtime.await_tool_result(state.runtime, tool_call.id) do
+    # Block until deliver_tool_result sends {:tool_result, ...} to our mailbox
+    timeout = 600_000
+
+    result =
+      receive do
+        {:tool_result, tool_call_id, content, is_error}
+        when tool_call_id == tool_call.id ->
+          Registry.unregister(tool_reg, {:awaiting_result, tool_call.id})
+          {:ok, content, is_error}
+      after
+        timeout ->
+          Registry.unregister(tool_reg, {:awaiting_result, tool_call.id})
+          {:error, :timeout}
+      end
+
+    case result do
       {:ok, content, is_error} ->
-        result = maybe_enrich_with_images(tool_call.name, {:ok, content})
-        {:ok, enriched} = result
+        {:ok, enriched} = maybe_enrich_with_images(tool_call.name, {:ok, content})
         SwarmAi.ToolResult.make(tool_call.id, enriched, is_error)
 
       {:error, :timeout} ->

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -298,7 +298,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   defp handle_backend_outcome({:returned, {:ok, value}}, scope, tool_call, task_id) do
     case Tasks.add_tool_result(scope, task_id, tool_call_ref(tool_call), value, false) do
-      {:ok, _interaction, _executor_status} ->
+      {:ok, _interaction} ->
         {:ok, encode_result(value)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -226,18 +226,23 @@ defmodule FrontmanServerWeb.TaskChannel do
            parsed_result,
            is_error
          ) do
-      {:ok, _interaction, :notified} ->
-        :ok
+      {:ok, _interaction} ->
+        # Deliver result to waiting executor via Swarm's internal registry
+        case SwarmAi.Runtime.deliver_tool_result(
+               FrontmanServer.AgentRuntime, task_id, tool_call_id, parsed_result, is_error) do
+          :delivered ->
+            :ok
 
-      {:ok, _interaction, :no_executor} ->
-        # No live executor (agent dead after server restart). If all pending
-        # tools are now resolved, resume the agent using scope.env_api_keys + model
-        # from the tool result's _meta (sent by the client per MCP spec).
-        {:ok, task} = Tasks.get_task(scope, task_id)
+          :no_executor ->
+            # No live executor (agent dead after server restart). If all pending
+            # tools are now resolved, resume the agent using scope.env_api_keys + model
+            # from the tool result's _meta (sent by the client per MCP spec).
+            {:ok, task} = Tasks.get_task(scope, task_id)
 
-        if Tasks.Interaction.all_pending_tools_resolved?(task.interactions) do
-          Logger.info("All pending tools resolved for #{task_id}, resuming agent")
-          maybe_resume_agent(socket, scope, task_id, meta)
+            if Tasks.Interaction.all_pending_tools_resolved?(task.interactions) do
+              Logger.info("All pending tools resolved for #{task_id}, resuming agent")
+              maybe_resume_agent(socket, scope, task_id, meta)
+            end
         end
 
       {:error, reason} ->
@@ -341,7 +346,11 @@ defmodule FrontmanServerWeb.TaskChannel do
            error_message,
            true
          ) do
-      {:ok, _interaction, _executor_status} ->
+      {:ok, _interaction} ->
+        # Deliver error to executor. Unlike success path, we don't auto-resume
+        # because MCP error responses don't carry _meta (env API keys + model).
+        SwarmAi.Runtime.deliver_tool_result(
+          FrontmanServer.AgentRuntime, task_id, tool_call.tool_call_id, error_message, true)
         :ok
 
       {:error, reason} ->
@@ -1024,7 +1033,8 @@ defmodule FrontmanServerWeb.TaskChannel do
     pending_requests = socket.assigns[:pending_requests] || %{}
 
     for {_request_id, {:tool_call, tc}} <- pending_requests do
-      Execution.notify_tool_result(scope, tc.tool_call_id, "Client disconnected", true)
+      SwarmAi.Runtime.deliver_tool_result(
+        FrontmanServer.AgentRuntime, task_id, tc.tool_call_id, "Client disconnected", true)
     end
 
     # Cancel any running execution. Without the channel, MCP tool results

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -227,9 +227,13 @@ defmodule FrontmanServerWeb.TaskChannel do
            is_error
          ) do
       {:ok, _interaction} ->
-        # Deliver result to waiting executor via Swarm's internal registry
+        # Deliver result to waiting executor via Swarm's internal registry.
+        # Encode non-binary results (maps from MCP.parse_tool_result) to JSON strings —
+        # maybe_enrich_with_images has a `when is_binary(content)` guard that skips
+        # image extraction when content is a map.
+        encoded_result = encode_for_delivery(parsed_result)
         case SwarmAi.Runtime.deliver_tool_result(
-               FrontmanServer.AgentRuntime, task_id, tool_call_id, parsed_result, is_error) do
+               FrontmanServer.AgentRuntime, task_id, tool_call_id, encoded_result, is_error) do
           :delivered ->
             :ok
 
@@ -249,6 +253,13 @@ defmodule FrontmanServerWeb.TaskChannel do
         Logger.warning("Failed to store tool result for #{tool_call_id}: #{inspect(reason)}")
     end
   end
+
+  # Encode non-binary tool results to JSON strings before delivering to PE.
+  # MCP.parse_tool_result can return maps when tool output is valid JSON.
+  # PE's process_result MFA calls maybe_enrich_with_images which has a
+  # `when is_binary(content)` guard — maps would skip image extraction.
+  defp encode_for_delivery(value) when is_binary(value), do: value
+  defp encode_for_delivery(value), do: Jason.encode!(value)
 
   defp maybe_resume_agent(socket, scope, task_id, meta) do
     scope = Scope.with_env_api_keys(scope, Registry.extract_env_keys(meta))

--- a/apps/frontman_server/test/frontman_server/tasks/execution/agent_strategy_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/agent_strategy_test.exs
@@ -1,0 +1,124 @@
+defmodule FrontmanServer.Tasks.Execution.AgentStrategyTest do
+  use ExUnit.Case, async: true
+
+  alias FrontmanServer.Tasks.Execution.AgentStrategy
+  alias SwarmAi.ToolCall
+
+  @moduledoc """
+  Unit tests for AgentStrategy — the domain's ExecutionStrategy implementation.
+
+  These tests verify AgentStrategy as a pure struct + behaviour without
+  standing up the full Swarm runtime, demonstrating the testability
+  improvement from the boundary redesign.
+  """
+
+  # Minimal mock modules for testing
+  defmodule MockBackendTool do
+    def name, do: "read_file"
+    def timeout_ms, do: 60_000
+    def on_timeout, do: :error
+    def execute(_args, _context), do: {:ok, "file contents"}
+  end
+
+  defmodule MockPauseTool do
+    def name, do: "browser_click"
+    def timeout_ms, do: 300_000
+    def on_timeout, do: :pause_agent
+    def execute(_args, _context), do: {:ok, "clicked"}
+  end
+
+  defp build_init_opts(overrides \\ []) do
+    defaults = [
+      scope: %FrontmanServer.Accounts.Scope{user: %{id: "test_user"}},
+      task_id: "task_123",
+      runtime: :test_runtime,
+      backend_tool_modules: [MockBackendTool],
+      mcp_tool_defs: [
+        %{name: "take_screenshot", on_timeout: :pause_agent, timeout_ms: 120_000},
+        %{name: "execute_js", on_timeout: :error, timeout_ms: 30_000}
+      ],
+      mcp_tools: [],
+      llm_opts: [api_key: "test_key", model: "test_model"]
+    ]
+
+    Keyword.merge(defaults, overrides)
+  end
+
+  describe "init/1" do
+    test "builds state with all required fields" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+
+      assert state.task_id == "task_123"
+      assert state.runtime == :test_runtime
+      assert is_map(state.backend_module_map)
+      assert Map.has_key?(state.backend_module_map, "read_file")
+    end
+
+    test "raises when required opts are missing" do
+      assert_raise KeyError, fn ->
+        AgentStrategy.init(scope: %FrontmanServer.Accounts.Scope{user: %{id: "u"}})
+      end
+    end
+
+    test "builds backend_module_map from backend_tool_modules" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+
+      assert state.backend_module_map["read_file"] == MockBackendTool
+      refute Map.has_key?(state.backend_module_map, "take_screenshot")
+    end
+  end
+
+  describe "on_deadline/2" do
+    test "returns :error for backend tools with :error policy" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+      tool_call = %ToolCall{id: "tc1", name: "read_file", arguments: "{}"}
+
+      assert {:error, ^state} = AgentStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :pause for backend tools with :pause_agent policy" do
+      {:ok, state} = AgentStrategy.init(build_init_opts(backend_tool_modules: [MockPauseTool]))
+      tool_call = %ToolCall{id: "tc1", name: "browser_click", arguments: "{}"}
+
+      assert {:pause, ^state} = AgentStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :pause for MCP tools with :pause_agent policy" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+      tool_call = %ToolCall{id: "tc1", name: "take_screenshot", arguments: "{}"}
+
+      assert {:pause, ^state} = AgentStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :error for MCP tools with :error policy" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+      tool_call = %ToolCall{id: "tc1", name: "execute_js", arguments: "{}"}
+
+      assert {:error, ^state} = AgentStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :error for unknown tools" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+      tool_call = %ToolCall{id: "tc1", name: "nonexistent_tool", arguments: "{}"}
+
+      assert {:error, ^state} = AgentStrategy.on_deadline(state, tool_call)
+    end
+  end
+
+  describe "struct properties" do
+    test "AgentStrategy is a plain struct (no closures, no PIDs)" do
+      {:ok, state} = AgentStrategy.init(build_init_opts())
+
+      # Verify it's a plain struct — fully serializable and testable
+      assert is_struct(state, AgentStrategy)
+
+      # All fields are data, not functions or PIDs
+      assert is_binary(state.task_id)
+      assert is_atom(state.runtime)
+      assert is_map(state.backend_module_map)
+      assert is_list(state.mcp_tool_defs)
+      assert is_list(state.mcp_tools)
+      assert is_list(state.llm_opts)
+    end
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/default_execution_strategy.ex
+++ b/apps/swarm_ai/lib/swarm_ai/default_execution_strategy.ex
@@ -60,6 +60,7 @@ defmodule SwarmAi.DefaultExecutionStrategy do
   Blocks until `deliver_tool_result/5` sends the result for this tool call.
 
   ParallelExecutor calls this once per tool in a supervised Task.
+  No internal timeout — PE's deadline terminates this process if needed (#760).
   """
   @impl SwarmAi.ExecutionStrategy
   def execute_tool(state, tool_call) do
@@ -67,9 +68,6 @@ defmodule SwarmAi.DefaultExecutionStrategy do
       case SwarmAi.Runtime.await_tool_result(state.runtime, tool_call.id) do
         {:ok, content, is_error} ->
           SwarmAi.ToolResult.make(tool_call.id, content, is_error)
-
-        {:error, :timeout} ->
-          SwarmAi.ToolResult.make(tool_call.id, "Tool result delivery timed out", true)
       end
 
     {result, state}

--- a/apps/swarm_ai/lib/swarm_ai/default_execution_strategy.ex
+++ b/apps/swarm_ai/lib/swarm_ai/default_execution_strategy.ex
@@ -1,0 +1,92 @@
+defmodule SwarmAi.DefaultExecutionStrategy do
+  @moduledoc """
+  Batteries-included `ExecutionStrategy` implementation.
+
+  Waits for external tool results via `SwarmAi.Runtime.await_tool_result/3`.
+  Suitable for tools whose results are delivered asynchronously (e.g. MCP
+  tools executed by a browser client).
+
+  ## Usage
+
+  Use directly:
+
+      SwarmAi.Runtime.run(runtime, key, agent, messages,
+        strategy: {SwarmAi.DefaultExecutionStrategy, runtime: runtime, tool_defs: defs}
+      )
+
+  Or as a base for domain-specific strategies via `use`:
+
+      defmodule MyApp.AgentStrategy do
+        use SwarmAi.DefaultExecutionStrategy
+
+        @impl SwarmAi.ExecutionStrategy
+        def on_deadline(state, tool_call) do
+          MyApp.Metrics.record_timeout(tool_call.name)
+          super(state, tool_call)
+        end
+      end
+
+  The `use` macro delegates all callbacks to `DefaultExecutionStrategy` and
+  marks them `defoverridable`, so you only override what differs.
+  """
+
+  @behaviour SwarmAi.ExecutionStrategy
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour SwarmAi.ExecutionStrategy
+
+      defdelegate init(opts), to: SwarmAi.DefaultExecutionStrategy
+      defdelegate execute_tool(state, tool_call), to: SwarmAi.DefaultExecutionStrategy
+      defdelegate on_deadline(state, tool_call), to: SwarmAi.DefaultExecutionStrategy
+
+      defoverridable init: 1, execute_tool: 2, on_deadline: 2
+    end
+  end
+
+  defstruct [:runtime, :tool_map]
+
+  @impl SwarmAi.ExecutionStrategy
+  def init(opts) do
+    state = %__MODULE__{
+      runtime: Keyword.fetch!(opts, :runtime),
+      tool_map: opts |> Keyword.get(:tool_defs, []) |> Map.new(&{&1.name, &1})
+    }
+
+    {:ok, state}
+  end
+
+  @doc """
+  Blocks until `deliver_tool_result/5` sends the result for this tool call.
+
+  ParallelExecutor calls this once per tool in a supervised Task.
+  """
+  @impl SwarmAi.ExecutionStrategy
+  def execute_tool(state, tool_call) do
+    result =
+      case SwarmAi.Runtime.await_tool_result(state.runtime, tool_call.id) do
+        {:ok, content, is_error} ->
+          SwarmAi.ToolResult.make(tool_call.id, content, is_error)
+
+        {:error, :timeout} ->
+          SwarmAi.ToolResult.make(tool_call.id, "Tool result delivery timed out", true)
+      end
+
+    {result, state}
+  end
+
+  @doc """
+  Returns the timeout policy for a tool. Looks up the tool in `tool_map`
+  for its `on_timeout` setting. Defaults to `:error` (continue loop).
+  """
+  @impl SwarmAi.ExecutionStrategy
+  def on_deadline(state, tool_call) do
+    policy =
+      case Map.get(state.tool_map, tool_call.name) do
+        %{on_timeout: :pause_agent} -> :pause
+        _ -> :error
+      end
+
+    {policy, state}
+  end
+end

--- a/apps/swarm_ai/lib/swarm_ai/execution_strategy.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_strategy.ex
@@ -1,0 +1,74 @@
+defmodule SwarmAi.ExecutionStrategy do
+  @moduledoc """
+  Behaviour for tool execution strategies.
+
+  Replaces the `{executor_fn, on_deadline_fn}` closure tuple with a composable,
+  testable module interface following the `{module, opts}` convention used by
+  Oban, Broadway, and other modern Elixir libraries.
+
+  ## Usage
+
+  Pass a strategy as `{module, opts}` to `SwarmAi.Runtime.run/5`:
+
+      SwarmAi.Runtime.run(MyApp.AgentRuntime, task_id, agent, messages,
+        strategy: {MyApp.AgentStrategy, scope: scope, task_id: task_id}
+      )
+
+  The `opts` keyword list is forwarded to `c:init/1`, which builds the
+  strategy's own state. `ParallelExecutor` then calls `c:execute_tool/2`
+  once per tool in a supervised `Task`, and `c:on_deadline/2` when a tool's
+  timeout fires.
+
+  ## Relationship to the Agent protocol
+
+  The `SwarmAi.Agent` protocol handles identity concerns: system prompt,
+  LLM client, available tools, `should_terminate?`. `ExecutionStrategy`
+  handles runtime mechanics: how to execute a tool, what to do on timeout.
+  They are complementary, not overlapping.
+  """
+
+  @type state :: term()
+
+  @doc """
+  Called once before execution starts. Build strategy state from opts.
+
+  Return `{:ok, state}` to proceed, or `{:error, reason}` to abort
+  the agent loop before it starts (dispatches `{:failed, ...}`).
+  """
+  @callback init(opts :: keyword()) :: {:ok, state()} | {:error, term()}
+
+  @doc """
+  Execute a single tool call. Returns the result and updated state.
+
+  `ParallelExecutor` calls this once per tool in a supervised `Task`,
+  handling parallelism and per-tool deadlines. The strategy only decides
+  how to execute the individual tool.
+
+  For MCP tools that wait on external results, implementations should call
+  `SwarmAi.Runtime.await_tool_result/3` to block until the result arrives.
+  For backend tools, implementations call the tool module directly.
+  """
+  @callback execute_tool(state(), SwarmAi.ToolCall.t()) ::
+              {SwarmAi.ToolResult.t(), state()}
+
+  @doc """
+  Called when a tool's deadline fires.
+
+  Return values:
+  - `{:error, state}` — produce an error `ToolResult`, agent loop continues
+  - `{:pause, state}` — cleanly halt the loop (Swarm emits `:paused` event)
+  """
+  @callback on_deadline(state(), SwarmAi.ToolCall.t()) ::
+              {:error | :pause, state()}
+
+  @doc """
+  Called after each LLM response to decide whether to continue the loop.
+
+  Return `:halt` to stop before the agent's own `should_terminate?` check.
+  Optional — defaults to always `:continue`.
+  """
+  @callback should_continue?(state(), SwarmAi.Loop.t()) ::
+              {:continue | :halt, state()}
+
+  @optional_callbacks should_continue?: 2
+end

--- a/apps/swarm_ai/lib/swarm_ai/execution_strategy.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_strategy.ex
@@ -44,8 +44,18 @@ defmodule SwarmAi.ExecutionStrategy do
   handling parallelism and per-tool deadlines. The strategy only decides
   how to execute the individual tool.
 
+  ## Timeout Contract
+
+  Implementations **must not** enforce their own timeouts (e.g. `receive..after`).
+  `ParallelExecutor` is the single timeout authority — it sets per-tool deadlines
+  via `Process.send_after` and terminates the task process when a deadline fires.
+  Internal timeouts create race conditions against PE's deadline mechanism (#760).
+
   For MCP tools that wait on external results, implementations should call
-  `SwarmAi.Runtime.await_tool_result/3` to block until the result arrives.
+  `SwarmAi.Runtime.await_tool_result/3` or use a bare `receive` to block
+  until the result arrives. PE will kill the process if the tool's deadline
+  expires.
+
   For backend tools, implementations call the tool module directly.
   """
   @callback execute_tool(state(), SwarmAi.ToolCall.t()) ::

--- a/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
@@ -1,6 +1,6 @@
 defmodule SwarmAi.ParallelExecutor do
   @moduledoc """
-  Runs tool executions in parallel with per-task deadlines.
+  Runs tool executions in parallel with per-tool deadlines.
 
   Accepts a list of `ToolExecution.t()` structs. PE is the sole execution
   authority — executors build descriptions, PE runs them.
@@ -8,6 +8,26 @@ defmodule SwarmAi.ParallelExecutor do
   - `Sync` executions are spawned as supervised tasks.
   - `Await` executions call their start MFA in PE's own process, then wait
     for `{:tool_result, message_key, content, is_error}` in PE's receive loop.
+
+  ## Timeout Ownership Contract (#760)
+
+  **PE is the single timeout authority.** Each `ToolExecution` struct carries a
+  `timeout_ms` value, and PE sets a `Process.send_after` deadline for each tool
+  independently. No other layer should implement its own timeout — doing so
+  creates race conditions between competing timeout mechanisms.
+
+  Strategy implementations (`ExecutionStrategy.execute_tool/2`) must block
+  without an internal timeout (e.g. bare `receive` without `after`). When a
+  deadline fires, PE terminates the task via `Task.Supervisor.terminate_child`
+  for Sync tools, or removes the awaiting entry for Await tools. Process-owned
+  resources like Registry keys are automatically cleaned up on process exit.
+
+  Timeout values flow end-to-end:
+
+      Tool definition (module.timeout_ms / MCP.timeout_ms)
+        → ToolExecution struct (timeout_ms field)
+        → PE Process.send_after deadline
+        → handle_deadline → on_timeout MFA callback
 
   ## Return values
 

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -136,6 +136,63 @@ defmodule SwarmAi.Runtime do
     end
   end
 
+  @doc """
+  Delivers a tool result to a waiting executor process.
+
+  Routes via the internal tool result Registry. Returns `:delivered` when
+  a live executor received the result, `:no_executor` when no process was
+  waiting (e.g. server restarted mid-execution).
+  """
+  @spec deliver_tool_result(atom(), term(), String.t(), term(), boolean()) ::
+          :delivered | :no_executor
+  def deliver_tool_result(runtime, _key, tool_call_id, result, is_error) do
+    tool_reg = tool_registry_name(runtime)
+
+    case Registry.lookup(tool_reg, {:awaiting_result, tool_call_id}) do
+      [{pid, _}] ->
+        send(pid, {:tool_result_delivered, tool_call_id, result, is_error})
+        :delivered
+
+      [] ->
+        :no_executor
+    end
+  end
+
+  @doc """
+  Registers the calling process to receive a tool result, then blocks.
+
+  Called from within `ExecutionStrategy.execute_tool/2` implementations.
+  The process is automatically unregistered when the call returns or the
+  process exits.
+
+  ## Options
+
+  - `:timeout` - Max ms to wait (default: 600_000 = 10 min safety net)
+
+  ## Returns
+
+  - `{:ok, content, is_error}` — result delivered
+  - `{:error, :timeout}` — safety-net timeout expired
+  """
+  @spec await_tool_result(atom(), String.t(), keyword()) ::
+          {:ok, term(), boolean()} | {:error, :timeout}
+  def await_tool_result(runtime, tool_call_id, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 600_000)
+    tool_reg = tool_registry_name(runtime)
+
+    {:ok, _} = Registry.register(tool_reg, {:awaiting_result, tool_call_id}, %{})
+
+    receive do
+      {:tool_result_delivered, ^tool_call_id, content, is_error} ->
+        Registry.unregister(tool_reg, {:awaiting_result, tool_call_id})
+        {:ok, content, is_error}
+    after
+      timeout ->
+        Registry.unregister(tool_reg, {:awaiting_result, tool_call_id})
+        {:error, :timeout}
+    end
+  end
+
   # --- Private ---
 
   defp spawn_and_await_registration(runtime, task, handshake) do
@@ -399,4 +456,8 @@ defmodule SwarmAi.Runtime do
   @doc false
   @spec task_supervisor_name(atom()) :: atom()
   def task_supervisor_name(runtime), do: :"#{runtime}.TaskSupervisor"
+
+  @doc false
+  @spec tool_registry_name(atom()) :: atom()
+  def tool_registry_name(runtime), do: :"#{runtime}.ToolRegistry"
 end

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -150,7 +150,7 @@ defmodule SwarmAi.Runtime do
 
     case Registry.lookup(tool_reg, {:awaiting_result, tool_call_id}) do
       [{pid, _}] ->
-        send(pid, {:tool_result_delivered, tool_call_id, result, is_error})
+        send(pid, {:tool_result, tool_call_id, result, is_error})
         :delivered
 
       [] ->
@@ -183,7 +183,7 @@ defmodule SwarmAi.Runtime do
     {:ok, _} = Registry.register(tool_reg, {:awaiting_result, tool_call_id}, %{})
 
     receive do
-      {:tool_result_delivered, ^tool_call_id, content, is_error} ->
+      {:tool_result, ^tool_call_id, content, is_error} ->
         Registry.unregister(tool_reg, {:awaiting_result, tool_call_id})
         {:ok, content, is_error}
     after

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -165,19 +165,26 @@ defmodule SwarmAi.Runtime do
   The process is automatically unregistered when the call returns or the
   process exits.
 
+  ## Timeout Ownership
+
+  Defaults to `:infinity` — `ParallelExecutor` is the single timeout
+  authority and will kill the calling process when the tool's deadline
+  fires (#760). An explicit `:timeout` option is available as an escape
+  hatch for callers outside PE's supervision (e.g. tests).
+
   ## Options
 
-  - `:timeout` - Max ms to wait (default: 600_000 = 10 min safety net)
+  - `:timeout` - Max ms to wait (default: `:infinity`)
 
   ## Returns
 
   - `{:ok, content, is_error}` — result delivered
-  - `{:error, :timeout}` — safety-net timeout expired
+  - `{:error, :timeout}` — explicit timeout expired (only when `:timeout` is set)
   """
   @spec await_tool_result(atom(), String.t(), keyword()) ::
           {:ok, term(), boolean()} | {:error, :timeout}
   def await_tool_result(runtime, tool_call_id, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, 600_000)
+    timeout = Keyword.get(opts, :timeout, :infinity)
     tool_reg = tool_registry_name(runtime)
 
     {:ok, _} = Registry.register(tool_reg, {:awaiting_result, tool_call_id}, %{})

--- a/apps/swarm_ai/lib/swarm_ai/runtime/supervisor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime/supervisor.ex
@@ -25,7 +25,8 @@ defmodule SwarmAi.Runtime.Supervisor do
       {SwarmAi.Runtime.TasksSupervisor,
        name: :"#{name}.TasksSupervisor",
        registry: registry_name,
-       task_supervisor: task_sup_name}
+       task_supervisor: task_sup_name,
+       tool_registry: SwarmAi.Runtime.tool_registry_name(name)}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/apps/swarm_ai/lib/swarm_ai/runtime/tasks_supervisor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime/tasks_supervisor.ex
@@ -12,9 +12,11 @@ defmodule SwarmAi.Runtime.TasksSupervisor do
   def init(opts) do
     registry_name = Keyword.fetch!(opts, :registry)
     task_sup_name = Keyword.fetch!(opts, :task_supervisor)
+    tool_registry_name = Keyword.fetch!(opts, :tool_registry)
 
     children = [
       {Registry, keys: :unique, name: registry_name},
+      {Registry, keys: :unique, name: tool_registry_name},
       {Task.Supervisor, name: task_sup_name}
     ]
 

--- a/apps/swarm_ai/test/swarm_ai/execution_strategy_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/execution_strategy_test.exs
@@ -1,0 +1,102 @@
+defmodule SwarmAi.ExecutionStrategyTest do
+  use ExUnit.Case, async: true
+
+  alias SwarmAi.{ExecutionStrategy, DefaultExecutionStrategy, ToolCall, ToolResult}
+
+  @moduledoc """
+  Unit tests for the ExecutionStrategy behaviour and DefaultExecutionStrategy.
+  """
+
+  describe "DefaultExecutionStrategy.init/1" do
+    test "builds state from opts" do
+      opts = [runtime: :test_runtime, tool_defs: []]
+      assert {:ok, %DefaultExecutionStrategy{runtime: :test_runtime}} = DefaultExecutionStrategy.init(opts)
+    end
+
+    test "raises when :runtime is missing" do
+      assert_raise KeyError, fn ->
+        DefaultExecutionStrategy.init(tool_defs: [])
+      end
+    end
+
+    test "builds tool_map from tool_defs" do
+      tool_def = %{name: "test_tool", on_timeout: :error, timeout_ms: 5000}
+      opts = [runtime: :test_runtime, tool_defs: [tool_def]]
+
+      {:ok, state} = DefaultExecutionStrategy.init(opts)
+      assert Map.has_key?(state.tool_map, "test_tool")
+      assert state.tool_map["test_tool"].on_timeout == :error
+    end
+
+    test "defaults tool_defs to empty list" do
+      opts = [runtime: :test_runtime]
+      {:ok, state} = DefaultExecutionStrategy.init(opts)
+      assert state.tool_map == %{}
+    end
+  end
+
+  describe "DefaultExecutionStrategy.on_deadline/2" do
+    test "returns :error for unknown tools" do
+      {:ok, state} = DefaultExecutionStrategy.init(runtime: :test_runtime, tool_defs: [])
+      tool_call = %ToolCall{id: "tc1", name: "unknown", arguments: "{}"}
+
+      assert {:error, ^state} = DefaultExecutionStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :error for tools with :error policy" do
+      tool_def = %{name: "fast_tool", on_timeout: :error, timeout_ms: 5000}
+      {:ok, state} = DefaultExecutionStrategy.init(runtime: :test_runtime, tool_defs: [tool_def])
+      tool_call = %ToolCall{id: "tc1", name: "fast_tool", arguments: "{}"}
+
+      assert {:error, ^state} = DefaultExecutionStrategy.on_deadline(state, tool_call)
+    end
+
+    test "returns :pause for tools with :pause_agent policy" do
+      tool_def = %{name: "interactive_tool", on_timeout: :pause_agent, timeout_ms: 60000}
+      {:ok, state} = DefaultExecutionStrategy.init(runtime: :test_runtime, tool_defs: [tool_def])
+      tool_call = %ToolCall{id: "tc1", name: "interactive_tool", arguments: "{}"}
+
+      assert {:pause, ^state} = DefaultExecutionStrategy.on_deadline(state, tool_call)
+    end
+  end
+
+  describe "DefaultExecutionStrategy `use` macro" do
+    defmodule TestStrategy do
+      use SwarmAi.DefaultExecutionStrategy
+
+      @impl SwarmAi.ExecutionStrategy
+      def on_deadline(state, tool_call) do
+        # Custom override: always pause
+        {:pause, state}
+      end
+    end
+
+    test "can override individual callbacks" do
+      {:ok, state} = TestStrategy.init(runtime: :test_runtime, tool_defs: [])
+      tool_call = %ToolCall{id: "tc1", name: "any_tool", arguments: "{}"}
+
+      # Our override always returns :pause
+      assert {:pause, ^state} = TestStrategy.on_deadline(state, tool_call)
+    end
+
+    test "delegates non-overridden callbacks" do
+      # init/1 is still delegated to DefaultExecutionStrategy
+      {:ok, state} = TestStrategy.init(runtime: :test_runtime, tool_defs: [])
+      assert %DefaultExecutionStrategy{} = state
+    end
+  end
+
+  describe "ExecutionStrategy behaviour" do
+    test "defines required callbacks" do
+      callbacks = SwarmAi.ExecutionStrategy.behaviour_info(:callbacks)
+      assert {:init, 1} in callbacks
+      assert {:execute_tool, 2} in callbacks
+      assert {:on_deadline, 2} in callbacks
+    end
+
+    test "defines optional callbacks" do
+      optional = SwarmAi.ExecutionStrategy.behaviour_info(:optional_callbacks)
+      assert {:should_continue?, 2} in optional
+    end
+  end
+end

--- a/apps/swarm_ai/test/swarm_ai/runtime/tool_delivery_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/runtime/tool_delivery_test.exs
@@ -1,0 +1,201 @@
+defmodule SwarmAi.Runtime.ToolDeliveryTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for SwarmAi.Runtime.deliver_tool_result/5 and await_tool_result/3.
+
+  These tests start a minimal Runtime supervision tree and verify the
+  tool result Registry mechanics — the core of the boundary redesign.
+  """
+
+  @runtime_name :"#{__MODULE__}.Runtime"
+
+  setup do
+    # Start a minimal Runtime supervision tree for each test
+    start_supervised!(
+      {SwarmAi.Runtime,
+       name: @runtime_name,
+       event_dispatcher: nil}
+    )
+
+    :ok
+  end
+
+  describe "deliver_tool_result/5" do
+    test "returns :no_executor when no process is waiting" do
+      assert :no_executor =
+               SwarmAi.Runtime.deliver_tool_result(
+                 @runtime_name,
+                 "task_1",
+                 "tc_1",
+                 "result content",
+                 false
+               )
+    end
+
+    test "returns :delivered when a process is waiting" do
+      tool_call_id = "tc_#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      # Spawn a process that awaits the tool result
+      waiter =
+        spawn(fn ->
+          result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 5_000)
+          send(test_pid, {:await_result, result})
+        end)
+
+      # Give the waiter time to register
+      Process.sleep(50)
+
+      # Deliver the result
+      assert :delivered =
+               SwarmAi.Runtime.deliver_tool_result(
+                 @runtime_name,
+                 "task_1",
+                 tool_call_id,
+                 "tool output",
+                 false
+               )
+
+      # Verify the waiter received it
+      assert_receive {:await_result, {:ok, "tool output", false}}, 1_000
+    end
+
+    test "delivers error results correctly" do
+      tool_call_id = "tc_err_#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      spawn(fn ->
+        result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 5_000)
+        send(test_pid, {:await_result, result})
+      end)
+
+      Process.sleep(50)
+
+      assert :delivered =
+               SwarmAi.Runtime.deliver_tool_result(
+                 @runtime_name,
+                 "task_1",
+                 tool_call_id,
+                 "error: something broke",
+                 true
+               )
+
+      assert_receive {:await_result, {:ok, "error: something broke", true}}, 1_000
+    end
+  end
+
+  describe "await_tool_result/3" do
+    test "blocks until result is delivered" do
+      tool_call_id = "tc_block_#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      # Start awaiting in a separate process
+      spawn(fn ->
+        result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 5_000)
+        send(test_pid, {:await_done, result})
+      end)
+
+      # Wait for registration
+      Process.sleep(50)
+
+      # Deliver after a short delay
+      SwarmAi.Runtime.deliver_tool_result(@runtime_name, "task_1", tool_call_id, "delayed", false)
+
+      assert_receive {:await_done, {:ok, "delayed", false}}, 1_000
+    end
+
+    test "returns {:error, :timeout} when no result arrives" do
+      tool_call_id = "tc_timeout_#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      spawn(fn ->
+        result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 100)
+        send(test_pid, {:await_done, result})
+      end)
+
+      # Don't deliver anything — let it timeout
+      assert_receive {:await_done, {:error, :timeout}}, 1_000
+    end
+
+    test "unregisters after receiving result" do
+      tool_call_id = "tc_unreg_#{System.unique_integer([:positive])}"
+      test_pid = self()
+      tool_reg = SwarmAi.Runtime.tool_registry_name(@runtime_name)
+
+      spawn(fn ->
+        result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 5_000)
+        send(test_pid, {:await_done, result})
+      end)
+
+      Process.sleep(50)
+
+      # Verify registered
+      assert [{_pid, _}] = Registry.lookup(tool_reg, {:awaiting_result, tool_call_id})
+
+      SwarmAi.Runtime.deliver_tool_result(@runtime_name, "task_1", tool_call_id, "done", false)
+      assert_receive {:await_done, {:ok, "done", false}}, 1_000
+
+      # Small delay for cleanup
+      Process.sleep(50)
+
+      # Verify unregistered
+      assert [] = Registry.lookup(tool_reg, {:awaiting_result, tool_call_id})
+    end
+
+    test "unregisters after timeout" do
+      tool_call_id = "tc_unreg_timeout_#{System.unique_integer([:positive])}"
+      test_pid = self()
+      tool_reg = SwarmAi.Runtime.tool_registry_name(@runtime_name)
+
+      spawn(fn ->
+        result = SwarmAi.Runtime.await_tool_result(@runtime_name, tool_call_id, timeout: 100)
+        send(test_pid, {:await_done, result})
+      end)
+
+      Process.sleep(50)
+      assert [{_pid, _}] = Registry.lookup(tool_reg, {:awaiting_result, tool_call_id})
+
+      assert_receive {:await_done, {:error, :timeout}}, 1_000
+      Process.sleep(50)
+
+      assert [] = Registry.lookup(tool_reg, {:awaiting_result, tool_call_id})
+    end
+
+    test "multiple concurrent tool results are routed correctly" do
+      test_pid = self()
+
+      ids =
+        for i <- 1..5 do
+          "tc_concurrent_#{i}_#{System.unique_integer([:positive])}"
+        end
+
+      # Spawn 5 concurrent waiters
+      for id <- ids do
+        spawn(fn ->
+          result = SwarmAi.Runtime.await_tool_result(@runtime_name, id, timeout: 5_000)
+          send(test_pid, {:await_done, id, result})
+        end)
+      end
+
+      Process.sleep(100)
+
+      # Deliver results in reverse order
+      for id <- Enum.reverse(ids) do
+        SwarmAi.Runtime.deliver_tool_result(@runtime_name, "task_1", id, "result_#{id}", false)
+      end
+
+      # All should receive correctly
+      for id <- ids do
+        assert_receive {:await_done, ^id, {:ok, content, false}}, 1_000
+        assert content == "result_#{id}"
+      end
+    end
+  end
+
+  describe "tool_registry_name/1" do
+    test "derives a deterministic name" do
+      assert SwarmAi.Runtime.tool_registry_name(:MyRuntime) == :"MyRuntime.ToolRegistry"
+    end
+  end
+end

--- a/apps/swarm_ai/test/swarm_ai/timeout_ownership_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/timeout_ownership_test.exs
@@ -1,0 +1,236 @@
+defmodule SwarmAi.TimeoutOwnershipTest do
+  @moduledoc """
+  Verifies the timeout ownership contract (#760):
+  ParallelExecutor is the single timeout authority for all tool types.
+
+  These tests demonstrate:
+  - PE's deadline kills blocked `receive` tasks (no internal after needed)
+  - Registry auto-cleans up when PE kills a process
+  - Per-tool timeout isolation in mixed batches
+  - No double-timeout race conditions
+  """
+
+  use ExUnit.Case, async: true
+
+  alias SwarmAi.{ParallelExecutor, ToolCall, ToolExecution, ToolResult}
+  alias SwarmAi.Message.ContentPart
+
+  # --- Test MFA callbacks ---
+
+  @doc """
+  Simulates an MCP tool that blocks in a bare `receive` with NO `after` clause,
+  exactly like the fixed AgentStrategy.execute_mcp_tool after #760.
+  PE must be the one to kill this process on deadline.
+  """
+  def run_blocking_receive(_tool_call) do
+    # Block forever — PE's deadline must terminate this task
+    receive do
+      :never -> :ok
+    end
+  end
+
+  @doc """
+  Simulates a tool that completes quickly.
+  """
+  def run_instant(content, tool_call) do
+    ToolResult.make(tool_call.id, content, false)
+  end
+
+  @doc """
+  Simulates a tool that takes a specific amount of time.
+  """
+  def run_slow(delay_ms, content, tool_call) do
+    Process.sleep(delay_ms)
+    ToolResult.make(tool_call.id, content, false)
+  end
+
+  def noop_timeout(_tool_call, _reason), do: :ok
+
+  def record_timeout(test_pid, tool_call, reason) do
+    send(test_pid, {:timeout_called, tool_call.id, reason})
+  end
+
+  # --- Helpers ---
+
+  defp make_tc(id, name), do: %ToolCall{id: id, name: name, arguments: "{}"}
+
+  defp start_sup do
+    {:ok, sup} = Task.Supervisor.start_link()
+    sup
+  end
+
+  defp content_text(%ToolResult{content: content}), do: ContentPart.extract_text(content)
+
+  # --- Tests ---
+
+  describe "PE kills blocked receive on deadline (#760)" do
+    test "Sync tool blocking in bare receive is terminated by PE deadline" do
+      sup = start_sup()
+      tc = make_tc("block1", "mcp_tool")
+
+      exec = %ToolExecution.Sync{
+        tool_call: tc,
+        timeout_ms: 50,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :noop_timeout, []}
+      }
+
+      # Should return within ~50ms, not hang forever
+      {:ok, [result]} = ParallelExecutor.run([exec], sup)
+      assert result.is_error == true
+      assert content_text(result) =~ "timed out"
+    end
+
+    test "on_timeout callback fires for blocked-receive tool" do
+      sup = start_sup()
+      test_pid = self()
+      tc = make_tc("block1", "mcp_tool")
+
+      exec = %ToolExecution.Sync{
+        tool_call: tc,
+        timeout_ms: 50,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
+      }
+
+      ParallelExecutor.run([exec], sup)
+      assert_receive {:timeout_called, "block1", :triggered}, 1_000
+    end
+  end
+
+  describe "per-tool timeout isolation (#760)" do
+    test "fast-timeout tool fails independently while slow-timeout tool succeeds" do
+      sup = start_sup()
+      fast_tc = make_tc("fast1", "fast_tool")
+      slow_tc = make_tc("slow1", "slow_tool")
+
+      # fast_tool: blocks forever, 30ms deadline → should timeout
+      fast_exec = %ToolExecution.Sync{
+        tool_call: fast_tc,
+        timeout_ms: 30,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :noop_timeout, []}
+      }
+
+      # slow_tool: takes 10ms to complete, 5000ms deadline → should succeed
+      slow_exec = %ToolExecution.Sync{
+        tool_call: slow_tc,
+        timeout_ms: 5_000,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_slow, [10, "slow_done"]},
+        on_timeout: {__MODULE__, :noop_timeout, []}
+      }
+
+      {:ok, [fast_result, slow_result]} = ParallelExecutor.run([fast_exec, slow_exec], sup)
+
+      # fast_tool timed out
+      assert fast_result.is_error == true
+      assert content_text(fast_result) =~ "timed out"
+
+      # slow_tool succeeded — fast_tool's timeout didn't affect it
+      assert slow_result.is_error == false
+      assert content_text(slow_result) == "slow_done"
+    end
+
+    test "different tools have different deadlines" do
+      sup = start_sup()
+      test_pid = self()
+      tc1 = make_tc("id1", "tool_a")
+      tc2 = make_tc("id2", "tool_b")
+
+      # tool_a: 30ms deadline
+      exec1 = %ToolExecution.Sync{
+        tool_call: tc1,
+        timeout_ms: 30,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
+      }
+
+      # tool_b: 100ms deadline
+      exec2 = %ToolExecution.Sync{
+        tool_call: tc2,
+        timeout_ms: 100,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
+      }
+
+      {:ok, [r1, r2]} = ParallelExecutor.run([exec1, exec2], sup)
+
+      # Both timed out, but tool_a should have timed out first
+      assert r1.is_error == true
+      assert r2.is_error == true
+
+      # Collect timeout callbacks — verify both fired
+      calls =
+        for _ <- 1..2 do
+          assert_receive {:timeout_called, id, :triggered}, 1_000
+          id
+        end
+
+      assert "id1" in calls
+      assert "id2" in calls
+    end
+  end
+
+  describe "Registry auto-cleanup on process kill (#760)" do
+    test "Registry key is cleaned up when PE kills the task" do
+      # Set up a dedicated Registry for this test
+      reg_name = :"test_tool_reg_#{System.unique_integer([:positive])}"
+      {:ok, _} = Registry.start_link(keys: :unique, name: reg_name)
+
+      sup = start_sup()
+      tc = make_tc("reg_test", "mcp_tool")
+
+      # Tool that registers in a Registry, then blocks forever
+      exec = %ToolExecution.Sync{
+        tool_call: tc,
+        timeout_ms: 50,
+        on_timeout_policy: :error,
+        run: {__MODULE__, :run_register_and_block, [reg_name, tc.id]},
+        on_timeout: {__MODULE__, :noop_timeout, []}
+      }
+
+      {:ok, [result]} = ParallelExecutor.run([exec], sup)
+      assert result.is_error == true
+
+      # Give the system a moment to process the EXIT signal
+      Process.sleep(50)
+
+      # Registry key should be auto-cleaned because the process died
+      assert Registry.lookup(reg_name, {:awaiting_result, tc.id}) == []
+    end
+  end
+
+  describe "pause_agent with blocked receive (#760)" do
+    test "interactive tool blocking in receive triggers :pause_agent via PE deadline" do
+      sup = start_sup()
+      tc = make_tc("q1", "question")
+
+      exec = %ToolExecution.Sync{
+        tool_call: tc,
+        timeout_ms: 50,
+        on_timeout_policy: :pause_agent,
+        run: {__MODULE__, :run_blocking_receive, []},
+        on_timeout: {__MODULE__, :noop_timeout, []}
+      }
+
+      assert {:halt, {:pause_agent, "q1", "question", 50}} =
+               ParallelExecutor.run([exec], sup)
+    end
+  end
+
+  # --- Helpers for Registry cleanup test ---
+
+  def run_register_and_block(reg_name, tool_call_id, _tool_call) do
+    Registry.register(reg_name, {:awaiting_result, tool_call_id}, %{})
+
+    receive do
+      :never -> :ok
+    end
+  end
+end


### PR DESCRIPTION
## What

Removes the hardcoded 600s MCP timeout from `AgentStrategy.execute_mcp_tool` and establishes PE as the single source of truth for all tool deadlines.

## Why

After #755 introduced parallel execution, timeout enforcement ended up scattered across two layers:

1. PE sets a `Process.send_after` deadline per tool (from `ToolExecution.timeout_ms`)
2. `AgentStrategy.execute_mcp_tool` has its own `receive..after 600_000`

These race each other. If PE's deadline fires first, it kills the task — but the inline `after` might also fire in edge cases. Worse, the 600s value is hardcoded and ignores the tool definition entirely, so interactive tools that should timeout at 120s actually wait 600s.

The fix is simple: PE already has everything it needs. The strategy just needs to get out of the way.

## Changes

**`agent_strategy.ex`** — the actual fix
- Replaced `receive..after 600_000` with bare `receive` (no `after`)
- PE kills the process on deadline, Registry auto-cleans up the key — no manual timeout needed
- Added comment explaining the contract so nobody re-adds a timeout here

**`runtime.ex`** — default timeout to infinity
- `await_tool_result` default changed from `600_000` to `:infinity`
- Same reasoning: PE owns the deadline, not the callee
- Explicit `timeout:` opt still works for tests and escape hatches

**`default_execution_strategy.ex`** — dead code removal
- Removed the `{:error, :timeout}` branch that is now unreachable

**`parallel_executor.ex`** + **`execution_strategy.ex`** — docs
- Added Timeout Ownership Contract section documenting PE as the single authority
- Documents the end-to-end flow: tool definition -> ToolExecution struct -> PE deadline -> on_timeout callback

**`timeout_ownership_test.exs`** — new tests
- PE kills a process stuck in bare `receive`
- `on_timeout` callback fires correctly
- Per-tool timeout isolation (fast tool times out, slow tool succeeds)
- Registry key auto-cleanup on process kill
- `:pause_agent` works with bare `receive`

## How to verify

```bash
mix test apps/swarm_ai/test/swarm_ai/timeout_ownership_test.exs
mix test apps/swarm_ai/test/swarm_ai/parallel_executor_test.exs
mix test apps/swarm_ai/test/swarm_ai/runtime/tool_delivery_test.exs
```

All existing PE and delivery tests pass unchanged — they already use explicit `timeout:` values.

## Answers to the questions from #760

> Should PE know about tool types at all?

No. PE is type-agnostic — it reads `timeout_ms` and `on_timeout_policy` from the `ToolExecution` struct. The strategy decides what those values are.

> Should the 60s timeout cover the full sub-agent tree?

For now, yes — sub-agents run inside the parent's Sync task, so PE's deadline covers the whole tree. Decoupling sub-agent timeouts is a bigger change and should be separate.

> Is Task.async (linked) the right primitive?

Not relevant anymore — PE uses `Task.Supervisor.async_nolink`, which is correct.

> Could we give each tool a timeout hint as metadata?

`SwarmAi.Tool.timeout_ms` already does this. The problem was that `AgentStrategy` was not using it. Now it does not need to — PE reads it from `ToolExecution.timeout_ms` and enforces it.

Closes #760
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
