### PR TITLE
refactor(e2e): align env strategy with MIX_ENV=e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,9 +40,8 @@ jobs:
     timeout-minutes: 20
 
     env:
-      # E2E mode: HTTPS on port 4002, separate DB, no watchers
-      E2E: "true"
-      MIX_ENV: dev
+      # E2E uses a dedicated Mix environment with HTTPS on port 4002.
+      MIX_ENV: e2e
       PHX_SERVER: "true"
       # Self-hosted runners can reuse Postgres state between runs.
       # Give each run its own database so migrations always start from a
@@ -125,11 +124,9 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('apps/frontman_server/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
 
-      # E2E compiles with E2E=true which sets code_reloader: false at compile
-      # time (config/dev.exs).  CI's lint/dialyzer jobs compile WITHOUT E2E,
-      # so code_reloader: true.  Sharing the same "build-dev-" cache between
-      # the two causes a compile_env mismatch that crashes Dialyzer.
-      # Use a separate "build-e2e-" prefix to isolate the two environments.
+      # E2E compiles under MIX_ENV=e2e while lint/dialyzer jobs compile under
+      # MIX_ENV=dev. Keep a dedicated "build-e2e-" cache prefix so the two
+      # environments never share compile artifacts.
       - name: Cache Mix _build
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:

--- a/.github/workflows/refresh-e2e-chatgpt-token.yml
+++ b/.github/workflows/refresh-e2e-chatgpt-token.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      MIX_ENV: dev
+      MIX_ENV: e2e
       CLOAK_KEY: "HE9hCRnQXEREL1X+1+cU4wPdVGqJMhwR05edbBBq1RY="
       E2E_CHATGPT_ACCESS_TOKEN: ${{ secrets.E2E_CHATGPT_ACCESS_TOKEN }}
       E2E_CHATGPT_REFRESH_TOKEN: ${{ secrets.E2E_CHATGPT_REFRESH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Refactor: move `env_api_keys` into `Scope` struct — eliminates ad-hoc `env_api_key` parameter threading across `Providers`, channels, and the execution pipeline. `Providers.prepare_api_key`, `resolve_api_key`, `available_provider_tiers`, and `model_config_data` all drop their `env_api_key` parameter and read from `scope.env_api_keys` instead.
 - Allow `.net` and `.org` origins in the server's allowed origin and external return URL allowlists.
+- Align E2E to a first-class `MIX_ENV=e2e` environment, remove `E2E=true` dev-branch config toggles, and standardize strict boolean env parsing across runtime and E2E setup.
 
 ## [0.15.0] - 2026-04-08
 

--- a/apps/frontman_server/config/dev.exs
+++ b/apps/frontman_server/config/dev.exs
@@ -21,68 +21,41 @@ config :frontman_server, FrontmanServer.Repo,
 # The watchers configuration can be used to run external
 # watchers to your application. For example, we can use it
 # to bundle .js and .css sources.
-# E2E mode: HTTPS on port 4002, separate database, no watchers.
-# Uses the same mkcert certificates as normal dev (covers localhost).
-# Activated by setting E2E=true in the environment.
-if System.get_env("E2E") do
-  config :frontman_server, FrontmanServerWeb.Endpoint,
-    url: [host: "localhost", port: 4002, scheme: "https"],
-    https: [
-      ip: {127, 0, 0, 1},
-      port: 4002,
-      cipher_suite: :strong,
-      keyfile: Path.expand("../../../.certs/frontman.local-key.pem", __DIR__),
-      certfile: Path.expand("../../../.certs/frontman.local.pem", __DIR__)
-    ],
-    check_origin: false,
-    code_reloader: false,
-    debug_errors: true,
-    secret_key_base: "NBTbU2SqLo+ghhs3jQiZAjRrQKhim/x/HXSbx49mBnt4pSvEkjTYYrj+prSCInNO",
-    server: true,
-    watchers: [],
-    live_reload: false
+config :frontman_server, FrontmanServerWeb.Endpoint,
+  # Binding to 0.0.0.0 allows access from containers/proxies
+  # URL host can be overridden via PHX_HOST env var for remote development
+  url: [
+    host: System.get_env("PHX_HOST") || "frontman.local",
+    port: String.to_integer(System.get_env("PHX_URL_PORT") || "4000"),
+    scheme: "https"
+  ],
+  https: [
+    ip: {0, 0, 0, 0},
+    port: String.to_integer(System.get_env("PORT") || "4000"),
+    cipher_suite: :strong,
+    keyfile: Path.expand("../../../.certs/frontman.local-key.pem", __DIR__),
+    certfile: Path.expand("../../../.certs/frontman.local.pem", __DIR__)
+  ],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "NBTbU2SqLo+ghhs3jQiZAjRrQKhim/x/HXSbx49mBnt4pSvEkjTYYrj+prSCInNO",
+  watchers: [
+    esbuild: {Esbuild, :install_and_run, [:frontman_server, ~w(--sourcemap=inline --watch)]},
+    esbuild: {Esbuild, :install_and_run, [:browser_test, ~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [:frontman_server, ~w(--watch)]}
+  ]
 
-  # Suppress debug-level noise in E2E (SQL queries, route errors, etc.)
-  config :logger, level: :info
-else
-  config :frontman_server, FrontmanServerWeb.Endpoint,
-    # Binding to 0.0.0.0 allows access from containers/proxies
-    # URL host can be overridden via PHX_HOST env var for remote development
-    url: [
-      host: System.get_env("PHX_HOST") || "frontman.local",
-      port: String.to_integer(System.get_env("PHX_URL_PORT") || "4000"),
-      scheme: "https"
-    ],
-    https: [
-      ip: {0, 0, 0, 0},
-      port: String.to_integer(System.get_env("PORT") || "4000"),
-      cipher_suite: :strong,
-      keyfile: Path.expand("../../../.certs/frontman.local-key.pem", __DIR__),
-      certfile: Path.expand("../../../.certs/frontman.local.pem", __DIR__)
-    ],
-    check_origin: false,
-    code_reloader: true,
-    debug_errors: true,
-    secret_key_base: "NBTbU2SqLo+ghhs3jQiZAjRrQKhim/x/HXSbx49mBnt4pSvEkjTYYrj+prSCInNO",
-    watchers: [
-      esbuild: {Esbuild, :install_and_run, [:frontman_server, ~w(--sourcemap=inline --watch)]},
-      esbuild: {Esbuild, :install_and_run, [:browser_test, ~w(--sourcemap=inline --watch)]},
-      tailwind: {Tailwind, :install_and_run, [:frontman_server, ~w(--watch)]}
+# Watch static and templates for browser reloading.
+config :frontman_server, FrontmanServerWeb.Endpoint,
+  live_reload: [
+    web_console_logger: true,
+    patterns: [
+      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/gettext/.*(po)$",
+      ~r"lib/frontman_server_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$"
     ]
-end
-
-# Watch static and templates for browser reloading (not needed in E2E mode).
-unless System.get_env("E2E") do
-  config :frontman_server, FrontmanServerWeb.Endpoint,
-    live_reload: [
-      web_console_logger: true,
-      patterns: [
-        ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
-        ~r"priv/gettext/.*(po)$",
-        ~r"lib/frontman_server_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$"
-      ]
-    ]
-end
+  ]
 
 # Enable dev routes for dashboard and mailbox
 config :frontman_server, dev_routes: true

--- a/apps/frontman_server/config/e2e.exs
+++ b/apps/frontman_server/config/e2e.exs
@@ -1,0 +1,61 @@
+import Config
+
+# Mark environment for runtime checks
+config :frontman_server, env: :e2e
+
+# Configure your database
+config :frontman_server, FrontmanServer.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "frontman_server_e2e",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :frontman_server, FrontmanServerWeb.Endpoint,
+  url: [host: "localhost", port: 4002, scheme: "https"],
+  https: [
+    ip: {127, 0, 0, 1},
+    port: 4002,
+    cipher_suite: :strong,
+    keyfile: Path.expand("../../../.certs/frontman.local-key.pem", __DIR__),
+    certfile: Path.expand("../../../.certs/frontman.local.pem", __DIR__)
+  ],
+  check_origin: false,
+  code_reloader: false,
+  debug_errors: true,
+  secret_key_base: "NBTbU2SqLo+ghhs3jQiZAjRrQKhim/x/HXSbx49mBnt4pSvEkjTYYrj+prSCInNO",
+  server: true,
+  watchers: [],
+  live_reload: false
+
+# Suppress debug-level noise in E2E (SQL queries, route errors, etc.)
+config :logger, level: :info
+
+# Keep dev routes available in E2E to match local development behavior.
+config :frontman_server, dev_routes: true
+
+# Include metadata and timestamps in logs.
+config :logger, :default_formatter,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id, :task_id, :pid, :reason]
+
+# Keep a higher stacktrace depth for easier local debugging.
+config :phoenix, :stacktrace_depth, 20
+
+# Initialize plugs at runtime for faster compilation.
+config :phoenix, :plug_init_mode, :runtime
+
+config :phoenix_live_view,
+  debug_heex_annotations: true,
+  debug_attributes: true,
+  enable_expensive_runtime_checks: true
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false
+
+# Placeholder Resend API key for E2E.
+config :frontman_server, FrontmanServer.Mailer, api_key: "re_dev_placeholder"
+
+# OpenTelemetry - configured in runtime.exs based on env vars

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -10,7 +10,42 @@ source!([
   System.get_env()
 ])
 
-if System.get_env("PHX_SERVER") do
+truthy_env_values = ~w(1 true yes on)
+falsy_env_values = ~w(0 false no off)
+accepted_env_values = truthy_env_values ++ falsy_env_values
+
+strict_boolean! = fn env_var_name, raw_value ->
+  normalized_value = raw_value |> String.trim() |> String.downcase()
+
+  cond do
+    normalized_value in truthy_env_values ->
+      true
+
+    normalized_value in falsy_env_values ->
+      false
+
+    true ->
+      raise Dotenvy.Error,
+        message:
+          "#{env_var_name} must be one of #{inspect(accepted_env_values)}; got: #{inspect(raw_value)}"
+  end
+end
+
+env_boolean = fn env_var_name, default_value ->
+  case env!(env_var_name, :string, :frontman_env_boolean_missing) do
+    :frontman_env_boolean_missing ->
+      default_value
+
+    raw_value ->
+      if String.trim(raw_value) == "" do
+        default_value
+      else
+        strict_boolean!.(env_var_name, raw_value)
+      end
+  end
+end
+
+if env_boolean.("PHX_SERVER", false) do
   config :frontman_server, FrontmanServerWeb.Endpoint, server: true
 end
 
@@ -19,7 +54,7 @@ config :frontman_server, cloak_key: env!("CLOAK_KEY", :string!)
 
 # LLM API keys — derived from the centralised :providers config so adding a
 # new provider doesn't require touching this file.
-if config_env() in [:dev, :test] do
+if config_env() in [:dev, :test, :e2e] do
   api_key_config =
     for {_id, %{config_key: key, env_var: var}} <-
           Application.get_env(:frontman_server, :providers, %{}),
@@ -78,16 +113,12 @@ else
   ]
 end
 
-# Dev/Test: Allow DB_HOST override for container development (e.g., DevPod)
+# Dev/Test/E2E: Allow DB_HOST override for container development (e.g., DevPod)
 # The docker bridge gateway IP (172.17.0.1) is used to connect from container to host PostgreSQL
-if config_env() in [:dev, :test] do
+if config_env() in [:dev, :test, :e2e] do
   db_host = env!("DB_HOST", :string, "localhost")
 
-  db_name =
-    case {config_env(), System.get_env("E2E")} do
-      {:dev, e2e} when e2e not in [nil, ""] -> env!("DB_NAME", :string, "frontman_server_e2e")
-      _ -> env!("DB_NAME", :string, nil)
-    end
+  db_name = env!("DB_NAME", :string, nil)
 
   repo_overrides = []
 
@@ -134,10 +165,10 @@ if config_env() == :prod do
       For example: ecto://USER:PASS@HOST/DATABASE
       """
 
-  maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
+  maybe_ipv6 = if env_boolean.("ECTO_IPV6", false), do: [:inet6], else: []
 
   # SSL can be disabled for local PostgreSQL (DATABASE_SSL=false)
-  use_ssl = System.get_env("DATABASE_SSL", "true") not in ~w(false 0)
+  use_ssl = env_boolean.("DATABASE_SSL", true)
 
   ssl_config =
     if use_ssl do

--- a/apps/frontman_server/envs/.e2e.env
+++ b/apps/frontman_server/envs/.e2e.env
@@ -1,4 +1,6 @@
+# Loaded automatically when MIX_ENV=e2e.
 CLOAK_KEY=HE9hCRnQXEREL1X+1+cU4wPdVGqJMhwR05edbBBq1RY=
+# Default local E2E DB name is frontman_server_e2e (override via DB_NAME as needed).
 # ChatGPT OAuth token for e2e test user — set these in your environment or CI secrets
 # E2E_CHATGPT_ACCESS_TOKEN=
 # E2E_CHATGPT_REFRESH_TOKEN=

--- a/apps/frontman_server/priv/repo/e2e_seeds.exs
+++ b/apps/frontman_server/priv/repo/e2e_seeds.exs
@@ -4,7 +4,7 @@
 # Reads token values from environment variables (set them in CI or locally).
 #
 # Usage:
-#   E2E=true MIX_ENV=dev mix run priv/repo/e2e_seeds.exs
+#   MIX_ENV=e2e mix run priv/repo/e2e_seeds.exs
 
 alias FrontmanServer.Accounts
 alias FrontmanServer.Providers.OAuthToken

--- a/docs/remote-development.md
+++ b/docs/remote-development.md
@@ -433,7 +433,7 @@ config :frontman_server, FrontmanServer.Repo,
   # ... other config
 
 # config/runtime.exs — dynamic override for containers
-if config_env() in [:dev, :test] do
+if config_env() in [:dev, :test, :e2e] do
   db_host = env!("DB_HOST", :string, "localhost")
   if db_host != "localhost" do
     config :frontman_server, FrontmanServer.Repo, hostname: db_host
@@ -443,6 +443,7 @@ end
 
 This means:
 - **Local dev**: `DB_HOST` unset → uses `localhost`
+- **Local e2e**: `MIX_ENV=e2e` + `DB_HOST` unset → uses `localhost`
 - **DevPod containers**: `DB_HOST=host.docker.internal` (or Docker gateway IP) → overrides hostname
 - **CI**: `DB_HOST` resolved dynamically to the Docker gateway IP (see `.github/workflows/ci.yml`)
 

--- a/test/e2e/.env.example
+++ b/test/e2e/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to .env and fill in real values.
 # .env is gitignored — never commit secrets.
+# Global setup runs Phoenix with MIX_ENV=e2e.
 E2E_CHATGPT_ACCESS_TOKEN=
 E2E_CHATGPT_REFRESH_TOKEN=
 E2E_CHATGPT_ACCOUNT_ID=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,39 @@
+# Frontman E2E Environment Contract
+
+`test/e2e/global-setup.ts` always boots the Phoenix app with `MIX_ENV=e2e`.
+
+## Server environment
+
+- Config file: `apps/frontman_server/config/e2e.exs`
+- HTTPS endpoint: `https://localhost:4002`
+- Default database: `frontman_server_e2e`
+- No code reloader/watchers/live reload
+
+## Runtime overrides
+
+`apps/frontman_server/config/runtime.exs` supports these overrides in `:e2e`:
+
+- `DB_HOST` (default: `localhost`)
+- `DB_NAME` (default comes from `config/e2e.exs`)
+- `PHX_SERVER` (default: `false`)
+
+Boolean env vars use one canonical parser in both Elixir and TS setup code.
+
+- Truthy: `1`, `true`, `yes`, `on`
+- Falsy: `0`, `false`, `no`, `off`
+- Empty/unset: use default
+- Any other value: raises immediately
+
+## Secrets
+
+Copy `test/e2e/.env.example` to `test/e2e/.env` and populate:
+
+- `E2E_CHATGPT_ACCESS_TOKEN`
+- `E2E_CHATGPT_REFRESH_TOKEN`
+- `E2E_CHATGPT_ACCOUNT_ID`
+
+Local run:
+
+```bash
+make e2e
+```

--- a/test/e2e/global-setup.ts
+++ b/test/e2e/global-setup.ts
@@ -3,7 +3,7 @@
  *
  * 1. Creates + migrates the e2e database
  * 2. Seeds the test user + ChatGPT OAuth token
- * 3. Starts the Phoenix server (E2E=true MIX_ENV=dev)
+ * 3. Starts the Phoenix server (MIX_ENV=e2e)
  * 4. Starts the client Vite dev server (for serving the Frontman UI JS)
  * 5. Waits for both to be ready
  */
@@ -35,11 +35,36 @@ function resolveBin(startDir: string, name: string): string {
   throw new Error(`Cannot find binary '${name}' starting from ${startDir}`);
 }
 
+// Keep in sync with strict boolean parsing in apps/frontman_server/config/runtime.exs.
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSY_ENV_VALUES = new Set(["0", "false", "no", "off"]);
+
+function parseEnvBoolean(name: string, defaultValue: boolean): boolean {
+  const rawValue = process.env[name];
+
+  if (!rawValue || rawValue.trim() === "") {
+    return defaultValue;
+  }
+
+  const normalizedValue = rawValue.trim().toLowerCase();
+
+  if (TRUTHY_ENV_VALUES.has(normalizedValue)) {
+    return true;
+  }
+
+  if (FALSY_ENV_VALUES.has(normalizedValue)) {
+    return false;
+  }
+
+  throw new Error(
+    `[e2e] ${name} must be one of ${JSON.stringify([...TRUTHY_ENV_VALUES, ...FALSY_ENV_VALUES])}; got: ${JSON.stringify(rawValue)}`,
+  );
+}
+
 const E2E_ENV = {
   ...process.env,
-  E2E: "true",
-  MIX_ENV: "dev",
-  PHX_SERVER: "true",
+  MIX_ENV: "e2e",
+  PHX_SERVER: parseEnvBoolean("PHX_SERVER", true) ? "true" : "false",
 } satisfies NodeJS.ProcessEnv;
 
 let phoenixProc: ChildProcess | undefined;


### PR DESCRIPTION
## Summary
- Promote E2E to a first-class Mix environment by adding `config/e2e.exs` and removing `E2E=true` branching from `config/dev.exs`.
- Align runtime config for `:e2e` by sharing DB override handling with dev/test and introducing strict boolean parsing for `PHX_SERVER`, `ECTO_IPV6`, and `DATABASE_SSL`.
- Update E2E setup and ops surfaces (Vitest global setup, CI workflows, env docs/examples, and changelog) to use the canonical `MIX_ENV=e2e` contract.

## Testing
- `cd apps/frontman_server && mix format --check-formatted && mix compile`
- `cd apps/frontman_server && MIX_ENV=e2e mix compile`

## Context
- Fixes #912
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
