### PR TITLE
chore(ci): move CLA assistant workflow to Node 24 runtime

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: rdkcentral/contributor-assistant_github-action@c18dc0f3e30006c6bd4064ffc5d86aebf66af04a # master (node24 runtime)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_PAT }}


### PR DESCRIPTION
## Summary
- switch the CLA workflow action from `contributor-assistant/github-action@v2.6.1` (Node 20 runtime) to the maintained fork pinned at `rdkcentral/contributor-assistant_github-action@c18dc0f3e30006c6bd4064ffc5d86aebf66af04a`
- resolve the GitHub Actions Node 20 deprecation warning in `cla.yml` without changing CLA prompts, token wiring, or signature file behavior
- keep the change scoped to `.github/workflows/cla.yml` to minimize CI risk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
