### PR TITLE
feat(marketing): add use-case pages and browser-aware canonical slug

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -90,7 +90,7 @@ export default defineConfig({
     "/blog/mobile-app": "/blog/ai-coding-agents-blind-to-ui/",
     "/blog/user-stories": "/blog/frontman-vs-cursor-vs-claude-code/",
     "/blog/welcome": "/blog/introducing-frontman/",
-    "/blog/what-are-browser-aware-ai-coding-tools": "/blog/what-are-framework-aware-ai-coding-tools/",
+    "/blog/what-are-framework-aware-ai-coding-tools": "/blog/what-are-browser-aware-ai-coding-tools/",
     "/blog/user-feedback": "/changelog/",
   },
   vite: {
@@ -221,7 +221,7 @@ export default defineConfig({
       if (item.url === 'https://frontman.sh/') {
         item.priority = 1.0;
         item.changefreq = 'weekly';
-      } else if (/\/(pricing|features|how-it-works)\/?$/.test(item.url)) {
+      } else if (/\/(pricing|features|how-it-works)\/?$/.test(item.url) || /\/use-cases\//.test(item.url)) {
         item.priority = 0.9;
         item.changefreq = 'monthly';
       } else if (/\/vs\//.test(item.url) || /(?<!\/docs)\/integrations\//.test(item.url)) {

--- a/apps/marketing/src/components/blocks/comparison/ComparisonAlternatives.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonAlternatives.astro
@@ -21,8 +21,8 @@ const { competitorName, alternatives } = Astro.props
 
 <section class="flex justify-center bg-zinc-950 px-6 py-16 text-zinc-50 max-md:px-5 max-md:py-10">
   <div class="w-full max-w-[720px]">
-    <h2 class="mb-3 text-[32px] font-bold tracking-tight text-zinc-50 max-md:text-2xl">{competitorName} Alternatives</h2>
-    <p class="mb-8 text-[17px] leading-[1.7] text-zinc-400">
+    <h2 class="mb-3 !text-[32px] !font-bold !tracking-tight !text-zinc-50 max-md:!text-2xl">{competitorName} Alternatives</h2>
+    <p class="mb-8 text-[17px] leading-[1.7] text-zinc-300">
       If {competitorName} isn't the right fit, here are other tools worth evaluating — and how they compare to Frontman.
     </p>
     <div class="grid gap-4 sm:grid-cols-2">
@@ -44,7 +44,7 @@ const { competitorName, alternatives } = Astro.props
             ]}>
               {isFrontman ? 'Frontman' : `Frontman vs ${alt.name}`}
             </h3>
-            <p class="text-sm leading-relaxed text-zinc-400">{alt.oneLiner}</p>
+            <p class="text-sm leading-relaxed text-zinc-300">{alt.oneLiner}</p>
           </a>
         )
       })}

--- a/apps/marketing/src/components/blocks/comparison/ComparisonArchitectureDiagram.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonArchitectureDiagram.astro
@@ -14,7 +14,7 @@ const { competitorName } = Astro.props
 
 <section class="flex justify-center bg-zinc-950 px-6 py-16 text-zinc-50 max-md:px-5 max-md:py-10">
   <div class="w-full max-w-[900px]">
-    <h2 class="mb-8 text-[32px] font-bold tracking-tight text-zinc-50 max-md:text-2xl">How Frontman and {competitorName} Work</h2>
+    <h2 class="mb-8 !text-[32px] !font-bold !tracking-tight !text-zinc-50 max-md:!text-2xl">How Frontman and {competitorName} Work</h2>
     <div class="flex justify-center rounded-2xl border border-white/[0.08] bg-white/[0.02] p-8 max-md:p-4">
       <slot />
     </div>

--- a/apps/marketing/src/components/blocks/comparison/ComparisonCTA.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonCTA.astro
@@ -9,25 +9,25 @@ import Button from '../../ui/Button.astro'
 
 <section class="flex justify-center border-t border-zinc-800 bg-zinc-950 px-6 py-20 max-md:px-5 max-md:py-12">
   <div class="w-full max-w-[720px]">
-    <h2 class="mb-2 text-4xl font-bold tracking-tight text-zinc-50 max-md:text-[28px]">Try Frontman</h2>
-    <p class="mb-8 text-[17px] text-zinc-500">One command. No account. No credit card. No prompt limits.</p>
+    <h2 class="mb-2 !text-4xl !font-bold !tracking-tight !text-zinc-50 max-md:!text-[28px]">Try Frontman</h2>
+    <p class="mb-8 text-[17px] text-zinc-300">One command. No account. No credit card. No prompt limits.</p>
     <div class="mb-8 flex flex-col gap-3">
       <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
         <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
-        <span class="text-[13px] text-zinc-500">Next.js</span>
+        <span class="text-[13px] text-zinc-300">Next.js</span>
       </div>
       <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
         <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
-        <span class="text-[13px] text-zinc-500">Vite (React, Vue, Svelte, SolidJS)</span>
+        <span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
       </div>
       <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
         <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
-        <span class="text-[13px] text-zinc-500">Astro</span>
+        <span class="text-[13px] text-zinc-300">Astro</span>
       </div>
     </div>
     <div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
       <Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-      <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-500 transition-colors hover:text-zinc-50">Join Discord</a>
+      <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 transition-colors hover:text-zinc-50">Join Discord</a>
     </div>
   </div>
 </section>

--- a/apps/marketing/src/components/blocks/comparison/ComparisonContentSection.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonContentSection.astro
@@ -19,14 +19,14 @@ const isLight = variant === 'light'
 ]}>
   <div class="w-full max-w-[720px]">
     <h2 class:list={[
-      'mb-6 text-[32px] font-bold tracking-tight max-md:text-2xl',
-      isLight ? 'text-zinc-950' : 'text-zinc-50',
+      'mb-6 !text-[32px] !font-bold !tracking-tight max-md:!text-2xl',
+      isLight ? '!text-zinc-950' : '!text-zinc-50',
     ]}>{title}</h2>
     <div class:list={[
       '[&_p]:mb-4 [&_p]:text-[17px] [&_p]:leading-[1.7]',
       isLight
-        ? '[&_p]:text-zinc-600 [&_strong]:text-zinc-950 [&_li]:text-zinc-600 [&_li_strong]:text-zinc-950 [&_code]:bg-black/[0.06] [&_.text-link]:text-violet-700 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-violet-800'
-        : '[&_p]:text-zinc-400 [&_strong]:text-zinc-50 [&_li]:text-zinc-400 [&_li_strong]:text-zinc-50 [&_code]:bg-white/[0.08] [&_.text-link]:text-primary-500 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-purple-400',
+        ? '[&_p]:text-zinc-950 [&_strong]:text-zinc-950 [&_li]:text-zinc-950 [&_code]:bg-black/[0.06] [&_.text-link]:text-violet-700 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-violet-800'
+        : '[&_p]:text-zinc-300 [&_strong]:text-zinc-50 [&_li]:text-zinc-300 [&_li_strong]:text-zinc-50 [&_code]:bg-white/[0.08] [&_.text-link]:text-primary-500 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-purple-400',
       '[&_strong]:font-semibold',
       '[&_code]:rounded [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm',
       '[&_ul]:my-4 [&_ul]:list-none [&_ul]:p-0',

--- a/apps/marketing/src/components/blocks/comparison/ComparisonFAQ.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonFAQ.astro
@@ -18,15 +18,15 @@ const { faqs } = Astro.props
 
 <section class="flex justify-center bg-zinc-950 px-6 py-16 text-zinc-50 max-md:px-5 max-md:py-10">
   <div class="w-full max-w-[720px]">
-    <h2 class="mb-6 text-[32px] font-bold tracking-tight text-zinc-50 max-md:text-2xl">Frequently Asked Questions</h2>
+    <h2 class="mb-6 !text-[32px] !font-bold !tracking-tight !text-zinc-50 max-md:!text-2xl">Frequently Asked Questions</h2>
     <div class="border-t border-zinc-800">
       {faqs.map((faq) => (
         <details class="group border-b border-zinc-800 cursor-pointer">
           <summary class="flex w-full items-center justify-between py-6 text-[17px] font-medium leading-[1.4] text-zinc-50 transition-colors [&::-webkit-details-marker]:hidden hover:text-white list-none">
             <span class="pr-6">{faq.question}</span>
-            <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-700 text-lg font-light text-zinc-500 transition-all duration-300 group-open:rotate-45 group-open:bg-zinc-800">+</span>
+          <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-700 text-lg font-light text-zinc-300 transition-all duration-300 group-open:rotate-45 group-open:bg-zinc-800">+</span>
           </summary>
-          <div class="max-w-[620px] pb-6 text-[15px] leading-[1.7] text-zinc-400">
+          <div class="max-w-[620px] pb-6 text-[15px] leading-[1.7] text-zinc-300">
             <p>{faq.answer}</p>
           </div>
         </details>

--- a/apps/marketing/src/components/blocks/comparison/ComparisonFeatureTable.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonFeatureTable.astro
@@ -32,7 +32,7 @@ function statusLabel(status: Status): string {
 
 <section class="flex justify-center bg-zinc-950 px-6 py-16 max-md:px-5 max-md:py-10">
   <div class="w-full max-w-[900px]">
-    <h2 class="mb-8 text-[32px] font-bold tracking-tight text-zinc-50 max-md:text-2xl">Feature Comparison</h2>
+    <h2 class="mb-8 !text-[32px] !font-bold !tracking-tight !text-zinc-50 max-md:!text-2xl">Feature Comparison</h2>
 
     <!-- Desktop table -->
     <div class="hidden md:block">

--- a/apps/marketing/src/components/blocks/comparison/ComparisonHero.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonHero.astro
@@ -19,9 +19,9 @@ const { title, subtitle } = Astro.props
 	<div class="w-full max-w-[720px]">
 		<p class="mb-3 font-mono text-[13px] uppercase tracking-[0.12em] text-primary-500">Comparison</p>
 		<h1 class="mb-2 text-5xl font-bold leading-[1.1] tracking-tight text-zinc-50 max-md:text-[32px]">{title}</h1>
-		<p class="mb-10 text-xl text-zinc-500 max-md:mb-6 max-md:text-[17px]">{subtitle}</p>
+		<p class="mb-10 text-xl text-zinc-300 max-md:mb-6 max-md:text-[17px]">{subtitle}</p>
 
-		<div class="[&_p]:mb-4 [&_p]:text-[17px] [&_p]:leading-[1.7] [&_p]:text-zinc-400 [&_strong]:text-zinc-50 [&_code]:rounded [&_code]:bg-white/[0.08] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_.summary-emphasis]:!mt-6 [&_.summary-emphasis]:border-l-[3px] [&_.summary-emphasis]:border-primary-500 [&_.summary-emphasis]:pl-4 [&_.summary-emphasis]:font-medium [&_.summary-emphasis]:!text-zinc-50 [&_.text-link]:text-primary-500 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-primary-400 [&_.comparison-disclosure]:mt-6 [&_.comparison-disclosure]:border-t [&_.comparison-disclosure]:border-white/[0.08] [&_.comparison-disclosure]:pt-4 [&_.comparison-disclosure]:text-[13px] [&_.comparison-disclosure]:italic [&_.comparison-disclosure]:text-zinc-600">
+		<div class="[&_p]:mb-4 [&_p]:text-[17px] [&_p]:leading-[1.7] [&_p]:text-zinc-300 [&_strong]:text-zinc-50 [&_code]:rounded [&_code]:bg-white/[0.08] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_.summary-emphasis]:!mt-6 [&_.summary-emphasis]:border-l-[3px] [&_.summary-emphasis]:border-primary-500 [&_.summary-emphasis]:pl-4 [&_.summary-emphasis]:font-medium [&_.summary-emphasis]:!text-zinc-50 [&_.text-link]:text-primary-500 [&_.text-link]:underline [&_.text-link]:underline-offset-2 [&_.text-link:hover]:text-primary-400 [&_.comparison-disclosure]:mt-6 [&_.comparison-disclosure]:border-t [&_.comparison-disclosure]:border-white/[0.08] [&_.comparison-disclosure]:pt-4 [&_.comparison-disclosure]:text-[13px] [&_.comparison-disclosure]:italic [&_.comparison-disclosure]:text-zinc-300">
 			<slot />
 		</div>
 	</div>

--- a/apps/marketing/src/components/blocks/comparison/ComparisonPricing.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonPricing.astro
@@ -33,27 +33,27 @@ const {
 
 <section class="flex justify-center bg-zinc-50 px-6 py-16 text-zinc-950 max-md:px-5 max-md:py-10">
   <div class="w-full max-w-[720px]">
-    <h2 class="mb-8 text-[32px] font-bold tracking-tight text-zinc-950 max-md:text-2xl">Pricing Comparison</h2>
+    <h2 class="mb-8 !text-[32px] !font-bold !tracking-tight !text-zinc-950 max-md:!text-2xl">Pricing Comparison</h2>
     <div class="grid grid-cols-2 gap-6 max-md:grid-cols-1">
       <!-- Frontman -->
       <div class="rounded-2xl border border-primary-500 bg-gradient-to-br from-primary-500/5 to-primary-500/[0.02] p-8 shadow-[0_0_0_1px_rgba(162,89,255,0.2)]">
-        <h3 class="mb-2 text-xl font-bold text-zinc-950">Frontman</h3>
+        <h3 class="mb-2 text-xl font-bold !text-zinc-950" style="color:#09090b">Frontman</h3>
         <div class="mb-1 text-4xl font-extrabold tracking-tight text-primary-500">{frontmanCost}</div>
-        <p class="mb-6 text-sm text-zinc-500">{frontmanModel}</p>
+        <p class="mb-6 text-sm text-zinc-700">{frontmanModel}</p>
         <ul class="m-0 list-none p-0">
           {frontmanFeatures.map((f) => (
-            <li class="relative py-1.5 pl-5 text-[15px] text-zinc-600 before:absolute before:left-0 before:text-zinc-400 before:content-['→']">{f}</li>
+            <li class="relative py-1.5 pl-5 text-[15px] text-zinc-950 before:absolute before:left-0 before:text-zinc-700 before:content-['→']">{f}</li>
           ))}
         </ul>
       </div>
       <!-- Competitor -->
       <div class="rounded-2xl border border-zinc-200 bg-white p-8">
-        <h3 class="mb-2 text-xl font-bold text-zinc-950">{competitorName}</h3>
+        <h3 class="mb-2 text-xl font-bold !text-zinc-950" style="color:#09090b">{competitorName}</h3>
         <div class="mb-1 text-4xl font-extrabold tracking-tight text-zinc-950">{competitorCost}</div>
-        <p class="mb-6 text-sm text-zinc-500">{competitorModel}</p>
+        <p class="mb-6 text-sm text-zinc-700">{competitorModel}</p>
         <ul class="m-0 list-none p-0">
           {competitorFeatures.map((f) => (
-            <li class="relative py-1.5 pl-5 text-[15px] text-zinc-600 before:absolute before:left-0 before:text-zinc-400 before:content-['→']">{f}</li>
+            <li class="relative py-1.5 pl-5 text-[15px] text-zinc-950 before:absolute before:left-0 before:text-zinc-700 before:content-['→']">{f}</li>
           ))}
         </ul>
       </div>

--- a/apps/marketing/src/components/ui/ComparisonDisclosure.astro
+++ b/apps/marketing/src/components/ui/ComparisonDisclosure.astro
@@ -10,6 +10,6 @@ const { competitor } = Astro.props
 const subject = competitor ? `Frontman and ${competitor}` : 'the tools on this page'
 ---
 
-<p class="comparison-disclosure mt-6 border-t border-white/[0.08] pt-4 text-[13px] italic text-zinc-600">
+<p class="comparison-disclosure mt-6 border-t border-white/[0.08] pt-4 text-[13px] italic text-zinc-300">
 	Disclosure: This page is published by the Frontman team. We've done our best to present {subject} accurately and fairly, but we are naturally biased toward our own product. We encourage you to try both tools and decide for yourself.
 </p>

--- a/apps/marketing/src/components/use-cases/UseCaseCtaSection.astro
+++ b/apps/marketing/src/components/use-cases/UseCaseCtaSection.astro
@@ -1,0 +1,30 @@
+---
+import Button from '../ui/Button.astro'
+
+type SecondaryLink = {
+	href: string,
+	label: string,
+}
+
+const { title, description, secondaryLinks } = Astro.props as {
+	title: string,
+	description: string,
+	secondaryLinks: Array<SecondaryLink>,
+}
+
+const secondaryCtaLinkClass =
+	'text-[15px] text-zinc-300 no-underline transition-colors hover:text-zinc-50'
+---
+
+<section class="flex justify-center border-t border-zinc-800 bg-[#09090b] px-5 py-[72px] text-zinc-50 md:px-6">
+	<div class="w-full max-w-[760px]">
+		<h2 class="mb-[10px] text-[30px] leading-[1.2] text-zinc-50 md:text-[36px]">{title}</h2>
+		<p class="mb-6 text-[17px] leading-[1.6] text-zinc-300">{description}</p>
+		<div class="flex flex-wrap items-center gap-5">
+			<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+			{secondaryLinks.map((link) => (
+				<a href={link.href} class={secondaryCtaLinkClass}>{link.label}</a>
+			))}
+		</div>
+	</div>
+</section>

--- a/apps/marketing/src/components/use-cases/UseCaseFaqSection.astro
+++ b/apps/marketing/src/components/use-cases/UseCaseFaqSection.astro
@@ -1,0 +1,33 @@
+---
+type FaqItem = {
+	question: string,
+	answer: string,
+}
+
+const { faqs } = Astro.props as {
+	faqs: Array<FaqItem>,
+}
+---
+
+<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+	<div class="w-full max-w-[760px]">
+		<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]">
+			Frequently Asked Questions
+		</h2>
+		<div class="border-t border-zinc-800">
+			{faqs.map((faq) => (
+				<details class="group border-b border-zinc-800">
+					<summary class="flex list-none items-center justify-between py-[22px] text-[17px] font-medium [&::-webkit-details-marker]:hidden">
+						<span>{faq.question}</span>
+						<span class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-700 text-[18px] text-zinc-300 transition-transform duration-200 group-open:rotate-45">
+							+
+						</span>
+					</summary>
+					<div>
+					<p class="m-0 pb-5 text-[15px] leading-[1.7] text-zinc-300">{faq.answer}</p>
+					</div>
+				</details>
+			))}
+		</div>
+	</div>
+</section>

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -139,6 +139,14 @@ export const footerNavigationData: FooterData = {
 			category: 'Resources',
 			subCategories: [
 				{
+					subCategory: 'Use Case: Designers',
+					subCategoryLink: '/use-cases/designers/'
+				},
+				{
+					subCategory: 'Use Case: Frontend Developers',
+					subCategoryLink: '/use-cases/frontend-developers/'
+				},
+				{
 					subCategory: 'AI Releases',
 					subCategoryLink: '/open-source-ai-releases/'
 				}

--- a/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
+++ b/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
@@ -65,7 +65,7 @@ For a designer or PM, it's a wall. You would need to know the file name, the com
 
 ## What Framework-Aware AI Changes
 
-Frontman takes a different approach — what we call [framework-aware AI](/blog/what-are-framework-aware-ai-coding-tools/). Instead of reading files and guessing what the UI looks like, it hooks into your framework — Next.js, Astro, Vite — and connects to the running browser. It has access to:
+Frontman takes a different approach - what we call [browser-aware AI](/blog/what-are-browser-aware-ai-coding-tools/). Instead of reading files and guessing what the UI looks like, it hooks into your framework - Next.js, Astro, Vite - and connects to the running browser. It has access to:
 
 - **The live UI** — the actual rendered page, not a code approximation
 - **Your component tree** — which component renders which element, mapped back to source files

--- a/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
+++ b/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
@@ -211,7 +211,7 @@ The right tool depends on what you're trying to do:
 
 **"I want an AI agent in VS Code."** Cline is the most popular. Roo Code if you want structured modes. Kilo Code if you need JetBrains support.
 
-**"I want to click things in the browser and have AI edit the code."** These are [framework-aware AI coding tools](/blog/what-are-framework-aware-ai-coding-tools/). Frontman if you want deep framework integration and BYOK. Stagewise if you want zero-install and IDE agent bridging.
+**"I want to click things in the browser and have AI edit the code."** These are [browser-aware AI coding tools](/blog/what-are-browser-aware-ai-coding-tools/). Frontman if you want deep framework integration and BYOK. Stagewise if you want zero-install and IDE agent bridging.
 
 **"I want to generate a new app from a prompt."** bolt.diy or OpenHands. See the [Frontman vs v0 comparison](/vs/v0/) for how generative and iterative workflows differ.
 

--- a/apps/marketing/src/content/blog/browser-aware-ai-tools-2026.md
+++ b/apps/marketing/src/content/blog/browser-aware-ai-tools-2026.md
@@ -86,7 +86,7 @@ Google's experimental MCP server exposing DevTools state to AI agents. Your agen
 
 **Want the most polished UX and don't mind paying:** Stagewise. The YC backing shows.
 
-**Want free + deep framework integration + full control:** Frontman. See [how deep framework integration affects design system consistency](/blog/what-are-framework-aware-ai-coding-tools/). No prompt limits, no account, BYOK, open source. The tradeoff is that it's early-stage with rougher edges.
+**Want free + deep framework integration + full control:** Frontman. See [how deep framework integration affects design system consistency](/blog/what-are-browser-aware-ai-coding-tools/). No prompt limits, no account, BYOK, open source. The tradeoff is that it's early-stage with rougher edges.
 
 **Want to add browser context to your existing agent:** Chrome DevTools MCP. Bare-bones but framework-agnostic and free.
 

--- a/apps/marketing/src/content/blog/frontman-launch.md
+++ b/apps/marketing/src/content/blog/frontman-launch.md
@@ -40,7 +40,7 @@ This means you can use Frontman to audit live UI against your design system. Cli
 
 ### How It Works
 
-Frontman installs as a plugin in your framework's dev server — one line in the config file. It supports Next.js, Vite (React, Vue, Svelte), and Astro. Your engineering team sets it up once; it takes about five minutes. This [framework-aware](/blog/what-are-framework-aware-ai-coding-tools/) approach means Frontman understands your component structure, not just raw files.
+Frontman installs as a plugin in your framework's dev server - one line in the config file. It supports Next.js, Vite (React, Vue, Svelte), and Astro. Your engineering team sets it up once; it takes about five minutes. This [browser-aware](/blog/what-are-browser-aware-ai-coding-tools/) approach means Frontman understands your component structure, not just raw files.
 
 Once running, anyone on the team can open the app in their browser and access Frontman. It runs entirely on your machine. Your code and your conversations with the AI never leave your local environment — there are no external servers involved.
 

--- a/apps/marketing/src/content/blog/multi-select.md
+++ b/apps/marketing/src/content/blog/multi-select.md
@@ -80,7 +80,7 @@ This changes the dynamics between design and engineering. Instead of being the t
 
 ## How It Works Under the Hood
 
-Frontman runs as middleware inside your dev server — it's part of the app, not a browser extension or screenshot tool. This is how [framework-aware AI tools understand your design system](/blog/what-are-framework-aware-ai-coding-tools/) at the source level. When you click an element, it resolves the click to the actual source file and line number using the framework's source map. It sees the live DOM, the component tree, computed styles, and your [design system context](/blog/runtime-context-gap/).
+Frontman runs as middleware inside your dev server - it's part of the app, not a browser extension or screenshot tool. This is how [browser-aware AI tools understand your design system](/blog/what-are-browser-aware-ai-coding-tools/) at the source level. When you click an element, it resolves the click to the actual source file and line number using the framework's source map. It sees the live DOM, the component tree, computed styles, and your [design system context](/blog/runtime-context-gap/).
 
 Multi-select collects all your selections and batches them into a single coordinated edit. Each selection carries its own instruction and source mapping. Frontman reasons about all of them together — if two fixes target the same component, both changes land in one clean edit without conflicts.
 

--- a/apps/marketing/src/content/blog/runtime-context-gap.md
+++ b/apps/marketing/src/content/blog/runtime-context-gap.md
@@ -31,7 +31,7 @@ When an AI coding tool edits your project, it's working from source text. Here's
 - **Compiled module graph.** Frameworks like Next.js, Vite, and Astro transform your source before serving it. The AI sees source files; the dev server sees the compiled, bundled, tree-shaken output.
 - **Registered routes and middleware.** File-based routing means the route table is a runtime artifact. Middleware ordering, redirect chains, and rewrite rules exist in the server's state, not in any single source file.
 - **Server logs and errors.** A component that renders fine might be throwing warnings server-side. The AI editing your code doesn't see `stdout`.
-- **Framework-specific context.** Astro island hydration directives, Next.js server/client component boundaries, Vite's HMR module graph — these are framework runtime concepts that source code only partially describes — which is why [framework-aware AI coding tools](/blog/what-are-framework-aware-ai-coding-tools/) take a different approach.
+- **Framework-specific context.** Astro island hydration directives, Next.js server/client component boundaries, Vite's HMR module graph - these are framework runtime concepts that source code only partially describes - which is why [browser-aware AI coding tools](/blog/what-are-browser-aware-ai-coding-tools/) take a different approach.
 
 ### An Uncomfortable Question
 

--- a/apps/marketing/src/content/blog/team-collaboration.md
+++ b/apps/marketing/src/content/blog/team-collaboration.md
@@ -59,7 +59,7 @@ Every change still goes through code review. Every change is a standard Git diff
 Every change is a Git commit on a branch. It goes through the same PR process as engineering work. If the diff is bad, it does not get merged. Frontman shows you the result via hot-reload before you commit — if the layout breaks, you see it immediately and undo it. The code review gate catches everything else.
 
 **"We tried giving non-devs access to the repo before."**
-Giving people VS Code access is not the same thing. Frontman [differs from general-purpose agents](/blog/what-are-framework-aware-ai-coding-tools/) — it's a constrained tool. You click an element, describe a change in plain English, and Frontman edits the source file. You cannot accidentally refactor the state management. You can update the padding. That is the right level of access for the right people.
+Giving people VS Code access is not the same thing. Frontman [differs from general-purpose agents](/blog/what-are-browser-aware-ai-coding-tools/) - it's a constrained tool. You click an element, describe a change in plain English, and Frontman edits the source file. You cannot accidentally refactor the state management. You can update the padding. That is the right level of access for the right people.
 
 **"Our engineers will push back on this."**
 Show them their PR queue. Count the tickets that say "update spacing," "fix typo," "change button color." Ask them if those are the problems they want to spend their week on. Every designer-authored PR is a PR the engineer did not have to write. They still review it — they just did not have to context-switch to create it.

--- a/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
+++ b/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
@@ -8,7 +8,7 @@ tags: ['tutorial', 'getting-started', 'ai']
 updatedDate: 2026-03-10T00:00:00Z
 ---
 
-This is a practical walkthrough. We'll take a Next.js app with a layout bug, install Frontman — one of the [framework-aware AI tools](/blog/what-are-framework-aware-ai-coding-tools/) — and fix the bug by clicking the broken element in the browser instead of describing it to an AI that can't see it.
+This is a practical walkthrough. We'll take a Next.js app with a layout bug, install Frontman - one of the [browser-aware AI tools](/blog/what-are-browser-aware-ai-coding-tools/) - and fix the bug by clicking the broken element in the browser instead of describing it to an AI that cannot see it.
 
 By the end you'll know whether runtime-aware AI coding actually saves time or is just a debugger with extra steps. Spoiler: it's both.
 

--- a/apps/marketing/src/content/blog/what-are-browser-aware-ai-coding-tools.md
+++ b/apps/marketing/src/content/blog/what-are-browser-aware-ai-coding-tools.md
@@ -1,7 +1,7 @@
 ---
-title: 'What Are Framework-Aware AI Coding Tools?'
+title: 'What Are Browser-Aware AI Coding Tools?'
 pubDate: 2026-03-17T10:00:00Z
-description: 'Framework-aware AI coding tools let you click on any element in your running app and describe what you want changed—in plain language. They understand your component library, your design system structure, and which file to edit. Here is what the category is, how the five current tools compare, and which ones matter for design and product teams.'
+description: 'Browser-aware AI coding tools let you click on any element in your running app and describe what you want changed in plain language. They use runtime context, and the strongest tools also understand framework structure and source mapping.'
 author: 'Danni Friedland'
 image: '/blog/what-are-framework-aware-ai-coding-tools-cover.png'
 tags: ['ai', 'design-systems', 'product-tools', 'comparison']
@@ -48,9 +48,9 @@ faq:
       in choosing a tool.
 ---
 
-If you run a design system across multiple product teams, you know the bottleneck. A designer spots a spacing inconsistency, an outdated color token, a component that doesn't match the latest Figma specs. They file a ticket. An engineer picks it up days later, makes a three-line change, opens a PR. Teams end up [bottlenecked on engineering](/blog/team-collaboration/) for changes that should take minutes.
+If you run a design system across multiple product teams, you know the bottleneck. A designer spots a spacing inconsistency, an outdated color token, or a component that does not match the latest Figma specs. They file a ticket. An engineer picks it up days later, makes a three-line change, opens a PR. Teams end up [bottlenecked on engineering](/blog/team-collaboration/) for changes that should take minutes.
 
-Framework-aware AI coding tools exist to short-circuit that loop. You open your running application in the browser, click on the element that needs to change, and describe what you want in plain language: "increase the padding to match our spacing scale," "swap this to use the secondary button variant," "this heading should be H2 semibold." The tool figures out which component file to edit, which design tokens to use, and makes the change — or select multiple elements to [fix design drift across your entire app](/blog/multi-select/). You see the result live.
+Browser-aware AI coding tools exist to short-circuit that loop. You open your running application in the browser, click on the element that needs to change, and describe what you want in plain language: "increase the padding to match our spacing scale," "swap this to use the secondary button variant," "this heading should be H2 semibold." The tool figures out which component file to edit, which design tokens to use, and makes the change - or select multiple elements to [fix design drift across your entire app](/blog/multi-select/). You see the result live.
 
 The difference between these tools and general-purpose AI coding assistants (Cursor, Copilot, Claude Code) is what they understand. A general-purpose tool reads your source files — a limitation we call the [Runtime Context Gap](/blog/runtime-context-gap/). A framework-aware tool understands your application's structure—it knows that the button you clicked lives in `src/components/ui/Button.tsx`, that it's used in 14 places, that your design system defines `--spacing-md` as `16px`, and that changing the padding here should use that token instead of hardcoding `20px`.
 

--- a/apps/marketing/src/layouts/ComparisonLayout.astro
+++ b/apps/marketing/src/layouts/ComparisonLayout.astro
@@ -55,8 +55,14 @@ type Props = {
   heroSubtitle: string
   features: ComparisonFeature[]
   faqs: FAQ[]
-  alternatives: Alternative[]
+  alternatives?: Alternative[]
   showArchitectureDiagram?: boolean
+  showAlternatives?: boolean
+  frontmanPricing?: {
+    cost?: string
+    model?: string
+    features?: string[]
+  }
 }
 
 const {
@@ -66,9 +72,18 @@ const {
   heroSubtitle,
   features,
   faqs,
-  alternatives,
-  showArchitectureDiagram = true,
+  alternatives = [],
+  showArchitectureDiagram,
+  showAlternatives = true,
+  frontmanPricing,
 } = Astro.props
+
+const shouldShowArchitectureDiagram =
+  showArchitectureDiagram === undefined
+    ? Astro.slots.has('architecture-diagram')
+    : showArchitectureDiagram
+
+const shouldShowAlternatives = showAlternatives && alternatives.length > 0
 ---
 
 <Layout title={seo.title} description={seo.description}>
@@ -85,7 +100,7 @@ const {
   </ComparisonHero>
 
   <!-- Architecture Diagram -->
-  {showArchitectureDiagram && (
+  {shouldShowArchitectureDiagram && (
     <ComparisonArchitectureDiagram competitorName={competitor.name}>
       <slot name="architecture-diagram" />
     </ComparisonArchitectureDiagram>
@@ -120,14 +135,22 @@ const {
     competitorCost={competitor.pricing.cost}
     competitorModel={competitor.pricing.model}
     competitorFeatures={competitor.pricing.features}
+    frontmanCost={frontmanPricing?.cost}
+    frontmanModel={frontmanPricing?.model}
+    frontmanFeatures={frontmanPricing?.features}
   />
 
   <!-- Alternatives -->
-  <ComparisonAlternatives competitorName={competitor.name} alternatives={alternatives} />
+  {shouldShowAlternatives && (
+    <ComparisonAlternatives competitorName={competitor.name} alternatives={alternatives} />
+  )}
 
   <!-- FAQ -->
   <ComparisonFAQ faqs={faqs} />
 
+  <!-- Optional post-FAQ section -->
+  {Astro.slots.has('post-faq') && <slot name="post-faq" />}
+
   <!-- CTA -->
-  <ComparisonCTA />
+  {Astro.slots.has('cta') ? <slot name="cta" /> : <ComparisonCTA />}
 </Layout>

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -34,7 +34,7 @@ const { title, description, ogImage, noindex, classes, article } = Astro.props
 ---
 
 <!doctype html>
-<html lang="en" class="scroll-animation dark relative">
+<html lang="en" class="scroll-animation relative">
 	<Header title={title} description={description} ogImage={ogImage} noindex={noindex} article={article} />
 	<body
 		class:list={[

--- a/apps/marketing/src/pages/compare.astro
+++ b/apps/marketing/src/pages/compare.astro
@@ -367,7 +367,7 @@ const linkCardClass =
 								+
 							</span>
 						</summary>
-					<div class="max-w-[620px] pb-6 text-[15px] leading-[1.7] text-zinc-300">
+					<div class="max-w-[620px] pb-6 text-[15px] leading-[1.7] text-zinc-600">
 							<p class="m-0">{faq.answer}</p>
 						</div>
 					</details>

--- a/apps/marketing/src/pages/compare.astro
+++ b/apps/marketing/src/pages/compare.astro
@@ -145,75 +145,116 @@ const faqJsonLd = {
 		}
 	}))
 }
+
+const textLinkClass =
+	'text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-400'
+const darkSectionTitleClass = 'mb-3 text-[24px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]'
+const lightSectionTitleClass = 'mb-3 text-[24px] font-bold tracking-[-0.02em] text-zinc-950 md:text-[32px]'
+const darkSectionDescriptionClass = 'mb-8 text-[17px] leading-[1.6] text-zinc-300'
+const darkSectionIntroClass = 'mb-8 text-[17px] leading-[1.6] text-zinc-300'
+const categoryCardClass = 'rounded-xl border border-white/[0.08] bg-white/[0.03] p-6'
+const matrixFeatureHeaderClass =
+	'sticky left-0 z-10 border-b border-white/10 bg-[#09090b] px-4 py-3 text-left text-sm font-semibold uppercase tracking-wider text-white/40'
+const matrixToolHeaderClass =
+	'min-w-[120px] border-b border-white/10 px-3 py-3 text-center text-sm font-bold text-white/70'
+const matrixToolHeaderHighlightedClass =
+	`${matrixToolHeaderClass} border-t-[3px] border-primary-500 bg-primary-500/10 text-primary-500`
+const matrixFeatureCellClass =
+	'sticky left-0 z-10 border-b border-white/5 bg-[#09090b] px-4 py-3 text-left text-sm text-white/85'
+const matrixStatusCellClass = 'border-b border-white/5 px-3 py-3 text-center'
+const matrixStatusCellHighlightedClass = `${matrixStatusCellClass} bg-primary-500/[0.06]`
+const statusYesClass = 'inline-block text-green-500'
+const statusNoClass = 'inline-block text-red-500'
+const statusPartialClass = 'inline-block text-amber-500'
+const pricingHeaderClass =
+	'border-b-2 border-zinc-200 px-4 py-3 text-left text-[13px] font-semibold uppercase tracking-[0.05em] text-zinc-700'
+const pricingCellClass = 'border-b border-zinc-100 px-4 py-[14px] text-[15px] text-zinc-700'
+const pricingCellHighlightedClass = `${pricingCellClass} bg-primary-500/[0.04]`
+const linkCardClass =
+	'group block rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 no-underline transition-colors hover:border-primary-500/40 hover:bg-primary-500/[0.06]'
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
 
 	<!-- Hero -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">AI Coding Tools Compared</h1>
-			<p class="hero-subtitle">
+	<section class="flex justify-center bg-[#09090b] px-5 pb-12 pt-20 text-zinc-50 md:px-6 md:pb-12 max-md:pt-12">
+		<div class="w-full max-w-[800px]">
+			<p class="mb-3 font-mono text-[13px] uppercase tracking-[0.12em] text-primary-500">Comparison</p>
+			<h1 class="mb-4 text-[32px] font-bold leading-[1.1] tracking-[-0.02em] text-zinc-50 md:text-[48px]">
+				AI Coding Tools Compared
+			</h1>
+			<p class="mb-6 text-[20px] leading-[1.5] text-zinc-300">
 				How Frontman stacks up against Cursor, Claude Code, GitHub Copilot, Windsurf, and Stagewise. Feature matrix, pricing, and architecture differences.
 			</p>
-			<p class="hero-summary-text">
-				<a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent that runs as framework middleware in your browser. It hooks into Next.js, Astro, or Vite, sees the live DOM and computed CSS via a browser-side MCP server, and lets you click elements to edit their source code with hot reload. The tools below approach AI-assisted coding from different directions. This page shows where they overlap and where they don't.
+			<p class="text-[17px] leading-[1.7] text-zinc-300">
+				<a href="https://frontman.sh" class={textLinkClass}>Frontman</a> is an open-source AI coding agent that runs as framework middleware in your browser. It hooks into Next.js, Astro, or Vite, sees the live DOM and computed CSS via a browser-side MCP server, and lets you click elements to edit their source code with hot reload. The tools below approach AI-assisted coding from different directions. This page shows where they overlap and where they don't.
 			</p>
 		</div>
 	</section>
 
 	<!-- Quick Category Overview -->
-	<section class="categories-section">
-		<div class="categories-container">
-			<h2 class="section-title">Tool Categories</h2>
-			<p class="section-description">These tools are not all the same kind of thing. Understanding the category helps you pick the right one.</p>
-			<div class="categories-grid">
-				<div class="category-card category-card--highlighted">
-					<h3 class="category-name">Browser Middleware</h3>
-					<p class="category-tool">Frontman</p>
-					<p class="category-desc">Installs as a framework plugin. Runs inside your dev server. Sees the rendered page from the inside: component tree, computed styles, routes, logs.</p>
+	<section class="flex justify-center bg-[#09090b] px-5 pb-16 pt-12 md:px-6 md:pt-12">
+		<div class="w-full max-w-[1000px]">
+			<h2 class={darkSectionTitleClass}>Tool Categories</h2>
+			<p class={darkSectionDescriptionClass}>
+				These tools are not all the same kind of thing. Understanding the category helps you pick the right one.
+			</p>
+			<div class="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-4">
+				<div class={`${categoryCardClass} border-primary-500/40 bg-primary-500/[0.06]`}>
+					<h3 class="mb-1 text-[14px] font-semibold uppercase tracking-[0.05em] text-primary-500">Browser Middleware</h3>
+					<p class="mb-2 text-[18px] font-bold text-zinc-50">Frontman</p>
+					<p class="m-0 text-[15px] leading-[1.6] text-zinc-300">
+						Installs as a framework plugin. Runs inside your dev server. Sees the rendered page from the inside: component tree, computed styles, routes, logs.
+					</p>
 				</div>
-				<div class="category-card">
-					<h3 class="category-name">AI IDEs</h3>
-					<p class="category-tool">Cursor, Windsurf</p>
-					<p class="category-desc">VS Code forks with built-in AI agents, autocomplete, and terminal integration. Work from file context. Windsurf adds an embedded browser preview panel.</p>
+				<div class={categoryCardClass}>
+				<h3 class="mb-1 text-[14px] font-semibold uppercase tracking-[0.05em] text-zinc-300">AI IDEs</h3>
+					<p class="mb-2 text-[18px] font-bold text-zinc-50">Cursor, Windsurf</p>
+				<p class="m-0 text-[15px] leading-[1.6] text-zinc-300">
+						VS Code forks with built-in AI agents, autocomplete, and terminal integration. Work from file context. Windsurf adds an embedded browser preview panel.
+					</p>
 				</div>
-				<div class="category-card">
-					<h3 class="category-name">Terminal Agent</h3>
-					<p class="category-tool">Claude Code</p>
-					<p class="category-desc">Runs in your terminal or IDE. Reads the full codebase, edits files, runs commands, handles git. Language-agnostic. Chrome extension (beta) for limited browser access.</p>
+				<div class={categoryCardClass}>
+				<h3 class="mb-1 text-[14px] font-semibold uppercase tracking-[0.05em] text-zinc-300">Terminal Agent</h3>
+					<p class="mb-2 text-[18px] font-bold text-zinc-50">Claude Code</p>
+				<p class="m-0 text-[15px] leading-[1.6] text-zinc-300">
+						Runs in your terminal or IDE. Reads the full codebase, edits files, runs commands, handles git. Language-agnostic. Chrome extension (beta) for limited browser access.
+					</p>
 				</div>
-				<div class="category-card">
-					<h3 class="category-name">IDE Assistant</h3>
-					<p class="category-tool">GitHub Copilot</p>
-					<p class="category-desc">IDE extension with inline autocomplete, agent mode, and code review. Works across any language. Integrated into the GitHub platform for PRs and issues.</p>
+				<div class={categoryCardClass}>
+				<h3 class="mb-1 text-[14px] font-semibold uppercase tracking-[0.05em] text-zinc-300">IDE Assistant</h3>
+					<p class="mb-2 text-[18px] font-bold text-zinc-50">GitHub Copilot</p>
+				<p class="m-0 text-[15px] leading-[1.6] text-zinc-300">
+						IDE extension with inline autocomplete, agent mode, and code review. Works across any language. Integrated into the GitHub platform for PRs and issues.
+					</p>
 				</div>
-				<div class="category-card">
-					<h3 class="category-name">Browser Overlay</h3>
-					<p class="category-tool">Stagewise</p>
-					<p class="category-desc">Zero-install CLI overlay injected into the browser. Bridges to IDE agents (Cursor, Copilot, etc.) or uses a built-in agent with prompt limits.</p>
+				<div class={categoryCardClass}>
+				<h3 class="mb-1 text-[14px] font-semibold uppercase tracking-[0.05em] text-zinc-300">Browser Overlay</h3>
+					<p class="mb-2 text-[18px] font-bold text-zinc-50">Stagewise</p>
+				<p class="m-0 text-[15px] leading-[1.6] text-zinc-300">
+						Zero-install CLI overlay injected into the browser. Bridges to IDE agents (Cursor, Copilot, etc.) or uses a built-in agent with prompt limits.
+					</p>
 				</div>
 			</div>
 		</div>
 	</section>
 
 	<!-- Full Feature Matrix -->
-	<section class="matrix-section">
-		<div class="matrix-container">
-			<h2 class="section-title">Full Feature Matrix</h2>
-			<p class="section-description">How each tool handles 16 capabilities that matter for AI-assisted development.</p>
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 md:px-6">
+		<div class="w-full max-w-[1100px]">
+			<h2 class={darkSectionTitleClass}>Full Feature Matrix</h2>
+			<p class={darkSectionDescriptionClass}>How each tool handles 16 capabilities that matter for AI-assisted development.</p>
 
-			<div class="matrix-wrapper">
-				<table class="matrix-table" role="grid">
+			<div class="overflow-x-auto [-webkit-overflow-scrolling:touch]">
+				<table class="w-full min-w-[800px] border-separate border-spacing-0" role="grid">
 					<thead>
 						<tr>
-							<th class="matrix-feature-header">Feature</th>
+							<th class={matrixFeatureHeaderClass}>Feature</th>
 							{tools.map((tool) => (
-								<th class={`matrix-tool-header ${tool.slug === '' ? 'matrix-tool-header--highlighted' : ''}`}>
+								<th class={tool.slug === '' ? matrixToolHeaderHighlightedClass : matrixToolHeaderClass}>
 									{tool.slug ? (
-										<a href={`/vs/${tool.slug}/`} class="matrix-tool-link">{tool.name}</a>
+										<a href={`/vs/${tool.slug}/`} class="text-inherit no-underline hover:underline hover:underline-offset-2">{tool.name}</a>
 									) : (
 										<span>{tool.name}</span>
 									)}
@@ -224,22 +265,22 @@ const faqJsonLd = {
 					<tbody>
 						{matrixFeatures.map((feature) => (
 							<tr>
-								<td class="matrix-feature-cell">{feature.name}</td>
+								<td class={matrixFeatureCellClass}>{feature.name}</td>
 								{tools.map((tool) => {
 									const status = feature.values[tool.name] || 'n/a'
 									return (
-										<td class={`matrix-status-cell ${tool.slug === '' ? 'matrix-status-cell--highlighted' : ''}`}>
+										<td class={tool.slug === '' ? matrixStatusCellHighlightedClass : matrixStatusCellClass}>
 											{status === 'yes' && (
-												<svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="Yes"><polyline points="20 6 9 17 4 12"></polyline></svg>
+												<svg class={statusYesClass} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="Yes"><polyline points="20 6 9 17 4 12"></polyline></svg>
 											)}
 											{status === 'no' && (
-												<svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="No"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+												<svg class={statusNoClass} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="No"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
 											)}
 											{status === 'partial' && (
-												<svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="Partial"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+												<svg class={statusPartialClass} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" aria-label="Partial"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
 											)}
 											{status === 'n/a' && (
-												<span class="status-na" aria-label="Not applicable">&mdash;</span>
+						<span class="text-[14px] text-zinc-300" aria-label="Not applicable">&mdash;</span>
 											)}
 										</td>
 									)
@@ -250,35 +291,41 @@ const faqJsonLd = {
 				</table>
 			</div>
 
-			<div class="matrix-legend">
-				<span class="legend-item"><svg class="status-icon status-icon--yes" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg> Yes</span>
-				<span class="legend-item"><svg class="status-icon status-icon--partial" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg> Partial</span>
-				<span class="legend-item"><svg class="status-icon status-icon--no" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg> No</span>
+			<div class="mt-4 flex gap-6 border-t border-white/5 pt-4 max-md:flex-wrap">
+			<span class="flex items-center gap-1.5 text-[13px] text-zinc-300"><svg class={statusYesClass} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg> Yes</span>
+			<span class="flex items-center gap-1.5 text-[13px] text-zinc-300"><svg class={statusPartialClass} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg> Partial</span>
+			<span class="flex items-center gap-1.5 text-[13px] text-zinc-300"><svg class={statusNoClass} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg> No</span>
 			</div>
 		</div>
 	</section>
 
 	<!-- Pricing Comparison -->
-	<section class="content-section content-section--light">
-		<div class="content-container-wide">
-			<h2 class="section-title section-title--dark">Pricing at a Glance</h2>
-			<div class="pricing-table-wrapper">
-				<table class="pricing-table">
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-zinc-950 md:px-6">
+		<div class="w-full max-w-[1000px]">
+			<h2 class={lightSectionTitleClass}>Pricing at a Glance</h2>
+			<div class="overflow-x-auto">
+				<table class="w-full border-collapse">
 					<thead>
 						<tr>
-							<th>Tool</th>
-							<th>Price</th>
-							<th>Model</th>
-							<th>Note</th>
+							<th class={pricingHeaderClass}>Tool</th>
+							<th class={pricingHeaderClass}>Price</th>
+							<th class={pricingHeaderClass}>Model</th>
+							<th class={pricingHeaderClass}>Note</th>
 						</tr>
 					</thead>
 					<tbody>
 						{pricing.map((p) => (
-							<tr class={p.name === 'Frontman' ? 'pricing-row--highlighted' : ''}>
-								<td class="pricing-tool-name">{p.name}</td>
-								<td class="pricing-price">{p.price}</td>
-								<td>{p.model}</td>
-								<td class="pricing-detail">{p.detail}</td>
+							<tr>
+								<td class={p.name === 'Frontman' ? `${pricingCellHighlightedClass} font-semibold text-primary-500` : `${pricingCellClass} font-semibold text-zinc-950`}>
+									{p.name}
+								</td>
+								<td class={p.name === 'Frontman' ? `${pricingCellHighlightedClass} font-bold text-zinc-950` : `${pricingCellClass} font-bold text-zinc-950`}>
+									{p.price}
+								</td>
+								<td class={p.name === 'Frontman' ? pricingCellHighlightedClass : pricingCellClass}>{p.model}</td>
+						<td class={p.name === 'Frontman' ? `${pricingCellHighlightedClass} text-[14px] text-zinc-700` : `${pricingCellClass} text-[14px] text-zinc-700`}>
+									{p.detail}
+								</td>
 							</tr>
 						))}
 					</tbody>
@@ -288,17 +335,19 @@ const faqJsonLd = {
 	</section>
 
 	<!-- Individual Comparison Links -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Detailed Comparisons</h2>
-			<p class="section-intro">Each page below has a full feature table, prose analysis, pricing breakdown, and FAQ with structured data for search engines.</p>
-			<div class="links-grid">
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[800px]">
+			<h2 class={darkSectionTitleClass}>Detailed Comparisons</h2>
+			<p class={darkSectionIntroClass}>
+				Each page below has a full feature table, prose analysis, pricing breakdown, and FAQ with structured data for search engines.
+			</p>
+			<div class="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-4 max-md:grid-cols-1">
 				{tools.filter(t => t.slug !== '').map((tool) => (
-					<a href={`/vs/${tool.slug}/`} class="link-card">
-						<span class="link-card-category">{tool.category}</span>
-						<h3 class="link-card-title">Frontman vs {tool.name}</h3>
-						<p class="link-card-desc">{tool.description}</p>
-						<span class="link-card-cta">Read full comparison &rarr;</span>
+					<a href={`/vs/${tool.slug}/`} class={linkCardClass}>
+					<span class="text-[12px] uppercase tracking-[0.05em] text-zinc-300">{tool.category}</span>
+						<h3 class="my-1 mb-2 text-[20px] font-bold text-zinc-50">Frontman vs {tool.name}</h3>
+					<p class="mb-3 text-[15px] leading-[1.5] text-zinc-300">{tool.description}</p>
+						<span class="text-[14px] font-medium text-primary-500 group-hover:underline group-hover:underline-offset-3">Read full comparison &rarr;</span>
 					</a>
 				))}
 			</div>
@@ -306,18 +355,20 @@ const faqJsonLd = {
 	</section>
 
 	<!-- FAQ -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Frequently Asked Questions</h2>
-			<div class="faq-list faq-list--light">
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-zinc-950 md:px-6">
+		<div class="w-full max-w-[800px]">
+			<h2 class={lightSectionTitleClass}>Frequently Asked Questions</h2>
+			<div class="border-t border-zinc-200">
 				{faqs.map((faq) => (
-					<details class="faq-item faq-item--light group">
-						<summary class="faq-question faq-question--light">
-							<span>{faq.question}</span>
-							<span class="faq-icon faq-icon--light">+</span>
+					<details class="group cursor-pointer border-b border-zinc-200">
+						<summary class="flex w-full list-none items-center justify-between py-6 text-[17px] font-medium leading-[1.4] text-zinc-950 transition-colors hover:text-black [&::-webkit-details-marker]:hidden">
+							<span class="pr-6">{faq.question}</span>
+					<span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-300 text-lg font-light text-zinc-300 transition-all duration-300 group-open:rotate-45 group-open:bg-zinc-100">
+								+
+							</span>
 						</summary>
-						<div class="faq-answer faq-answer--light">
-							<p>{faq.answer}</p>
+					<div class="max-w-[620px] pb-6 text-[15px] leading-[1.7] text-zinc-300">
+							<p class="m-0">{faq.answer}</p>
 						</div>
 					</details>
 				))}
@@ -326,481 +377,37 @@ const faqJsonLd = {
 	</section>
 
 	<!-- Related -->
-	<section class="content-section">
-		<div class="content-container">
-			<p>For an in-depth review of the open-source tools in this list, see <a href="/blog/best-open-source-ai-coding-tools-2026/" class="text-link">Best Open-Source AI Coding Tools in 2026</a>.</p>
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[800px]">
+			<p class="m-0 text-[17px] leading-[1.7] text-zinc-300">
+				For an in-depth review of the open-source tools in this list, see <a href="/blog/best-open-source-ai-coding-tools-2026/" class={textLinkClass}>Best Open-Source AI Coding Tools in 2026</a>.
+			</p>
 		</div>
 	</section>
 
 	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman</h2>
-			<p class="cta-description">One command. No account. No credit card.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
+	<section class="flex justify-center border-t border-zinc-800 bg-[#09090b] px-5 py-20 text-zinc-50 md:px-6 max-md:py-12">
+		<div class="w-full max-w-[720px]">
+			<h2 class="mb-2 text-[28px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[36px]">Try Frontman</h2>
+			<p class="mb-8 text-[17px] text-zinc-300">One command. No account. No credit card.</p>
+			<div class="mb-8 flex flex-col gap-3">
+				<div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+					<code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
+						<span class="text-[13px] text-zinc-300">Next.js</span>
 				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
+				<div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+					<code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
+						<span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
 				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
+				<div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+					<code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
+					<span class="text-[13px] text-zinc-300">Astro</span>
 				</div>
 			</div>
-			<div class="cta-links">
+			<div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
 				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
+				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 no-underline transition-colors hover:text-zinc-50">Join Discord</a>
 			</div>
 		</div>
 	</section>
 </Layout>
-
-<style>
-	@reference "../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 48px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 800px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 16px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		line-height: 1.5;
-		color: #a1a1aa;
-		margin-bottom: 24px;
-	}
-	.hero-summary-text {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #71717a;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover { color: #c084fc; }
-
-	/* Categories */
-	.categories-section {
-		background: #09090b;
-		padding: 48px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.categories-container {
-		max-width: 1000px;
-		width: 100%;
-	}
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 12px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark { color: #09090b; }
-	.section-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.section-intro {
-		font-size: 17px;
-		color: #a1a1aa;
-		margin-bottom: 32px;
-		line-height: 1.6;
-	}
-	.categories-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-		gap: 16px;
-	}
-	.category-card {
-		padding: 24px;
-		border-radius: 12px;
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.category-card--highlighted {
-		border-color: rgba(162, 89, 255, 0.4);
-		background: rgba(162, 89, 255, 0.06);
-	}
-	.category-name {
-		font-size: 14px;
-		font-weight: 600;
-		color: #71717a;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		margin-bottom: 4px;
-	}
-	.category-card--highlighted .category-name { color: #A259FF; }
-	.category-tool {
-		font-size: 18px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.category-desc {
-		font-size: 15px;
-		line-height: 1.6;
-		color: #a1a1aa;
-	}
-
-	/* Matrix */
-	.matrix-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.matrix-container {
-		max-width: 1100px;
-		width: 100%;
-	}
-	.matrix-wrapper {
-		overflow-x: auto;
-		-webkit-overflow-scrolling: touch;
-	}
-	.matrix-table {
-		width: 100%;
-		min-width: 800px;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.matrix-feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-3 px-4;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		position: sticky;
-		left: 0;
-		background: #09090b;
-		z-index: 1;
-	}
-	.matrix-tool-header {
-		@apply text-center text-sm font-bold py-3 px-3;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		min-width: 120px;
-	}
-	.matrix-tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-	}
-	.matrix-tool-link {
-		color: inherit;
-		text-decoration: none;
-	}
-	.matrix-tool-link:hover {
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.matrix-feature-cell {
-		@apply text-left text-sm py-3 px-4;
-		color: rgba(255, 255, 255, 0.85);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-		position: sticky;
-		left: 0;
-		background: #09090b;
-		z-index: 1;
-	}
-	.matrix-status-cell {
-		@apply text-center py-3 px-3;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.matrix-status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.06);
-	}
-	tr:last-child .matrix-feature-cell,
-	tr:last-child .matrix-status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-	.status-na { color: #52525b; font-size: 14px; }
-
-	.matrix-legend {
-		display: flex;
-		gap: 24px;
-		margin-top: 16px;
-		padding-top: 16px;
-		border-top: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.legend-item {
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		font-size: 13px;
-		color: #71717a;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 800px;
-		width: 100%;
-	}
-	.content-container-wide {
-		max-width: 1000px;
-		width: 100%;
-	}
-
-	/* Pricing table */
-	.pricing-table-wrapper {
-		overflow-x: auto;
-	}
-	.pricing-table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-	.pricing-table th {
-		text-align: left;
-		font-size: 13px;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: #71717a;
-		padding: 12px 16px;
-		border-bottom: 2px solid #e4e4e7;
-	}
-	.pricing-table td {
-		font-size: 15px;
-		color: #52525b;
-		padding: 14px 16px;
-		border-bottom: 1px solid #f4f4f5;
-	}
-	.pricing-row--highlighted td {
-		background: rgba(162, 89, 255, 0.04);
-	}
-	.pricing-tool-name {
-		font-weight: 600;
-		color: #09090b;
-	}
-	.pricing-row--highlighted .pricing-tool-name {
-		color: #A259FF;
-	}
-	.pricing-price {
-		font-weight: 700;
-		color: #09090b;
-	}
-	.pricing-detail {
-		font-size: 14px;
-		color: #a1a1aa;
-	}
-
-	/* Links grid */
-	.links-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-		gap: 16px;
-	}
-	.link-card {
-		display: block;
-		padding: 24px;
-		border-radius: 12px;
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		background: rgba(255, 255, 255, 0.03);
-		text-decoration: none;
-		transition: border-color 0.2s, background 0.2s;
-	}
-	.link-card:hover {
-		border-color: rgba(162, 89, 255, 0.4);
-		background: rgba(162, 89, 255, 0.06);
-	}
-	.link-card-category {
-		font-size: 12px;
-		color: #71717a;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-	.link-card-title {
-		font-size: 20px;
-		font-weight: 700;
-		color: #fafafa;
-		margin: 4px 0 8px;
-	}
-	.link-card-desc {
-		font-size: 15px;
-		line-height: 1.5;
-		color: #a1a1aa;
-		margin-bottom: 12px;
-	}
-	.link-card-cta {
-		font-size: 14px;
-		font-weight: 500;
-		color: #A259FF;
-	}
-	.link-card:hover .link-card-cta {
-		text-decoration: underline;
-		text-underline-offset: 3px;
-	}
-
-	/* FAQ */
-	.faq-list { border-top: 1px solid #27272a; }
-	.faq-list--light { border-top: 1px solid #e4e4e7; }
-	.faq-item { border-bottom: 1px solid #27272a; cursor: pointer; }
-	.faq-item--light { border-bottom: 1px solid #e4e4e7; }
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question--light { color: #09090b; }
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question--light:hover { color: #000; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.faq-icon--light { border-color: #d4d4d8; }
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.group[open] .faq-icon--light {
-		background: #f4f4f5;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-	.faq-answer--light p { color: #52525b; }
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix { color: #A259FF; margin-right: 8px; }
-	.command-label { font-size: 13px; color: #71717a; }
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover { color: #fafafa; }
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 32px; }
-		.hero-title { font-size: 32px; }
-		.categories-section { padding: 32px 20px 48px; }
-		.categories-grid { grid-template-columns: 1fr; }
-		.section-title { font-size: 24px; }
-		.matrix-section { padding: 40px 20px; }
-		.content-section { padding: 40px 20px; }
-		.links-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>

--- a/apps/marketing/src/pages/use-cases/designers.astro
+++ b/apps/marketing/src/pages/use-cases/designers.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro'
-import Button from '../../components/ui/Button.astro'
+import UseCaseFaqSection from '../../components/use-cases/UseCaseFaqSection.astro'
+import UseCaseCtaSection from '../../components/use-cases/UseCaseCtaSection.astro'
 
 const SEO = {
 	title: 'AI Code Editor for Designers: Edit UI Without an IDE',
@@ -83,21 +84,35 @@ const comparisonRows = [
 		notes: 'Output still needs integration into real codebase'
 	}
 ]
+
+const textLinkClass =
+	'text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-400'
+const proseBulletBaseClass =
+	'relative py-2 pl-[22px] text-[17px] leading-[1.6] before:absolute before:left-0 before:top-[17px] before:h-2 before:w-2 before:rounded-full before:bg-primary-500'
+const tableHeaderClass =
+	'border-b border-zinc-800 bg-[#111113] px-[14px] py-3 text-left text-[12px] uppercase tracking-[0.06em] text-zinc-300'
+const tableCellClass =
+	'border-b border-zinc-800 bg-[#09090b] px-[14px] py-3 text-left text-[14px] leading-[1.5] text-zinc-300'
+const highlightedTableCellClass = `${tableCellClass} bg-slate-900`
+const tableToolCellClass = `${tableCellClass} font-semibold text-zinc-50`
+const highlightedTableToolCellClass = `${tableToolCellClass} bg-slate-900`
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
 
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Use Case</p>
-			<h1 class="hero-title">AI Code Editor for Designers</h1>
-			<p class="hero-subtitle">
+	<section class="flex justify-center bg-[#09090b] px-5 pb-9 pt-12 text-zinc-50 md:px-6 md:pb-12 md:pt-20">
+		<div class="w-full max-w-[760px]">
+			<p class="mb-3 font-mono text-[13px] uppercase tracking-[0.12em] text-primary-500">Use Case</p>
+			<h1 class="mb-[14px] text-[34px] font-bold leading-[1.1] tracking-[-0.02em] text-zinc-50 md:text-[48px]">
+				AI Code Editor for Designers
+			</h1>
+			<p class="mb-[18px] text-[18px] leading-[1.5] text-zinc-300 md:text-[20px]">
 				Frontman is an AI code editor for designers: click elements in your running app,
 				describe changes in plain English, and get source code edits with hot reload.
 			</p>
-			<p class="hero-summary">
-				<a href="https://frontman.sh" class="text-link">Frontman</a> is a vertically integrated
+			<p class="text-[17px] leading-[1.7] text-zinc-300">
+				<a href="https://frontman.sh" class={textLinkClass}>Frontman</a> is a vertically integrated
 				AI agent that lives inside your framework and is accessible from the browser. Instead of
 				screenshots, tickets, and waiting for a sprint slot, designers can iterate directly on
 				the live app while engineering keeps normal review control.
@@ -105,84 +120,114 @@ const comparisonRows = [
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Why designers get blocked</h2>
-			<div class="prose-content">
-				<p>
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]">
+				Why designers get blocked
+			</h2>
+			<div>
+				<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 					The problem is not spotting visual issues. The problem is shipping them. Designers see spacing,
 					copy, and hierarchy issues immediately, but fixing them often means screenshots, annotations,
 					tickets, and backlog negotiations.
 				</p>
-				<p>
+				<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 					That handoff loop slows down design quality and product velocity. Frontman removes the loop for
 					visual frontend work by letting designers work on the real running application.
 				</p>
-				<ul>
-					<li><strong>No IDE required</strong> for routine visual refinements.</li>
-					<li><strong>No guessing</strong> from static mocks: edits happen on real layouts and real data.</li>
-					<li><strong>No process rewrite</strong>: code still goes through the existing PR workflow.</li>
+				<ul class="my-3 list-none p-0">
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>No IDE required</strong> for routine visual refinements.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>No guessing</strong> from static mocks: edits happen on real layouts and real data.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>No process rewrite</strong>: code still goes through the existing PR workflow.
+					</li>
 				</ul>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">How designers use Frontman</h2>
-			<div class="steps-grid">
-				<div class="step-card">
-					<span class="step-number">1</span>
-					<h3>Open the running app</h3>
-					<p>Navigate to the app in your browser and enter Frontman mode.</p>
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-[#09090b] md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-[#09090b] md:text-[32px]">
+				How designers use Frontman
+			</h2>
+			<div class="grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<span class="mb-2.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-violet-100 text-[13px] font-bold text-violet-700">
+						1
+					</span>
+					<h3 class="mb-2 text-[18px] text-slate-900">Open the running app</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Navigate to the app in your browser and enter Frontman mode.
+					</p>
 				</div>
-				<div class="step-card">
-					<span class="step-number">2</span>
-					<h3>Click what looks wrong</h3>
-					<p>Select the real element on screen instead of describing file paths.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<span class="mb-2.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-violet-100 text-[13px] font-bold text-violet-700">
+						2
+					</span>
+					<h3 class="mb-2 text-[18px] text-slate-900">Click what looks wrong</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Select the real element on screen instead of describing file paths.
+					</p>
 				</div>
-				<div class="step-card">
-					<span class="step-number">3</span>
-					<h3>Describe the change</h3>
-					<p>Use plain language: spacing, typography, hierarchy, copy, interaction states.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<span class="mb-2.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-violet-100 text-[13px] font-bold text-violet-700">
+						3
+					</span>
+					<h3 class="mb-2 text-[18px] text-slate-900">Describe the change</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Use plain language: spacing, typography, hierarchy, copy, interaction states.
+					</p>
 				</div>
-				<div class="step-card">
-					<span class="step-number">4</span>
-					<h3>Review and ship</h3>
-					<p>See the update instantly, iterate if needed, and send through normal code review.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<span class="mb-2.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-violet-100 text-[13px] font-bold text-violet-700">
+						4
+					</span>
+					<h3 class="mb-2 text-[18px] text-slate-900">Review and ship</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						See the update instantly, iterate if needed, and send through normal code review.
+					</p>
 				</div>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container-wide">
-			<h2 class="section-title">Comparison: Designer-to-Code Options</h2>
-			<p class="section-intro">
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[1080px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]">
+				Comparison: Designer-to-Code Options
+			</h2>
+			<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 				These tools solve different parts of the workflow. Frontman is built for editing existing
 				production UI with runtime context.
 			</p>
-			<div class="table-wrap">
-				<table class="comparison-table">
+			<div class="overflow-x-auto rounded-xl border border-zinc-800">
+				<table class="w-full min-w-[940px] border-collapse">
 					<thead>
 						<tr>
-							<th>Tool</th>
-							<th>Best For</th>
-							<th>Existing App</th>
-							<th>Source Code Edits</th>
-							<th>IDE Required</th>
-							<th>Notes</th>
+							<th class={tableHeaderClass}>Tool</th>
+							<th class={tableHeaderClass}>Best For</th>
+							<th class={tableHeaderClass}>Existing App</th>
+							<th class={tableHeaderClass}>Source Code Edits</th>
+							<th class={tableHeaderClass}>IDE Required</th>
+							<th class={tableHeaderClass}>Notes</th>
 						</tr>
 					</thead>
 					<tbody>
 						{comparisonRows.map((row) => (
-							<tr class={row.tool === 'Frontman' ? 'highlight-row' : ''}>
-								<td class="tool-cell">{row.tool}</td>
-								<td>{row.bestFor}</td>
-								<td>{row.existingApp}</td>
-								<td>{row.sourceEdits}</td>
-								<td>{row.ideRequired}</td>
-								<td>{row.notes}</td>
+							<tr>
+								<td class={row.tool === 'Frontman' ? highlightedTableToolCellClass : tableToolCellClass}>
+									{row.tool}
+								</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.bestFor}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.existingApp}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.sourceEdits}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.ideRequired}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.notes}</td>
 							</tr>
 						))}
 					</tbody>
@@ -191,358 +236,45 @@ const comparisonRows = [
 		</div>
 	</section>
 
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What designers can ship faster</h2>
-			<div class="prose-content prose-content--dark">
-				<ul>
-					<li>Typography hierarchy fixes across marketing pages and product surfaces.</li>
-					<li>Spacing and alignment consistency in reusable components.</li>
-					<li>Copy and CTA refinements discovered during product reviews.</li>
-					<li>Responsive tweaks for breakpoints that are hard to catch in design files.</li>
-					<li>Small visual QA issues before launch, without creating ticket debt.</li>
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-[#09090b] md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-[#09090b] md:text-[32px]">
+				What designers can ship faster
+			</h2>
+			<div>
+				<ul class="my-3 list-none p-0">
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						Typography hierarchy fixes across marketing pages and product surfaces.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						Spacing and alignment consistency in reusable components.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						Copy and CTA refinements discovered during product reviews.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						Responsive tweaks for breakpoints that are hard to catch in design files.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						Small visual QA issues before launch, without creating ticket debt.
+					</li>
 				</ul>
-				<p>
-					For deeper architecture context, see <a href="/how-it-works/" class="text-link">how Frontman works</a>.
-					For tool-level tradeoffs, see <a href="/compare/" class="text-link">the full comparison matrix</a>.
+				<p class="mb-0 text-[17px] leading-[1.7] text-zinc-600">
+					For deeper architecture context, see <a href="/how-it-works/" class={textLinkClass}>how Frontman works</a>.
+					For tool-level tradeoffs, see <a href="/compare/" class={textLinkClass}>the full comparison matrix</a>.
 				</p>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
+	<UseCaseFaqSection faqs={faqs} />
 
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Design on the real thing</h2>
-			<p class="cta-description">
-				If your team is tired of visual ticket ping-pong, start with one page and one workflow.
-			</p>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="/use-cases/frontend-developers/" class="cta-secondary">Frontend developer workflow</a>
-				<a href="/integrations/" class="cta-secondary">Supported integrations</a>
-			</div>
-		</div>
-	</section>
+	<UseCaseCtaSection
+		title="Design on the real thing"
+		description="If your team is tired of visual ticket ping-pong, start with one page and one workflow."
+		secondaryLinks={[
+			{href: '/use-cases/frontend-developers/', label: 'Frontend developer workflow'},
+			{href: '/integrations/', label: 'Supported integrations'},
+		]}
+	/>
 </Layout>
-
-<style>
-	@reference "../../styles/global.css";
-
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 48px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #a259ff;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		margin-bottom: 14px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		line-height: 1.5;
-		color: #a1a1aa;
-		margin-bottom: 18px;
-	}
-	.hero-summary {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #71717a;
-	}
-
-	.text-link {
-		color: #a259ff;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.content-container-wide {
-		max-width: 1080px;
-		width: 100%;
-	}
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		letter-spacing: -0.02em;
-		margin-bottom: 20px;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-	.section-intro {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 12px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.6;
-		padding: 8px 0 8px 22px;
-		position: relative;
-		color: #a1a1aa;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 17px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #a259ff;
-	}
-
-	.steps-grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 16px;
-	}
-	.step-card {
-		background: white;
-		border: 1px solid #e4e4e7;
-		border-radius: 12px;
-		padding: 18px;
-	}
-	.step-number {
-		display: inline-flex;
-		width: 28px;
-		height: 28px;
-		border-radius: 999px;
-		align-items: center;
-		justify-content: center;
-		font-size: 13px;
-		font-weight: 700;
-		background: #ede9fe;
-		color: #6d28d9;
-		margin-bottom: 10px;
-	}
-	.step-card h3 {
-		font-size: 18px;
-		margin: 0 0 8px;
-		color: #111827;
-	}
-	.step-card p {
-		font-size: 15px;
-		line-height: 1.6;
-		margin: 0;
-		color: #4b5563;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-		border: 1px solid #27272a;
-		border-radius: 12px;
-	}
-	.comparison-table {
-		width: 100%;
-		border-collapse: collapse;
-		min-width: 940px;
-	}
-	.comparison-table th,
-	.comparison-table td {
-		padding: 12px 14px;
-		text-align: left;
-		border-bottom: 1px solid #27272a;
-		font-size: 14px;
-		line-height: 1.5;
-	}
-	.comparison-table th {
-		font-size: 12px;
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		color: #a1a1aa;
-		background: #111113;
-	}
-	.comparison-table td {
-		color: #d4d4d8;
-		background: #09090b;
-	}
-	.tool-cell {
-		font-weight: 600;
-		color: #fafafa !important;
-	}
-	.highlight-row td {
-		background: #111827;
-	}
-
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-	}
-	.faq-question {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 22px 0;
-		font-size: 17px;
-		font-weight: 500;
-		list-style: none;
-	}
-	.faq-question::-webkit-details-marker {
-		display: none;
-	}
-	.faq-icon {
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		color: #71717a;
-		transition: transform 0.2s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 0 0 20px;
-		margin: 0;
-	}
-
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 72px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		line-height: 1.2;
-		margin-bottom: 10px;
-	}
-	.cta-description {
-		font-size: 17px;
-		line-height: 1.6;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 20px;
-		flex-wrap: wrap;
-	}
-	.cta-secondary {
-		font-size: 15px;
-		color: #71717a;
-		text-decoration: none;
-	}
-	.cta-secondary:hover {
-		color: #fafafa;
-	}
-
-	@media (max-width: 900px) {
-		.steps-grid {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 768px) {
-		.hero-section,
-		.content-section,
-		.cta-section {
-			padding-left: 20px;
-			padding-right: 20px;
-		}
-		.hero-section {
-			padding-top: 48px;
-			padding-bottom: 36px;
-		}
-		.hero-title {
-			font-size: 34px;
-		}
-		.hero-subtitle {
-			font-size: 18px;
-		}
-		.section-title {
-			font-size: 26px;
-		}
-		.cta-title {
-			font-size: 30px;
-		}
-	}
-</style>

--- a/apps/marketing/src/pages/use-cases/designers.astro
+++ b/apps/marketing/src/pages/use-cases/designers.astro
@@ -1,0 +1,548 @@
+---
+import Layout from '../../layouts/Layout.astro'
+import Button from '../../components/ui/Button.astro'
+
+const SEO = {
+	title: 'AI Code Editor for Designers: Edit UI Without an IDE',
+	description:
+		'Frontman is an AI code editor for designers. Click elements in your running app, describe UI changes in plain English, and generate real source code edits with hot reload.'
+}
+
+const faqs = [
+	{
+		question: 'Can designers use Frontman without writing code?',
+		answer:
+			'Yes. Designers can click an element in the running app, describe the change in plain English, and review the updated UI instantly. Frontman writes source code edits behind the scenes, and engineering reviews changes in the normal PR flow.'
+	},
+	{
+		question: 'Is Frontman a replacement for Figma?',
+		answer:
+			'No. Figma remains the best place for exploration and early concepts. Frontman is for production UI changes in a real app. Teams use both: Figma for design exploration, Frontman for shipping visual refinements in code.'
+	},
+	{
+		question: 'Will this break our design system?',
+		answer:
+			'Frontman is designed to reuse your existing components, tokens, and conventions. It works from runtime context plus source files, so changes are applied in your actual component layer instead of one-off visual overrides.'
+	},
+	{
+		question: 'Do designers need IDE or terminal access?',
+		answer:
+			'No IDE is required for day-to-day usage. A developer installs Frontman once into the project. After setup, designers and PMs can work from the browser on the running app.'
+	},
+	{
+		question: 'Which frameworks are supported for designer workflows?',
+		answer:
+			'Frontman supports Next.js, Astro, and Vite projects (React, Vue, Svelte). If your product runs on one of these stacks, designers can use the same click-to-edit workflow directly in the browser.'
+	}
+]
+
+const faqJsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'FAQPage',
+	mainEntity: faqs.map((faq) => ({
+		'@type': 'Question',
+		name: faq.question,
+		acceptedAnswer: {
+			'@type': 'Answer',
+			text: faq.answer
+		}
+	}))
+}
+
+const comparisonRows = [
+	{
+		tool: 'Frontman',
+		bestFor: 'Editing existing production UI with live context',
+		existingApp: 'Yes',
+		sourceEdits: 'Yes',
+		ideRequired: 'No',
+		notes: 'Browser workflow, framework-aware, BYOK, open source core'
+	},
+	{
+		tool: 'Figma Dev Mode',
+		bestFor: 'Design handoff and specs',
+		existingApp: 'Partial',
+		sourceEdits: 'No',
+		ideRequired: 'No',
+		notes: 'Great for inspection, still requires developer implementation'
+	},
+	{
+		tool: 'Locofy',
+		bestFor: 'Converting design artifacts to starter code',
+		existingApp: 'Partial',
+		sourceEdits: 'Partial',
+		ideRequired: 'Usually',
+		notes: 'Useful for generation, less suited for targeted production fixes'
+	},
+	{
+		tool: 'Anima',
+		bestFor: 'Prototype export and handoff acceleration',
+		existingApp: 'Partial',
+		sourceEdits: 'No',
+		ideRequired: 'No',
+		notes: 'Output still needs integration into real codebase'
+	}
+]
+---
+
+<Layout title={SEO.title} description={SEO.description}>
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+
+	<section class="hero-section">
+		<div class="hero-container">
+			<p class="hero-label">Use Case</p>
+			<h1 class="hero-title">AI Code Editor for Designers</h1>
+			<p class="hero-subtitle">
+				Frontman is an AI code editor for designers: click elements in your running app,
+				describe changes in plain English, and get source code edits with hot reload.
+			</p>
+			<p class="hero-summary">
+				<a href="https://frontman.sh" class="text-link">Frontman</a> is a vertically integrated
+				AI agent that lives inside your framework and is accessible from the browser. Instead of
+				screenshots, tickets, and waiting for a sprint slot, designers can iterate directly on
+				the live app while engineering keeps normal review control.
+			</p>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container">
+			<h2 class="section-title">Why designers get blocked</h2>
+			<div class="prose-content">
+				<p>
+					The problem is not spotting visual issues. The problem is shipping them. Designers see spacing,
+					copy, and hierarchy issues immediately, but fixing them often means screenshots, annotations,
+					tickets, and backlog negotiations.
+				</p>
+				<p>
+					That handoff loop slows down design quality and product velocity. Frontman removes the loop for
+					visual frontend work by letting designers work on the real running application.
+				</p>
+				<ul>
+					<li><strong>No IDE required</strong> for routine visual refinements.</li>
+					<li><strong>No guessing</strong> from static mocks: edits happen on real layouts and real data.</li>
+					<li><strong>No process rewrite</strong>: code still goes through the existing PR workflow.</li>
+				</ul>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section content-section--light">
+		<div class="content-container">
+			<h2 class="section-title section-title--dark">How designers use Frontman</h2>
+			<div class="steps-grid">
+				<div class="step-card">
+					<span class="step-number">1</span>
+					<h3>Open the running app</h3>
+					<p>Navigate to the app in your browser and enter Frontman mode.</p>
+				</div>
+				<div class="step-card">
+					<span class="step-number">2</span>
+					<h3>Click what looks wrong</h3>
+					<p>Select the real element on screen instead of describing file paths.</p>
+				</div>
+				<div class="step-card">
+					<span class="step-number">3</span>
+					<h3>Describe the change</h3>
+					<p>Use plain language: spacing, typography, hierarchy, copy, interaction states.</p>
+				</div>
+				<div class="step-card">
+					<span class="step-number">4</span>
+					<h3>Review and ship</h3>
+					<p>See the update instantly, iterate if needed, and send through normal code review.</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container-wide">
+			<h2 class="section-title">Comparison: Designer-to-Code Options</h2>
+			<p class="section-intro">
+				These tools solve different parts of the workflow. Frontman is built for editing existing
+				production UI with runtime context.
+			</p>
+			<div class="table-wrap">
+				<table class="comparison-table">
+					<thead>
+						<tr>
+							<th>Tool</th>
+							<th>Best For</th>
+							<th>Existing App</th>
+							<th>Source Code Edits</th>
+							<th>IDE Required</th>
+							<th>Notes</th>
+						</tr>
+					</thead>
+					<tbody>
+						{comparisonRows.map((row) => (
+							<tr class={row.tool === 'Frontman' ? 'highlight-row' : ''}>
+								<td class="tool-cell">{row.tool}</td>
+								<td>{row.bestFor}</td>
+								<td>{row.existingApp}</td>
+								<td>{row.sourceEdits}</td>
+								<td>{row.ideRequired}</td>
+								<td>{row.notes}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section content-section--light">
+		<div class="content-container">
+			<h2 class="section-title section-title--dark">What designers can ship faster</h2>
+			<div class="prose-content prose-content--dark">
+				<ul>
+					<li>Typography hierarchy fixes across marketing pages and product surfaces.</li>
+					<li>Spacing and alignment consistency in reusable components.</li>
+					<li>Copy and CTA refinements discovered during product reviews.</li>
+					<li>Responsive tweaks for breakpoints that are hard to catch in design files.</li>
+					<li>Small visual QA issues before launch, without creating ticket debt.</li>
+				</ul>
+				<p>
+					For deeper architecture context, see <a href="/how-it-works/" class="text-link">how Frontman works</a>.
+					For tool-level tradeoffs, see <a href="/compare/" class="text-link">the full comparison matrix</a>.
+				</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container">
+			<h2 class="section-title">Frequently Asked Questions</h2>
+			<div class="faq-list">
+				{faqs.map((faq) => (
+					<details class="faq-item group">
+						<summary class="faq-question">
+							<span>{faq.question}</span>
+							<span class="faq-icon">+</span>
+						</summary>
+						<div class="faq-answer">
+							<p>{faq.answer}</p>
+						</div>
+					</details>
+				))}
+			</div>
+		</div>
+	</section>
+
+	<section class="cta-section">
+		<div class="cta-container">
+			<h2 class="cta-title">Design on the real thing</h2>
+			<p class="cta-description">
+				If your team is tired of visual ticket ping-pong, start with one page and one workflow.
+			</p>
+			<div class="cta-links">
+				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+				<a href="/use-cases/frontend-developers/" class="cta-secondary">Frontend developer workflow</a>
+				<a href="/integrations/" class="cta-secondary">Supported integrations</a>
+			</div>
+		</div>
+	</section>
+</Layout>
+
+<style>
+	@reference "../../styles/global.css";
+
+	.hero-section {
+		background: #09090b;
+		color: #fafafa;
+		padding: 80px 24px 48px;
+		display: flex;
+		justify-content: center;
+	}
+	.hero-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.hero-label {
+		@apply font-mono;
+		font-size: 13px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: #a259ff;
+		margin-bottom: 12px;
+	}
+	.hero-title {
+		font-size: 48px;
+		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.02em;
+		margin-bottom: 14px;
+	}
+	.hero-subtitle {
+		font-size: 20px;
+		line-height: 1.5;
+		color: #a1a1aa;
+		margin-bottom: 18px;
+	}
+	.hero-summary {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #71717a;
+	}
+
+	.text-link {
+		color: #a259ff;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+	.text-link:hover {
+		color: #c084fc;
+	}
+
+	.content-section {
+		background: #09090b;
+		color: #fafafa;
+		padding: 64px 24px;
+		display: flex;
+		justify-content: center;
+	}
+	.content-section--light {
+		background: #fafafa;
+		color: #09090b;
+	}
+	.content-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.content-container-wide {
+		max-width: 1080px;
+		width: 100%;
+	}
+	.section-title {
+		font-size: 32px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		margin-bottom: 20px;
+	}
+	.section-title--dark {
+		color: #09090b;
+	}
+	.section-intro {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		margin-bottom: 16px;
+	}
+
+	.prose-content p {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		margin-bottom: 16px;
+	}
+	.prose-content--dark p {
+		color: #52525b;
+	}
+	.prose-content ul {
+		list-style: none;
+		padding: 0;
+		margin: 12px 0;
+	}
+	.prose-content li {
+		font-size: 17px;
+		line-height: 1.6;
+		padding: 8px 0 8px 22px;
+		position: relative;
+		color: #a1a1aa;
+	}
+	.prose-content--dark li {
+		color: #52525b;
+	}
+	.prose-content li::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 17px;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: #a259ff;
+	}
+
+	.steps-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 16px;
+	}
+	.step-card {
+		background: white;
+		border: 1px solid #e4e4e7;
+		border-radius: 12px;
+		padding: 18px;
+	}
+	.step-number {
+		display: inline-flex;
+		width: 28px;
+		height: 28px;
+		border-radius: 999px;
+		align-items: center;
+		justify-content: center;
+		font-size: 13px;
+		font-weight: 700;
+		background: #ede9fe;
+		color: #6d28d9;
+		margin-bottom: 10px;
+	}
+	.step-card h3 {
+		font-size: 18px;
+		margin: 0 0 8px;
+		color: #111827;
+	}
+	.step-card p {
+		font-size: 15px;
+		line-height: 1.6;
+		margin: 0;
+		color: #4b5563;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid #27272a;
+		border-radius: 12px;
+	}
+	.comparison-table {
+		width: 100%;
+		border-collapse: collapse;
+		min-width: 940px;
+	}
+	.comparison-table th,
+	.comparison-table td {
+		padding: 12px 14px;
+		text-align: left;
+		border-bottom: 1px solid #27272a;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+	.comparison-table th {
+		font-size: 12px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: #a1a1aa;
+		background: #111113;
+	}
+	.comparison-table td {
+		color: #d4d4d8;
+		background: #09090b;
+	}
+	.tool-cell {
+		font-weight: 600;
+		color: #fafafa !important;
+	}
+	.highlight-row td {
+		background: #111827;
+	}
+
+	.faq-list {
+		border-top: 1px solid #27272a;
+	}
+	.faq-item {
+		border-bottom: 1px solid #27272a;
+	}
+	.faq-question {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 22px 0;
+		font-size: 17px;
+		font-weight: 500;
+		list-style: none;
+	}
+	.faq-question::-webkit-details-marker {
+		display: none;
+	}
+	.faq-icon {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		border: 1px solid #3f3f46;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 18px;
+		color: #71717a;
+		transition: transform 0.2s ease;
+	}
+	.group[open] .faq-icon {
+		transform: rotate(45deg);
+	}
+	.faq-answer p {
+		font-size: 15px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		padding: 0 0 20px;
+		margin: 0;
+	}
+
+	.cta-section {
+		background: #09090b;
+		border-top: 1px solid #27272a;
+		padding: 72px 24px;
+		display: flex;
+		justify-content: center;
+	}
+	.cta-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.cta-title {
+		font-size: 36px;
+		line-height: 1.2;
+		margin-bottom: 10px;
+	}
+	.cta-description {
+		font-size: 17px;
+		line-height: 1.6;
+		color: #71717a;
+		margin-bottom: 24px;
+	}
+	.cta-links {
+		display: flex;
+		align-items: center;
+		gap: 20px;
+		flex-wrap: wrap;
+	}
+	.cta-secondary {
+		font-size: 15px;
+		color: #71717a;
+		text-decoration: none;
+	}
+	.cta-secondary:hover {
+		color: #fafafa;
+	}
+
+	@media (max-width: 900px) {
+		.steps-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 768px) {
+		.hero-section,
+		.content-section,
+		.cta-section {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
+		.hero-section {
+			padding-top: 48px;
+			padding-bottom: 36px;
+		}
+		.hero-title {
+			font-size: 34px;
+		}
+		.hero-subtitle {
+			font-size: 18px;
+		}
+		.section-title {
+			font-size: 26px;
+		}
+		.cta-title {
+			font-size: 30px;
+		}
+	}
+</style>

--- a/apps/marketing/src/pages/use-cases/frontend-developers.astro
+++ b/apps/marketing/src/pages/use-cases/frontend-developers.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro'
-import Button from '../../components/ui/Button.astro'
+import UseCaseFaqSection from '../../components/use-cases/UseCaseFaqSection.astro'
+import UseCaseCtaSection from '../../components/use-cases/UseCaseCtaSection.astro'
 
 const SEO = {
 	title: 'AI Tool for Frontend Development with Runtime Context',
@@ -79,20 +80,34 @@ const comparisonRows = [
 		bestFor: 'Quick overlay workflow across frameworks'
 	}
 ]
+
+const textLinkClass =
+	'text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-400'
+const proseBulletBaseClass =
+	'relative py-2 pl-[22px] text-[17px] leading-[1.6] before:absolute before:left-0 before:top-[17px] before:h-2 before:w-2 before:rounded-full before:bg-primary-500'
+const tableHeaderClass =
+	'border-b border-zinc-800 bg-[#111113] px-[14px] py-3 text-left text-[12px] uppercase tracking-[0.06em] text-zinc-300'
+const tableCellClass =
+	'border-b border-zinc-800 bg-[#09090b] px-[14px] py-3 text-left text-[14px] leading-[1.5] text-zinc-300'
+const highlightedTableCellClass = `${tableCellClass} bg-slate-900`
+const tableToolCellClass = `${tableCellClass} font-semibold text-zinc-50`
+const highlightedTableToolCellClass = `${tableToolCellClass} bg-slate-900`
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
 
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Use Case</p>
-			<h1 class="hero-title">AI Tool for Frontend Development</h1>
-			<p class="hero-subtitle">
+	<section class="flex justify-center bg-[#09090b] px-5 pb-9 pt-12 text-zinc-50 md:px-6 md:pb-12 md:pt-20">
+		<div class="w-full max-w-[760px]">
+			<p class="mb-3 font-mono text-[13px] uppercase tracking-[0.12em] text-primary-500">Use Case</p>
+			<h1 class="mb-[14px] text-[34px] font-bold leading-[1.1] tracking-[-0.02em] text-zinc-50 md:text-[48px]">
+				AI Tool for Frontend Development
+			</h1>
+			<p class="mb-[18px] text-[18px] leading-[1.5] text-zinc-300 md:text-[20px]">
 				Frontman is an AI tool for frontend development that works from the running browser,
 				not just source files. Click an element, describe the change, and get a real code edit.
 			</p>
-			<p class="hero-summary">
+			<p class="text-[17px] leading-[1.7] text-zinc-300">
 				For CSS, layout, and component iteration, runtime context matters. Frontman connects to your
 				framework as middleware, sees the live DOM and styles, and applies changes with hot reload
 				while keeping your normal git workflow.
@@ -100,76 +115,98 @@ const comparisonRows = [
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Why file-only agents miss frontend intent</h2>
-			<div class="prose-content">
-				<p>
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]">
+				Why file-only agents miss frontend intent
+			</h2>
+			<div>
+				<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 					Frontend bugs are often runtime bugs: cascade conflicts, breakpoint behavior, unexpected component
 					nesting, and state-driven UI drift. Reading source files alone does not reveal the final rendered state.
 				</p>
-				<p>
+				<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 					Frontman closes that gap by combining runtime context with source-level edits. You can target the real
 					element on screen, then iterate in seconds instead of describing visual intent through a terminal loop.
 				</p>
-				<ul>
-					<li><strong>Rendered DOM visibility</strong> for actual structure and state.</li>
-					<li><strong>Computed CSS visibility</strong> for real spacing and style values.</li>
-					<li><strong>Framework awareness</strong> for safer edits in Next.js, Astro, and Vite apps.</li>
+				<ul class="my-3 list-none p-0">
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>Rendered DOM visibility</strong> for actual structure and state.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>Computed CSS visibility</strong> for real spacing and style values.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-300`}>
+						<strong>Framework awareness</strong> for safer edits in Next.js, Astro, and Vite apps.
+					</li>
 				</ul>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Frontend tasks where Frontman is strongest</h2>
-			<div class="task-grid">
-				<div class="task-card">
-					<h3>Layout and spacing fixes</h3>
-					<p>Resolve alignment issues and spacing inconsistencies directly on the rendered UI.</p>
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-[#09090b] md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-[#09090b] md:text-[32px]">
+				Frontend tasks where Frontman is strongest
+			</h2>
+			<div class="grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<h3 class="mb-2 text-[18px] text-slate-900">Layout and spacing fixes</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Resolve alignment issues and spacing inconsistencies directly on the rendered UI.
+					</p>
 				</div>
-				<div class="task-card">
-					<h3>Responsive tweaks</h3>
-					<p>Adjust behavior at breakpoints while seeing live component interactions.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<h3 class="mb-2 text-[18px] text-slate-900">Responsive tweaks</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Adjust behavior at breakpoints while seeing live component interactions.
+					</p>
 				</div>
-				<div class="task-card">
-					<h3>Component polish</h3>
-					<p>Refine states, typography, and hierarchy without manually tracing through files.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<h3 class="mb-2 text-[18px] text-slate-900">Component polish</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Refine states, typography, and hierarchy without manually tracing through files.
+					</p>
 				</div>
-				<div class="task-card">
-					<h3>Visual QA cleanup</h3>
-					<p>Fix copy, style, and consistency bugs discovered during review before they pile up.</p>
+				<div class="rounded-xl border border-zinc-200 bg-white p-[18px]">
+					<h3 class="mb-2 text-[18px] text-slate-900">Visual QA cleanup</h3>
+					<p class="m-0 text-[15px] leading-[1.6] text-slate-600">
+						Fix copy, style, and consistency bugs discovered during review before they pile up.
+					</p>
 				</div>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container-wide">
-			<h2 class="section-title">Frontend Workflow Comparison</h2>
-			<p class="section-intro">
+	<section class="flex justify-center bg-[#09090b] px-5 py-16 text-zinc-50 md:px-6">
+		<div class="w-full max-w-[980px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-zinc-50 md:text-[32px]">
+				Frontend Workflow Comparison
+			</h2>
+			<p class="mb-4 text-[17px] leading-[1.7] text-zinc-300">
 				Each tool can be useful. This table focuses on frontend editing accuracy and speed for existing apps.
 			</p>
-			<div class="table-wrap">
-				<table class="comparison-table">
+			<div class="overflow-x-auto rounded-xl border border-zinc-800">
+				<table class="w-full min-w-[760px] border-collapse">
 					<thead>
 						<tr>
-							<th>Tool</th>
-							<th>Sees Runtime UI</th>
-							<th>Click-to-Edit</th>
-							<th>Framework Context</th>
-							<th>Best For</th>
+							<th class={tableHeaderClass}>Tool</th>
+							<th class={tableHeaderClass}>Sees Runtime UI</th>
+							<th class={tableHeaderClass}>Click-to-Edit</th>
+							<th class={tableHeaderClass}>Framework Context</th>
+							<th class={tableHeaderClass}>Best For</th>
 						</tr>
 					</thead>
 					<tbody>
 						{comparisonRows.map((row) => (
-							<tr class={row.tool === 'Frontman' ? 'highlight-row' : ''}>
-								<td class="tool-cell">{row.tool}</td>
-								<td>{row.seesRuntime}</td>
-								<td>{row.clickToEdit}</td>
-								<td>{row.frameworkContext}</td>
-								<td>{row.bestFor}</td>
+							<tr>
+								<td class={row.tool === 'Frontman' ? highlightedTableToolCellClass : tableToolCellClass}>
+									{row.tool}
+								</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.seesRuntime}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.clickToEdit}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.frameworkContext}</td>
+								<td class={row.tool === 'Frontman' ? highlightedTableCellClass : tableCellClass}>{row.bestFor}</td>
 							</tr>
 						))}
 					</tbody>
@@ -178,347 +215,43 @@ const comparisonRows = [
 		</div>
 	</section>
 
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Where Frontman fits in your stack</h2>
-			<div class="prose-content prose-content--dark">
-				<p>
+	<section class="flex justify-center bg-zinc-50 px-5 py-16 text-[#09090b] md:px-6">
+		<div class="w-full max-w-[760px]">
+			<h2 class="mb-5 text-[26px] font-bold tracking-[-0.02em] text-[#09090b] md:text-[32px]">
+				Where Frontman fits in your stack
+			</h2>
+			<div>
+				<p class="mb-4 text-[17px] leading-[1.7] text-zinc-600">
 					Use Frontman when visual accuracy and iteration speed matter. Keep your IDE agent for backend logic,
 					terminal workflows, and broad codebase refactors. This split keeps each tool in its high-leverage lane.
 				</p>
-				<ul>
-					<li><strong>Frontman</strong> for browser-native UI edits and fast visual iteration.</li>
-					<li><strong>IDE agent</strong> for architecture, data layer, tests, and large refactors.</li>
-					<li><strong>Shared repo workflow</strong> so all changes remain reviewable in git.</li>
+				<ul class="my-3 list-none p-0">
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						<strong>Frontman</strong> for browser-native UI edits and fast visual iteration.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						<strong>IDE agent</strong> for architecture, data layer, tests, and large refactors.
+					</li>
+					<li class={`${proseBulletBaseClass} text-zinc-600`}>
+						<strong>Shared repo workflow</strong> so all changes remain reviewable in git.
+					</li>
 				</ul>
-				<p>
-					Need deeper architecture context? Read <a href="/how-it-works/" class="text-link">how Frontman works</a>.
-					Want full market context? Use the <a href="/compare/" class="text-link">comparison hub</a>.
+				<p class="mb-0 text-[17px] leading-[1.7] text-zinc-600">
+					Need deeper architecture context? Read <a href="/how-it-works/" class={textLinkClass}>how Frontman works</a>.
+					Want full market context? Use the <a href="/compare/" class={textLinkClass}>comparison hub</a>.
 				</p>
 			</div>
 		</div>
 	</section>
 
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
+	<UseCaseFaqSection faqs={faqs} />
 
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Ship frontend fixes at browser speed</h2>
-			<p class="cta-description">
-				Use Frontman for runtime-aware frontend edits, and keep the rest of your toolchain intact.
-			</p>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="/use-cases/designers/" class="cta-secondary">Designer workflow</a>
-				<a href="/integrations/" class="cta-secondary">Framework integrations</a>
-			</div>
-		</div>
-	</section>
+	<UseCaseCtaSection
+		title="Ship frontend fixes at browser speed"
+		description="Use Frontman for runtime-aware frontend edits, and keep the rest of your toolchain intact."
+		secondaryLinks={[
+			{href: '/use-cases/designers/', label: 'Designer workflow'},
+			{href: '/integrations/', label: 'Framework integrations'},
+		]}
+	/>
 </Layout>
-
-<style>
-	@reference "../../styles/global.css";
-
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 48px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #a259ff;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		margin-bottom: 14px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		line-height: 1.5;
-		color: #a1a1aa;
-		margin-bottom: 18px;
-	}
-	.hero-summary {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #71717a;
-	}
-
-	.text-link {
-		color: #a259ff;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.content-container-wide {
-		max-width: 980px;
-		width: 100%;
-	}
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		letter-spacing: -0.02em;
-		margin-bottom: 20px;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-	.section-intro {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 12px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.6;
-		padding: 8px 0 8px 22px;
-		position: relative;
-		color: #a1a1aa;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 17px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #a259ff;
-	}
-
-	.task-grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 16px;
-	}
-	.task-card {
-		background: white;
-		border: 1px solid #e4e4e7;
-		border-radius: 12px;
-		padding: 18px;
-	}
-	.task-card h3 {
-		font-size: 18px;
-		margin: 0 0 8px;
-		color: #111827;
-	}
-	.task-card p {
-		font-size: 15px;
-		line-height: 1.6;
-		margin: 0;
-		color: #4b5563;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-		border: 1px solid #27272a;
-		border-radius: 12px;
-	}
-	.comparison-table {
-		width: 100%;
-		border-collapse: collapse;
-		min-width: 760px;
-	}
-	.comparison-table th,
-	.comparison-table td {
-		padding: 12px 14px;
-		text-align: left;
-		border-bottom: 1px solid #27272a;
-		font-size: 14px;
-		line-height: 1.5;
-	}
-	.comparison-table th {
-		font-size: 12px;
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		color: #a1a1aa;
-		background: #111113;
-	}
-	.comparison-table td {
-		color: #d4d4d8;
-		background: #09090b;
-	}
-	.tool-cell {
-		font-weight: 600;
-		color: #fafafa !important;
-	}
-	.highlight-row td {
-		background: #111827;
-	}
-
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-	}
-	.faq-question {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 22px 0;
-		font-size: 17px;
-		font-weight: 500;
-		list-style: none;
-	}
-	.faq-question::-webkit-details-marker {
-		display: none;
-	}
-	.faq-icon {
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		color: #71717a;
-		transition: transform 0.2s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 0 0 20px;
-		margin: 0;
-	}
-
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 72px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 760px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		line-height: 1.2;
-		margin-bottom: 10px;
-	}
-	.cta-description {
-		font-size: 17px;
-		line-height: 1.6;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 20px;
-		flex-wrap: wrap;
-	}
-	.cta-secondary {
-		font-size: 15px;
-		color: #71717a;
-		text-decoration: none;
-	}
-	.cta-secondary:hover {
-		color: #fafafa;
-	}
-
-	@media (max-width: 900px) {
-		.task-grid {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 768px) {
-		.hero-section,
-		.content-section,
-		.cta-section {
-			padding-left: 20px;
-			padding-right: 20px;
-		}
-		.hero-section {
-			padding-top: 48px;
-			padding-bottom: 36px;
-		}
-		.hero-title {
-			font-size: 34px;
-		}
-		.hero-subtitle {
-			font-size: 18px;
-		}
-		.section-title {
-			font-size: 26px;
-		}
-		.cta-title {
-			font-size: 30px;
-		}
-	}
-</style>

--- a/apps/marketing/src/pages/use-cases/frontend-developers.astro
+++ b/apps/marketing/src/pages/use-cases/frontend-developers.astro
@@ -1,0 +1,524 @@
+---
+import Layout from '../../layouts/Layout.astro'
+import Button from '../../components/ui/Button.astro'
+
+const SEO = {
+	title: 'AI Tool for Frontend Development with Runtime Context',
+	description:
+		'Frontman is an AI tool for frontend development that sees your running app. Click elements, describe UI fixes, and generate source code edits with hot reload.'
+}
+
+const faqs = [
+	{
+		question: 'How is Frontman different from Cursor for frontend work?',
+		answer:
+			'Cursor is an IDE-first workflow that reads files and proposes edits. Frontman is browser-first and runtime-aware. It sees the rendered DOM, computed styles, and component context while you click real elements in your running app.'
+	},
+	{
+		question: 'Can I use Frontman with my existing AI stack?',
+		answer:
+			'Yes. Teams commonly use Frontman for visual frontend changes and keep Cursor, Copilot, or Claude Code for refactors, backend work, and terminal-heavy tasks. Frontman edits normal source files, so workflows stay compatible.'
+	},
+	{
+		question: 'What frontend stacks are supported?',
+		answer:
+			'Frontman supports Next.js, Astro, and Vite projects (React, Vue, Svelte). It installs as framework middleware so the agent can access runtime and source context together.'
+	},
+	{
+		question: 'Is Frontman useful for CSS and layout debugging?',
+		answer:
+			'Yes. This is a core use case. Because Frontman sees computed CSS and layout context, it can fix spacing, alignment, responsive behavior, and component styling with less trial-and-error than file-only agents.'
+	},
+	{
+		question: 'Does Frontman replace a full IDE agent?',
+		answer:
+			'No. Frontman is specialized for visual frontend iteration on running apps. IDE agents are still better for broad refactors, backend architecture changes, and complex codebase-wide tasks.'
+	}
+]
+
+const faqJsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'FAQPage',
+	mainEntity: faqs.map((faq) => ({
+		'@type': 'Question',
+		name: faq.question,
+		acceptedAnswer: {
+			'@type': 'Answer',
+			text: faq.answer
+		}
+	}))
+}
+
+const comparisonRows = [
+	{
+		tool: 'Frontman',
+		seesRuntime: 'Yes',
+		clickToEdit: 'Yes',
+		frameworkContext: 'Deep',
+		bestFor: 'Visual edits on existing frontend apps'
+	},
+	{
+		tool: 'Cursor',
+		seesRuntime: 'Partial',
+		clickToEdit: 'No',
+		frameworkContext: 'File-level',
+		bestFor: 'General coding and refactoring'
+	},
+	{
+		tool: 'GitHub Copilot',
+		seesRuntime: 'No',
+		clickToEdit: 'No',
+		frameworkContext: 'File-level',
+		bestFor: 'Autocomplete and IDE assistance'
+	},
+	{
+		tool: 'Stagewise',
+		seesRuntime: 'Yes',
+		clickToEdit: 'Yes',
+		frameworkContext: 'Limited',
+		bestFor: 'Quick overlay workflow across frameworks'
+	}
+]
+---
+
+<Layout title={SEO.title} description={SEO.description}>
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+
+	<section class="hero-section">
+		<div class="hero-container">
+			<p class="hero-label">Use Case</p>
+			<h1 class="hero-title">AI Tool for Frontend Development</h1>
+			<p class="hero-subtitle">
+				Frontman is an AI tool for frontend development that works from the running browser,
+				not just source files. Click an element, describe the change, and get a real code edit.
+			</p>
+			<p class="hero-summary">
+				For CSS, layout, and component iteration, runtime context matters. Frontman connects to your
+				framework as middleware, sees the live DOM and styles, and applies changes with hot reload
+				while keeping your normal git workflow.
+			</p>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container">
+			<h2 class="section-title">Why file-only agents miss frontend intent</h2>
+			<div class="prose-content">
+				<p>
+					Frontend bugs are often runtime bugs: cascade conflicts, breakpoint behavior, unexpected component
+					nesting, and state-driven UI drift. Reading source files alone does not reveal the final rendered state.
+				</p>
+				<p>
+					Frontman closes that gap by combining runtime context with source-level edits. You can target the real
+					element on screen, then iterate in seconds instead of describing visual intent through a terminal loop.
+				</p>
+				<ul>
+					<li><strong>Rendered DOM visibility</strong> for actual structure and state.</li>
+					<li><strong>Computed CSS visibility</strong> for real spacing and style values.</li>
+					<li><strong>Framework awareness</strong> for safer edits in Next.js, Astro, and Vite apps.</li>
+				</ul>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section content-section--light">
+		<div class="content-container">
+			<h2 class="section-title section-title--dark">Frontend tasks where Frontman is strongest</h2>
+			<div class="task-grid">
+				<div class="task-card">
+					<h3>Layout and spacing fixes</h3>
+					<p>Resolve alignment issues and spacing inconsistencies directly on the rendered UI.</p>
+				</div>
+				<div class="task-card">
+					<h3>Responsive tweaks</h3>
+					<p>Adjust behavior at breakpoints while seeing live component interactions.</p>
+				</div>
+				<div class="task-card">
+					<h3>Component polish</h3>
+					<p>Refine states, typography, and hierarchy without manually tracing through files.</p>
+				</div>
+				<div class="task-card">
+					<h3>Visual QA cleanup</h3>
+					<p>Fix copy, style, and consistency bugs discovered during review before they pile up.</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container-wide">
+			<h2 class="section-title">Frontend Workflow Comparison</h2>
+			<p class="section-intro">
+				Each tool can be useful. This table focuses on frontend editing accuracy and speed for existing apps.
+			</p>
+			<div class="table-wrap">
+				<table class="comparison-table">
+					<thead>
+						<tr>
+							<th>Tool</th>
+							<th>Sees Runtime UI</th>
+							<th>Click-to-Edit</th>
+							<th>Framework Context</th>
+							<th>Best For</th>
+						</tr>
+					</thead>
+					<tbody>
+						{comparisonRows.map((row) => (
+							<tr class={row.tool === 'Frontman' ? 'highlight-row' : ''}>
+								<td class="tool-cell">{row.tool}</td>
+								<td>{row.seesRuntime}</td>
+								<td>{row.clickToEdit}</td>
+								<td>{row.frameworkContext}</td>
+								<td>{row.bestFor}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section content-section--light">
+		<div class="content-container">
+			<h2 class="section-title section-title--dark">Where Frontman fits in your stack</h2>
+			<div class="prose-content prose-content--dark">
+				<p>
+					Use Frontman when visual accuracy and iteration speed matter. Keep your IDE agent for backend logic,
+					terminal workflows, and broad codebase refactors. This split keeps each tool in its high-leverage lane.
+				</p>
+				<ul>
+					<li><strong>Frontman</strong> for browser-native UI edits and fast visual iteration.</li>
+					<li><strong>IDE agent</strong> for architecture, data layer, tests, and large refactors.</li>
+					<li><strong>Shared repo workflow</strong> so all changes remain reviewable in git.</li>
+				</ul>
+				<p>
+					Need deeper architecture context? Read <a href="/how-it-works/" class="text-link">how Frontman works</a>.
+					Want full market context? Use the <a href="/compare/" class="text-link">comparison hub</a>.
+				</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="content-section">
+		<div class="content-container">
+			<h2 class="section-title">Frequently Asked Questions</h2>
+			<div class="faq-list">
+				{faqs.map((faq) => (
+					<details class="faq-item group">
+						<summary class="faq-question">
+							<span>{faq.question}</span>
+							<span class="faq-icon">+</span>
+						</summary>
+						<div class="faq-answer">
+							<p>{faq.answer}</p>
+						</div>
+					</details>
+				))}
+			</div>
+		</div>
+	</section>
+
+	<section class="cta-section">
+		<div class="cta-container">
+			<h2 class="cta-title">Ship frontend fixes at browser speed</h2>
+			<p class="cta-description">
+				Use Frontman for runtime-aware frontend edits, and keep the rest of your toolchain intact.
+			</p>
+			<div class="cta-links">
+				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+				<a href="/use-cases/designers/" class="cta-secondary">Designer workflow</a>
+				<a href="/integrations/" class="cta-secondary">Framework integrations</a>
+			</div>
+		</div>
+	</section>
+</Layout>
+
+<style>
+	@reference "../../styles/global.css";
+
+	.hero-section {
+		background: #09090b;
+		color: #fafafa;
+		padding: 80px 24px 48px;
+		display: flex;
+		justify-content: center;
+	}
+	.hero-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.hero-label {
+		@apply font-mono;
+		font-size: 13px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: #a259ff;
+		margin-bottom: 12px;
+	}
+	.hero-title {
+		font-size: 48px;
+		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.02em;
+		margin-bottom: 14px;
+	}
+	.hero-subtitle {
+		font-size: 20px;
+		line-height: 1.5;
+		color: #a1a1aa;
+		margin-bottom: 18px;
+	}
+	.hero-summary {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #71717a;
+	}
+
+	.text-link {
+		color: #a259ff;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+	.text-link:hover {
+		color: #c084fc;
+	}
+
+	.content-section {
+		background: #09090b;
+		color: #fafafa;
+		padding: 64px 24px;
+		display: flex;
+		justify-content: center;
+	}
+	.content-section--light {
+		background: #fafafa;
+		color: #09090b;
+	}
+	.content-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.content-container-wide {
+		max-width: 980px;
+		width: 100%;
+	}
+	.section-title {
+		font-size: 32px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		margin-bottom: 20px;
+	}
+	.section-title--dark {
+		color: #09090b;
+	}
+	.section-intro {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		margin-bottom: 16px;
+	}
+
+	.prose-content p {
+		font-size: 17px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		margin-bottom: 16px;
+	}
+	.prose-content--dark p {
+		color: #52525b;
+	}
+	.prose-content ul {
+		list-style: none;
+		padding: 0;
+		margin: 12px 0;
+	}
+	.prose-content li {
+		font-size: 17px;
+		line-height: 1.6;
+		padding: 8px 0 8px 22px;
+		position: relative;
+		color: #a1a1aa;
+	}
+	.prose-content--dark li {
+		color: #52525b;
+	}
+	.prose-content li::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 17px;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: #a259ff;
+	}
+
+	.task-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 16px;
+	}
+	.task-card {
+		background: white;
+		border: 1px solid #e4e4e7;
+		border-radius: 12px;
+		padding: 18px;
+	}
+	.task-card h3 {
+		font-size: 18px;
+		margin: 0 0 8px;
+		color: #111827;
+	}
+	.task-card p {
+		font-size: 15px;
+		line-height: 1.6;
+		margin: 0;
+		color: #4b5563;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid #27272a;
+		border-radius: 12px;
+	}
+	.comparison-table {
+		width: 100%;
+		border-collapse: collapse;
+		min-width: 760px;
+	}
+	.comparison-table th,
+	.comparison-table td {
+		padding: 12px 14px;
+		text-align: left;
+		border-bottom: 1px solid #27272a;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+	.comparison-table th {
+		font-size: 12px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: #a1a1aa;
+		background: #111113;
+	}
+	.comparison-table td {
+		color: #d4d4d8;
+		background: #09090b;
+	}
+	.tool-cell {
+		font-weight: 600;
+		color: #fafafa !important;
+	}
+	.highlight-row td {
+		background: #111827;
+	}
+
+	.faq-list {
+		border-top: 1px solid #27272a;
+	}
+	.faq-item {
+		border-bottom: 1px solid #27272a;
+	}
+	.faq-question {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 22px 0;
+		font-size: 17px;
+		font-weight: 500;
+		list-style: none;
+	}
+	.faq-question::-webkit-details-marker {
+		display: none;
+	}
+	.faq-icon {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		border: 1px solid #3f3f46;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 18px;
+		color: #71717a;
+		transition: transform 0.2s ease;
+	}
+	.group[open] .faq-icon {
+		transform: rotate(45deg);
+	}
+	.faq-answer p {
+		font-size: 15px;
+		line-height: 1.7;
+		color: #a1a1aa;
+		padding: 0 0 20px;
+		margin: 0;
+	}
+
+	.cta-section {
+		background: #09090b;
+		border-top: 1px solid #27272a;
+		padding: 72px 24px;
+		display: flex;
+		justify-content: center;
+	}
+	.cta-container {
+		max-width: 760px;
+		width: 100%;
+	}
+	.cta-title {
+		font-size: 36px;
+		line-height: 1.2;
+		margin-bottom: 10px;
+	}
+	.cta-description {
+		font-size: 17px;
+		line-height: 1.6;
+		color: #71717a;
+		margin-bottom: 24px;
+	}
+	.cta-links {
+		display: flex;
+		align-items: center;
+		gap: 20px;
+		flex-wrap: wrap;
+	}
+	.cta-secondary {
+		font-size: 15px;
+		color: #71717a;
+		text-decoration: none;
+	}
+	.cta-secondary:hover {
+		color: #fafafa;
+	}
+
+	@media (max-width: 900px) {
+		.task-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 768px) {
+		.hero-section,
+		.content-section,
+		.cta-section {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
+		.hero-section {
+			padding-top: 48px;
+			padding-bottom: 36px;
+		}
+		.hero-title {
+			font-size: 34px;
+		}
+		.hero-subtitle {
+			font-size: 18px;
+		}
+		.section-title {
+			font-size: 26px;
+		}
+		.cta-title {
+			font-size: 30px;
+		}
+	}
+</style>

--- a/apps/marketing/src/pages/vs/bolt.astro
+++ b/apps/marketing/src/pages/vs/bolt.astro
@@ -5,263 +5,247 @@
 // Key angle: Bolt generates new apps from scratch in a sandbox.
 //            Frontman lets designers/PMs iterate on the real product with AI — no IDE needed.
 
-import Layout from '../../layouts/Layout.astro'
-import ComparisonHero from '../../components/blocks/comparison/ComparisonHero.astro'
-import ComparisonFeatureTable from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-import type { ComparisonFeature } from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-import ComparisonPricing from '../../components/blocks/comparison/ComparisonPricing.astro'
-import ComparisonCTA from '../../components/blocks/comparison/ComparisonCTA.astro'
-import IntegrationContentSection from '../../components/blocks/integrations/IntegrationContentSection.astro'
-import IntegrationFAQ from '../../components/blocks/integrations/IntegrationFAQ.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs Bolt.new: Iterate on Your Real Product vs Generate New Apps',
-	description:
-		'Honest comparison for designers and PMs. Bolt generates new apps from prompts. Frontman lets you click elements in your real product, describe changes, and ship — no IDE needed. Feature table, pricing, and real differences.',
+const seo: SEOInfo = {
+  title: 'Frontman vs Bolt.new: Iterate on Your Real Product vs Generate New Apps',
+  description:
+    'Honest comparison for designers and PMs. Bolt generates new apps from prompts. Frontman lets you click elements in your real product, describe changes, and ship — no IDE needed. Feature table, pricing, and real differences.',
 }
 
-// Feature comparison data
+const competitor: CompetitorInfo = {
+  name: 'Bolt.new',
+  slug: 'bolt',
+  url: 'https://bolt.new',
+  category: 'DeveloperApplication',
+  description:
+    'AI-powered app generation platform by StackBlitz that creates full-stack apps in a WebContainer sandbox.',
+  pricing: {
+    cost: '$0–$2,250/mo',
+    model: 'Token-based, proprietary',
+    features: [
+      'Free: 300K tokens/day, 1M/month',
+      'Pro: $25/month (10M tokens/month)',
+      'Teams: $30/user/month (shared pool)',
+      'Enterprise: custom pricing',
+      'Per-seat pricing means costs scale with team size',
+    ],
+  },
+}
+
 const features: ComparisonFeature[] = [
-	{
-		name: 'Iterate on your real product',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Click elements in your running app and describe changes',
-		competitorNote: 'Generates new apps in a sandbox environment',
-	},
-	{
-		name: 'Works with existing design systems',
-		frontman: 'yes',
-		competitor: 'partial',
-		frontmanNote: 'Sees your actual components, tokens, and styles',
-		competitorNote: 'Prompt-to-app is the primary flow',
-	},
-	{
-		name: 'No IDE or coding required',
-		frontman: 'yes',
-		competitor: 'yes',
-		frontmanNote: 'Point, click, describe — changes happen in source',
-		competitorNote: 'Chat-based interface for generating apps',
-	},
-	{
-		name: 'Sees live DOM & computed styles',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Understands what actually renders, not just source code',
-		competitorNote: 'Sandbox preview only',
-	},
-	{
-		name: 'Click-to-select elements',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Select any element in your running product',
-		competitorNote: 'Chat-only interface',
-	},
-	{
-		name: 'Generate apps from scratch',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Core workflow: prompt to full-stack app',
-	},
-	{
-		name: 'Built-in hosting & databases',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Bolt Cloud with unlimited databases',
-	},
-	{
-		name: 'Figma import',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Import Figma designs into generated code',
-	},
-	{
-		name: 'Mobile app support',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Expo for React Native',
-	},
-	{
-		name: 'Component tree awareness',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Knows your React, Vue, or Svelte component hierarchy',
-		competitorNote: 'No runtime integration with frameworks',
-	},
-	{
-		name: 'Cross-team collaboration',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Designers and PMs edit alongside engineers in the same codebase',
-		competitorNote: 'Single-user sandbox sessions',
-	},
-	{
-		name: 'Hot reload feedback loop',
-		frontman: 'yes',
-		competitor: 'yes',
-		frontmanNote: 'Instant via framework HMR — see changes live',
-		competitorNote: 'Instant in sandbox preview',
-	},
-	{
-		name: 'Open source',
-		frontman: 'yes',
-		competitor: 'partial',
-		frontmanNote: 'Apache 2.0 client / AGPL-3.0 server',
-		competitorNote: 'bolt.diy is MIT but WebContainers needs commercial license',
-	},
-	{
-		name: 'BYOK (bring your own key)',
-		frontman: 'yes',
-		competitor: 'partial',
-		frontmanNote: 'Any LLM provider — no per-seat fees from Frontman',
-		competitorNote: 'Commercial Bolt locked to Anthropic; bolt.diy supports 19+ providers',
-	},
-	{
-		name: 'Self-hostable',
-		frontman: 'yes',
-		competitor: 'partial',
-		frontmanNote: 'Runs on your infrastructure',
-		competitorNote: 'bolt.diy can be self-hosted',
-	},
+  {
+    name: 'Iterate on your real product',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Click elements in your running app and describe changes',
+    competitorNote: 'Generates new apps in a sandbox environment',
+  },
+  {
+    name: 'Works with existing design systems',
+    frontman: 'yes',
+    competitor: 'partial',
+    frontmanNote: 'Sees your actual components, tokens, and styles',
+    competitorNote: 'Prompt-to-app is the primary flow',
+  },
+  {
+    name: 'No IDE or coding required',
+    frontman: 'yes',
+    competitor: 'yes',
+    frontmanNote: 'Point, click, describe — changes happen in source',
+    competitorNote: 'Chat-based interface for generating apps',
+  },
+  {
+    name: 'Sees live DOM & computed styles',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Understands what actually renders, not just source code',
+    competitorNote: 'Sandbox preview only',
+  },
+  {
+    name: 'Click-to-select elements',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Select any element in your running product',
+    competitorNote: 'Chat-only interface',
+  },
+  {
+    name: 'Generate apps from scratch',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Core workflow: prompt to full-stack app',
+  },
+  {
+    name: 'Built-in hosting & databases',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Bolt Cloud with unlimited databases',
+  },
+  {
+    name: 'Figma import',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Import Figma designs into generated code',
+  },
+  {
+    name: 'Mobile app support',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Expo for React Native',
+  },
+  {
+    name: 'Component tree awareness',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Knows your React, Vue, or Svelte component hierarchy',
+    competitorNote: 'No runtime integration with frameworks',
+  },
+  {
+    name: 'Cross-team collaboration',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Designers and PMs edit alongside engineers in the same codebase',
+    competitorNote: 'Single-user sandbox sessions',
+  },
+  {
+    name: 'Hot reload feedback loop',
+    frontman: 'yes',
+    competitor: 'yes',
+    frontmanNote: 'Instant via framework HMR — see changes live',
+    competitorNote: 'Instant in sandbox preview',
+  },
+  {
+    name: 'Open source',
+    frontman: 'yes',
+    competitor: 'partial',
+    frontmanNote: 'Apache 2.0 client / AGPL-3.0 server',
+    competitorNote: 'bolt.diy is MIT but WebContainers needs commercial license',
+  },
+  {
+    name: 'BYOK (bring your own key)',
+    frontman: 'yes',
+    competitor: 'partial',
+    frontmanNote: 'Any LLM provider — no per-seat fees from Frontman',
+    competitorNote: 'Commercial Bolt locked to Anthropic; bolt.diy supports 19+ providers',
+  },
+  {
+    name: 'Self-hostable',
+    frontman: 'yes',
+    competitor: 'partial',
+    frontmanNote: 'Runs on your infrastructure',
+    competitorNote: 'bolt.diy can be self-hosted',
+  },
 ]
 
-// FAQ data
-const faqs = [
-	{
-		question: 'Is Frontman an alternative to Bolt.new?',
-		answer: 'They solve different problems. Bolt.new generates new apps from chat prompts in a sandbox. Frontman lets you iterate on your existing product — click elements, describe changes, and ship. If your team already has a product and design system, Frontman is built for your workflow. They are complementary, not competing.',
-	},
-	{
-		question: 'Can designers and PMs use Frontman without an IDE?',
-		answer: 'Yes. Frontman runs in the browser alongside your real product. You click an element, describe the change you want, review the diff, and approve it. No VS Code, no terminal, no pull request workflow to learn. Your engineering team reviews the changes like any other code update.',
-	},
-	{
-		question: 'Can I use Bolt.new and Frontman together?',
-		answer: 'Yes, and it is a natural workflow. Use Bolt to generate an initial prototype, clone the result locally, add Frontman middleware to your dev server, and then iterate visually — clicking elements, describing changes, and getting source code edits with full browser context.',
-	},
-	{
-		question: 'Does Frontman work with our design system?',
-		answer: 'Yes. Because Frontman sees your actual running app — the real DOM, computed styles, and component tree — it understands your design system tokens, component library, and CSS approach. MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed.',
-	},
-	{
-		question: 'Is Frontman really free compared to Bolt\'s token system?',
-		answer: 'Yes. Frontman is completely free with BYOK — you bring your own API keys and pay your LLM provider directly. No per-seat fees, no token limits, no monthly subscription from Frontman. Bolt\'s free tier caps you at 300K tokens per day. Heavy Bolt usage costs $25 to $2,250 per month depending on your plan.',
-	},
-	{
-		question: 'How does Frontman fit into a multi-team workflow?',
-		answer: 'Frontman bridges the gap between design and engineering. Designers and PMs can make UI changes directly in the running product, and engineers review those changes as normal code diffs. No more design-to-dev handoff delays, no more "can you move this 2px left" tickets. Everyone works on the same codebase.',
-	},
-	{
-		question: 'What about bolt.diy (the open-source fork)?',
-		answer: 'bolt.diy is the MIT-licensed community fork with BYOK support for 19+ providers. But like Bolt itself, bolt.diy is a prompt-to-app generator that runs in a sandbox. Frontman is a different tool — it lets your team iterate on your real product with AI that sees the live DOM, component tree, and design system.',
-	},
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an alternative to Bolt.new?',
+    answer:
+      'They solve different problems. Bolt.new generates new apps from chat prompts in a sandbox. Frontman lets you iterate on your existing product — click elements, describe changes, and ship. If your team already has a product and design system, Frontman is built for your workflow. They are complementary, not competing.',
+  },
+  {
+    question: 'Can designers and PMs use Frontman without an IDE?',
+    answer:
+      'Yes. Frontman runs in the browser alongside your real product. You click an element, describe the change you want, review the diff, and approve it. No VS Code, no terminal, no pull request workflow to learn. Your engineering team reviews the changes like any other code update.',
+  },
+  {
+    question: 'Can I use Bolt.new and Frontman together?',
+    answer:
+      'Yes, and it is a natural workflow. Use Bolt to generate an initial prototype, clone the result locally, add Frontman middleware to your dev server, and then iterate visually — clicking elements, describing changes, and getting source code edits with full browser context.',
+  },
+  {
+    question: 'Does Frontman work with our design system?',
+    answer:
+      'Yes. Because Frontman sees your actual running app — the real DOM, computed styles, and component tree — it understands your design system tokens, component library, and CSS approach. MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed.',
+  },
+  {
+    question: 'Is Frontman really free compared to Bolt\'s token system?',
+    answer:
+      'Yes. Frontman is completely free with BYOK — you bring your own API keys and pay your LLM provider directly. No per-seat fees, no token limits, no monthly subscription from Frontman. Bolt\'s free tier caps you at 300K tokens per day. Heavy Bolt usage costs $25 to $2,250 per month depending on your plan.',
+  },
+  {
+    question: 'How does Frontman fit into a multi-team workflow?',
+    answer:
+      'Frontman bridges the gap between design and engineering. Designers and PMs can make UI changes directly in the running product, and engineers review those changes as normal code diffs. No more design-to-dev handoff delays, no more "can you move this 2px left" tickets. Everyone works on the same codebase.',
+  },
+  {
+    question: 'What about bolt.diy (the open-source fork)?',
+    answer:
+      'bolt.diy is the MIT-licensed community fork with BYOK support for 19+ providers. But like Bolt itself, bolt.diy is a prompt-to-app generator that runs in a sandbox. Frontman is a different tool — it lets your team iterate on your real product with AI that sees the live DOM, component tree, and design system.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer,
-		},
-	})),
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Bolt.new"
+  heroSubtitle="Iterate on Your Real Product vs Generate New Apps"
+  features={features}
+  faqs={faqs}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://bolt.new" class="text-link" rel="nofollow">Bolt.new</a> both use AI for frontend work, but they solve different problems at different stages. Bolt generates entire apps from chat prompts in a sandbox. Frontman lets your team — designers, PMs, and engineers — iterate on the product you already ship.
+    </p>
+    <p>
+      <strong>Frontman</strong> is an open-source AI agent that hooks into your dev server. It sees the live DOM, your component library, computed styles, and design tokens. Click any element in your running product, describe the change in plain English, and Frontman edits the source files. No IDE needed — designers and PMs work directly in the browser. Free and unlimited with BYOK.
+    </p>
+    <p>
+      <strong>Bolt.new</strong> is StackBlitz\'s AI-powered app generation platform. Describe what you want in a chat prompt — or import a Figma design — and Bolt generates a complete app in a WebContainer sandbox. Great for prototypes and MVPs. Token-based pricing starting at free (300K tokens/day).
+    </p>
+    <p class="summary-emphasis">
+      The core difference: Bolt generates new apps from scratch. Frontman lets your whole team iterate on the product you already have — with AI that understands your design system and real codebase.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<ComparisonHero title="Frontman vs Bolt.new" subtitle="Iterate on Your Real Product vs Generate New Apps">
-		<p>
-			<a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://bolt.new" class="text-link" rel="nofollow">Bolt.new</a> both use AI for frontend work, but they solve different problems at different stages. Bolt generates entire apps from chat prompts in a sandbox. Frontman lets your team — designers, PMs, and engineers — iterate on the product you already ship.
-		</p>
-		<p>
-			<strong>Frontman</strong> is an open-source AI agent that hooks into your dev server. It sees the live DOM, your component library, computed styles, and design tokens. Click any element in your running product, describe the change in plain English, and Frontman edits the source files. No IDE needed — designers and PMs work directly in the browser. Free and unlimited with BYOK.
-		</p>
-		<p>
-			<strong>Bolt.new</strong> is StackBlitz's AI-powered app generation platform. Describe what you want in a chat prompt — or import a Figma design — and Bolt generates a complete app in a WebContainer sandbox. Great for prototypes and MVPs. Token-based pricing starting at free (300K tokens/day).
-		</p>
-		<p class="summary-emphasis">
-			The core difference: Bolt generates new apps from scratch. Frontman lets your whole team iterate on the product you already have — with AI that understands your design system and real codebase.
-		</p>
-		<ComparisonDisclosure competitor="Bolt" />
-	</ComparisonHero>
+  <Fragment slot="competitor-strengths">
+    <p>Bolt.new is the fastest way to go from an idea to a working app — and it is genuinely great at that.</p>
+    <p><strong>Prompt-to-app is the core loop.</strong> Describe what you want ("a project management app with Kanban boards and user auth") and Bolt generates a complete, working app in its sandbox. For prototyping an idea to show stakeholders or validating a concept before committing engineering resources, it is hard to beat.</p>
+    <p>Bolt generates backend code, database schemas, and API routes — not just UI. The WebContainer sandbox runs a full Node.js environment in the browser, so you get a working app, not a static mockup.</p>
+    <p><strong>Bolt Cloud removes deployment friction.</strong> Generated apps deploy to Bolt Cloud with hosting, databases, and custom domains. From idea to shareable URL without touching infrastructure — useful when a PM needs a quick proof-of-concept.</p>
+    <p><strong>Figma-to-code.</strong> Import Figma designs and Bolt converts them into working code. A natural bridge for design teams exploring a new concept.</p>
+    <p><strong>Mobile via Expo.</strong> Bolt can also generate React Native apps via Expo — Frontman is web-only.</p>
+    <p><strong>bolt.diy is fully open.</strong> The community fork (bolt.diy) is MIT-licensed and supports 19+ LLM providers via BYOK. If you want the Bolt experience without vendor lock-in, bolt.diy is a real option — though the WebContainers API itself requires a commercial license for production use.</p>
+  </Fragment>
 
-	<!-- Feature Comparison Table -->
-	<ComparisonFeatureTable competitorName="Bolt.new" features={features} />
+  <Fragment slot="frontman-differentiators">
+    <p>Bolt builds new apps. Frontman helps your team iterate on the product you already have. The overlap is "AI + frontend," but the workflows do not intersect.</p>
+    <p><strong>Your real product, not a sandbox.</strong> Frontman works inside your actual running application. It sees your component library, design tokens, computed styles, and routing. When a designer clicks a button and says "make this match our updated brand colors," Frontman edits the real source files — using your actual design system components, not generating new ones from scratch.</p>
+    <p><strong>Built for teams with an existing design system.</strong> Bolt\'s sandbox does not know about your design tokens, component conventions, or how your UI actually behaves across breakpoints. Frontman sees all of this because it runs inside your real app. Changes respect your existing patterns instead of inventing new ones.</p>
+    <p><strong>Click-to-edit instead of chat-to-generate.</strong> Bolt\'s interface is chat-first — you describe what you want and it generates entire files. Frontman is visual-first — a designer or PM clicks an element in the running product, describes the change, and the AI edits the source with full context. No need to describe where something is or what it looks like.</p>
+    <p><strong>Bridges design and engineering.</strong> Frontman lets designers and PMs make UI changes directly, with engineers reviewing the diffs like normal code. No more "can you move this 2px" tickets. No more screenshot-annotated Figma comments that get lost. Changes happen in the same codebase, through the same review process.</p>
+    <p><strong>Open source and BYOK.</strong> Bolt.new is a proprietary SaaS with per-seat token pricing. Frontman\'s client libraries are Apache 2.0, server is AGPL-3.0. You bring your own API keys — no per-seat fees, no token limits, no monthly subscription from Frontman. For a growing team, the cost difference compounds fast.</p>
+  </Fragment>
 
-	<!-- What Bolt.new Does Well -->
-	<IntegrationContentSection title="What Bolt.new Does Well" variant="light">
-		<p>Bolt.new is the fastest way to go from an idea to a working app — and it's genuinely great at that.</p>
-		<p><strong>Prompt-to-app is the core loop.</strong> Describe what you want ("a project management app with Kanban boards and user auth") and Bolt generates a complete, working app in its sandbox. For prototyping an idea to show stakeholders or validating a concept before committing engineering resources, it's hard to beat.</p>
-		<p>Bolt generates backend code, database schemas, and API routes — not just UI. The WebContainer sandbox runs a full Node.js environment in the browser, so you get a working app, not a static mockup.</p>
-		<p><strong>Bolt Cloud removes deployment friction.</strong> Generated apps deploy to Bolt Cloud with hosting, databases, and custom domains. From idea to shareable URL without touching infrastructure — useful when a PM needs a quick proof-of-concept.</p>
-		<p><strong>Figma-to-code.</strong> Import Figma designs and Bolt converts them into working code. A natural bridge for design teams exploring a new concept.</p>
-		<p><strong>Mobile via Expo.</strong> Bolt can also generate React Native apps via Expo — Frontman is web-only.</p>
-		<p><strong>bolt.diy is fully open.</strong> The community fork (bolt.diy) is MIT-licensed and supports 19+ LLM providers via BYOK. If you want the Bolt experience without vendor lock-in, bolt.diy is a real option — though the WebContainers API itself requires a commercial license for production use.</p>
-	</IntegrationContentSection>
+  <Fragment slot="who-should-use-competitor">
+    <p>Bolt.new is the better choice when you are starting from zero:</p>
+    <ul>
+      <li><strong>Prototyping and proof-of-concepts</strong> — a PM needs a working demo to validate an idea with stakeholders before committing engineering time</li>
+      <li><strong>Greenfield app generation</strong> — turning a chat prompt into a complete full-stack app as fast as possible</li>
+      <li><strong>Hackathon-speed exploration</strong> — go from idea to shareable URL in minutes</li>
+      <li><strong>Figma-to-code for new projects</strong> — converting designs into working apps when there is no existing codebase</li>
+      <li><strong>Mobile apps via Expo</strong> — generating React Native apps from prompts</li>
+      <li><strong>Quick deployment</strong> — Bolt Cloud handles hosting, databases, and custom domains</li>
+    </ul>
+  </Fragment>
 
-	<!-- Where Frontman Is Different -->
-	<IntegrationContentSection title="Where Frontman Is Different">
-		<p>Bolt builds new apps. Frontman helps your team iterate on the product you already have. The overlap is "AI + frontend," but the workflows don't intersect.</p>
-		<p><strong>Your real product, not a sandbox.</strong> Frontman works inside your actual running application. It sees your component library, design tokens, computed styles, and routing. When a designer clicks a button and says "make this match our updated brand colors," Frontman edits the real source files — using your actual design system components, not generating new ones from scratch.</p>
-		<p><strong>Built for teams with an existing design system.</strong> Bolt's sandbox doesn't know about your design tokens, component conventions, or how your UI actually behaves across breakpoints. Frontman sees all of this because it runs inside your real app. Changes respect your existing patterns instead of inventing new ones.</p>
-		<p><strong>Click-to-edit instead of chat-to-generate.</strong> Bolt's interface is chat-first — you describe what you want and it generates entire files. Frontman is visual-first — a designer or PM clicks an element in the running product, describes the change, and the AI edits the source with full context. No need to describe where something is or what it looks like.</p>
-		<p><strong>Bridges design and engineering.</strong> Frontman lets designers and PMs make UI changes directly, with engineers reviewing the diffs like normal code. No more "can you move this 2px" tickets. No more screenshot-annotated Figma comments that get lost. Changes happen in the same codebase, through the same review process.</p>
-		<p><strong>Open source and BYOK.</strong> Bolt.new is a proprietary SaaS with per-seat token pricing. Frontman's client libraries are Apache 2.0, server is AGPL-3.0. You bring your own API keys — no per-seat fees, no token limits, no monthly subscription from Frontman. For a growing team, the cost difference compounds fast.</p>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Bolt.new -->
-	<IntegrationContentSection title="Who Should Use Bolt.new" variant="light">
-		<p>Bolt.new is the better choice when you're starting from zero:</p>
-		<ul>
-			<li><strong>Prototyping and proof-of-concepts</strong> — a PM needs a working demo to validate an idea with stakeholders before committing engineering time</li>
-			<li><strong>Greenfield app generation</strong> — turning a chat prompt into a complete full-stack app as fast as possible</li>
-			<li><strong>Hackathon-speed exploration</strong> — go from idea to shareable URL in minutes</li>
-			<li><strong>Figma-to-code for new projects</strong> — converting designs into working apps when there's no existing codebase</li>
-			<li><strong>Mobile apps via Expo</strong> — generating React Native apps from prompts</li>
-			<li><strong>Quick deployment</strong> — Bolt Cloud handles hosting, databases, and custom domains</li>
-		</ul>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Frontman -->
-	<IntegrationContentSection title="Who Should Use Frontman">
-		<p>Frontman is the better choice when your team has a real product and wants to move faster on UI:</p>
-		<ul>
-			<li><strong>Designers iterating on a live product</strong> — click elements, describe changes, see them instantly — no IDE, no handoff tickets</li>
-			<li><strong>PMs making UI tweaks</strong> — update copy, adjust spacing, refine layouts directly in the running product instead of filing Jira tickets</li>
-			<li><strong>Teams with an existing design system</strong> — Frontman sees your actual tokens, components, and styles, so changes respect your system instead of reinventing it</li>
-			<li><strong>Multi-team orgs reducing design-to-dev bottlenecks</strong> — designers and PMs contribute changes that engineers review as normal code diffs</li>
-			<li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
-			<li><strong>Growing teams watching costs</strong> — open source, BYOK, no per-seat fees — scales with your team without scaling your bill</li>
-		</ul>
-		<p>A natural workflow: use Bolt to generate an initial prototype, clone it locally, add Frontman middleware, and let your whole team iterate visually from there.</p>
-	</IntegrationContentSection>
-
-	<!-- Pricing Comparison -->
-	<ComparisonPricing
-		competitorName="Bolt.new"
-		competitorCost="$0–$2,250/mo"
-		competitorModel="Token-based, proprietary"
-		competitorFeatures={[
-			'Free: 300K tokens/day, 1M/month',
-			'Pro: $25/month (10M tokens/month)',
-			'Teams: $30/user/month (shared pool)',
-			'Enterprise: custom pricing',
-			'Per-seat pricing means costs scale with team size',
-		]}
-	/>
-
-	<!-- FAQ -->
-	<IntegrationFAQ faqs={faqs} />
-
-	<!-- CTA -->
-	<ComparisonCTA />
-</Layout>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when your team has a real product and wants to move faster on UI:</p>
+    <ul>
+      <li><strong>Designers iterating on a live product</strong> — click elements, describe changes, see them instantly — no IDE, no handoff tickets</li>
+      <li><strong>PMs making UI tweaks</strong> — update copy, adjust spacing, refine layouts directly in the running product instead of filing Jira tickets</li>
+      <li><strong>Teams with an existing design system</strong> — Frontman sees your actual tokens, components, and styles, so changes respect your system instead of reinventing it</li>
+      <li><strong>Multi-team orgs reducing design-to-dev bottlenecks</strong> — designers and PMs contribute changes that engineers review as normal code diffs</li>
+      <li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
+      <li><strong>Growing teams watching costs</strong> — open source, BYOK, no per-seat fees — scales with your team without scaling your bill</li>
+    </ul>
+    <p>A natural workflow: use Bolt to generate an initial prototype, clone it locally, add Frontman middleware, and let your whole team iterate visually from there.</p>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/claude-code.astro
+++ b/apps/marketing/src/pages/vs/claude-code.astro
@@ -3,800 +3,209 @@
 // Targets "claude code vs" and "claude code alternative" queries
 // Claude Code is Anthropic's agentic coding tool — terminal-native, multi-surface.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
 import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs Claude Code: Browser vs Terminal (2026)',
-	description:
-		'Frontman sees your browser DOM and running app. Claude Code works in the terminal. Compare features, architecture, and pricing side by side.'
+const seo: SEOInfo = {
+  title: 'Frontman vs Claude Code: Browser vs Terminal (2026)',
+  description:
+    'Frontman sees your browser DOM and running app. Claude Code works in the terminal. Compare features, architecture, and pricing side by side.',
 }
 
-// Comparison data
+const frontmanPricingFeatures = [
+  'Unlimited usage, no caps',
+  'Bring your own API keys (Claude, ChatGPT, OpenRouter)',
+  'Or sign in with Claude/ChatGPT subscription via OAuth',
+  'Apache 2.0 (client) / AGPL-3.0 (server)',
+  'You pay your LLM provider directly',
+]
+
+const competitorPricingFeatures = [
+  'No free tier for Claude Code',
+  'Pro: $20/month — included, usage limits apply',
+  'Max 5x: $100/month — 5x Pro usage',
+  'Max 20x: $200/month — 20x Pro usage',
+  'API: pay-per-token (Sonnet $3/$15, Opus $5/$25 per MTok)',
+  'Team: $20-100/seat/month',
+]
+
+const competitor: CompetitorInfo = {
+  name: 'Claude Code',
+  slug: 'claude-code',
+  url: 'https://claude.ai/code',
+  category: 'DeveloperApplication',
+  description:
+    'Agentic coding assistant from Anthropic that runs in terminal, IDEs, and web with strong shell and git workflows.',
+  pricing: {
+    cost: '$20–$200/mo',
+    model: 'Subscription, proprietary',
+    features: competitorPricingFeatures,
+  },
+}
+
 type Status = 'yes' | 'no' | 'partial'
 
 type Feature = {
-	name: string
-	frontman: Status
-	claudeCode: Status
-	frontmanNote?: string
-	claudeCodeNote?: string
+  name: string
+  frontman: Status
+  claudeCode: Status
+  frontmanNote?: string
+  claudeCodeNote?: string
 }
 
 const features: Feature[] = [
-	{ name: 'Sees live DOM & styles', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Browser-side MCP server inspects the live page', claudeCodeNote: 'Chrome extension (beta) — screenshots and DOM, not component tree' },
-	{ name: 'Sees computed CSS', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Runtime values, not class names', claudeCodeNote: 'Reads source files; Chrome extension sees DOM but not computed styles' },
-	{ name: 'Click-to-select elements', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Visual component selection', claudeCodeNote: 'Chrome extension is AI-driven, not developer-directed' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Instant in browser via HMR', claudeCodeNote: 'Edits files; can refresh via Chrome extension but no HMR integration' },
-	{ name: 'File editing', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Edits source files', claudeCodeNote: 'Full file system access with diff review' },
-	{ name: 'Terminal commands', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'Runs shell commands, builds, tests, git operations' },
-	{ name: 'Agent mode', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Browser-context agent', claudeCodeNote: 'Agentic search, multi-step plans, sub-agents' },
-	{ name: 'Multi-file refactoring', frontman: 'partial', claudeCode: 'yes', frontmanNote: 'Can edit multiple files, not primary workflow', claudeCodeNote: 'Full codebase reasoning, cross-file edits' },
-	{ name: 'Framework-aware', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Deep plugin for Next.js, Astro, Vite', claudeCodeNote: 'Framework-agnostic; reads files, not runtime' },
-	{ name: 'Designer/PM friendly', frontman: 'yes', claudeCode: 'no', frontmanNote: 'No IDE or terminal needed', claudeCodeNote: 'Requires terminal or IDE proficiency' },
-	{ name: 'Open source', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', claudeCodeNote: 'Proprietary ("All rights reserved")' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Any LLM provider directly', claudeCodeNote: 'Claude models only (via subscription or API key)' },
-	{ name: 'Self-hostable', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Everything runs locally', claudeCodeNote: 'Runs locally but requires Anthropic API' },
-	{ name: 'Works in the browser', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Primary interface is the browser', claudeCodeNote: 'claude.ai/code web interface exists; Chrome extension is beta' },
-	{ name: 'Git & PR workflows', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'Commits, branches, PRs, GitHub Actions integration' },
-	{ name: 'MCP support', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Browser-side MCP server', claudeCodeNote: 'First-class MCP with hundreds of integrations' },
-	{ name: 'IDE integration', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'VS Code, JetBrains, Cursor, Windsurf' },
-	{ name: 'Backend coding', frontman: 'partial', claudeCode: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', claudeCodeNote: 'Any language, any framework, any stack' },
+  { name: 'Sees live DOM & styles', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Browser-side MCP server inspects the live page', claudeCodeNote: 'Chrome extension (beta) — screenshots and DOM, not component tree' },
+  { name: 'Sees computed CSS', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Runtime values, not class names', claudeCodeNote: 'Reads source files; Chrome extension sees DOM but not computed styles' },
+  { name: 'Click-to-select elements', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Visual component selection', claudeCodeNote: 'Chrome extension is AI-driven, not developer-directed' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Instant in browser via HMR', claudeCodeNote: 'Edits files; can refresh via Chrome extension but no HMR integration' },
+  { name: 'File editing', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Edits source files', claudeCodeNote: 'Full file system access with diff review' },
+  { name: 'Terminal commands', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'Runs shell commands, builds, tests, git operations' },
+  { name: 'Agent mode', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Browser-context agent', claudeCodeNote: 'Agentic search, multi-step plans, sub-agents' },
+  { name: 'Multi-file refactoring', frontman: 'partial', claudeCode: 'yes', frontmanNote: 'Can edit multiple files, not primary workflow', claudeCodeNote: 'Full codebase reasoning, cross-file edits' },
+  { name: 'Framework-aware', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Deep plugin for Next.js, Astro, Vite', claudeCodeNote: 'Framework-agnostic; reads files, not runtime' },
+  { name: 'Designer/PM friendly', frontman: 'yes', claudeCode: 'no', frontmanNote: 'No IDE or terminal needed', claudeCodeNote: 'Requires terminal or IDE proficiency' },
+  { name: 'Open source', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', claudeCodeNote: 'Proprietary ("All rights reserved")' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Any LLM provider directly', claudeCodeNote: 'Claude models only (via subscription or API key)' },
+  { name: 'Self-hostable', frontman: 'yes', claudeCode: 'no', frontmanNote: 'Everything runs locally', claudeCodeNote: 'Runs locally but requires Anthropic API' },
+  { name: 'Works in the browser', frontman: 'yes', claudeCode: 'partial', frontmanNote: 'Primary interface is the browser', claudeCodeNote: 'claude.ai/code web interface exists; Chrome extension is beta' },
+  { name: 'Git & PR workflows', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'Commits, branches, PRs, GitHub Actions integration' },
+  { name: 'MCP support', frontman: 'yes', claudeCode: 'yes', frontmanNote: 'Browser-side MCP server', claudeCodeNote: 'First-class MCP with hundreds of integrations' },
+  { name: 'IDE integration', frontman: 'no', claudeCode: 'yes', claudeCodeNote: 'VS Code, JetBrains, Cursor, Windsurf' },
+  { name: 'Backend coding', frontman: 'partial', claudeCode: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', claudeCodeNote: 'Any language, any framework, any stack' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
+const comparisonFeatures: ComparisonFeature[] = features.map((feature) => ({
+  name: feature.name,
+  frontman: feature.frontman,
+  competitor: feature.claudeCode,
+  frontmanNote: feature.frontmanNote,
+  competitorNote: feature.claudeCodeNote,
+}))
 
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'Is Frontman an alternative to Claude Code?',
-		answer: 'They solve different problems. Claude Code is a terminal-native agentic coding tool that reads your codebase, edits files, runs commands, and handles git workflows. It works with any language and any project. Frontman is browser middleware for frontend development — it hooks into your framework (Next.js, Astro, Vite), sees the live DOM, and lets you click elements to edit their source code. For visual frontend editing with runtime context, Frontman is the tool. For general-purpose agentic coding across your full stack, Claude Code is the tool.'
-	},
-	{
-		question: 'Can Claude Code see what my app looks like in the browser?',
-		answer: 'Partially. Claude Code has a Chrome extension (beta) that can open tabs, take screenshots, read console errors, and click elements. But this is AI-driven automation — Claude decides what to look at and interact with. It is not a developer-directed "click this element, change it" workflow. The Chrome extension also doesn\'t access the framework component tree, computed CSS values, or server-side context. Frontman provides all of this by default because it runs inside your dev server as middleware.'
-	},
-	{
-		question: 'Can I use Frontman and Claude Code together?',
-		answer: 'Yes. Claude Code runs in your terminal or IDE. Frontman runs in the browser. They edit the same source files. Use Claude Code for backend work, refactoring, test writing, git operations, and complex multi-file changes. Use Frontman for visual frontend edits where you want to click a UI element, see computed styles, and get immediate hot-reload feedback.'
-	},
-	{
-		question: 'Is Frontman free compared to Claude Code?',
-		answer: 'Yes. Claude Code requires a paid Claude subscription: Pro ($20/month), Max ($100-200/month), or API access (pay-per-token). There is no free tier for Claude Code. Frontman is free to self-host with no limits — you bring your own API keys and pay your LLM provider directly. The Frontman client libraries are Apache 2.0 and the server is AGPL-3.0.'
-	},
-	{
-		question: 'What does Frontman see that Claude Code cannot?',
-		answer: 'Frontman hooks into your framework as middleware. It sees the React/Vue/Svelte component tree with props and state, computed CSS (actual pixel values, not class names), server-side routes and logs, the full DOM as rendered at the current viewport, and uses source maps to trace any clicked element back to its exact file and line. Claude Code reads source files and can take screenshots via the Chrome extension, but it does not have access to the framework runtime, component hierarchy, or computed styles.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an alternative to Claude Code?',
+    answer:
+      'They solve different problems. Claude Code is a terminal-native agentic coding tool that reads your codebase, edits files, runs commands, and handles git workflows. It works with any language and any project. Frontman is browser middleware for frontend development — it hooks into your framework (Next.js, Astro, Vite), sees the live DOM, and lets you click elements to edit their source code. For visual frontend editing with runtime context, Frontman is the tool. For general-purpose agentic coding across your full stack, Claude Code is the tool.',
+  },
+  {
+    question: 'Can Claude Code see what my app looks like in the browser?',
+    answer:
+      'Partially. Claude Code has a Chrome extension (beta) that can open tabs, take screenshots, read console errors, and click elements. But this is AI-driven automation — Claude decides what to look at and interact with. It is not a developer-directed "click this element, change it" workflow. The Chrome extension also does not access the framework component tree, computed CSS values, or server-side context. Frontman provides all of this by default because it runs inside your dev server as middleware.',
+  },
+  {
+    question: 'Can I use Frontman and Claude Code together?',
+    answer:
+      'Yes. Claude Code runs in your terminal or IDE. Frontman runs in the browser. They edit the same source files. Use Claude Code for backend work, refactoring, test writing, git operations, and complex multi-file changes. Use Frontman for visual frontend edits where you want to click a UI element, see computed styles, and get immediate hot-reload feedback.',
+  },
+  {
+    question: 'Is Frontman free compared to Claude Code?',
+    answer:
+      'Yes. Claude Code requires a paid Claude subscription: Pro ($20/month), Max ($100-200/month), or API access (pay-per-token). There is no free tier for Claude Code. Frontman is free to self-host with no limits — you bring your own API keys and pay your LLM provider directly. The Frontman client libraries are Apache 2.0 and the server is AGPL-3.0.',
+  },
+  {
+    question: 'What does Frontman see that Claude Code cannot?',
+    answer:
+      'Frontman hooks into your framework as middleware. It sees the React/Vue/Svelte component tree with props and state, computed CSS (actual pixel values, not class names), server-side routes and logs, the full DOM as rendered at the current viewport, and uses source maps to trace any clicked element back to its exact file and line. Claude Code reads source files and can take screenshots via the Chrome extension, but it does not have access to the framework runtime, component hierarchy, or computed styles.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Claude Code"
+  heroSubtitle="Browser Middleware vs Terminal Agent"
+  features={comparisonFeatures}
+  faqs={faqs}
+  frontmanPricing={{ features: frontmanPricingFeatures }}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> is open-source browser middleware for AI-assisted frontend editing. It hooks into Next.js, Astro, or Vite as a framework plugin, runs a browser-side MCP server that inspects the live DOM and computed CSS, and lets you click any element to edit its source code with hot reload. Apache 2.0 client libraries, AGPL-3.0 server, BYOK.
+    </p>
+    <p>
+      <a href="https://claude.ai/code" class="text-link" rel="nofollow">Claude Code</a> is Anthropic\'s agentic coding tool. It runs in your terminal, VS Code, JetBrains, a desktop app, or on the web at claude.ai/code. Claude Code reads your entire codebase, edits files, runs shell commands, handles git operations, and can spawn sub-agents for parallel work. It works with any language and any project type. A Chrome extension (beta) provides limited browser interaction.
+    </p>
+    <p class="summary-emphasis">
+      These tools start from opposite ends. Claude Code starts at the terminal and works outward. Frontman starts at the browser and works inward. Both edit source files, but they see different things when doing it.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs Claude Code</h1>
-			<p class="hero-subtitle">Browser Middleware vs Terminal Agent</p>
+  <Fragment slot="competitor-strengths">
+    <p>Claude Code is among the most capable agentic coding tools available. Here is what it does well and why.</p>
+    <p>Claude Code runs wherever you have a terminal: Bash, zsh, PowerShell. It also runs in VS Code, JetBrains, a standalone desktop app, the web, and Slack. You pick the surface that fits your workflow. Most competing AI coding tools force you into a specific IDE.</p>
+    <p>Codebase understanding is where Claude Code pulls ahead. It uses agentic search to map your project without manual file selection. It reads, navigates, and reasons about multi-file dependencies. For large codebases where context gathering is the bottleneck, this matters more than in tools that require you to @-mention specific files.</p>
+    <p>Shell access makes it autonomous in practice. Claude Code can run builds, execute tests, check lint, do git operations, and react to command output. It does not just edit files and hope they compile. When a build fails, it reads the error and tries again. This feedback loop between code edits and terminal results is how it handles complex multi-step tasks.</p>
+    <p>Git and PR workflows are built in. Claude Code commits changes, creates branches, opens pull requests, and integrates with GitHub Actions for automated code review and issue triage. You can @claude in a Slack channel and it will produce a PR. For teams where the bottleneck is going from "code works locally" to "PR is merged," that is a direct time save.</p>
+    <p>MCP integration covers hundreds of servers: Jira, Sentry, Notion, Slack, GitHub, PostgreSQL, and more. Claude Code can also serve as an MCP server itself and supports the agent SDK for building custom agents.</p>
+    <p>Claude Code can also spawn multiple sub-agents working on different parts of a task simultaneously. For large refactoring jobs where different modules can be updated independently, parallel sub-agents reduce wall-clock time.</p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> is open-source browser middleware for AI-assisted frontend editing. It hooks into Next.js, Astro, or Vite as a framework plugin, runs a browser-side MCP server that inspects the live DOM and computed CSS, and lets you click any element to edit its source code with hot reload. Apache 2.0 client libraries, AGPL-3.0 server, BYOK.
-				</p>
-				<p>
-					<a href="https://claude.ai/code" class="text-link" rel="nofollow">Claude Code</a> is Anthropic's agentic coding tool. It runs in your terminal, VS Code, JetBrains, a desktop app, or on the web at claude.ai/code. Claude Code reads your entire codebase, edits files, runs shell commands, handles git operations, and can spawn sub-agents for parallel work. It works with any language and any project type. A Chrome extension (beta) provides limited browser interaction.
-				</p>
-				<p class="summary-emphasis">
-					These tools start from opposite ends. Claude Code starts at the terminal and works outward. Frontman starts at the browser and works inward. Both edit source files, but they see different things when doing it.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="Claude Code" />
-		</div>
-	</section>
+  <Fragment slot="frontman-differentiators">
+    <p>Claude Code is a general-purpose coding agent. It edits files across your codebase through terminal commands and file operations. What it does not do is see what your frontend actually looks like when it renders. That is where Frontman comes in.</p>
+    <p>The biggest difference is architectural. Frontman installs as a plugin for Next.js, Astro, or Vite and runs inside your dev server. When you click a button in the browser, Frontman knows which React/Vue/Svelte component rendered it, the exact file and line number (via source maps), the component\'s props and state, and every computed CSS property. Claude Code reads your source files and can take screenshots through the Chrome extension, but it does not have access to the framework\'s runtime state or component hierarchy.</p>
+    <p>The editing model is different too. With Frontman, you click the element you want to change. The AI already has the context: the component, its styles, its position on the page. With Claude Code, you describe the change in text. The Chrome extension lets Claude interact with browsers, but that interaction is AI-driven (Claude decides what to look at), not developer-directed (you point at the thing you want changed).</p>
+    <p>Frontman also keeps hot reload in the loop. It edits source files, and the framework\'s HMR immediately shows the result in the browser. Edit, see, edit again. Claude Code edits files too, but there is no built-in visual verification step. You have to switch to the browser yourself or explicitly ask Claude to take a screenshot via the Chrome extension.</p>
+    <p>On licensing and pricing: Frontman\'s client libraries are Apache 2.0. The server is AGPL-3.0. You bring your own API keys to Claude, ChatGPT, OpenRouter, or any OpenAI-compatible provider. Claude Code is proprietary, requires a paid Anthropic subscription (minimum $20/month), and only works with Claude models.</p>
+    <p>Finally, Frontman requires no terminal. Designers and PMs can open the app in a browser, click elements, and describe changes. Changes produce real code diffs for developer review. Claude Code requires terminal literacy at minimum, or IDE proficiency for the extension.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="who-should-use-competitor">
+    <p>Claude Code is the better choice when you need an autonomous coding agent across the full development cycle:</p>
+    <ul>
+      <li><strong>Full-stack developers.</strong> Any language, any framework, with terminal access and git integration.</li>
+      <li><strong>Complex refactoring and migration.</strong> Multi-file changes across a large codebase with automated test verification.</li>
+      <li><strong>CI/CD and automation.</strong> GitHub Actions integration, Slack-triggered PRs, automated code review.</li>
+      <li><strong>Terminal-native workflows.</strong> If you live in the terminal and want an AI that does too.</li>
+      <li><strong>Teams already paying for Claude.</strong> If you have a Claude Pro/Max subscription, Claude Code is included.</li>
+      <li><strong>Backend-heavy projects.</strong> Python, Go, Rust, Elixir, infrastructure, deployment scripts.</li>
+    </ul>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">Claude Code</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.claudeCode)}>
-									<div class="status-content">
-										{feature.claudeCode === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.claudeCode === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.claudeCode === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.claudeCodeNote && <span class="status-note">{feature.claudeCodeNote}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when you need the AI to see what your frontend renders:</p>
+    <ul>
+      <li><strong>Frontend developers frustrated by AI breaking CSS and layout.</strong> Frontman sees computed styles, the rendered page, and responsive behavior at the current viewport.</li>
+      <li><strong>Teams where designers or PMs need to make UI changes.</strong> Click elements in the browser, describe changes, review real code diffs. No terminal or IDE required.</li>
+      <li><strong>Next.js, Astro, or Vite projects</strong> where framework middleware provides runtime context that file reading alone cannot.</li>
+      <li><strong>Open-source and BYOK.</strong> Apache 2.0 client libs, AGPL-3.0 server, any LLM provider, self-hostable, no subscription fee.</li>
+      <li><strong>Visual editing workflows</strong> where the feedback loop matters: click, describe, see the result via hot reload, iterate.</li>
+    </ul>
+    <p>Many developers use both. Claude Code for backend, refactoring, tests, and deployment automation. Frontman for visual frontend changes where the AI needs to see the rendered page.</p>
+    <p>For a detailed technical comparison including Cursor, read our <a href="/blog/frontman-vs-cursor-vs-claude-code/" class="text-link">full comparison of Frontman, Cursor, and Claude Code</a>. Also see: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a>, <a href="/vs/windsurf/" class="text-link">Frontman vs Windsurf</a>.</p>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">Claude Code</span>
-								<span>
-									{feature.claudeCode === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.claudeCode === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.claudeCode === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- What Claude Code Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What Claude Code Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Claude Code is among the most capable agentic coding tools available. Here's what it does well and why.</p>
-				<p>Claude Code runs wherever you have a terminal: Bash, zsh, PowerShell. It also runs in VS Code, JetBrains, a standalone desktop app, the web, and Slack. You pick the surface that fits your workflow. Most competing AI coding tools force you into a specific IDE.</p>
-				<p>Codebase understanding is where Claude Code pulls ahead. It uses agentic search to map your project without manual file selection. It reads, navigates, and reasons about multi-file dependencies. For large codebases where context gathering is the bottleneck, this matters more than in tools that require you to @-mention specific files.</p>
-				<p>Shell access makes it autonomous in practice. Claude Code can run builds, execute tests, check lint, do git operations, and react to command output. It doesn't just edit files and hope they compile. When a build fails, it reads the error and tries again. This feedback loop between code edits and terminal results is how it handles complex multi-step tasks.</p>
-				<p>Git and PR workflows are built in. Claude Code commits changes, creates branches, opens pull requests, and integrates with GitHub Actions for automated code review and issue triage. You can @claude in a Slack channel and it will produce a PR. For teams where the bottleneck is going from "code works locally" to "PR is merged," that's a direct time save.</p>
-				<p>MCP integration covers hundreds of servers: Jira, Sentry, Notion, Slack, GitHub, PostgreSQL, and more. Claude Code can also serve as an MCP server itself and supports the agent SDK for building custom agents.</p>
-				<p>Claude Code can also spawn multiple sub-agents working on different parts of a task simultaneously. For large refactoring jobs where different modules can be updated independently, parallel sub-agents reduce wall-clock time.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p>Claude Code is a general-purpose coding agent. It edits files across your codebase through terminal commands and file operations. What it doesn't do is see what your frontend actually looks like when it renders. That's where Frontman comes in.</p>
-
-				<p>The biggest difference is architectural. Frontman installs as a plugin for Next.js, Astro, or Vite and runs inside your dev server. When you click a button in the browser, Frontman knows which React/Vue/Svelte component rendered it, the exact file and line number (via source maps), the component's props and state, and every computed CSS property. Claude Code reads your source files and can take screenshots through the Chrome extension, but it doesn't have access to the framework's runtime state or component hierarchy.</p>
-
-				<p>The editing model is different too. With Frontman, you click the element you want to change. The AI already has the context: the component, its styles, its position on the page. With Claude Code, you describe the change in text. The Chrome extension lets Claude interact with browsers, but that interaction is AI-driven (Claude decides what to look at), not developer-directed (you point at the thing you want changed).</p>
-
-				<p>Frontman also keeps hot reload in the loop. It edits source files, and the framework's HMR immediately shows the result in the browser. Edit, see, edit again. Claude Code edits files too, but there's no built-in visual verification step. You have to switch to the browser yourself or explicitly ask Claude to take a screenshot via the Chrome extension.</p>
-
-				<p>On licensing and pricing: Frontman's client libraries are Apache 2.0. The server is AGPL-3.0. You bring your own API keys to Claude, ChatGPT, OpenRouter, or any OpenAI-compatible provider. Claude Code is proprietary, requires a paid Anthropic subscription (minimum $20/month), and only works with Claude models.</p>
-
-				<p>Finally, Frontman requires no terminal. Designers and PMs can open the app in a browser, click elements, and describe changes. Changes produce real code diffs for developer review. Claude Code requires terminal literacy at minimum, or IDE proficiency for the extension.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Claude Code -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Who Should Use Claude Code</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Claude Code is the better choice when you need an autonomous coding agent across the full development cycle:</p>
-				<ul>
-					<li><strong>Full-stack developers.</strong> Any language, any framework, with terminal access and git integration.</li>
-					<li><strong>Complex refactoring and migration.</strong> Multi-file changes across a large codebase with automated test verification.</li>
-					<li><strong>CI/CD and automation.</strong> GitHub Actions integration, Slack-triggered PRs, automated code review.</li>
-					<li><strong>Terminal-native workflows.</strong> If you live in the terminal and want an AI that does too.</li>
-					<li><strong>Teams already paying for Claude.</strong> If you have a Claude Pro/Max subscription, Claude Code is included.</li>
-					<li><strong>Backend-heavy projects.</strong> Python, Go, Rust, Elixir, infrastructure, deployment scripts.</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Frontman -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use Frontman</h2>
-			<div class="prose-content">
-				<p>Frontman is the better choice when you need the AI to see what your frontend renders:</p>
-				<ul>
-					<li><strong>Frontend developers frustrated by AI breaking CSS and layout.</strong> Frontman sees computed styles, the rendered page, and responsive behavior at the current viewport.</li>
-					<li><strong>Teams where designers or PMs need to make UI changes.</strong> Click elements in the browser, describe changes, review real code diffs. No terminal or IDE required.</li>
-					<li><strong>Next.js, Astro, or Vite projects</strong> where framework middleware provides runtime context that file reading alone cannot.</li>
-					<li><strong>Open-source and BYOK.</strong> Apache 2.0 client libs, AGPL-3.0 server, any LLM provider, self-hostable, no subscription fee.</li>
-					<li><strong>Visual editing workflows</strong> where the feedback loop matters: click, describe, see the result via hot reload, iterate.</li>
-				</ul>
-				<p>Many developers use both. Claude Code for backend, refactoring, tests, and deployment automation. Frontman for visual frontend changes where the AI needs to see the rendered page.</p>
-				<p>For a detailed technical comparison including Cursor, read our <a href="/blog/frontman-vs-cursor-vs-claude-code/" class="text-link">full comparison of Frontman, Cursor, and Claude Code</a>. Also see: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a>, <a href="/vs/windsurf/" class="text-link">Frontman vs Windsurf</a>.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Pricing -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Pricing Comparison</h2>
-			<div class="pricing-grid">
-				<div class="pricing-card pricing-card--highlighted">
-					<h3 class="pricing-name">Frontman</h3>
-					<div class="pricing-cost">Free</div>
-					<p class="pricing-model">Open source, BYOK</p>
-					<ul class="pricing-features">
-						<li>Unlimited usage, no caps</li>
-						<li>Bring your own API keys (Claude, ChatGPT, OpenRouter)</li>
-						<li>Or sign in with Claude/ChatGPT subscription via OAuth</li>
-						<li>Apache 2.0 (client) / AGPL-3.0 (server)</li>
-						<li>You pay your LLM provider directly</li>
-					</ul>
-				</div>
-				<div class="pricing-card">
-					<h3 class="pricing-name">Claude Code</h3>
-					<div class="pricing-cost">$20–$200/mo</div>
-					<p class="pricing-model">Subscription, proprietary</p>
-					<ul class="pricing-features">
-						<li>No free tier for Claude Code</li>
-						<li>Pro: $20/month — included, usage limits apply</li>
-						<li>Max 5x: $100/month — 5x Pro usage</li>
-						<li>Max 20x: $200/month — 20x Pro usage</li>
-						<li>API: pay-per-token (Sonnet $3/$15, Opus $5/$25 per MTok)</li>
-						<li>Team: $20-100/seat/month</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman</h2>
-			<p class="cta-description">One command. No account. No credit card. No usage limits.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.hero-summary code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-
-	/* Pricing */
-	.pricing-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
-	}
-	.pricing-card {
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid #e4e4e7;
-		background: white;
-	}
-	.pricing-card--highlighted {
-		border-color: #A259FF;
-		background: linear-gradient(135deg, rgba(162, 89, 255, 0.05), rgba(162, 89, 255, 0.02));
-		box-shadow: 0 0 0 1px rgba(162, 89, 255, 0.2);
-	}
-	.pricing-name {
-		font-size: 20px;
-		font-weight: 700;
-		color: #09090b;
-		margin-bottom: 8px;
-	}
-	.pricing-cost {
-		font-size: 36px;
-		font-weight: 800;
-		color: #09090b;
-		margin-bottom: 4px;
-		letter-spacing: -0.02em;
-	}
-	.pricing-card--highlighted .pricing-cost {
-		color: #A259FF;
-	}
-	.pricing-model {
-		font-size: 14px;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.pricing-features {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	.pricing-features li {
-		font-size: 15px;
-		color: #52525b;
-		padding: 6px 0;
-		padding-left: 20px;
-		position: relative;
-	}
-	.pricing-features li::before {
-		content: '\2192';
-		position: absolute;
-		left: 0;
-		color: #a1a1aa;
-	}
-
-	/* FAQ */
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-		cursor: pointer;
-	}
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.pricing-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="cta">
+    <section class="flex justify-center border-t border-zinc-800 bg-zinc-950 px-6 py-20 max-md:px-5 max-md:py-12">
+      <div class="w-full max-w-[720px]">
+        <h2 class="mb-2 text-4xl font-bold tracking-tight text-zinc-50 max-md:text-[28px]">Try Frontman</h2>
+        <p class="mb-8 text-[17px] text-zinc-300">One command. No account. No credit card. No usage limits.</p>
+        <div class="mb-8 flex flex-col gap-3">
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
+            <span class="text-[13px] text-zinc-300">Next.js</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
+            <span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
+            <span class="text-[13px] text-zinc-300">Astro</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
+          <Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+          <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 transition-colors hover:text-zinc-50">Join Discord</a>
+        </div>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/copilot.astro
+++ b/apps/marketing/src/pages/vs/copilot.astro
@@ -4,800 +4,207 @@
 // Targets "copilot alternative for design teams" and "github copilot vs" queries
 // Positions Frontman as the tool that lets non-developers participate in UI iteration
 
-// Components
-import Layout from '../../layouts/Layout.astro'
 import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs GitHub Copilot (2026) — For Design System Teams',
-	description:
-		'Copilot is for developers in the IDE. Frontman is for everyone who thinks in what they see — designers, PMs, engineers doing visual work. No IDE required.'
+const seo: SEOInfo = {
+  title: 'Frontman vs GitHub Copilot (2026) — For Design System Teams',
+  description:
+    'Copilot is for developers in the IDE. Frontman is for everyone who thinks in what they see — designers, PMs, engineers doing visual work. No IDE required.',
 }
 
-// Comparison data
+const frontmanPricingFeatures = [
+  'Unlimited usage, no caps',
+  'Bring your own API keys (Claude, ChatGPT, OpenRouter)',
+  'Or sign in with Claude/ChatGPT subscription via OAuth',
+  'Apache 2.0 (client) / AGPL-3.0 (server)',
+  'You pay your LLM provider directly',
+]
+
+const competitorPricingFeatures = [
+  'Free: 50 chats/month, 2,000 completions/month',
+  'Pro: $10/month — unlimited completions, 300 premium requests',
+  'Pro+: $39/month — 1,500 premium requests, all models',
+  'Business: $19/user/month — policy management, SSO',
+  'Enterprise: $39/user/month — custom models, IP indemnity',
+]
+
+const competitor: CompetitorInfo = {
+  name: 'GitHub Copilot',
+  slug: 'copilot',
+  url: 'https://github.com/features/copilot',
+  category: 'DeveloperApplication',
+  description:
+    'AI coding assistant integrated into IDEs and GitHub with autocomplete, chat, and agent workflows.',
+  pricing: {
+    cost: '$0–$39/mo',
+    model: 'Freemium, proprietary',
+    features: competitorPricingFeatures,
+  },
+}
+
 type Status = 'yes' | 'no' | 'partial'
 
 type Feature = {
-	name: string
-	frontman: Status
-	copilot: Status
-	frontmanNote?: string
-	copilotNote?: string
+  name: string
+  frontman: Status
+  copilot: Status
+  frontmanNote?: string
+  copilotNote?: string
 }
 
 const features: Feature[] = [
-	{ name: 'Designer/PM friendly', frontman: 'yes', copilot: 'no', frontmanNote: 'No IDE needed — click elements in the browser', copilotNote: 'Requires IDE proficiency' },
-	{ name: 'Click-to-select elements', frontman: 'yes', copilot: 'no', frontmanNote: 'Point at any component to edit it', copilotNote: 'Must describe or find in file tree' },
-	{ name: 'Works in the browser', frontman: 'yes', copilot: 'no', frontmanNote: 'No IDE or dev environment required', copilotNote: 'IDE extension (VS Code, JetBrains, etc.)' },
-	{ name: 'Sees live DOM & styles', frontman: 'yes', copilot: 'no', frontmanNote: 'Inspects the running page, not just source files', copilotNote: 'File-only context; no browser awareness' },
-	{ name: 'Sees computed CSS', frontman: 'yes', copilot: 'no', frontmanNote: 'Actual rendered values, not just class names', copilotNote: 'Reads source files only' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', copilot: 'partial', frontmanNote: 'Instant visual feedback in browser', copilotNote: 'Agent mode can trigger builds but doesn\'t see the result' },
-	{ name: 'Framework-aware', frontman: 'yes', copilot: 'partial', frontmanNote: 'Deep plugin for Next.js, Astro, Vite', copilotNote: 'Language-level context, not framework runtime' },
-	{ name: 'Inline autocomplete', frontman: 'no', copilot: 'yes', copilotNote: 'Tab completion, multi-line predictions' },
-	{ name: 'Agent mode', frontman: 'yes', copilot: 'yes', frontmanNote: 'Browser-context agent', copilotNote: 'IDE agent with terminal, MCP, multi-file editing' },
-	{ name: 'Coding agent (async)', frontman: 'no', copilot: 'yes', copilotNote: 'Assigns issues, creates PRs autonomously' },
-	{ name: 'Multi-file refactoring', frontman: 'partial', copilot: 'yes', frontmanNote: 'Can edit multiple files, but not primary workflow', copilotNote: 'Full cross-file edits via agent mode' },
-	{ name: 'Code review', frontman: 'no', copilot: 'yes', copilotNote: 'PR reviews on GitHub, diff reviews in IDE' },
-	{ name: 'Open source', frontman: 'yes', copilot: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', copilotNote: 'Proprietary (extension and service)' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', copilot: 'no', frontmanNote: 'Any LLM provider directly', copilotNote: 'Uses GitHub\'s model pool; no custom API keys' },
-	{ name: 'Self-hostable', frontman: 'yes', copilot: 'no', frontmanNote: 'Runs in your own infrastructure', copilotNote: 'Cloud service, GitHub-hosted' },
-	{ name: 'Backend coding', frontman: 'partial', copilot: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', copilotNote: 'Any language, any framework' },
-	{ name: 'Multi-model choice', frontman: 'yes', copilot: 'yes', frontmanNote: 'BYOK: Claude, GPT, OpenRouter, any provider', copilotNote: 'Claude, GPT, Gemini, Grok — GitHub-hosted' },
+  { name: 'Designer/PM friendly', frontman: 'yes', copilot: 'no', frontmanNote: 'No IDE needed — click elements in the browser', copilotNote: 'Requires IDE proficiency' },
+  { name: 'Click-to-select elements', frontman: 'yes', copilot: 'no', frontmanNote: 'Point at any component to edit it', copilotNote: 'Must describe or find in file tree' },
+  { name: 'Works in the browser', frontman: 'yes', copilot: 'no', frontmanNote: 'No IDE or dev environment required', copilotNote: 'IDE extension (VS Code, JetBrains, etc.)' },
+  { name: 'Sees live DOM & styles', frontman: 'yes', copilot: 'no', frontmanNote: 'Inspects the running page, not just source files', copilotNote: 'File-only context; no browser awareness' },
+  { name: 'Sees computed CSS', frontman: 'yes', copilot: 'no', frontmanNote: 'Actual rendered values, not just class names', copilotNote: 'Reads source files only' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', copilot: 'partial', frontmanNote: 'Instant visual feedback in browser', copilotNote: 'Agent mode can trigger builds but does not see the result' },
+  { name: 'Framework-aware', frontman: 'yes', copilot: 'partial', frontmanNote: 'Deep plugin for Next.js, Astro, Vite', copilotNote: 'Language-level context, not framework runtime' },
+  { name: 'Inline autocomplete', frontman: 'no', copilot: 'yes', copilotNote: 'Tab completion, multi-line predictions' },
+  { name: 'Agent mode', frontman: 'yes', copilot: 'yes', frontmanNote: 'Browser-context agent', copilotNote: 'IDE agent with terminal, MCP, multi-file editing' },
+  { name: 'Coding agent (async)', frontman: 'no', copilot: 'yes', copilotNote: 'Assigns issues, creates PRs autonomously' },
+  { name: 'Multi-file refactoring', frontman: 'partial', copilot: 'yes', frontmanNote: 'Can edit multiple files, but not primary workflow', copilotNote: 'Full cross-file edits via agent mode' },
+  { name: 'Code review', frontman: 'no', copilot: 'yes', copilotNote: 'PR reviews on GitHub, diff reviews in IDE' },
+  { name: 'Open source', frontman: 'yes', copilot: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', copilotNote: 'Proprietary (extension and service)' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', copilot: 'no', frontmanNote: 'Any LLM provider directly', copilotNote: 'Uses GitHub\'s model pool; no custom API keys' },
+  { name: 'Self-hostable', frontman: 'yes', copilot: 'no', frontmanNote: 'Runs in your own infrastructure', copilotNote: 'Cloud service, GitHub-hosted' },
+  { name: 'Backend coding', frontman: 'partial', copilot: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', copilotNote: 'Any language, any framework' },
+  { name: 'Multi-model choice', frontman: 'yes', copilot: 'yes', frontmanNote: 'BYOK: Claude, GPT, OpenRouter, any provider', copilotNote: 'Claude, GPT, Gemini, Grok — GitHub-hosted' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
+const comparisonFeatures: ComparisonFeature[] = features.map((feature) => ({
+  name: feature.name,
+  frontman: feature.frontman,
+  competitor: feature.copilot,
+  frontmanNote: feature.frontmanNote,
+  competitorNote: feature.copilotNote,
+}))
 
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'Can designers and PMs actually use Frontman without developer help?',
-		answer: 'Yes. Frontman runs as an overlay on your existing app — no IDE, terminal, or dev environment needed. A designer or PM opens the app in their browser, clicks an element, describes what they want changed in plain English, and Frontman edits the source code. The change shows up instantly via hot reload. All edits produce real code diffs that developers review through their normal PR process. It\'s designed so non-developers can contribute UI changes without bottlenecking the engineering team.'
-	},
-	{
-		question: 'How does Frontman help teams maintain a design system?',
-		answer: 'When someone clicks a component in the browser, Frontman sees the actual rendered output — computed styles, spacing, typography — not just the source code. This means a design system lead can spot where a component deviates from the system (wrong padding, incorrect color token, mismatched font size), click it, and describe the fix. The AI sees the gap between what\'s rendered and what should be rendered, and edits the source to match. It closes the feedback loop between design intent and shipped UI without filing a ticket and waiting for a sprint.'
-	},
-	{
-		question: 'Does Frontman replace GitHub Copilot for our engineering team?',
-		answer: 'No, and it shouldn\'t. Copilot is the better tool for your developers — autocomplete, multi-file refactoring, code review, backend work. Frontman solves a different problem: letting non-developers participate in UI iteration and giving everyone browser-level context for visual changes. Most teams use both. Developers keep Copilot in their IDE. Designers, PMs, and frontend devs use Frontman in the browser when the change is visual and the AI needs to see what\'s actually rendered.'
-	},
-	{
-		question: 'Does Frontman work alongside GitHub Copilot?',
-		answer: 'Yes. Frontman runs in the browser as framework middleware (Next.js, Astro, Vite). Copilot runs in your IDE. They edit the same source files. Changes from either tool are reflected via hot reload and normal file watching. There is no conflict — they operate in completely separate environments.'
-	},
-	{
-		question: 'What does Frontman see that GitHub Copilot cannot?',
-		answer: 'Frontman integrates with your framework as a plugin and runs a browser-side MCP server. It sees the live DOM tree, computed CSS styles (actual pixel values, not just class names), the component tree with props and state, viewport layout and responsive behavior, and server-side routes and logs. Copilot reads your source files in the IDE. It knows what your code says but not what it renders. When a PM asks "make this card match the design system spacing," Frontman can measure the actual rendered spacing and fix it. Copilot would have to guess from class names.'
-	},
-	{
-		question: 'Is Frontman free? How does pricing compare to Copilot?',
-		answer: 'Yes. Copilot Free gives you 50 chat requests and 2,000 completions per month. Copilot Pro is $10/month per seat, Business is $19/user/month. Frontman is free to self-host with no per-seat pricing and no usage limits. You bring your own API keys to Claude, ChatGPT, or OpenRouter and pay those providers directly. For a growing team where you want to give designers and PMs access too, there\'s no marginal cost per additional user.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Can designers and PMs actually use Frontman without developer help?',
+    answer:
+      'Yes. Frontman runs as an overlay on your existing app — no IDE, terminal, or dev environment needed. A designer or PM opens the app in their browser, clicks an element, describes what they want changed in plain English, and Frontman edits the source code. The change shows up instantly via hot reload. All edits produce real code diffs that developers review through their normal PR process. It is designed so non-developers can contribute UI changes without bottlenecking the engineering team.',
+  },
+  {
+    question: 'How does Frontman help teams maintain a design system?',
+    answer:
+      'When someone clicks a component in the browser, Frontman sees the actual rendered output — computed styles, spacing, typography — not just the source code. This means a design system lead can spot where a component deviates from the system (wrong padding, incorrect color token, mismatched font size), click it, and describe the fix. The AI sees the gap between what is rendered and what should be rendered, and edits the source to match. It closes the feedback loop between design intent and shipped UI without filing a ticket and waiting for a sprint.',
+  },
+  {
+    question: 'Does Frontman replace GitHub Copilot for our engineering team?',
+    answer:
+      'No, and it should not. Copilot is the better tool for your developers — autocomplete, multi-file refactoring, code review, backend work. Frontman solves a different problem: letting non-developers participate in UI iteration and giving everyone browser-level context for visual changes. Most teams use both. Developers keep Copilot in their IDE. Designers, PMs, and frontend devs use Frontman in the browser when the change is visual and the AI needs to see what is actually rendered.',
+  },
+  {
+    question: 'Does Frontman work alongside GitHub Copilot?',
+    answer:
+      'Yes. Frontman runs in the browser as framework middleware (Next.js, Astro, Vite). Copilot runs in your IDE. They edit the same source files. Changes from either tool are reflected via hot reload and normal file watching. There is no conflict — they operate in completely separate environments.',
+  },
+  {
+    question: 'What does Frontman see that GitHub Copilot cannot?',
+    answer:
+      'Frontman integrates with your framework as a plugin and runs a browser-side MCP server. It sees the live DOM tree, computed CSS styles (actual pixel values, not just class names), the component tree with props and state, viewport layout and responsive behavior, and server-side routes and logs. Copilot reads your source files in the IDE. It knows what your code says but not what it renders. When a PM asks "make this card match the design system spacing," Frontman can measure the actual rendered spacing and fix it. Copilot would have to guess from class names.',
+  },
+  {
+    question: 'Is Frontman free? How does pricing compare to Copilot?',
+    answer:
+      'Yes. Copilot Free gives you 50 chat requests and 2,000 completions per month. Copilot Pro is $10/month per seat, Business is $19/user/month. Frontman is free to self-host with no per-seat pricing and no usage limits. You bring your own API keys to Claude, ChatGPT, or OpenRouter and pay those providers directly. For a growing team where you want to give designers and PMs access too, there is no marginal cost per additional user.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs GitHub Copilot"
+  heroSubtitle="Your Whole Team Edits UI vs Developers Code Faster"
+  features={comparisonFeatures}
+  faqs={faqs}
+  frontmanPricing={{ features: frontmanPricingFeatures }}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent that lives in your browser. Designers, PMs, and developers click elements in a running app, describe changes in plain English, and Frontman edits the actual source code — with hot reload showing results instantly. No IDE required. It integrates with your framework (Next.js, Astro, or Vite) as a plugin, using a browser-side MCP server to inspect the live DOM, computed styles, and component tree.
+    </p>
+    <p>
+      <a href="https://github.com/features/copilot" class="text-link" rel="nofollow">GitHub Copilot</a> is an AI coding assistant built into your IDE. It provides inline autocomplete, agent mode with multi-file editing, code review, and terminal integration. Copilot makes your developers faster across any language and framework — but it requires IDE proficiency and does not see what the app actually renders in a browser.
+    </p>
+    <p class="summary-emphasis">
+      Copilot accelerates your engineering team in the IDE. Frontman lets your entire product team — designers, PMs, and developers — iterate on UI together in the browser. Growing teams use both.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs GitHub Copilot</h1>
-			<p class="hero-subtitle">Your Whole Team Edits UI vs Developers Code Faster</p>
+  <Fragment slot="competitor-strengths">
+    <p>GitHub Copilot is the most widely adopted AI coding tool in the world, and for real reasons. It is the right choice for your engineering team\'s day-to-day coding work.</p>
+    <p><strong>Autocomplete accelerates developers.</strong> Copilot\'s inline suggestions predict what you are about to type — often multiple lines ahead. For raw coding speed, it is hard to beat. This is a developer productivity tool through and through.</p>
+    <p><strong>Agentic coding and code review.</strong> Copilot\'s agent can plan multi-step changes across files, run terminal commands, and create pull requests from GitHub issues. It also reviews PRs directly on GitHub. For teams on GitHub, this integration is hard to match.</p>
+    <p><strong>Any language, any framework.</strong> Python, Go, Rust, TypeScript, Java, SQL — Copilot handles your full stack. Frontman is focused on frontend frameworks (Next.js, Astro, Vite).</p>
+    <p>If your goal is to make your developers faster in the IDE, Copilot is the proven tool. The question is what happens when the people who care most about UI quality — designers, PMs, design system leads — cannot use an IDE.</p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent that lives in your browser. Designers, PMs, and developers click elements in a running app, describe changes in plain English, and Frontman edits the actual source code — with hot reload showing results instantly. No IDE required. It integrates with your framework (Next.js, Astro, or Vite) as a plugin, using a browser-side MCP server to inspect the live DOM, computed styles, and component tree.
-				</p>
-				<p>
-					<a href="https://github.com/features/copilot" class="text-link" rel="nofollow">GitHub Copilot</a> is an AI coding assistant built into your IDE. It provides inline autocomplete, agent mode with multi-file editing, code review, and terminal integration. Copilot makes your developers faster across any language and framework — but it requires IDE proficiency and doesn't see what the app actually renders in a browser.
-				</p>
-				<p class="summary-emphasis">
-					Copilot accelerates your engineering team in the IDE. Frontman lets your entire product team — designers, PMs, and developers — iterate on UI together in the browser. Growing teams use both.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="GitHub Copilot" />
-		</div>
-	</section>
+  <Fragment slot="frontman-differentiators">
+    <p>In most teams, the people closest to UI quality — designers, PMs, design system leads — cannot directly fix what they see. They file tickets, write specs, and wait. <strong>Frontman closes that gap.</strong></p>
+    <p><strong>Anyone on the team can edit UI.</strong> Frontman runs in the browser as an overlay on your running app. No IDE, no terminal, no dev environment. A designer spots a component that is off-brand — wrong spacing, incorrect color token — clicks it, describes the fix, and Frontman edits the source code. Hot reload shows the result instantly. The change goes through your normal code review process.</p>
+    <p><strong>The AI sees what is actually rendered.</strong> IDE-based tools like Copilot read source files but never see the browser. Frontman\'s browser-side MCP server inspects the live DOM, computed CSS (actual pixel values, not just class names), the component tree, and viewport behavior. When someone says "this card does not match the design system," Frontman can measure the gap between what is rendered and what should be.</p>
+    <p><strong>Click-to-edit, not file-to-edit.</strong> Instead of knowing which file to open, you point at the element. Frontman resolves the source location via source maps — the exact file, component, and line. This is the interaction model that makes it accessible to non-developers.</p>
+    <p><strong>Design system consistency at scale.</strong> When multiple teams ship UI against a shared design system, drift is inevitable. Frontman lets the people who own the system — not just the developers who implement it — spot and fix inconsistencies directly. No ticket, no sprint, no context loss.</p>
+    <p><strong>Open source, no per-seat cost.</strong> Apache 2.0 client, AGPL-3.0 server. You connect your own API keys to Claude, ChatGPT, or OpenRouter. No per-user pricing means you can give access to your whole product team without a procurement conversation for every new seat.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="who-should-use-competitor">
+    <p>Copilot is the right tool for your engineering team\'s coding workflow:</p>
+    <ul>
+      <li><strong>Your developers</strong> — autocomplete, agent mode, and code review make them faster in the IDE across any language</li>
+      <li><strong>Full-stack and backend work</strong> — Python, Go, Rust, Java, infrastructure — Copilot covers everything beyond the frontend</li>
+      <li><strong>Teams on GitHub</strong> — the platform integration (issues, PRs, code review, autonomous coding agent) is unmatched</li>
+      <li><strong>Large codebase refactoring</strong> — renaming across dozens of files, updating APIs, migrating patterns</li>
+    </ul>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">GitHub Copilot</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.copilot)}>
-									<div class="status-content">
-										{feature.copilot === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.copilot === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.copilot === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.copilotNote && <span class="status-note">{feature.copilotNote}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is built for teams where UI quality is a shared responsibility — not just a developer task:</p>
+    <ul>
+      <li><strong>Design system teams</strong> — designers and system leads can spot and fix component inconsistencies directly in the browser, without filing tickets or waiting for sprint capacity</li>
+      <li><strong>Product managers who iterate on UI</strong> — click the element, describe the change, see it live. No IDE setup, no context-switching through Figma-to-Jira-to-PR workflows</li>
+      <li><strong>Growing startups with multiple product teams</strong> — when several teams ship against a shared system, Frontman gives non-developers a way to maintain consistency without bottlenecking engineering</li>
+      <li><strong>Frontend developers who want browser context</strong> — the AI sees computed styles, rendered output, and viewport behavior, not just class names in source files</li>
+      <li><strong>Next.js, Astro, or Vite projects</strong> — deep framework plugin integration provides richer context than generic file reading</li>
+    </ul>
+    <p>Most teams use both. Copilot in the IDE for your developers. Frontman in the browser for your whole product team.</p>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">Copilot</span>
-								<span>
-									{feature.copilot === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.copilot === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.copilot === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- What GitHub Copilot Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What GitHub Copilot Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>GitHub Copilot is the most widely adopted AI coding tool in the world, and for real reasons. It's the right choice for your engineering team's day-to-day coding work.</p>
-				<p><strong>Autocomplete accelerates developers.</strong> Copilot's inline suggestions predict what you're about to type — often multiple lines ahead. For raw coding speed, it's hard to beat. This is a developer productivity tool through and through.</p>
-				<p><strong>Agentic coding and code review.</strong> Copilot's agent can plan multi-step changes across files, run terminal commands, and create pull requests from GitHub issues. It also reviews PRs directly on GitHub. For teams on GitHub, this integration is hard to match.</p>
-				<p><strong>Any language, any framework.</strong> Python, Go, Rust, TypeScript, Java, SQL — Copilot handles your full stack. Frontman is focused on frontend frameworks (Next.js, Astro, Vite).</p>
-				<p>If your goal is to make your developers faster in the IDE, Copilot is the proven tool. The question is what happens when the people who care most about UI quality — designers, PMs, design system leads — can't use an IDE.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p>In most teams, the people closest to UI quality — designers, PMs, design system leads — can't directly fix what they see. They file tickets, write specs, and wait. <strong>Frontman closes that gap.</strong></p>
-
-				<p><strong>Anyone on the team can edit UI.</strong> Frontman runs in the browser as an overlay on your running app. No IDE, no terminal, no dev environment. A designer spots a component that's off-brand — wrong spacing, incorrect color token — clicks it, describes the fix, and Frontman edits the source code. Hot reload shows the result instantly. The change goes through your normal code review process.</p>
-
-				<p><strong>The AI sees what's actually rendered.</strong> IDE-based tools like Copilot read source files but never see the browser. Frontman's browser-side MCP server inspects the live DOM, computed CSS (actual pixel values, not just class names), the component tree, and viewport behavior. When someone says "this card doesn't match the design system," Frontman can measure the gap between what's rendered and what should be.</p>
-
-				<p><strong>Click-to-edit, not file-to-edit.</strong> Instead of knowing which file to open, you point at the element. Frontman resolves the source location via source maps — the exact file, component, and line. This is the interaction model that makes it accessible to non-developers.</p>
-
-				<p><strong>Design system consistency at scale.</strong> When multiple teams ship UI against a shared design system, drift is inevitable. Frontman lets the people who own the system — not just the developers who implement it — spot and fix inconsistencies directly. No ticket, no sprint, no context loss.</p>
-
-				<p><strong>Open source, no per-seat cost.</strong> Apache 2.0 client, AGPL-3.0 server. You connect your own API keys to Claude, ChatGPT, or OpenRouter. No per-user pricing means you can give access to your whole product team without a procurement conversation for every new seat.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use GitHub Copilot -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Who Should Use GitHub Copilot</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Copilot is the right tool for your engineering team's coding workflow:</p>
-				<ul>
-					<li><strong>Your developers</strong> — autocomplete, agent mode, and code review make them faster in the IDE across any language</li>
-					<li><strong>Full-stack and backend work</strong> — Python, Go, Rust, Java, infrastructure — Copilot covers everything beyond the frontend</li>
-					<li><strong>Teams on GitHub</strong> — the platform integration (issues, PRs, code review, autonomous coding agent) is unmatched</li>
-					<li><strong>Large codebase refactoring</strong> — renaming across dozens of files, updating APIs, migrating patterns</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Frontman -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use Frontman</h2>
-			<div class="prose-content">
-				<p>Frontman is built for teams where UI quality is a shared responsibility — not just a developer task:</p>
-				<ul>
-					<li><strong>Design system teams</strong> — designers and system leads can spot and fix component inconsistencies directly in the browser, without filing tickets or waiting for sprint capacity</li>
-					<li><strong>Product managers who iterate on UI</strong> — click the element, describe the change, see it live. No IDE setup, no context-switching through Figma-to-Jira-to-PR workflows</li>
-					<li><strong>Growing startups with multiple product teams</strong> — when several teams ship against a shared system, Frontman gives non-developers a way to maintain consistency without bottlenecking engineering</li>
-					<li><strong>Frontend developers who want browser context</strong> — the AI sees computed styles, rendered output, and viewport behavior, not just class names in source files</li>
-					<li><strong>Next.js, Astro, or Vite projects</strong> — deep framework plugin integration provides richer context than generic file reading</li>
-				</ul>
-				<p>Most teams use both. Copilot in the IDE for your developers. Frontman in the browser for your whole product team.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Pricing -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Pricing Comparison</h2>
-			<div class="pricing-grid">
-				<div class="pricing-card pricing-card--highlighted">
-					<h3 class="pricing-name">Frontman</h3>
-					<div class="pricing-cost">Free</div>
-					<p class="pricing-model">Open source, BYOK</p>
-					<ul class="pricing-features">
-						<li>Unlimited usage, no caps</li>
-						<li>Bring your own API keys (Claude, ChatGPT, OpenRouter)</li>
-						<li>Or sign in with Claude/ChatGPT subscription via OAuth</li>
-						<li>Apache 2.0 (client) / AGPL-3.0 (server)</li>
-						<li>You pay your LLM provider directly</li>
-					</ul>
-				</div>
-				<div class="pricing-card">
-					<h3 class="pricing-name">GitHub Copilot</h3>
-					<div class="pricing-cost">$0–$39/mo</div>
-					<p class="pricing-model">Freemium, proprietary</p>
-					<ul class="pricing-features">
-						<li>Free: 50 chats/month, 2,000 completions/month</li>
-						<li>Pro: $10/month — unlimited completions, 300 premium requests</li>
-						<li>Pro+: $39/month — 1,500 premium requests, all models</li>
-						<li>Business: $19/user/month — policy management, SSO</li>
-						<li>Enterprise: $39/user/month — custom models, IP indemnity</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman With Your Team</h2>
-			<p class="cta-description">Share these with your frontend developer — one command adds Frontman to your app. Then anyone on the team can start editing UI in the browser.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.hero-summary strong {
-		color: #fafafa;
-	}
-	.hero-summary code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-
-	/* Pricing */
-	.pricing-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
-	}
-	.pricing-card {
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid #e4e4e7;
-		background: white;
-	}
-	.pricing-card--highlighted {
-		border-color: #A259FF;
-		background: linear-gradient(135deg, rgba(162, 89, 255, 0.05), rgba(162, 89, 255, 0.02));
-		box-shadow: 0 0 0 1px rgba(162, 89, 255, 0.2);
-	}
-	.pricing-name {
-		font-size: 20px;
-		font-weight: 700;
-		color: #09090b;
-		margin-bottom: 8px;
-	}
-	.pricing-cost {
-		font-size: 36px;
-		font-weight: 800;
-		color: #09090b;
-		margin-bottom: 4px;
-		letter-spacing: -0.02em;
-	}
-	.pricing-card--highlighted .pricing-cost {
-		color: #A259FF;
-	}
-	.pricing-model {
-		font-size: 14px;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.pricing-features {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	.pricing-features li {
-		font-size: 15px;
-		color: #52525b;
-		padding: 6px 0;
-		padding-left: 20px;
-		position: relative;
-	}
-	.pricing-features li::before {
-		content: '\2192';
-		position: absolute;
-		left: 0;
-		color: #a1a1aa;
-	}
-
-	/* FAQ */
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-		cursor: pointer;
-	}
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.pricing-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="cta">
+    <section class="flex justify-center border-t border-zinc-800 bg-zinc-950 px-6 py-20 max-md:px-5 max-md:py-12">
+      <div class="w-full max-w-[720px]">
+        <h2 class="mb-2 text-4xl font-bold tracking-tight text-zinc-50 max-md:text-[28px]">Try Frontman With Your Team</h2>
+        <p class="mb-8 text-[17px] text-zinc-300">Share these with your frontend developer — one command adds Frontman to your app. Then anyone on the team can start editing UI in the browser.</p>
+        <div class="mb-8 flex flex-col gap-3">
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
+            <span class="text-[13px] text-zinc-300">Next.js</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
+            <span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
+            <span class="text-[13px] text-zinc-300">Astro</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
+          <Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+          <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 transition-colors hover:text-zinc-50">Join Discord</a>
+        </div>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/index.astro
+++ b/apps/marketing/src/pages/vs/index.astro
@@ -72,142 +72,38 @@ const comparisons = [
 		tags: ['Design Tool', 'Visual Editor', 'Open Source']
 	}
 ]
+
+const comparisonCardClass =
+	'group block rounded-2xl border border-white/[0.08] bg-white/[0.03] p-6 no-underline transition-colors hover:border-primary-500/40 hover:bg-primary-500/[0.06] md:p-8'
 ---
 
 <Layout title={SEO.title} description={SEO.description}>
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparisons</p>
-			<h1 class="hero-title">Frontman vs Other AI Coding Tools</h1>
-			<p class="hero-subtitle">
+	<section class="flex justify-center bg-[#09090b] px-5 pb-9 pt-12 text-zinc-50 md:px-6 md:pb-12 md:pt-20">
+		<div class="w-full max-w-[720px]">
+			<p class="mb-3 font-mono text-[13px] uppercase tracking-[0.12em] text-primary-500">Comparisons</p>
+			<h1 class="mb-4 text-[32px] font-bold leading-[1.1] tracking-[-0.02em] text-zinc-50 md:text-[48px]">
+				Frontman vs Other AI Coding Tools
+			</h1>
+			<p class="text-[18px] leading-[1.6] text-zinc-300">
 				Honest, detailed comparisons with other AI coding tools. We show what each tool does well, where Frontman is different, and who should use what.
 			</p>
 		</div>
 	</section>
 
-	<section class="cards-section">
-		<div class="cards-container">
+	<section class="flex justify-center bg-[#09090b] px-5 pb-12 pt-4 md:px-6 md:pb-20 md:pt-6">
+		<div class="flex w-full max-w-[720px] flex-col gap-5">
 			{comparisons.map((comp) => (
-				<a href={comp.href} class="comparison-card">
-					<h2 class="card-title">{comp.title}</h2>
-					<p class="card-description">{comp.description}</p>
-					<div class="card-tags">
+				<a href={comp.href} class={comparisonCardClass}>
+					<h2 class="mb-3 text-[20px] font-bold tracking-[-0.01em] text-zinc-50 md:text-[24px]">{comp.title}</h2>
+						<p class="mb-4 text-[16px] leading-[1.6] text-zinc-300">{comp.description}</p>
+					<div class="mb-4 flex flex-wrap gap-2">
 						{comp.tags.map((tag) => (
-							<span class="card-tag">{tag}</span>
+							<span class="rounded-md bg-white/[0.06] px-2.5 py-1 text-[12px] tracking-[0.02em] text-zinc-300">{tag}</span>
 						))}
 					</div>
-					<span class="card-cta">Read comparison &rarr;</span>
+					<span class="text-[15px] font-medium text-primary-500 group-hover:underline group-hover:underline-offset-3">Read comparison &rarr;</span>
 				</a>
 			))}
 		</div>
 	</section>
 </Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 48px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 16px;
-	}
-	.hero-subtitle {
-		font-size: 18px;
-		line-height: 1.6;
-		color: #a1a1aa;
-	}
-
-	.cards-section {
-		background: #09090b;
-		padding: 24px 24px 80px;
-		display: flex;
-		justify-content: center;
-	}
-	.cards-container {
-		max-width: 720px;
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		gap: 20px;
-	}
-
-	.comparison-card {
-		display: block;
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		background: rgba(255, 255, 255, 0.03);
-		text-decoration: none;
-		transition: border-color 0.2s, background 0.2s;
-	}
-	.comparison-card:hover {
-		border-color: rgba(162, 89, 255, 0.4);
-		background: rgba(162, 89, 255, 0.06);
-	}
-
-	.card-title {
-		font-size: 24px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 12px;
-		letter-spacing: -0.01em;
-	}
-	.card-description {
-		font-size: 16px;
-		line-height: 1.6;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.card-tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 8px;
-		margin-bottom: 16px;
-	}
-	.card-tag {
-		font-size: 12px;
-		padding: 4px 10px;
-		border-radius: 6px;
-		background: rgba(255, 255, 255, 0.06);
-		color: #71717a;
-		letter-spacing: 0.02em;
-	}
-	.card-cta {
-		font-size: 15px;
-		font-weight: 500;
-		color: #A259FF;
-	}
-	.comparison-card:hover .card-cta {
-		text-decoration: underline;
-		text-underline-offset: 3px;
-	}
-
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 32px; }
-		.hero-title { font-size: 32px; }
-		.cards-section { padding: 16px 20px 48px; }
-		.comparison-card { padding: 24px; }
-		.card-title { font-size: 20px; }
-	}
-</style>

--- a/apps/marketing/src/pages/vs/lovable.astro
+++ b/apps/marketing/src/pages/vs/lovable.astro
@@ -1,282 +1,257 @@
 ---
 // /vs/lovable — Frontman vs Lovable Comparison Page
-// ICP: Designers & PMs at Series A+ startups with multiple teams and an existing design system.
+// ICP: Designers & PMs at startup teams with existing design systems.
 // Key angle: Lovable generates new apps from scratch for non-coders.
-//            Frontman lets designers/PMs iterate on the real product with AI — no IDE needed.
+//            Frontman lets teams iterate on the real product with AI — no IDE needed.
 
-// Layout
-import Layout from '../../layouts/Layout.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// Reusable comparison components
-import ComparisonHero from '../../components/blocks/comparison/ComparisonHero.astro'
-import ComparisonFeatureTable from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-import ComparisonPricing from '../../components/blocks/comparison/ComparisonPricing.astro'
-import ComparisonCTA from '../../components/blocks/comparison/ComparisonCTA.astro'
-import IntegrationContentSection from '../../components/blocks/integrations/IntegrationContentSection.astro'
-import IntegrationFAQ from '../../components/blocks/integrations/IntegrationFAQ.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
-
-// Types
-import type { ComparisonFeature } from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-
-// SEO
-const SEO = {
-	title: 'Frontman vs Lovable: Iterate on Your Real Product vs Generate New Apps',
-	description:
-		'Honest comparison for designers and PMs. Lovable generates new apps from prompts for non-coders. Frontman lets your team click elements in your real product, describe changes, and ship — no IDE needed. Feature table, pricing, and real differences.',
+const seo: SEOInfo = {
+  title: 'Frontman vs Lovable: Iterate on Your Real Product vs Generate New Apps',
+  description:
+    'Honest comparison for designers and PMs. Lovable generates new apps from prompts for non-coders. Frontman lets your team click elements in the real product, describe changes, and ship — no IDE needed. Feature table, pricing, and real differences.',
 }
 
-// Feature comparison data
+const competitor: CompetitorInfo = {
+  name: 'Lovable',
+  slug: 'lovable',
+  url: 'https://lovable.dev',
+  category: 'DeveloperApplication',
+  description: 'Proprietary AI app-generation platform for no-code and low-code frontend creation.',
+  pricing: {
+    cost: '$0–$2,250/mo',
+    model: 'Credit-based proprietary SaaS',
+    features: [
+      'Free: 5 credits/day, 30/month',
+      'Pro: $25–$2,250/month (scales with usage)',
+      'Business: $50–$4,300/month (team features)',
+      'Enterprise: custom pricing',
+      'Every interaction consumes credits (0.5–2+ per action)',
+    ],
+  },
+}
+
 const features: ComparisonFeature[] = [
-	{
-		name: 'Iterate on your real product',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Click elements in your running app and describe changes',
-		competitorNote: 'Generates new apps in a hosted sandbox',
-	},
-	{
-		name: 'Works with existing design systems',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Sees your actual components, tokens, and styles',
-		competitorNote: 'Cannot import existing code',
-	},
-	{
-		name: 'No IDE or coding required',
-		frontman: 'yes',
-		competitor: 'yes',
-		frontmanNote: 'Point, click, describe — changes happen in source',
-		competitorNote: 'No code needed at all',
-	},
-	{
-		name: 'Sees live DOM & computed styles',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Understands what actually renders, not just source code',
-		competitorNote: 'Sandbox preview only',
-	},
-	{
-		name: 'Click-to-select elements',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Select any element in your running product',
-		competitorNote: 'Chat interface only',
-	},
-	{
-		name: 'Generate apps from scratch',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Core workflow: prompt to full-stack app',
-	},
-	{
-		name: 'Built-in hosting & databases',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Lovable Cloud with Supabase-based infra',
-	},
-	{
-		name: 'Authentication out of the box',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'Email, phone, Google OAuth',
-	},
-	{
-		name: 'Component tree awareness',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Knows your React, Vue, or Svelte component hierarchy',
-	},
-	{
-		name: 'Cross-team collaboration',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Designers and PMs edit alongside engineers in the same codebase',
-		competitorNote: 'Single-user sandbox sessions',
-	},
-	{
-		name: 'Hot reload feedback loop',
-		frontman: 'yes',
-		competitor: 'yes',
-		frontmanNote: 'Instant via framework HMR — see changes live',
-		competitorNote: 'In sandbox preview',
-	},
-	{
-		name: 'Framework-aware middleware',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Next.js, Astro, Vite',
-		competitorNote: 'React + Tailwind only',
-	},
-	{
-		name: 'Multi-framework support',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'React, Vue, Svelte, Next.js, Astro',
-		competitorNote: 'React + Tailwind only',
-	},
-	{
-		name: 'Open source',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Apache 2.0 / AGPL-3.0',
-		competitorNote: 'Proprietary',
-	},
-	{
-		name: 'BYOK (bring your own key)',
-		frontman: 'yes',
-		competitor: 'no',
-		frontmanNote: 'Any LLM provider — no per-seat fees from Frontman',
-		competitorNote: 'Uses their models',
-	},
-	{ name: 'Self-hostable', frontman: 'yes', competitor: 'no' },
-	{
-		name: 'Enterprise compliance',
-		frontman: 'no',
-		competitor: 'yes',
-		competitorNote: 'SOC 2 Type II, ISO 27001, GDPR',
-	},
+  {
+    name: 'Iterate on your real product',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Click elements in your running app and describe changes',
+    competitorNote: 'Generates new apps in a hosted sandbox',
+  },
+  {
+    name: 'Works with existing design systems',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Sees your actual components, tokens, and styles',
+    competitorNote: 'Cannot import existing code',
+  },
+  {
+    name: 'No IDE or coding required',
+    frontman: 'yes',
+    competitor: 'yes',
+    frontmanNote: 'Point, click, describe — changes happen in source',
+    competitorNote: 'No code needed at all',
+  },
+  {
+    name: 'Sees live DOM & computed styles',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Understands what actually renders, not just source code',
+    competitorNote: 'Sandbox preview only',
+  },
+  {
+    name: 'Click-to-select elements',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Select any element in your running product',
+    competitorNote: 'Chat interface only',
+  },
+  {
+    name: 'Generate apps from scratch',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Core workflow: prompt to full-stack app',
+  },
+  {
+    name: 'Built-in hosting & databases',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Lovable Cloud with Supabase-based infra',
+  },
+  {
+    name: 'Authentication out of the box',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'Email, phone, Google OAuth',
+  },
+  {
+    name: 'Component tree awareness',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Knows your React, Vue, or Svelte component hierarchy',
+  },
+  {
+    name: 'Cross-team collaboration',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Designers and PMs edit alongside engineers in the same codebase',
+    competitorNote: 'Single-user sandbox sessions',
+  },
+  {
+    name: 'Hot reload feedback loop',
+    frontman: 'yes',
+    competitor: 'yes',
+    frontmanNote: 'Instant via framework HMR — see changes live',
+    competitorNote: 'Instant in sandbox preview',
+  },
+  {
+    name: 'Framework-aware middleware',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Next.js, Astro, Vite',
+    competitorNote: 'React + Tailwind only',
+  },
+  {
+    name: 'Multi-framework support',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'React, Vue, Svelte, Next.js, Astro',
+    competitorNote: 'React + Tailwind only',
+  },
+  {
+    name: 'Open source',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Apache 2.0 / AGPL-3.0',
+    competitorNote: 'Proprietary',
+  },
+  {
+    name: 'BYOK (bring your own key)',
+    frontman: 'yes',
+    competitor: 'no',
+    frontmanNote: 'Any LLM provider — no per-seat fees from Frontman',
+    competitorNote: 'Uses their models',
+  },
+  { name: 'Self-hostable', frontman: 'yes', competitor: 'no' },
+  {
+    name: 'Enterprise compliance',
+    frontman: 'no',
+    competitor: 'yes',
+    competitorNote: 'SOC 2 Type II, ISO 27001, GDPR',
+  },
 ]
 
-// FAQ data
-const faqs = [
-	{
-		question: 'Is Frontman an alternative to Lovable?',
-		answer: 'They solve different problems. Lovable generates new full-stack apps from text prompts for non-technical users. Frontman lets designers, PMs, and engineers iterate on the product they already have — click elements, describe changes, and ship. If your team already has a product and design system, Frontman is built for your workflow. They are complementary, not competing.',
-	},
-	{
-		question: 'Can designers and PMs use Frontman without an IDE?',
-		answer: 'Yes. Frontman runs in the browser alongside your real product. You click an element, describe the change you want, review the diff, and approve it. No VS Code, no terminal, no pull request workflow to learn. Your engineering team reviews the changes like any other code update.',
-	},
-	{
-		question: 'Can I use Lovable and Frontman together?',
-		answer: 'Yes, and it is a natural workflow. Generate your initial app with Lovable, export the code to GitHub, clone it locally, then add Frontman middleware to iterate visually with full browser context. Lovable gets you from zero to something. Frontman helps your team refine and iterate on what you have.',
-	},
-	{
-		question: 'Does Frontman work with our design system?',
-		answer: 'Yes. Because Frontman sees your actual running app — the real DOM, computed styles, and component tree — it understands your design system tokens, component library, and CSS approach. MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed.',
-	},
-	{
-		question: 'How does Frontman fit into a multi-team workflow?',
-		answer: 'Frontman bridges the gap between design and engineering. Designers and PMs can make UI changes directly in the running product, and engineers review those changes as normal code diffs. No more design-to-dev handoff delays, no more "can you move this 2px left" tickets. Everyone works on the same codebase.',
-	},
-	{
-		question: 'How does pricing work for a growing team?',
-		answer: 'Frontman is free while in beta. We plan to introduce per-seat team pricing — details are coming soon. The client libraries are Apache 2.0 and the server is AGPL-3.0, so self-hosting will always be an option. You bring your own API keys to Anthropic, OpenAI, or OpenRouter, or sign in with a Claude or ChatGPT subscription via OAuth. Lovable\'s credit-based pricing starts at $25/month and scales to $2,250/month for heavy use — plus every interaction costs credits.',
-	},
-	{
-		question: 'Which supports more frameworks?',
-		answer: 'Frontman. Lovable generates React + Tailwind + Vite only — no Vue, Svelte, Astro, or Next.js server components. Frontman works with Next.js, Astro, and Vite, covering React, Vue, and Svelte. If your product isn\'t React + Tailwind, Lovable isn\'t an option.',
-	},
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an alternative to Lovable?',
+    answer:
+      'They solve different problems. Lovable generates new full-stack apps from text prompts for non-technical users. Frontman lets designers, PMs, and engineers iterate on the product they already have — click elements, describe changes, and ship. If your team already has a product and design system, Frontman is built for your workflow. They are complementary, not competing.',
+  },
+  {
+    question: 'Can designers and PMs use Frontman without an IDE?',
+    answer:
+      'Yes. Frontman runs in the browser alongside your real product. You click an element, describe the change you want, review the diff, and approve it. No VS Code, no terminal, no pull request workflow to learn. Your engineering team reviews the changes like any other code update.',
+  },
+  {
+    question: 'Can I use Lovable and Frontman together?',
+    answer:
+      'Yes, and it is a natural workflow. Generate your initial app with Lovable, export the code to GitHub, clone it locally, then add Frontman middleware to iterate visually with full browser context. Lovable gets you from zero to something. Frontman helps your team refine and iterate on what you have.',
+  },
+  {
+    question: 'Does Frontman work with our design system?',
+    answer:
+      'Yes. Because Frontman sees your actual running app — the real DOM, computed styles, and component tree — it understands your design system tokens, component library, and CSS approach. MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed.',
+  },
+  {
+    question: 'How does Frontman fit into a multi-team workflow?',
+    answer:
+      'Frontman bridges the gap between design and engineering. Designers and PMs can make UI changes directly in the running product, and engineers review those changes as normal code diffs. No more design-to-dev handoff delays, no more "can you move this 2px left" tickets. Everyone works on the same codebase.',
+  },
+  {
+    question: 'How does pricing work for a growing team?',
+    answer:
+      'Frontman is free while in beta. We plan to introduce per-seat team pricing — details are coming soon. The client libraries are Apache 2.0 and the server is AGPL-3.0, so self-hosting will always be an option. You bring your own API keys to Anthropic, OpenAI, or OpenRouter, or sign in with a Claude or ChatGPT subscription via OAuth. Lovable\'s credit-based pricing starts at $25/month and scales to $2,250/month for heavy use — plus every interaction costs credits.',
+  },
+  {
+    question: 'Which supports more frameworks?',
+    answer:
+      'Frontman. Lovable generates React + Tailwind + Vite only — no Vue, Svelte, Astro, or Next.js server components. Frontman works with Next.js, Astro, and Vite, covering React, Vue, and Svelte. If your product is not React + Tailwind, Lovable is not the best option.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	'@context': 'https://schema.org',
-	'@type': 'FAQPage',
-	mainEntity: faqs.map((faq) => ({
-		'@type': 'Question',
-		name: faq.question,
-		acceptedAnswer: {
-			'@type': 'Answer',
-			text: faq.answer,
-		},
-	})),
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Lovable"
+  heroSubtitle="Iterate on Your Real Product vs Generate a New One"
+  features={features}
+  faqs={faqs}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://lovable.dev" class="text-link" rel="nofollow">Lovable</a> both use AI for frontend work, but they solve different problems at different stages. Lovable generates complete apps from text prompts in a hosted sandbox. Frontman lets your team — designers, PMs, and engineers — iterate on the product you already ship.
+    </p>
+    <p>
+      <strong>Frontman</strong> is an open-source AI agent that hooks into your dev server. It sees the live DOM, your component library, computed styles, and design tokens. Click any element in your running product, describe the change in plain English, and Frontman edits the source files. No IDE needed — designers and PMs work directly in the browser. Free and unlimited with BYOK.
+    </p>
+    <p>
+      <strong>Lovable</strong> (formerly GPT-Engineer) is an AI-powered app generation platform. Describe what you want and Lovable builds a complete React + Tailwind + Vite app with hosting, databases, authentication, and deployment — all in a hosted sandbox. Credit-based pricing starts at $25/month for serious use. Proprietary SaaS with SOC 2 Type II and ISO 27001 compliance.
+    </p>
+    <p class="summary-emphasis">
+      The core difference: Lovable creates new apps from scratch. Frontman lets your whole team iterate on the product you already have — with AI that understands your design system and real codebase.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<ComparisonHero
-		title="Frontman vs Lovable"
-		subtitle="Iterate on Your Real Product vs Generate a New One"
-	>
-		<p>
-			<a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://lovable.dev" class="text-link" rel="nofollow">Lovable</a> both use AI for frontend work, but they solve different problems at different stages. Lovable generates complete apps from text prompts in a hosted sandbox. Frontman lets your team — designers, PMs, and engineers — iterate on the product you already ship.
-		</p>
-		<p>
-			<strong>Frontman</strong> is an open-source AI agent that hooks into your dev server. It sees the live DOM, your component library, computed styles, and design tokens. Click any element in your running product, describe the change in plain English, and Frontman edits the source files. No IDE needed — designers and PMs work directly in the browser. Free and unlimited with BYOK.
-		</p>
-		<p>
-			<strong>Lovable</strong> (formerly GPT-Engineer) is an AI-powered app generation platform. Describe what you want and Lovable builds a complete React + Tailwind + Vite app with hosting, databases, authentication, and deployment — all in a hosted sandbox. Credit-based pricing starting at $25/month for serious use. Proprietary SaaS with SOC 2 Type II and ISO 27001 compliance.
-		</p>
-		<p class="summary-emphasis">
-			The core difference: Lovable creates new apps from scratch. Frontman lets your whole team iterate on the product you already have — with AI that understands your design system and real codebase.
-		</p>
-		<ComparisonDisclosure competitor="Lovable" />
-	</ComparisonHero>
+  <Fragment slot="competitor-strengths">
+    <p>Lovable is the fastest way to go from an idea to a working app — and it's genuinely great at that.</p>
+    <p><strong>Full-stack app generation from prompts.</strong> Describe what you want and Lovable generates a complete working app. React frontend, Supabase backend, authentication, database schema, and deployment — all in one flow.</p>
+    <p><strong>Lovable Cloud is a full platform.</strong> Hosted databases, authentication, file storage, edge functions, and custom domains are managed through the Lovable interface. You do not need to know what Supabase is or how to configure it.</p>
+    <p><strong>MCP and integrations.</strong> Lovable supports MCP and has built-in integrations with Stripe, Shopify, and Slack. For building apps that connect to external services, Lovable provides a guided path without manual API integration.</p>
+    <p>SOC 2 Type II and ISO 27001 certification, GDPR compliance, and EU data residency. For organizations that require these certifications, Lovable has them.</p>
+    <p><strong>Designed for non-developers.</strong> The entire UX is built around people who have never written code. You never touch a terminal or an IDE. For generating something from scratch, Lovable makes app development accessible to everyone.</p>
+  </Fragment>
 
-	<!-- Feature Comparison Table -->
-	<ComparisonFeatureTable competitorName="Lovable" features={features} />
+  <Fragment slot="frontman-differentiators">
+    <p>Lovable builds new apps. Frontman helps your team iterate on the product you already have. The overlap is \"AI + frontend,\" but the workflows do not intersect.</p>
+    <p><strong>Your real product, not a sandbox.</strong> Frontman works inside your actual running application. It sees your component library, design tokens, computed styles, and routing. When a designer clicks a button and says \"make this match our updated brand colors,\" Frontman edits the real source files using your actual design system.</p>
+    <p><strong>Built for teams with an existing design system.</strong> Lovable\'s sandbox does not know your design tokens, component conventions, or breakpoint behavior. Frontman sees all of this because it runs inside your real app. Changes respect your existing patterns instead of inventing new ones.</p>
+    <p><strong>Click-to-edit instead of chat-to-generate.</strong> Lovable\'s interface is chat-first — you describe what you want and it generates entire apps. Frontman is visual-first — a designer or PM clicks an element in the running product, describes the change, and the AI edits the source with full context.</p>
+    <p><strong>Bridges design and engineering.</strong> Frontman lets designers and PMs make UI changes directly, with engineers reviewing the diffs like normal code. No more screenshot-annotated design comments that get lost.</p>
+    <p><strong>Multi-framework support.</strong> Lovable generates React + Tailwind only. No Vue, Svelte, Astro, or Next.js server components. Frontman works with Next.js, Astro, and Vite — covering React, Vue, and Svelte.</p>
+    <p><strong>Open source and BYOK.</strong> Lovable is proprietary SaaS with credit-based pricing. Frontman\'s client libraries are Apache 2.0, server is AGPL-3.0. You bring your own API keys — no per-seat fees, no token limits, no monthly subscription.</p>
+  </Fragment>
 
-	<!-- What Lovable Does Well -->
-	<IntegrationContentSection title="What Lovable Does Well" variant="light">
-		<p>Lovable is the fastest way to go from an idea to a working app — and it's genuinely great at that.</p>
-		<p><strong>Full-stack app generation from prompts.</strong> Describe what you want ("a project management tool with kanban boards, user authentication, and a dashboard") and Lovable generates a complete working app. React frontend, Supabase backend, authentication, database schema, and deployment. For a PM prototyping an idea to show stakeholders before committing engineering resources, it's hard to beat.</p>
-		<p><strong>Lovable Cloud is a real platform.</strong> Hosted databases, authentication (email, phone, Google OAuth), file storage, edge functions, and custom domains — all managed through the Lovable interface. You don't need to know what Supabase is or how to configure it. The platform handles infrastructure so users can focus on the product.</p>
-		<p><strong>MCP and third-party integrations.</strong> Lovable supports MCP (Model Context Protocol) and has built-in integrations with Stripe, Shopify, and Slack. For building apps that connect to external services, Lovable provides a guided path that doesn't require manual API integration.</p>
-		<p>SOC 2 Type II and ISO 27001 certification, GDPR compliance, and EU data residency. For organizations that require these certifications, Lovable has them and open-source tools typically don't.</p>
-		<p><strong>Designed for non-developers.</strong> The entire UX is built around people who have never written code. You never touch a terminal or an IDE. For generating something from scratch, Lovable makes app development accessible to people without engineering backgrounds.</p>
-	</IntegrationContentSection>
+  <Fragment slot="who-should-use-competitor">
+    <p>Lovable is the better choice when you are starting from zero:</p>
+    <ul>
+      <li><strong>Prototyping and proof-of-concepts</strong> — a PM needs a working demo to validate an idea quickly</li>
+      <li><strong>Non-technical founders</strong> — you have an app idea and no engineering team to build it</li>
+      <li><strong>Greenfield app generation</strong> — turning a chat prompt into a complete full-stack app fast</li>
+      <li><strong>Internal tools from scratch</strong> — building admin dashboards without hiring developers</li>
+      <li><strong>Enterprise compliance requirements</strong> — SOC 2 Type II and ISO 27001 are mandatory for your organization</li>
+      <li><strong>No existing codebase</strong> — you are starting from scratch and want AI to generate everything</li>
+    </ul>
+  </Fragment>
 
-	<!-- Where Frontman Is Different -->
-	<IntegrationContentSection title="Where Frontman Is Different">
-		<p>Lovable builds new apps. Frontman helps your team iterate on the product you already have. The overlap is "AI + frontend," but the workflows don't intersect.</p>
-		<p><strong>Your real product, not a sandbox.</strong> Frontman works inside your actual running application. It sees your component library, design tokens, computed styles, and routing. When a designer clicks a button and says "make this match our updated brand colors," Frontman edits the real source files — using your actual design system components, not generating new ones from scratch. With Lovable, everything lives in a hosted sandbox — and once you enable Lovable Cloud, you cannot disconnect from their infrastructure.</p>
-		<p><strong>Built for teams with an existing design system.</strong> Lovable's sandbox doesn't know about your design tokens, component conventions, or how your UI actually behaves across breakpoints. Frontman sees all of this because it runs inside your real app. Changes respect your existing patterns instead of inventing new ones.</p>
-		<p><strong>Click-to-edit instead of chat-to-generate.</strong> Lovable's interface is chat-first — you describe what you want and it generates entire apps. Frontman is visual-first — a designer or PM clicks an element in the running product, describes the change, and the AI edits the source with full context. No need to describe where something is or what it looks like.</p>
-		<p><strong>Bridges design and engineering.</strong> Frontman lets designers and PMs make UI changes directly, with engineers reviewing the diffs like normal code. No more "can you move this 2px" tickets. No more screenshot-annotated Figma comments that get lost. Changes happen in the same codebase, through the same review process.</p>
-		<p><strong>Multi-framework support.</strong> Lovable generates React + Tailwind only. No Vue, Svelte, Astro, or Next.js server components. Frontman works with Next.js, Astro, and Vite — covering React, Vue, and Svelte. If your product isn't React + Tailwind, Lovable isn't an option.</p>
-		<p><strong>Open source and BYOK.</strong> Lovable is proprietary SaaS with credit-based pricing. Frontman's client libraries are Apache 2.0, server is AGPL-3.0. You bring your own API keys — no per-seat fees, no token limits, no monthly subscription from Frontman. For a growing team, the cost difference compounds fast.</p>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Lovable -->
-	<IntegrationContentSection title="Who Should Use Lovable" variant="light">
-		<p>Lovable is the better choice when you're starting from zero:</p>
-		<ul>
-			<li><strong>Prototyping and proof-of-concepts</strong> — a PM needs a working demo to validate an idea with stakeholders before committing engineering time</li>
-			<li><strong>Non-technical founders</strong> — you have an app idea and no engineering team to build it</li>
-			<li><strong>Greenfield app generation</strong> — turning a chat prompt into a complete full-stack app as fast as possible</li>
-			<li><strong>Internal tools from scratch</strong> — building admin dashboards or workflow tools without hiring developers</li>
-			<li><strong>Enterprise compliance requirements</strong> — SOC 2 Type II and ISO 27001 are non-negotiable for your organization</li>
-			<li><strong>No existing codebase</strong> — you're starting completely from scratch and want AI to generate everything</li>
-		</ul>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Frontman -->
-	<IntegrationContentSection title="Who Should Use Frontman">
-		<p>Frontman is the better choice when your team has a real product and wants to move faster on UI:</p>
-		<ul>
-			<li><strong>Designers iterating on a live product</strong> — click elements, describe changes, see them instantly — no IDE, no handoff tickets</li>
-			<li><strong>PMs making UI tweaks</strong> — update copy, adjust spacing, refine layouts directly in the running product instead of filing Jira tickets</li>
-			<li><strong>Teams with an existing design system</strong> — Frontman sees your actual tokens, components, and styles, so changes respect your system instead of reinventing it</li>
-			<li><strong>Multi-team orgs reducing design-to-dev bottlenecks</strong> — designers and PMs contribute changes that engineers review as normal code diffs</li>
-			<li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
-			<li><strong>Growing teams watching costs</strong> — open source, BYOK, no per-seat fees — scales with your team without scaling your bill</li>
-		</ul>
-		<p>A natural workflow: generate your starting point with Lovable, export to GitHub, add Frontman middleware, and let your whole team iterate visually from there.</p>
-		<p>Also see: <a href="/vs/bolt/" class="text-link">Frontman vs Bolt.new</a> and <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a> for comparisons with other tools in this space.</p>
-	</IntegrationContentSection>
-
-	<!-- Pricing Comparison -->
-	<ComparisonPricing
-		competitorName="Lovable"
-		competitorCost="$0–$2,250/mo"
-		competitorModel="Credit-based, proprietary SaaS"
-		competitorFeatures={[
-			'Free: 5 credits/day, 30/month',
-			'Pro: $25–$2,250/month (scaling credit packs)',
-			'Business: $50–$4,300/month (team features)',
-			'Enterprise: Custom pricing',
-			'Every interaction costs credits (0.5–2+ per action)',
-		]}
-	/>
-
-	<!-- FAQ -->
-	<IntegrationFAQ faqs={faqs} />
-
-	<!-- CTA -->
-	<ComparisonCTA />
-</Layout>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when your team has a real product and wants to move faster on UI:</p>
+    <ul>
+      <li><strong>Designers iterating on a live product</strong> — click elements, describe changes, see them instantly — no IDE, no handoff tickets</li>
+      <li><strong>PMs making UI tweaks</strong> — update copy, adjust spacing, refine layouts directly in the running product instead of filing Jira tickets</li>
+      <li><strong>Teams with an existing design system</strong> — Frontman sees your actual tokens, components, and styles, so changes respect your system instead of reinventing it</li>
+      <li><strong>Multi-team orgs reducing design-to-dev bottlenecks</strong> — designers and PMs contribute changes that engineers review as normal code diffs</li>
+      <li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
+      <li><strong>Growing teams watching costs</strong> — open source, BYOK, no per-seat fees — scales with your team without scaling your bill</li>
+    </ul>
+    <p>A natural workflow: generate your starting point with Lovable, export to GitHub, add Frontman middleware, and let your whole team iterate visually from there.</p>
+    <p>Also see: <a href="/vs/bolt/" class="text-link">Frontman vs Bolt.new</a> and <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a> for comparisons with other tools in this space.</p>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/onlook.astro
+++ b/apps/marketing/src/pages/vs/onlook.astro
@@ -2,183 +2,154 @@
 // /vs/onlook — Frontman vs Onlook Comparison Page
 // Key angle: Onlook is a design tool that outputs code (for designers).
 // Frontman is a dev tool that uses the browser (for developers).
-// Different audiences, different architectures.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
-import ComparisonHero from '../../components/blocks/comparison/ComparisonHero.astro'
-import ComparisonFeatureTable from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-import ComparisonPricing from '../../components/blocks/comparison/ComparisonPricing.astro'
-import ComparisonCTA from '../../components/blocks/comparison/ComparisonCTA.astro'
-import IntegrationContentSection from '../../components/blocks/integrations/IntegrationContentSection.astro'
-import IntegrationFAQ from '../../components/blocks/integrations/IntegrationFAQ.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-import type { ComparisonFeature } from '../../components/blocks/comparison/ComparisonFeatureTable.astro'
-
-// SEO
-const SEO = {
-	title: 'Frontman vs Onlook: Dev Tool vs Design Tool for AI Code Editing',
-	description:
-		'Honest comparison of Frontman and Onlook. Onlook is a Figma-like editor that outputs React code in a sandbox. Frontman edits your existing running app via browser middleware. Feature table, architecture differences, and real trade-offs.'
+const seo: SEOInfo = {
+  title: 'Frontman vs Onlook: Dev Tool vs Design Tool for AI Code Editing',
+  description:
+    'Honest comparison of Frontman and Onlook. Onlook is a Figma-like editor that outputs React code in a sandbox. Frontman edits your existing running app via browser middleware. Feature table, architecture differences, and real trade-offs.',
 }
 
-// Comparison data
+const competitor: CompetitorInfo = {
+  name: 'Onlook',
+  slug: 'onlook',
+  url: 'https://onlook.dev',
+  category: 'DeveloperApplication',
+  description: 'YC-backed visual code editing tool with a Figma-like interface for AI-generated UI edits.',
+  pricing: {
+    cost: 'Free / Contact',
+    model: 'Open source and paid cloud options',
+    features: [
+      'Free and open-source (Apache 2.0 + AGPL-3.0 hybrid paths)',
+      'Cloud pricing undisclosed (contact for enterprise)',
+      'Figma import and design-to-code workflows',
+      'Deploy through Freestyle with hosting options',
+    ],
+  },
+}
+
 const features: ComparisonFeature[] = [
-	{ name: 'Edits your real codebase', frontman: 'yes', competitor: 'partial', frontmanNote: 'Edits actual source files on your machine', competitorNote: 'Edits code in sandbox, export to GitHub' },
-	{ name: 'Sees live DOM & styles', frontman: 'yes', competitor: 'yes', frontmanNote: 'From your real running app', competitorNote: 'From sandbox preview' },
-	{ name: 'Visual element selection', frontman: 'yes', competitor: 'yes', frontmanNote: 'Click to select in browser', competitorNote: 'Figma-like canvas with layers' },
-	{ name: 'Drag & resize elements', frontman: 'no', competitor: 'yes', competitorNote: 'Figma-like drag/resize on canvas' },
-	{ name: 'Figma-like canvas', frontman: 'no', competitor: 'yes', competitorNote: 'Infinite canvas with design tools' },
-	{ name: 'Figma import', frontman: 'no', competitor: 'yes' },
-	{ name: 'Real-time collaboration', frontman: 'no', competitor: 'yes', competitorNote: 'Multi-user editing, spatial comments' },
-	{ name: 'Framework-aware middleware', frontman: 'yes', competitor: 'no', frontmanNote: 'Hooks into Next.js/Astro/Vite runtime', competitorNote: 'Sandbox environment' },
-	{ name: 'Server-side context', frontman: 'yes', competitor: 'no', frontmanNote: 'Routes, logs, real backend data', competitorNote: 'Sandbox only' },
-	{ name: 'Component tree access', frontman: 'yes', competitor: 'partial', frontmanNote: 'React fiber, Vue, Svelte', competitorNote: 'React components in sandbox' },
-	{ name: 'Multi-framework support', frontman: 'yes', competitor: 'no', frontmanNote: 'Next.js, Astro, Vite — React/Vue/Svelte', competitorNote: 'Next.js + TailwindCSS primarily' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', competitor: 'no', frontmanNote: 'Any LLM', competitorNote: 'Uses their models' },
-	{ name: 'Works on existing projects', frontman: 'yes', competitor: 'partial', frontmanNote: 'Designed for this', competitorNote: 'Can import from GitHub but runs in sandbox' },
-	{ name: 'Designer/PM friendly', frontman: 'yes', competitor: 'yes', frontmanNote: 'Click and describe', competitorNote: 'Figma-like interface' },
-	{ name: 'Open source', frontman: 'yes', competitor: 'yes', frontmanNote: 'Apache 2.0 / AGPL-3.0', competitorNote: 'Apache 2.0' },
-	{ name: 'Deploy built-in', frontman: 'no', competitor: 'yes', competitorNote: 'Freestyle hosting' },
+  { name: 'Edits your real codebase', frontman: 'yes', competitor: 'partial', frontmanNote: 'Edits actual source files on your machine', competitorNote: 'Edits code in sandbox, export to GitHub' },
+  { name: 'Sees live DOM & styles', frontman: 'yes', competitor: 'yes', frontmanNote: 'From your real running app', competitorNote: 'From sandbox preview' },
+  { name: 'Visual element selection', frontman: 'yes', competitor: 'yes', frontmanNote: 'Click to select in browser', competitorNote: 'Figma-like canvas with layers' },
+  { name: 'Drag & resize elements', frontman: 'no', competitor: 'yes', competitorNote: 'Figma-like drag/resize on canvas' },
+  { name: 'Figma-like canvas', frontman: 'no', competitor: 'yes', competitorNote: 'Infinite canvas with design tools' },
+  { name: 'Figma import', frontman: 'no', competitor: 'yes' },
+  { name: 'Real-time collaboration', frontman: 'no', competitor: 'yes', competitorNote: 'Multi-user editing, spatial comments' },
+  { name: 'Framework-aware middleware', frontman: 'yes', competitor: 'no', frontmanNote: 'Hooks into Next.js/Astro/Vite runtime', competitorNote: 'Sandbox environment' },
+  { name: 'Server-side context', frontman: 'yes', competitor: 'no', frontmanNote: 'Routes, logs, real backend data', competitorNote: 'Sandbox only' },
+  { name: 'Component tree access', frontman: 'yes', competitor: 'partial', frontmanNote: 'React fiber, Vue, Svelte', competitorNote: 'React components in sandbox' },
+  { name: 'Multi-framework support', frontman: 'yes', competitor: 'no', frontmanNote: 'Next.js, Astro, Vite — React/Vue/Svelte', competitorNote: 'Next.js + TailwindCSS primarily' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', competitor: 'no', frontmanNote: 'Any LLM', competitorNote: 'Uses their models' },
+  { name: 'Works on existing projects', frontman: 'yes', competitor: 'partial', frontmanNote: 'Designed for this', competitorNote: 'Can import from GitHub but runs in sandbox' },
+  { name: 'Designer/PM friendly', frontman: 'yes', competitor: 'yes', frontmanNote: 'Click and describe', competitorNote: 'Figma-like interface' },
+  { name: 'Open source', frontman: 'yes', competitor: 'yes', frontmanNote: 'Apache 2.0 / AGPL-3.0', competitorNote: 'Apache 2.0' },
+  { name: 'Deploy built-in', frontman: 'no', competitor: 'yes', competitorNote: 'Freestyle hosting' },
 ]
 
-// FAQ data
-const faqs = [
-	{
-		question: 'Is Frontman an alternative to Onlook?',
-		answer: 'They target different audiences. Onlook is a design tool for creating and editing UI visually with a Figma-like interface. Frontman is a dev tool for editing existing apps by clicking elements in your browser. Onlook targets designers who want to output real code. Frontman targets developers who want browser-aware AI coding on their existing projects.'
-	},
-	{
-		question: 'Both are open source — what\'s the difference?',
-		answer: 'Architecture. Onlook runs your app in a sandboxed web container (CodeSandbox SDK). Frontman hooks into your actual dev server as middleware. Onlook sees a sandbox preview. Frontman sees your real running application with real data and real backend state. Both are open source — Onlook is Apache 2.0, Frontman is Apache 2.0 (client) / AGPL-3.0 (server).'
-	},
-	{
-		question: 'Can designers use Frontman?',
-		answer: 'Yes, but differently. Frontman lets anyone click elements and describe changes in plain English — no IDE needed. But Onlook provides a more familiar design-tool interface with a canvas, layers panel, drag/resize, and spatial comments that designers may prefer for purely visual work.'
-	},
-	{
-		question: 'Which supports more frameworks?',
-		answer: 'Frontman. It works with Next.js, Astro, and Vite (covering React, Vue, and Svelte). Onlook primarily supports Next.js with TailwindCSS. Vue is mentioned on Onlook\'s roadmap but is not practically available yet.'
-	},
-	{
-		question: 'Which is better for existing projects?',
-		answer: 'Frontman. It\'s designed specifically for existing codebases — it hooks into your dev server and edits your actual source files. Onlook can import repositories from GitHub but runs the code in a sandbox, which means you lose your real backend, real APIs, and runtime context.'
-	},
-	{
-		question: 'Why does Onlook have 24,000+ stars and Frontman has ~130?',
-		answer: 'Onlook is backed by Y Combinator, has been around longer, and targets a larger audience that includes both designers and developers. Frontman is newer and targets a more specific niche: developers who want browser-aware AI coding on their existing projects with full runtime context.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an alternative to Onlook?',
+    answer:
+      'They target different audiences. Onlook is a design tool for creating and editing UI visually with a Figma-like interface. Frontman is a dev tool for editing existing apps by clicking elements in your browser. Onlook targets designers who want to output real code. Frontman targets developers who want browser-aware AI coding on their existing projects.',
+  },
+  {
+    question: 'Both are open source — what\'s the difference?',
+    answer:
+      'Architecture. Onlook runs your app in a sandboxed web container (CodeSandbox SDK). Frontman hooks into your actual dev server as middleware. Onlook sees a sandbox preview. Frontman sees your real running application with real data and real backend context.',
+  },
+  {
+    question: 'Can designers use Frontman?',
+    answer:
+      'Yes, but differently. Frontman lets anyone click elements and describe changes in plain English — no IDE needed. But Onlook provides a more familiar design-tool interface with a canvas, layers panel, drag/resize, and spatial comments that designers may prefer for purely visual work.',
+  },
+  {
+    question: 'Which supports more frameworks?',
+    answer:
+      'Frontman. It works with Next.js, Astro, and Vite (covering React, Vue, and Svelte). Onlook primarily supports Next.js with TailwindCSS. Vue is mentioned on Onlook\'s roadmap but is not practically available yet.',
+  },
+  {
+    question: 'Which is better for existing projects?',
+    answer:
+      'Frontman. It\'s designed specifically for existing codebases — it hooks into your dev server and edits your actual source files. Onlook can import repositories from GitHub but runs the code in a sandbox, which means you lose your real backend, real APIs, and runtime context.',
+  },
+  {
+    question: 'Why does Onlook have more GitHub stars than Frontman?',
+    answer:
+      'Onlook is YC-backed, has been around longer, and targets a larger audience that includes both designers and developers. Frontman is newer and targets a more specific niche: developers who want browser-aware AI coding on their existing projects with full runtime context.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Onlook"
+  heroSubtitle="Dev Tool vs Design Tool for AI Code Editing"
+  features={features}
+  faqs={faqs}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://onlook.dev" class="text-link" rel="nofollow">Onlook</a> both use AI to help edit frontend code visually, but they're built for different people. Onlook is a Figma-like editor that outputs React code in a sandbox. Frontman is a developer tool that hooks into your running app in the browser.
+    </p>
+    <p>
+      <strong>Frontman</strong> is an open-source AI coding agent that installs as middleware in your dev server (Next.js, Astro, Vite). It sees the live DOM, component tree, computed CSS, and server-side context of your real running application. You click elements in your browser, describe changes in plain English, and Frontman edits the actual source files with hot reload. Free and unlimited — bring your own API keys.
+    </p>
+    <p>
+      <strong>Onlook</strong> is an open-source, YC-backed visual editor described as \"Cursor for Designers.\" It provides a Figma-like canvas with layers, drag/resize, brand tokens, and spatial comments. Apps run in a CodeSandbox SDK web container — not your real dev server. It supports AI chat with project context, Figma import, GitHub integration, real-time collaboration, and Freestyle deployment. Primarily supports Next.js + TailwindCSS.
+    </p>
+    <p class="summary-emphasis">
+      The core difference: Onlook is a design tool that generates code in a sandbox. Frontman is a dev tool that edits your real running app. Different audiences, different architectures.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<ComparisonHero
-		title="Frontman vs Onlook"
-		subtitle="Dev Tool vs Design Tool for AI Code Editing"
-	>
-		<p>
-			<a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://onlook.dev" class="text-link" rel="nofollow">Onlook</a> both use AI to help edit frontend code visually, but they're built for different people. Onlook is a Figma-like design tool that outputs real React code. Frontman is a developer tool that hooks into your running app in the browser.
-		</p>
-		<p>
-			<strong>Frontman</strong> is an open-source AI coding agent that installs as middleware in your dev server (Next.js, Astro, Vite). It sees the live DOM, component tree, computed CSS, and server-side context of your real running application. You click elements in your browser, describe changes in plain English, and Frontman edits the actual source files with hot reload. Free and unlimited — bring your own API keys.
-		</p>
-		<p>
-			<strong>Onlook</strong> is an open-source, YC-backed visual editor described as "Cursor for Designers." It provides a Figma-like canvas with layers, drag/resize, brand tokens, and spatial comments. Apps run in a CodeSandbox SDK web container — not your real dev server. It supports AI chat with project context, Figma import, GitHub integration, real-time collaboration, and deploy to Freestyle hosting. Primarily supports Next.js + TailwindCSS. Still under active development.
-		</p>
-		<p class="summary-emphasis">
-			The core difference: Onlook is a design tool that generates code in a sandbox. Frontman is a dev tool that edits your real running app. Different audiences, different architectures.
-		</p>
-		<ComparisonDisclosure competitor="Onlook" />
-	</ComparisonHero>
+  <Fragment slot="competitor-strengths">
+    <p>Onlook has 24,800+ GitHub stars and YC backing. Its target audience is designers who want to edit real code without learning an IDE.</p>
+    <p><strong>Figma-like editing experience.</strong> Onlook provides a canvas, layers panel, drag/resize, and visual property editors that feel familiar to designers. You can select elements, move them around, adjust spacing and typography — all without touching code. This is a different interaction model from text-based AI coding.</p>
+    <p><strong>Real-time collaboration.</strong> Multiple users can edit simultaneously with spatial comments, similar to Figma multiplayer. Frontman has no collaboration features.</p>
+    <p><strong>Figma import.</strong> Onlook can import designs from Figma, bridging the designer-to-developer handoff. Frontman has no Figma integration.</p>
+    <p><strong>GitHub integration and deploy.</strong> Onlook can import repositories from GitHub, create pull requests, and deploy to Freestyle hosting. It is trying to be a complete workflow from design to production.</p>
+    <p><strong>AI chat with project context.</strong> Onlook includes AI chat that understands your project structure and can make changes across files. It also supports MCP for extending AI capabilities.</p>
+  </Fragment>
 
-	<!-- Feature Table -->
-	<ComparisonFeatureTable competitorName="Onlook" features={features} />
+  <Fragment slot="frontman-differentiators">
+    <p>Both tools involve clicking UI elements and getting code changes. The difference is where your code runs. <strong>Onlook runs your app in a sandbox. Frontman runs inside your real app.</strong></p>
+    <p><strong>Your real dev server, not a sandbox.</strong> Onlook runs your code in a CodeSandbox SDK web container. This means no real backend, no real API calls, no real database queries, no server-side rendering with real data. Frontman installs as middleware in your actual Next.js, Astro, or Vite dev server. It sees everything your app sees because it <em>is</em> your app.</p>
+    <p><strong>Framework middleware integration.</strong> Frontman hooks into the framework runtime — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to the React fiber tree, Vue reactivity graph, component props and state, server-side routes, and server logs. When you click a button, Frontman knows which component rendered it, what props it received, and what API endpoint it calls.</p>
+    <p><strong>Edits your actual source files.</strong> Frontman writes changes directly to your source files on disk. Hot module replacement shows the result instantly in your browser. Onlook edits code inside its sandbox, and you export changes back to your repository via GitHub integration.</p>
+    <p><strong>Multi-framework support.</strong> Frontman works with Next.js, Astro, and Vite (which covers React, Vue, and Svelte). Onlook primarily supports Next.js with TailwindCSS. If your project uses Astro, Vue, or Svelte, Frontman is the option that works today.</p>
+    <p><strong>BYOK and truly free.</strong> Frontman lets you bring your own API keys — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API. No usage limits, no credits, no subscription from Frontman. Onlook uses its own AI models with no BYOK option.</p>
+  </Fragment>
 
-	<!-- What Onlook Does Well -->
-	<IntegrationContentSection title="What Onlook Does Well" variant="light">
-		<p>Onlook has 24,800+ GitHub stars and YC backing. Its target audience is designers who want to edit real code without learning an IDE.</p>
-		<p><strong>Figma-like editing experience.</strong> Onlook provides a canvas, layers panel, drag/resize, and visual property editors that feel familiar to designers. You can select elements, move them around, adjust spacing and typography — all without touching code. This is a different interaction model from text-based AI coding.</p>
-		<p><strong>Real-time collaboration.</strong> Multiple users can edit simultaneously with spatial comments, similar to Figma's multiplayer. This makes it viable for design reviews and pair design sessions. Frontman has no collaboration features.</p>
-		<p><strong>Figma import.</strong> Onlook can import designs from Figma, bridging the designer-to-developer handoff. Frontman has no Figma integration.</p>
-		<p><strong>GitHub integration and deploy.</strong> Onlook can import repositories from GitHub, create pull requests, and deploy to Freestyle hosting. It's trying to be a complete workflow from design to production.</p>
-		<p><strong>AI chat with project context.</strong> Onlook includes AI chat that understands your project structure and can make changes across files. It also supports MCP for extending AI capabilities.</p>
-	</IntegrationContentSection>
+  <Fragment slot="who-should-use-competitor">
+    <p>Onlook is the better choice when visual design tools matter more than runtime context:</p>
+    <ul>
+      <li><strong>Designers editing code</strong> — the Figma-like canvas, layers panel, and drag/resize feel natural for design workflows</li>
+      <li><strong>New Next.js + Tailwind projects</strong> — Onlook\'s sandbox works well for projects that do not require a real backend</li>
+      <li><strong>Team design reviews</strong> — real-time collaboration and spatial comments make it useful for reviewing UI changes with stakeholders</li>
+      <li><strong>Figma-to-code workflows</strong> — import Figma designs and iterate visually</li>
+      <li><strong>Prototyping and greenfield work</strong> — when you do not have an existing backend or runtime to connect to</li>
+    </ul>
+  </Fragment>
 
-	<!-- Where Frontman Is Different -->
-	<IntegrationContentSection title="Where Frontman Is Different">
-		<p>Both tools involve clicking UI elements and getting code changes. The difference is where your code runs. <strong>Onlook runs your app in a sandbox. Frontman runs inside your real app.</strong></p>
-
-		<p><strong>Your real dev server, not a sandbox.</strong> Onlook runs your code in a CodeSandbox SDK web container. This means no real backend, no real API calls, no real database queries, no server-side rendering with real data. Frontman installs as middleware in your actual Next.js, Astro, or Vite dev server. It sees everything your app sees because it <em>is</em> your app.</p>
-
-		<p><strong>Framework middleware integration.</strong> Frontman hooks into the framework runtime — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to the React fiber tree, Vue reactivity graph, component props and state, server-side routes, and server logs. When you click a button, Frontman knows which component rendered it, what props it received, and what API endpoint it calls.</p>
-
-		<p><strong>Edits your actual source files.</strong> Frontman writes changes directly to your source files on disk. Hot module replacement shows the result instantly in your browser. Onlook edits code inside its sandbox, and you export changes back to your repository via GitHub integration. The roundtrip adds friction when iterating quickly.</p>
-
-		<p><strong>Multi-framework support.</strong> Frontman works with Next.js, Astro, and Vite (which covers React, Vue, and Svelte). Onlook primarily supports Next.js with TailwindCSS. If your project uses Astro, Vue, or Svelte, Frontman is the option that works today.</p>
-
-		<p><strong>BYOK and truly free.</strong> Frontman lets you bring your own API keys — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API. No usage limits, no credits, no subscription from Frontman. Onlook uses its own AI models with no BYOK option.</p>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Onlook -->
-	<IntegrationContentSection title="Who Should Use Onlook" variant="light">
-		<p>Onlook is the better choice when visual design tools matter more than runtime context:</p>
-		<ul>
-			<li><strong>Designers editing code</strong> — the Figma-like canvas, layers panel, and drag/resize feel natural for design workflows</li>
-			<li><strong>New Next.js + Tailwind projects</strong> — Onlook's sandbox works well for projects that don't need a real backend</li>
-			<li><strong>Team design reviews</strong> — real-time collaboration and spatial comments make it useful for reviewing UI changes with stakeholders</li>
-			<li><strong>Figma-to-code workflows</strong> — import Figma designs and iterate on them visually</li>
-			<li><strong>Prototyping and greenfield work</strong> — when you don't have an existing backend or runtime to connect to</li>
-		</ul>
-	</IntegrationContentSection>
-
-	<!-- Who Should Use Frontman -->
-	<IntegrationContentSection title="Who Should Use Frontman">
-		<p>Frontman is the better choice when you need to edit an existing, running application:</p>
-		<ul>
-			<li><strong>Existing codebases</strong> — your app is already built, has a real backend, real API integrations, and you need to edit the frontend with full context</li>
-			<li><strong>Developers, not designers</strong> — you think in components and props, not layers and frames, and want AI that understands your framework runtime</li>
-			<li><strong>Server-side context matters</strong> — you need the AI to understand routes, server logs, API responses, and real database state alongside the visual UI</li>
-			<li><strong>Non-Next.js frameworks</strong> — Astro, Vite with Vue, Svelte, or React projects that Onlook doesn't support</li>
-			<li><strong>BYOK and vendor-independent</strong> — you want to use your own LLM provider with no usage limits or cloud dependency</li>
-			<li><strong>Quick iteration on live apps</strong> — click an element in your browser, describe the change, see it instantly via hot reload on your real dev server</li>
-		</ul>
-		<p>Also see: <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a> for a comparison with another browser-based AI coding tool, or <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a> for a comparison with an AI-powered IDE.</p>
-	</IntegrationContentSection>
-
-	<!-- Pricing -->
-	<ComparisonPricing
-		competitorName="Onlook"
-		competitorCost="Free / Contact"
-		competitorModel="Open source self-hosted, cloud pricing undisclosed"
-		competitorFeatures={[
-			'Free to self-host (Apache 2.0)',
-			'Cloud version available (book a demo)',
-			'Enterprise options with Docker/cloud deploy',
-			'Deploy to Freestyle hosting included',
-		]}
-	/>
-
-	<!-- FAQ -->
-	<IntegrationFAQ faqs={faqs} />
-
-	<!-- CTA -->
-	<ComparisonCTA />
-</Layout>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when you need to edit an existing, running application:</p>
+    <ul>
+      <li><strong>Existing codebases</strong> — your app is already built, has a real backend, real API integrations, and you need to edit the frontend with full context</li>
+      <li><strong>Developers, not designers</strong> — you think in components and props, not layers and frames, and want AI that understands your framework runtime</li>
+      <li><strong>Server-side context matters</strong> — you need the AI to understand routes, server logs, API responses, and real database state alongside the visual UI</li>
+      <li><strong>Non-Next.js frameworks</strong> — Astro, Vite with Vue, Svelte, or React projects that Onlook does not support</li>
+      <li><strong>BYOK and vendor-independent</strong> — you want to use your own LLM provider with no usage limits or cloud dependency</li>
+      <li><strong>Quick iteration on live apps</strong> — click an element in your browser, describe the change, see it instantly via hot reload on your real dev server</li>
+    </ul>
+    <p>Also see: <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a> for a comparison with another browser-based AI coding tool, or <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a> for a comparison with an AI-powered IDE.</p>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/openclaw.astro
+++ b/apps/marketing/src/pages/vs/openclaw.astro
@@ -5,721 +5,211 @@
 // KEY ANGLE: Not a competitor — a complement. Frontman is the specialized frontend
 // visual editing layer that OpenClaw's general-purpose browser tool lacks.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
 import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs OpenClaw: Specialized Frontend Editing Meets General-Purpose AI Agent (2026)',
-	description:
-		'OpenClaw is a general-purpose AI agent. Frontman is a browser-based visual frontend editor. See how they compare — and how they work together as an OpenClaw skill.'
+const seo: SEOInfo = {
+  title: 'Frontman vs OpenClaw: Specialized Frontend Editing Meets General-Purpose AI Agent (2026)',
+  description:
+    'OpenClaw is a general-purpose AI agent. Frontman is a browser-based visual frontend editor. See how they compare — and how they work together as an OpenClaw skill.',
 }
 
-// Comparison data
+const competitor: CompetitorInfo = {
+  name: 'OpenClaw',
+  slug: 'openclaw',
+  url: 'https://openclaw.ai',
+  category: 'DeveloperApplication',
+  description:
+    'Open-source general-purpose AI agent with browser automation, shell access, messaging integrations, and a large skills ecosystem.',
+  pricing: {
+    cost: 'Free',
+    model: 'Open source (MIT)',
+    features: [
+      'Free and open source (MIT)',
+      '5,400+ community skills via ClawHub',
+      'Supports multi-channel messaging (Slack, Telegram, Discord, WhatsApp)',
+      'Local-first architecture with markdown-based storage',
+      'Bring your own API keys for model providers',
+    ],
+  },
+}
+
 type Status = 'yes' | 'no' | 'partial'
 
 type Feature = {
-	name: string
-	frontman: Status
-	openclaw: Status
-	frontmanNote?: string
-	openclawNote?: string
+  name: string
+  frontman: Status
+  openclaw: Status
+  frontmanNote?: string
+  openclawNote?: string
 }
 
 const features: Feature[] = [
-	{ name: 'Browser-based UI editing', frontman: 'yes', openclaw: 'partial', frontmanNote: 'Click elements, describe changes, get source-level edits', openclawNote: 'General browser automation — click, type, navigate' },
-	{ name: 'Sees live DOM & computed CSS', frontman: 'yes', openclaw: 'partial', frontmanNote: 'MCP server exposes full DOM tree, runtime CSS values', openclawNote: 'Can read page content, limited CSS introspection' },
-	{ name: 'Component tree awareness', frontman: 'yes', openclaw: 'no', frontmanNote: 'Knows which React/Vue/Svelte component renders each element', openclawNote: 'Sees HTML elements, not framework components' },
-	{ name: 'Source map resolution', frontman: 'yes', openclaw: 'no', frontmanNote: 'Maps DOM node → source file + line number', openclawNote: 'Cannot trace DOM to source' },
-	{ name: 'Framework integration', frontman: 'yes', openclaw: 'no', frontmanNote: 'Native plugins for Next.js, Astro, Vite', openclawNote: 'Framework-agnostic — no dev server integration' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', openclaw: 'no', frontmanNote: 'Edits source → HMR updates browser instantly', openclawNote: 'Can edit files, must manually refresh to verify' },
-	{ name: 'Shell command execution', frontman: 'no', openclaw: 'yes', openclawNote: 'Full terminal access, script execution' },
-	{ name: 'Multi-channel messaging', frontman: 'no', openclaw: 'yes', openclawNote: 'Slack, Telegram, Discord, WhatsApp, and more' },
-	{ name: 'General web automation', frontman: 'no', openclaw: 'yes', openclawNote: 'Navigate any site, fill forms, extract data' },
-	{ name: 'File system management', frontman: 'partial', openclaw: 'yes', frontmanNote: 'Edits source files for frontend changes', openclawNote: 'Full file system access, any file type' },
-	{ name: 'Skills/plugin ecosystem', frontman: 'no', openclaw: 'yes', openclawNote: '5,400+ community skills on ClawHub' },
-	{ name: 'Works together', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Available as an OpenClaw skill', openclawNote: 'Can use Frontman via skill install' },
-	{ name: 'Open source', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Apache 2.0 / AGPL-3.0', openclawNote: 'MIT' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', openclaw: 'yes', frontmanNote: 'OpenRouter, Anthropic, OpenAI', openclawNote: 'Any LLM provider' },
-	{ name: 'Local-first / self-hostable', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Runs on your machine, code never leaves', openclawNote: 'All data stored locally as markdown' },
+  { name: 'Browser-based UI editing', frontman: 'yes', openclaw: 'partial', frontmanNote: 'Click elements, describe changes, get source-level edits', openclawNote: 'General browser automation — click, type, navigate' },
+  { name: 'Sees live DOM & computed CSS', frontman: 'yes', openclaw: 'partial', frontmanNote: 'MCP server exposes full DOM tree, runtime CSS values', openclawNote: 'Can read page content, limited CSS introspection' },
+  { name: 'Component tree awareness', frontman: 'yes', openclaw: 'no', frontmanNote: 'Knows which React/Vue/Svelte component renders each element', openclawNote: 'Sees HTML elements, not framework components' },
+  { name: 'Source map resolution', frontman: 'yes', openclaw: 'no', frontmanNote: 'Maps DOM node → source file + line number', openclawNote: 'Cannot trace DOM to source' },
+  { name: 'Framework integration', frontman: 'yes', openclaw: 'no', frontmanNote: 'Native plugins for Next.js, Astro, Vite', openclawNote: 'Framework-agnostic — no dev server integration' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', openclaw: 'no', frontmanNote: 'Edits source → HMR updates browser instantly', openclawNote: 'Can edit files, must manually refresh to verify' },
+  { name: 'Shell command execution', frontman: 'no', openclaw: 'yes', openclawNote: 'Full terminal access, script execution' },
+  { name: 'Multi-channel messaging', frontman: 'no', openclaw: 'yes', openclawNote: 'Slack, Telegram, Discord, WhatsApp, and more' },
+  { name: 'General web automation', frontman: 'no', openclaw: 'yes', openclawNote: 'Navigate any site, fill forms, extract data' },
+  { name: 'File system management', frontman: 'partial', openclaw: 'yes', frontmanNote: 'Edits source files for frontend changes', openclawNote: 'Full file system access, any file type' },
+  { name: 'Skills/plugin ecosystem', frontman: 'no', openclaw: 'yes', openclawNote: '5,400+ community skills on ClawHub' },
+  { name: 'Works together', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Available as an OpenClaw skill', openclawNote: 'Can use Frontman via skill install' },
+  { name: 'Open source', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Apache 2.0 / AGPL-3.0', openclawNote: 'MIT' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', openclaw: 'yes', frontmanNote: 'OpenRouter, Anthropic, OpenAI', openclawNote: 'Any LLM provider' },
+  { name: 'Local-first / self-hostable', frontman: 'yes', openclaw: 'yes', frontmanNote: 'Runs on your machine, code never leaves', openclawNote: 'All data stored locally as markdown' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
+const comparisonFeatures: ComparisonFeature[] = features.map((feature) => ({
+  name: feature.name,
+  frontman: feature.frontman,
+  competitor: feature.openclaw,
+  frontmanNote: feature.frontmanNote,
+  competitorNote: feature.openclawNote,
+}))
 
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'Is Frontman a competitor to OpenClaw?',
-		answer: 'No. They serve different purposes and work well together. OpenClaw is a general-purpose AI agent that can control your browser, run shell commands, and work across messaging apps. Frontman is a specialized frontend editing tool that understands your component tree, computed CSS, and source maps. Frontman is available as an OpenClaw skill — install it with openclaw skill install frontman-dev.'
-	},
-	{
-		question: 'How do I use Frontman with OpenClaw?',
-		answer: 'Install the Frontman skill in OpenClaw with openclaw skill install frontman-dev. Then install Frontman in your project (npx @frontman-ai/nextjs install for Next.js, npx astro add @frontman-ai/astro for Astro, or npx @frontman-ai/vite install for Vite). Start your dev server and tell your OpenClaw agent to open localhost/frontman. The agent can then click elements, describe changes, and get real source-level edits with hot reload.'
-	},
-	{
-		question: 'What can Frontman do that OpenClaw browser tool cannot?',
-		answer: 'Frontman integrates with your framework as a dev server plugin and creates a browser-side MCP server. This gives it access to the component tree (which React/Vue/Svelte component renders each element), computed CSS values (runtime pixels, not class names), source map resolution (DOM node to exact file and line number), and hot reload feedback. OpenClaw browser tool sees HTML elements and can interact with them, but cannot trace them back to source components or make targeted source-level edits.'
-	},
-	{
-		question: 'What can OpenClaw do that Frontman cannot?',
-		answer: 'OpenClaw is a general-purpose agent. It runs shell commands, manages files, browses the open web, works across messaging channels (Slack, Telegram, Discord, WhatsApp), and has 5,400+ community skills for tasks like email, calendar, API integrations, and data extraction. Frontman is focused exclusively on visual frontend editing in your development environment.'
-	},
-	{
-		question: 'Can my designers use this combination?',
-		answer: 'Yes. Designers describe UI changes in whatever messaging app your team uses — Slack, Discord, Telegram. OpenClaw receives the message, uses the Frontman skill to open the app in the browser, click the relevant element, and make the edit. It posts a screenshot of the result back to the channel. The code diff goes through your normal review process. No IDE or terminal needed.'
-	},
-	{
-		question: 'Is this combination open source?',
-		answer: 'Yes. Frontman client libraries are Apache 2.0, the server is AGPL-3.0. OpenClaw is MIT licensed. The Frontman skill on ClawHub is MIT-0. Both tools run locally — your code and conversations never leave your machine. You bring your own API keys to both.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman a competitor to OpenClaw?',
+    answer:
+      'No. They serve different purposes and work well together. OpenClaw is a general-purpose AI agent that can control your browser, run shell commands, and work across messaging apps. Frontman is a specialized frontend editing tool that understands your component tree, computed CSS, and source maps. Frontman is available as an OpenClaw skill — install it with openclaw skill install frontman-dev.',
+  },
+  {
+    question: 'How do I use Frontman with OpenClaw?',
+    answer:
+      'Install the Frontman skill in OpenClaw with openclaw skill install frontman-dev. Then install Frontman in your project (npx @frontman-ai/nextjs install for Next.js, npx astro add @frontman-ai/astro for Astro, or npx @frontman-ai/vite install for Vite). Start your dev server and tell your OpenClaw agent to open localhost/frontman. The agent can then click elements, describe changes, and get real source-level edits with hot reload.',
+  },
+  {
+    question: 'What can Frontman do that OpenClaw browser tool cannot?',
+    answer:
+      'Frontman integrates with your framework as a dev server plugin and creates a browser-side MCP server. This gives it access to the component tree (which React/Vue/Svelte component renders each element), computed CSS values (runtime pixels, not class names), source map resolution (DOM node to exact file and line number), and hot reload feedback. OpenClaw browser tool sees HTML elements and can interact with them, but cannot trace them back to source components or make targeted source-level edits.',
+  },
+  {
+    question: 'What can OpenClaw do that Frontman cannot?',
+    answer:
+      'OpenClaw is a general-purpose agent. It runs shell commands, manages files, browses the open web, works across messaging channels (Slack, Telegram, Discord, WhatsApp), and has 5,400+ community skills for tasks like email, calendar, API integrations, and data extraction. Frontman is focused exclusively on visual frontend editing in your development environment.',
+  },
+  {
+    question: 'Can my designers use this combination?',
+    answer:
+      'Yes. Designers describe UI changes in whatever messaging app your team uses — Slack, Discord, Telegram. OpenClaw receives the message, uses the Frontman skill to open the app in the browser, click the relevant element, and make the edit. It posts a screenshot of the result back to the channel. The code diff goes through your normal review process. No IDE or terminal needed.',
+  },
+  {
+    question: 'Is this combination open source?',
+    answer:
+      'Yes. Frontman client libraries are Apache 2.0, the server is AGPL-3.0. OpenClaw is MIT licensed. The Frontman skill on ClawHub is MIT-0. Both tools run locally — your code and conversations never leave your machine. You bring your own API keys to both.',
+  },
 ]
-
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs OpenClaw"
+  heroSubtitle="Specialized Frontend Editing Meets General-Purpose AI Agent"
+  features={comparisonFeatures}
+  faqs={faqs}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://openclaw.ai" class="text-link" rel="nofollow">OpenClaw</a> is the most popular open-source AI agent in 2026 — 250,000+ GitHub stars, 5,400+ community skills, and support for every messaging platform from Slack to WhatsApp. It can control your browser, run shell commands, and automate workflows across your entire stack.
+    </p>
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent built specifically for frontend development. It installs as a plugin in your dev server (Next.js, Astro, or Vite) and creates a browser-side MCP server that sees your component tree, computed CSS, source maps, and rendered DOM. Click any element, describe a change, and Frontman edits the source file with instant hot reload.
+    </p>
+    <p class="summary-emphasis">
+      They are not competitors — they are complementary. Frontman is available as an OpenClaw skill. Use OpenClaw for general-purpose automation, and Frontman for precise visual frontend editing in your codebase.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs OpenClaw</h1>
-			<p class="hero-subtitle">Specialized Frontend Editing Meets General-Purpose AI Agent</p>
+  <Fragment slot="competitor-strengths">
+    <p>OpenClaw became the fastest-growing open-source project in history for a reason. It is genuinely useful across a wide range of tasks.</p>
+    <p><strong>General-purpose automation.</strong> OpenClaw runs shell commands, manages files, calls APIs, and orchestrates multi-step workflows. It is not limited to any specific domain — it handles whatever you throw at it.</p>
+    <p><strong>Multi-channel support.</strong> Slack, Telegram, Discord, WhatsApp, Signal, iMessage, Teams, Matrix, IRC, and more. You talk to your agent where you already talk to your team.</p>
+    <p><strong>Community skills ecosystem.</strong> 5,400+ skills on ClawHub covering everything from email management to database administration to CI/CD automation. Installing a new capability is one command.</p>
+    <p><strong>Browser automation.</strong> OpenClaw can open tabs, navigate sites, click buttons, fill forms, take screenshots, and extract data. It works with any website, not just your own projects.</p>
+    <p><strong>Local-first architecture.</strong> All data — memory, conversations, files — stored as markdown on your disk. No external servers, no vendor lock-in. MIT licensed.</p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://openclaw.ai" class="text-link" rel="nofollow">OpenClaw</a> is the most popular open-source AI agent in 2026 — 250,000+ GitHub stars, 5,400+ community skills, and support for every messaging platform from Slack to WhatsApp. It can control your browser, run shell commands, and automate workflows across your entire stack.
-				</p>
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent built specifically for frontend development. It installs as a plugin in your dev server (Next.js, Astro, or Vite) and creates a browser-side MCP server that sees your component tree, computed CSS, source maps, and rendered DOM. Click any element, describe a change, and Frontman edits the source file with instant hot reload.
-				</p>
-				<p class="summary-emphasis">
-					They are not competitors — they are complementary. Frontman is available as an OpenClaw skill. Use OpenClaw for general-purpose automation, and Frontman for precise visual frontend editing in your codebase.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="OpenClaw" />
-		</div>
-	</section>
+  <Fragment slot="frontman-differentiators">
+    <p><strong>It understands your component tree.</strong> OpenClaw's browser tool sees HTML elements. Frontman sees React components, Vue instances, Svelte blocks, and Astro islands. When you click a card on screen, Frontman knows it is your <code>Card</code> component from <code>@company/ui</code>, rendered at line 47 of <code>Card.tsx</code>, with specific props and token-derived styles.</p>
+    <p><strong>It reads computed CSS, not class names.</strong> OpenClaw can read the page source and see <code>class="p-4 shadow-md"</code>. Frontman sees that <code>p-4</code> computes to <code>padding: 16px</code> and <code>shadow-md</code> renders as <code>box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1)</code>. When you say "make the shadow more subtle," Frontman knows the current runtime value.</p>
+    <p><strong>Source map resolution.</strong> Click a DOM element, and Frontman resolves it to the exact source file, component, and line number through the framework's source maps. No guessing which file to edit. This is possible because Frontman installs as a framework plugin inside your dev server — it has access to the build pipeline.</p>
+    <p><strong>Hot reload feedback loop.</strong> Frontman edits the source file, and the framework's HMR updates the browser instantly. Edit → see result → iterate. The AI verifies its own work by taking a screenshot after each edit. OpenClaw can edit files too, but it does not integrate with your dev server's hot reload pipeline.</p>
+    <p><strong>Click-to-select workflow.</strong> Instead of describing which element to change in words, you click it in the browser. The AI already has full context — the component, its styles, its position in the layout, and the source file. "Make this button primary" is unambiguous because the AI knows which button you mean.</p>
+    <p><strong>Real source file edits.</strong> Every change Frontman makes is a real edit to your source code — the same files your engineers write by hand. No CSS overrides, no separate layer. Changes go through your existing code review process.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="who-should-use-competitor">
+    <p><strong>Use OpenClaw alone</strong> if you need a general-purpose AI agent for shell automation, web scraping, multi-channel messaging, file management, or workflow orchestration. You do not need Frontman unless you are doing frontend development.</p>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">OpenClaw</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.openclaw)}>
-									<div class="status-content">
-										{feature.openclaw === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.openclaw === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.openclaw === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.openclawNote && <span class="status-note">{feature.openclawNote}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-frontman">
+    <p><strong>Use Frontman alone</strong> if you want browser-based visual editing for your dev server and your team already has a workflow that does not involve OpenClaw. Frontman works standalone — no OpenClaw required.</p>
+    <p><strong>Use both together</strong> if you want the best of both worlds: OpenClaw's general-purpose capabilities (messaging, shell, files, skills ecosystem) combined with Frontman's deep frontend editing (component tree, computed CSS, source maps, hot reload). This is the recommended setup for product teams where designers and PMs are involved in UI iteration.</p>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">OpenClaw</span>
-								<span>
-									{feature.openclaw === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.openclaw === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.openclaw === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- What OpenClaw Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What OpenClaw Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>OpenClaw became the fastest-growing open-source project in history for a reason. It is genuinely useful across a wide range of tasks.</p>
-				<p><strong>General-purpose automation.</strong> OpenClaw runs shell commands, manages files, calls APIs, and orchestrates multi-step workflows. It is not limited to any specific domain — it handles whatever you throw at it.</p>
-				<p><strong>Multi-channel support.</strong> Slack, Telegram, Discord, WhatsApp, Signal, iMessage, Teams, Matrix, IRC, and more. You talk to your agent where you already talk to your team.</p>
-				<p><strong>Community skills ecosystem.</strong> 5,400+ skills on ClawHub covering everything from email management to database administration to CI/CD automation. Installing a new capability is one command.</p>
-				<p><strong>Browser automation.</strong> OpenClaw can open tabs, navigate sites, click buttons, fill forms, take screenshots, and extract data. It works with any website, not just your own projects.</p>
-				<p><strong>Local-first architecture.</strong> All data — memory, conversations, files — stored as markdown on your disk. No external servers, no vendor lock-in. MIT licensed.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p><strong>It understands your component tree.</strong> OpenClaw's browser tool sees HTML elements. Frontman sees React components, Vue instances, Svelte blocks, and Astro islands. When you click a card on screen, Frontman knows it is your <code>Card</code> component from <code>@company/ui</code>, rendered at line 47 of <code>Card.tsx</code>, with specific props and token-derived styles.</p>
-
-				<p><strong>It reads computed CSS, not class names.</strong> OpenClaw can read the page source and see <code>class="p-4 shadow-md"</code>. Frontman sees that <code>p-4</code> computes to <code>padding: 16px</code> and <code>shadow-md</code> renders as <code>box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1)</code>. When you say "make the shadow more subtle," Frontman knows the current runtime value.</p>
-
-				<p><strong>Source map resolution.</strong> Click a DOM element, and Frontman resolves it to the exact source file, component, and line number through the framework's source maps. No guessing which file to edit. This is possible because Frontman installs as a framework plugin inside your dev server — it has access to the build pipeline.</p>
-
-				<p><strong>Hot reload feedback loop.</strong> Frontman edits the source file, and the framework's HMR updates the browser instantly. Edit → see result → iterate. The AI verifies its own work by taking a screenshot after each edit. OpenClaw can edit files too, but it does not integrate with your dev server's hot reload pipeline.</p>
-
-				<p><strong>Click-to-select workflow.</strong> Instead of describing which element to change in words, you click it in the browser. The AI already has full context — the component, its styles, its position in the layout, and the source file. "Make this button primary" is unambiguous because the AI knows which button you mean.</p>
-
-				<p><strong>Real source file edits.</strong> Every change Frontman makes is a real edit to your source code — the same files your engineers write by hand. No CSS overrides, no separate layer. Changes go through your existing code review process.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Using Them Together -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Using Them Together</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Frontman is available as an OpenClaw skill. Install it in one command:</p>
-				<pre class="install-code"><code>openclaw skill install frontman-dev</code></pre>
-				<p>Then install the Frontman plugin in your project:</p>
-				<pre class="install-code"><code>npx @frontman-ai/nextjs install    # Next.js
+  <Fragment slot="post-faq">
+    <section class="flex justify-center bg-zinc-50 px-6 py-16 text-zinc-950 max-md:px-5 max-md:py-10">
+      <div class="w-full max-w-[720px]">
+        <h2 class="mb-6 !text-[32px] !font-bold !tracking-tight !text-zinc-950 max-md:!text-2xl">Using Them Together</h2>
+        <p class="text-zinc-700">Frontman is available as an OpenClaw skill. Install it in one command:</p>
+        <pre class="mb-4 overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>openclaw skill install frontman-dev</code></pre>
+        <p class="text-zinc-700">Then install the Frontman plugin in your project:</p>
+        <pre class="mb-4 overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>npx @frontman-ai/nextjs install    # Next.js
 npx astro add @frontman-ai/astro    # Astro
 npx @frontman-ai/vite install       # Vite</code></pre>
-				<p>Once both are running, your OpenClaw agent gains specialized frontend editing capabilities. A typical workflow:</p>
-				<ul>
-					<li><strong>Designer in Slack:</strong> "The hero section spacing is off — it should be 48px gap, not 32"</li>
-					<li><strong>OpenClaw receives the message</strong> via Slack channel integration</li>
-					<li><strong>Frontman skill activates</strong> — opens the app in the browser, clicks the hero section</li>
-					<li><strong>Frontman's MCP server</strong> provides component tree, computed CSS, source location</li>
-					<li><strong>Source file edited</strong> — HMR updates the browser instantly</li>
-					<li><strong>Screenshot posted back to Slack</strong> — designer confirms it looks right</li>
-					<li><strong>PR opened</strong> — engineer reviews and merges as normal</li>
-				</ul>
-				<p>OpenClaw handles the messaging, shell commands, git operations, and PR creation. Frontman handles the visual editing. Each tool does what it is best at.</p>
-			</div>
-		</div>
-	</section>
+        <p class="text-zinc-700">Once both are running, your OpenClaw agent gains specialized frontend editing capabilities. A typical workflow:</p>
+        <ul>
+          <li><strong>Designer in Slack:</strong> "The hero section spacing is off — it should be 48px gap, not 32"</li>
+          <li><strong>OpenClaw receives the message</strong> via Slack channel integration</li>
+          <li><strong>Frontman skill activates</strong> — opens the app in the browser, clicks the hero section</li>
+          <li><strong>Frontman's MCP server</strong> provides component tree, computed CSS, source location</li>
+          <li><strong>Source file edited</strong> — HMR updates the browser instantly</li>
+          <li><strong>Screenshot posted back to Slack</strong> — designer confirms it looks right</li>
+          <li><strong>PR opened</strong> — engineer reviews and merges as normal</li>
+        </ul>
+        <p class="text-zinc-700">OpenClaw handles the messaging, shell commands, git operations, and PR creation. Frontman handles the visual editing. Each tool does what it is best at.</p>
+      </div>
+    </section>
+  </Fragment>
 
-	<!-- Who Should Use What -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use What</h2>
-			<div class="prose-content">
-				<p><strong>Use OpenClaw alone</strong> if you need a general-purpose AI agent for shell automation, web scraping, multi-channel messaging, file management, or workflow orchestration. You do not need Frontman unless you are doing frontend development.</p>
-				<p><strong>Use Frontman alone</strong> if you want browser-based visual editing for your dev server and your team already has a workflow that does not involve OpenClaw. Frontman works standalone — no OpenClaw required.</p>
-				<p><strong>Use both together</strong> if you want the best of both worlds: OpenClaw's general-purpose capabilities (messaging, shell, files, skills ecosystem) combined with Frontman's deep frontend editing (component tree, computed CSS, source maps, hot reload). This is the recommended setup for product teams where designers and PMs are involved in UI iteration.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Frequently Asked Questions</h2>
-			<div class="faq-list faq-list--light">
-				{faqs.map((faq) => (
-					<details class="faq-item faq-item--light group">
-						<summary class="faq-question faq-question--light">
-							<span>{faq.question}</span>
-							<span class="faq-icon faq-icon--light">+</span>
-						</summary>
-						<div class="faq-answer faq-answer--light">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Add Visual Frontend Editing to Your AI Agent</h2>
-			<p class="cta-description">Install the Frontman skill in OpenClaw. Free, open source, BYOK.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> openclaw skill install frontman-dev</code>
-					<span class="command-label">OpenClaw skill</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 0.9em;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-	.install-code {
-		background: rgba(0, 0, 0, 0.06);
-		border: 1px solid rgba(0, 0, 0, 0.1);
-		border-radius: 8px;
-		padding: 12px 16px;
-		margin: 16px 0;
-		overflow-x: auto;
-	}
-	.install-code code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #09090b;
-		background: none;
-		padding: 0;
-	}
-
-	/* FAQ - light variant */
-	.faq-list--light {
-		border-top: 1px solid #e4e4e7;
-	}
-	.faq-item--light {
-		border-bottom: 1px solid #e4e4e7;
-		cursor: pointer;
-	}
-	.faq-question--light {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #09090b;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question--light::-webkit-details-marker { display: none; }
-	.faq-question--light:hover { color: #3f3f46; }
-	.faq-question--light span:first-child { padding-right: 24px; }
-	.faq-icon--light {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #d4d4d8;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #a1a1aa;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon--light {
-		transform: rotate(45deg);
-		background: #f4f4f5;
-	}
-	.faq-answer--light p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #52525b;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="cta">
+    <section class="flex justify-center border-t border-zinc-800 bg-zinc-950 px-6 py-20 max-md:px-5 max-md:py-12">
+      <div class="w-full max-w-[720px]">
+        <h2 class="mb-2 !text-4xl !font-bold !tracking-tight !text-zinc-50 max-md:!text-[28px]">Add Visual Frontend Editing to Your AI Agent</h2>
+        <p class="mb-8 text-[17px] text-zinc-300">Install the Frontman skill in OpenClaw. Free, open source, BYOK.</p>
+        <div class="mb-8 flex flex-col gap-3">
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> openclaw skill install frontman-dev</code>
+            <span class="text-[13px] text-zinc-300">OpenClaw skill</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
+            <span class="text-[13px] text-zinc-300">Next.js</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
+            <span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
+            <span class="text-[13px] text-zinc-300">Astro</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
+          <Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+          <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 transition-colors hover:text-zinc-50">Join Discord</a>
+        </div>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/stagewise.astro
+++ b/apps/marketing/src/pages/vs/stagewise.astro
@@ -1,812 +1,182 @@
 ---
 // /vs/stagewise — Frontman vs Stagewise Comparison Page
-// Fixes Perplexity hallucination: AI currently describes Frontman as "prompt-to-app generation"
-// when compared to Stagewise. This page provides authoritative, factual comparison content.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
-import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  Alternative,
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs Stagewise (2026) — Which Browser AI Tool Is Worth It?',
-	description:
-		'Both let you click UI elements and edit code with AI. Frontman is free with BYOK and no limits. Stagewise costs €20/mo for 100 prompts/day. Side-by-side feature breakdown.'
+const seo: SEOInfo = {
+  title: 'Frontman vs Stagewise (2026) — Which Browser AI Tool Is Worth It?',
+  description:
+    'Both let you click UI elements and edit code with AI. Frontman is free with BYOK and no limits. Stagewise costs €20/mo for 100 prompts/day. Side-by-side feature breakdown.',
 }
 
-// Comparison data
-type Status = 'yes' | 'no' | 'partial'
-
-type Feature = {
-	name: string
-	frontman: Status
-	stagewise: Status
-	frontmanNote?: string
-	stagewiseNote?: string
+const competitor: CompetitorInfo = {
+  name: 'Stagewise',
+  slug: 'stagewise',
+  url: 'https://stagewise.io',
+  category: 'DeveloperApplication',
+  description:
+    'CLI-based browser overlay for AI coding context, with built-in agent options and IDE-agent bridge workflows.',
+  pricing: {
+    cost: '€0–€20/mo',
+    model: 'Freemium, AGPL-3.0',
+    features: [
+      'Free: ~10 prompts/day',
+      'Pro: €20/month (~100 prompts/day)',
+      'Built-in agent uses their infrastructure',
+      'IDE agent bridge mode may bypass limits',
+      'AGPL-3.0 license',
+    ],
+  },
 }
 
-const features: Feature[] = [
-	{ name: 'Click-to-select elements', frontman: 'yes', stagewise: 'yes', frontmanNote: 'In your running app', stagewiseNote: 'In your running app' },
-	{ name: 'Sees live DOM & styles', frontman: 'yes', stagewise: 'yes', frontmanNote: 'Via framework middleware', stagewiseNote: 'Via CLI-injected toolbar' },
-	{ name: 'Natural language code edits', frontman: 'yes', stagewise: 'yes', frontmanNote: 'Self-contained agent', stagewiseNote: 'Built-in agent or IDE agent bridge' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', stagewise: 'yes', frontmanNote: 'Instant via HMR', stagewiseNote: 'Instant via HMR' },
-	{ name: 'Deep framework middleware', frontman: 'yes', stagewise: 'no', frontmanNote: 'Component tree, props, server state', stagewiseNote: 'DOM-level only' },
-	{ name: 'Truly unlimited and free', frontman: 'yes', stagewise: 'no', frontmanNote: 'BYOK, no prompt limits', stagewiseNote: '10 prompts/day free, 100/day for €20/mo' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', stagewise: 'partial', frontmanNote: 'Any LLM provider directly', stagewiseNote: 'Via IDE agent bridge only' },
-	{ name: 'Zero codebase install', frontman: 'no', stagewise: 'yes', frontmanNote: 'Requires framework adapter', stagewiseNote: 'npx stagewise@latest — nothing installed' },
-	{ name: 'IDE agent bridge', frontman: 'no', stagewise: 'yes', stagewiseNote: 'Cursor, Copilot, Windsurf, Cline, etc.' },
-	{ name: 'Framework-agnostic', frontman: 'partial', stagewise: 'yes', frontmanNote: 'Next.js, Astro, Vite', stagewiseNote: 'Any framework including Angular' },
-	{ name: 'Server-side context', frontman: 'yes', stagewise: 'no', frontmanNote: 'Routes, server logs, query timing', stagewiseNote: 'Browser-only context' },
-	{ name: 'Designer/PM friendly', frontman: 'yes', stagewise: 'yes', frontmanNote: 'No IDE needed', stagewiseNote: 'No IDE needed' },
-	{ name: 'Open source', frontman: 'yes', stagewise: 'yes', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0', stagewiseNote: 'AGPL-3.0' },
-	{ name: 'Self-hostable (fully local)', frontman: 'yes', stagewise: 'partial', frontmanNote: 'Everything runs locally', stagewiseNote: 'Built-in agent has SaaS dependency' },
-	{ name: 'Plugin system', frontman: 'no', stagewise: 'yes', stagewiseNote: 'Extensible via plugins' },
-	{ name: 'VS Code extension', frontman: 'no', stagewise: 'yes', stagewiseNote: 'Stagewise VSCode extension' },
+const features: ComparisonFeature[] = [
+  { name: 'Click-to-select elements', frontman: 'yes', competitor: 'yes', frontmanNote: 'In your running app', competitorNote: 'In your running app' },
+  { name: 'Sees live DOM & styles', frontman: 'yes', competitor: 'yes', frontmanNote: 'Via framework middleware', competitorNote: 'Via CLI-injected toolbar' },
+  { name: 'Natural language code edits', frontman: 'yes', competitor: 'yes', frontmanNote: 'Self-contained agent', competitorNote: 'Built-in agent or IDE agent bridge' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', competitor: 'yes', frontmanNote: 'Instant via HMR', competitorNote: 'Instant via HMR' },
+  { name: 'Deep framework middleware', frontman: 'yes', competitor: 'no', frontmanNote: 'Component tree, props, server state', competitorNote: 'DOM-level only' },
+  { name: 'Truly unlimited and free', frontman: 'yes', competitor: 'no', frontmanNote: 'BYOK, no prompt limits', competitorNote: '10 prompts/day free, 100/day for €20/mo' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', competitor: 'partial', frontmanNote: 'Any LLM provider directly', competitorNote: 'Via IDE agent bridge only' },
+  { name: 'Zero codebase install', frontman: 'no', competitor: 'yes', frontmanNote: 'Requires framework adapter', competitorNote: 'npx stagewise@latest — nothing installed' },
+  { name: 'IDE agent bridge', frontman: 'no', competitor: 'yes', competitorNote: 'Cursor, Copilot, Windsurf, Cline, etc.' },
+  { name: 'Framework-agnostic', frontman: 'partial', competitor: 'yes', frontmanNote: 'Next.js, Astro, Vite', competitorNote: 'Any framework including Angular' },
+  { name: 'Server-side context', frontman: 'yes', competitor: 'no', frontmanNote: 'Routes, server logs, query timing', competitorNote: 'Browser-only context' },
+  { name: 'Designer/PM friendly', frontman: 'yes', competitor: 'yes', frontmanNote: 'No IDE needed', competitorNote: 'No IDE needed' },
+  { name: 'Open source', frontman: 'yes', competitor: 'yes', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0', competitorNote: 'AGPL-3.0' },
+  { name: 'Self-hostable (fully local)', frontman: 'yes', competitor: 'partial', frontmanNote: 'Everything runs locally', competitorNote: 'Built-in agent has SaaS dependency' },
+  { name: 'Plugin system', frontman: 'no', competitor: 'yes', competitorNote: 'Extensible via plugins' },
+  { name: 'VS Code extension', frontman: 'no', competitor: 'yes', competitorNote: 'Stagewise VSCode extension' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
-
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'What is the difference between Frontman and Stagewise?',
-		answer: 'Both tools let you click elements in your running app and describe changes in natural language. The key difference is architecture: Stagewise is a CLI overlay that injects a toolbar into your browser and can bridge to IDE agents like Cursor. Frontman installs as framework middleware (Next.js, Astro, Vite) and runs its own self-contained agent with deep access to the component tree, props, server state, and computed styles. Stagewise is faster to try (zero install), but Frontman gives deeper context and is fully free with no prompt limits.'
-	},
-	{
-		question: 'Is Frontman a free alternative to Stagewise?',
-		answer: 'Yes. Stagewise\'s free tier is limited to 10 prompts per day. Their Pro plan costs €20/month for 100 prompts/day. Frontman is completely free — you bring your own API keys (Claude, ChatGPT, or OpenRouter) and pay your LLM provider directly. There are no prompt limits, no subscription fees, and no usage caps. The client libraries are Apache 2.0 and the server is AGPL-3.0.'
-	},
-	{
-		question: 'Can I use Stagewise and Frontman together?',
-		answer: 'In theory, yes — they operate differently. Stagewise injects a toolbar via CLI, while Frontman runs as framework middleware. However, using both simultaneously on the same dev server may cause conflicts. Most developers choose one based on their workflow: Stagewise if they want to bridge to an existing IDE agent, Frontman if they want a self-contained agent with deeper framework context.'
-	},
-	{
-		question: 'Does Frontman work with Cursor like Stagewise does?',
-		answer: 'Differently. Stagewise acts as a bridge — it sends browser context to Cursor\'s agent for code edits. Frontman is a self-contained agent that doesn\'t need Cursor or any IDE. It has its own AI agent that reads the browser context and generates code edits directly. You can still use Cursor for backend coding alongside Frontman for visual frontend editing — they edit the same source files.'
-	},
-	{
-		question: 'Which tool has deeper browser context?',
-		answer: 'Frontman. Because it installs as framework middleware (not a CLI overlay), Frontman has access to the component tree at the framework level — React fiber nodes, Vue reactivity graph, or Svelte component tree. It also sees server-side context like routes, server logs, and query timing. Stagewise sees the DOM and computed styles but operates at a shallower level since it doesn\'t integrate into the framework\'s runtime.'
-	},
-	{
-		question: 'Which tool is easier to set up?',
-		answer: 'Stagewise. You run npx stagewise@latest in a second terminal and it works with any framework immediately — no changes to your codebase. Frontman requires installing a framework adapter (e.g., npx @frontman-ai/nextjs install for Next.js) which adds a small amount of middleware to your dev server. Frontman\'s setup takes about 60 seconds more but provides deeper integration in return.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'What is the difference between Frontman and Stagewise?',
+    answer:
+      'Both tools let you click elements in your running app and describe changes in natural language. The key difference is architecture: Stagewise is a CLI overlay that injects a toolbar into your browser and can bridge to IDE agents like Cursor. Frontman installs as framework middleware (Next.js, Astro, Vite) and runs its own self-contained agent with deep access to the component tree, props, server state, and computed styles. Stagewise is faster to try (zero install), but Frontman gives deeper context and is fully free with no prompt limits.',
+  },
+  {
+    question: 'Is Frontman a free alternative to Stagewise?',
+    answer:
+      'Yes. Stagewise\'s free tier is limited to 10 prompts per day. Their Pro plan costs €20/month for 100 prompts/day. Frontman is completely free — you bring your own API keys (Claude, ChatGPT, or OpenRouter) and pay your LLM provider directly. There are no prompt limits, no subscription fees, and no usage caps. The client libraries are Apache 2.0 and the server is AGPL-3.0.',
+  },
+  {
+    question: 'Can I use Stagewise and Frontman together?',
+    answer:
+      'In theory, yes — they operate differently. Stagewise injects a toolbar via CLI, while Frontman runs as framework middleware. However, using both simultaneously on the same dev server may cause conflicts. Most developers choose one based on their workflow: Stagewise if they want to bridge to an existing IDE agent, Frontman if they want a self-contained agent with deeper framework context.',
+  },
+  {
+    question: 'Does Frontman work with Cursor like Stagewise does?',
+    answer:
+      'Differently. Stagewise acts as a bridge — it sends browser context to Cursor\'s agent for code edits. Frontman is a self-contained agent that doesn\'t need Cursor or any IDE. It has its own AI agent that reads the browser context and generates code edits directly. You can still use Cursor for backend coding alongside Frontman for visual frontend editing — they edit the same source files.',
+  },
+  {
+    question: 'Which tool has deeper browser context?',
+    answer:
+      'Frontman. Because it installs as framework middleware (not a CLI overlay), Frontman has access to the component tree at the framework level — React fiber nodes, Vue reactivity graph, or Svelte component tree. It also sees server-side context like routes, server logs, and query timing. Stagewise sees the DOM and computed styles but operates at a shallower level since it doesn\'t integrate into the framework\'s runtime.',
+  },
+  {
+    question: 'Which tool is easier to set up?',
+    answer:
+      'Stagewise. You run npx stagewise@latest in a second terminal and it works with any framework immediately — no changes to your codebase. Frontman requires installing a framework adapter (e.g., npx @frontman-ai/nextjs install for Next.js) which adds a small amount of middleware to your dev server. Frontman\'s setup takes about 60 seconds more but provides deeper integration in return.',
+  },
 ]
 
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
+const alternatives: Alternative[] = [
+  { name: 'Frontman', slug: '', oneLiner: 'Framework-aware browser middleware with deep runtime context and no prompt caps.' },
+  { name: 'Cursor', slug: 'cursor', oneLiner: 'General-purpose AI IDE with agent mode and autocomplete.' },
+  { name: 'Windsurf', slug: 'windsurf', oneLiner: 'AI IDE with embedded browser preview and Cascade agent.' },
+  { name: 'GitHub Copilot', slug: 'copilot', oneLiner: 'IDE-native assistant with strong GitHub workflow integration.' },
+  { name: 'Claude Code', slug: 'claude-code', oneLiner: 'Terminal-first agent with shell and git automation.' },
+]
+
+const frontmanPricingFeatures = [
+  'Unlimited prompts, no daily caps',
+  'Bring your own API keys',
+  'Apache 2.0 (client) / AGPL-3.0 (server)',
+  'You pay your LLM provider directly',
+  'Self-hostable, fully local',
+]
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Stagewise"
+  heroSubtitle="Two Browser-Based AI Coding Tools, Different Architecture"
+  features={features}
+  faqs={faqs}
+  alternatives={alternatives}
+  frontmanPricing={{ features: frontmanPricingFeatures }}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://stagewise.io" class="text-link" rel="nofollow">Stagewise</a> both let you click elements in your running app, describe changes in natural language, and get real source code edits. They solve the same problem — AI coding tools that can't see the browser — but with fundamentally different architectures.
+    </p>
+    <p>
+      <strong>Frontman</strong> is an open-source AI coding agent that hooks into your dev server as framework middleware (Next.js, Astro, Vite). It runs its own self-contained agent with deep access to the component tree, computed styles, server routes, and server logs. Free and unlimited — you bring your own API keys.
+    </p>
+    <p>
+      <strong>Stagewise</strong> is a YC-backed CLI tool that injects a toolbar into your browser. It captures DOM context and routes it to its own built-in agent or bridges to IDE agents like Cursor, Copilot, and Windsurf. Framework-agnostic with zero codebase changes, but limited to 10 free prompts/day (€20/month for 100/day).
+    </p>
+    <p class="summary-emphasis">
+      The core tradeoff: Stagewise is faster to try and bridges to your existing IDE. Frontman goes deeper into the framework runtime and is fully free with no prompt limits.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs Stagewise</h1>
-			<p class="hero-subtitle">Two Browser-Based AI Coding Tools, Different Architecture</p>
+  <Fragment slot="competitor-strengths">
+    <p>Stagewise has real traction — 6,500+ GitHub stars and YC backing. It deserves credit for popularizing the "click elements in the browser, describe changes" workflow.</p>
+    <p><strong>Zero installation friction.</strong> Run <code>npx stagewise@latest</code> in a terminal next to your dev server. No framework adapters, no config files, no changes to your codebase. You're editing visually in 30 seconds. This is the lowest barrier to entry of any browser-based AI coding tool.</p>
+    <p>Stagewise can route browser context to your existing IDE agent — Cursor, Copilot, Windsurf, Cline, and others. If you're already invested in an IDE agent's workflow, Stagewise adds browser awareness without switching tools.</p>
+    <p><strong>Framework-agnostic.</strong> Because Stagewise operates as a CLI overlay rather than framework middleware, it works with any framework — including Angular, which Frontman doesn't support. If your stack isn't Next.js, Astro, or Vite, Stagewise is the option that works today.</p>
+    <p><strong>Plugin system and VS Code extension.</strong> Stagewise has an extensibility layer and a dedicated VS Code extension. Frontman currently has neither.</p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://stagewise.io" class="text-link" rel="nofollow">Stagewise</a> both let you click elements in your running app, describe changes in natural language, and get real source code edits. They solve the same problem — AI coding tools that can't see the browser — but with fundamentally different architectures.
-				</p>
-				<p>
-					<strong>Frontman</strong> is an open-source AI coding agent that hooks into your dev server as framework middleware (Next.js, Astro, Vite). It runs its own self-contained agent with deep access to the component tree, computed styles, server routes, and server logs. Free and unlimited — you bring your own API keys.
-				</p>
-				<p>
-					<strong>Stagewise</strong> is a YC-backed CLI tool that injects a toolbar into your browser. It captures DOM context and routes it to its own built-in agent or bridges to IDE agents like Cursor, Copilot, and Windsurf. Framework-agnostic with zero codebase changes, but limited to 10 free prompts/day (€20/month for 100/day).
-				</p>
-				<p class="summary-emphasis">
-					The core tradeoff: Stagewise is faster to try and bridges to your existing IDE. Frontman goes deeper into the framework runtime and is fully free with no prompt limits.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="Stagewise" />
-		</div>
-	</section>
+  <Fragment slot="frontman-differentiators">
+    <p>Frontman and Stagewise look similar on the surface — both let you click elements and describe changes. The difference is depth. Stagewise injects a toolbar on top of your app. Frontman wires into the app itself.</p>
+    <p><strong>Framework middleware vs CLI overlay.</strong> Frontman installs as a plugin into your dev server — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to information a CLI overlay can't reach: the React fiber tree, Vue reactivity graph, component props, server-side routes, server logs, and query timing. When you click a button, Frontman knows not just what DOM element it is, but which component rendered it, what props it received, and what server endpoint it calls.</p>
+    <p><strong>Fully free, no prompt limits.</strong> Stagewise's free tier caps you at 10 prompts per day. Their Pro plan is €20/month for 100 prompts/day. Frontman has no prompt limits, no subscription, and no usage-based pricing. You bring your own API keys (Claude, ChatGPT, or OpenRouter) and pay your LLM provider directly at their standard rates. For a team of 3 developers using AI coding tools daily, the cost difference is significant: €0/month vs €60/month for Stagewise Pro.</p>
+    <p><strong>Self-contained agent.</strong> Frontman runs its own AI agent — it doesn't need Cursor, Copilot, or any IDE running alongside it. The agent has full access to the framework runtime context and generates code edits directly. This means faster iteration (no roundtrip through an IDE agent) and simpler architecture (one tool instead of two).</p>
+    <p>Because Frontman is framework middleware, it sees both sides: the client-side DOM and the server-side context. It knows your routes, sees server logs, and can access server-side state. Stagewise operates purely on the client side.</p>
+    <p><strong>True BYOK.</strong> Frontman connects directly to any LLM provider — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API. Stagewise's "bring your own model" works through IDE agent bridges, not direct API key input.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="who-should-use-competitor">
+    <p>Stagewise is the better choice when you want browser-based AI coding with minimal commitment:</p>
+    <ul>
+      <li><strong>Quick evaluation</strong> — want to try browser-aware AI editing in 30 seconds without installing anything into your project</li>
+      <li><strong>IDE agent users</strong> — already using Cursor, Copilot, or Windsurf and want to add browser context to your existing agent</li>
+      <li><strong>Angular or non-supported framework</strong> — your stack isn't Next.js, Astro, or Vite and you need something framework-agnostic</li>
+      <li><strong>Occasional use</strong> — 10 prompts/day is enough for your workflow and you don't want to manage API keys</li>
+    </ul>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">Stagewise</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.stagewise)}>
-									<div class="status-content">
-										{feature.stagewise === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.stagewise === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.stagewise === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.stagewiseNote && <span class="status-note">{feature.stagewiseNote}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when you need deeper integration and freedom from prompt limits:</p>
+    <ul>
+      <li><strong>Daily frontend development</strong> — 10 prompts/day isn't enough and you don't want to pay €20/month for a cap of 100</li>
+      <li><strong>Next.js, Astro, or Vite projects</strong> — Frontman's middleware gives you deeper context than any CLI overlay</li>
+      <li><strong>Teams with designers or PMs</strong> — non-technical team members can make visual changes without an IDE or a Cursor subscription</li>
+      <li><strong>Open-source and vendor-independent</strong> — you want full control with no SaaS dependency, no prompt caps, and no monthly fees</li>
+      <li><strong>Server-side context matters</strong> — you need the AI to understand routes, server logs, and server-side state alongside the visual UI</li>
+    </ul>
+    <p>If you hit Stagewise's prompt limits or need deeper framework context, Frontman is worth evaluating.</p>
+    <p>Also see: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a> for a comparison with a full AI-powered IDE.</p>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">Stagewise</span>
-								<span>
-									{feature.stagewise === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.stagewise === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.stagewise === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- What Stagewise Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What Stagewise Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Stagewise has real traction — 6,500+ GitHub stars and YC backing. It deserves credit for popularizing the "click elements in the browser, describe changes" workflow.</p>
-				<p><strong>Zero installation friction.</strong> Run <code>npx stagewise@latest</code> in a terminal next to your dev server. No framework adapters, no config files, no changes to your codebase. You're editing visually in 30 seconds. This is the lowest barrier to entry of any browser-based AI coding tool.</p>
-				<p>Stagewise can route browser context to your existing IDE agent — Cursor, Copilot, Windsurf, Cline, and others. If you're already invested in an IDE agent's workflow, Stagewise adds browser awareness without switching tools.</p>
-				<p><strong>Framework-agnostic.</strong> Because Stagewise operates as a CLI overlay rather than framework middleware, it works with any framework — including Angular, which Frontman doesn't support. If your stack isn't Next.js, Astro, or Vite, Stagewise is the option that works today.</p>
-				<p><strong>Plugin system and VS Code extension.</strong> Stagewise has an extensibility layer and a dedicated VS Code extension. Frontman currently has neither.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p>Frontman and Stagewise look similar on the surface — both let you click elements and describe changes. The difference is depth. Stagewise injects a toolbar on top of your app. Frontman wires into the app itself.</p>
-
-				<p><strong>Framework middleware vs CLI overlay.</strong> Frontman installs as a plugin into your dev server — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to information a CLI overlay can't reach: the React fiber tree, Vue reactivity graph, component props, server-side routes, server logs, and query timing. When you click a button, Frontman knows not just what DOM element it is, but which component rendered it, what props it received, and what server endpoint it calls.</p>
-
-				<p><strong>Fully free, no prompt limits.</strong> Stagewise's free tier caps you at 10 prompts per day. Their Pro plan is €20/month for 100 prompts/day. Frontman has no prompt limits, no subscription, and no usage-based pricing. You bring your own API keys (Claude, ChatGPT, or OpenRouter) and pay your LLM provider directly at their standard rates. For a team of 3 developers using AI coding tools daily, the cost difference is significant: €0/month vs €60/month for Stagewise Pro.</p>
-
-				<p><strong>Self-contained agent.</strong> Frontman runs its own AI agent — it doesn't need Cursor, Copilot, or any IDE running alongside it. The agent has full access to the framework runtime context and generates code edits directly. This means faster iteration (no roundtrip through an IDE agent) and simpler architecture (one tool instead of two).</p>
-
-				<p>Because Frontman is framework middleware, it sees both sides: the client-side DOM and the server-side context. It knows your routes, sees server logs, and can access server-side state. Stagewise operates purely on the client side.</p>
-
-				<p><strong>True BYOK.</strong> Frontman connects directly to any LLM provider — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API. Stagewise's "bring your own model" works through IDE agent bridges, not direct API key input.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Stagewise -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Who Should Use Stagewise</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Stagewise is the better choice when you want browser-based AI coding with minimal commitment:</p>
-				<ul>
-					<li><strong>Quick evaluation</strong> — want to try browser-aware AI editing in 30 seconds without installing anything into your project</li>
-					<li><strong>IDE agent users</strong> — already using Cursor, Copilot, or Windsurf and want to add browser context to your existing agent</li>
-					<li><strong>Angular or non-supported framework</strong> — your stack isn't Next.js, Astro, or Vite and you need something framework-agnostic</li>
-					<li><strong>Occasional use</strong> — 10 prompts/day is enough for your workflow and you don't want to manage API keys</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Frontman -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use Frontman</h2>
-			<div class="prose-content">
-				<p>Frontman is the better choice when you need deeper integration and freedom from prompt limits:</p>
-				<ul>
-					<li><strong>Daily frontend development</strong> — 10 prompts/day isn't enough and you don't want to pay €20/month for a cap of 100</li>
-					<li><strong>Next.js, Astro, or Vite projects</strong> — Frontman's middleware gives you deeper context than any CLI overlay</li>
-					<li><strong>Teams with designers or PMs</strong> — non-technical team members can make visual changes without an IDE or a Cursor subscription</li>
-					<li><strong>Open-source and vendor-independent</strong> — you want full control with no SaaS dependency, no prompt caps, and no monthly fees</li>
-					<li><strong>Server-side context matters</strong> — you need the AI to understand routes, server logs, and server-side state alongside the visual UI</li>
-				</ul>
-				<p>If you hit Stagewise's prompt limits or need deeper framework context, Frontman is worth evaluating.</p>
-				<p>Also see: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a> for a comparison with a full AI-powered IDE.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Pricing -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Pricing Comparison</h2>
-			<div class="pricing-grid">
-				<div class="pricing-card pricing-card--highlighted">
-					<h3 class="pricing-name">Frontman</h3>
-					<div class="pricing-cost">Free</div>
-					<p class="pricing-model">Open source, BYOK</p>
-					<ul class="pricing-features">
-						<li>Unlimited prompts, no daily caps</li>
-						<li>Bring your own API keys</li>
-						<li>Apache 2.0 (client) / AGPL-3.0 (server)</li>
-						<li>You pay your LLM provider directly</li>
-						<li>Self-hostable, fully local</li>
-					</ul>
-				</div>
-				<div class="pricing-card">
-					<h3 class="pricing-name">Stagewise</h3>
-					<div class="pricing-cost">€0–€20/mo</div>
-					<p class="pricing-model">Freemium, AGPL-3.0</p>
-					<ul class="pricing-features">
-						<li>Free: ~10 prompts/day</li>
-						<li>Pro: €20/month (~100 prompts/day)</li>
-						<li>Built-in agent uses their infrastructure</li>
-						<li>IDE agent bridge mode may bypass limits</li>
-						<li>AGPL-3.0 license</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- Related -->
-	<section class="content-section">
-		<div class="content-container">
-			<p>Part of our <a href="/blog/best-open-source-ai-coding-tools-2026/" class="text-link">best open-source AI coding tools comparison</a> covering 12 tools across CLI, IDE, and browser categories.</p>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman</h2>
-			<p class="cta-description">One command. No account. No credit card. No prompt limits.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.hero-summary strong {
-		color: #fafafa;
-	}
-	.hero-summary code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-
-	/* Pricing */
-	.pricing-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
-	}
-	.pricing-card {
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid #e4e4e7;
-		background: white;
-	}
-	.pricing-card--highlighted {
-		border-color: #A259FF;
-		background: linear-gradient(135deg, rgba(162, 89, 255, 0.05), rgba(162, 89, 255, 0.02));
-		box-shadow: 0 0 0 1px rgba(162, 89, 255, 0.2);
-	}
-	.pricing-name {
-		font-size: 20px;
-		font-weight: 700;
-		color: #09090b;
-		margin-bottom: 8px;
-	}
-	.pricing-cost {
-		font-size: 36px;
-		font-weight: 800;
-		color: #09090b;
-		margin-bottom: 4px;
-		letter-spacing: -0.02em;
-	}
-	.pricing-card--highlighted .pricing-cost {
-		color: #A259FF;
-	}
-	.pricing-model {
-		font-size: 14px;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.pricing-features {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	.pricing-features li {
-		font-size: 15px;
-		color: #52525b;
-		padding: 6px 0;
-		padding-left: 20px;
-		position: relative;
-	}
-	.pricing-features li::before {
-		content: '\2192';
-		position: absolute;
-		left: 0;
-		color: #a1a1aa;
-	}
-
-	/* FAQ */
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-		cursor: pointer;
-	}
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.pricing-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="post-faq">
+    <section class="flex justify-center bg-zinc-950 px-6 py-16 text-zinc-50 max-md:px-5 max-md:py-10">
+      <div class="w-full max-w-[720px]">
+        <p class="text-[17px] leading-[1.7] text-zinc-300">
+          Part of our <a href="/blog/best-open-source-ai-coding-tools-2026/" class="text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-400">best open-source AI coding tools comparison</a> covering 12 tools across CLI, IDE, and browser categories.
+        </p>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/v0.astro
+++ b/apps/marketing/src/pages/vs/v0.astro
@@ -1,816 +1,179 @@
 ---
 // /vs/v0 — Frontman vs v0 Comparison Page
-// Targets "v0 alternative open source" queries (overcrowded space, 6+ tools)
 // Key angle: v0 generates new UI in a sandbox, Frontman edits your real codebase in the browser.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
-import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  Alternative,
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs v0 (2026) — Open-Source Alternative for Real Codebases',
-	description:
-		'v0 generates new UI in a sandbox. Frontman edits your real codebase in the browser — free, open-source, BYOK. Feature matrix, pricing, and architecture compared.'
+const seo: SEOInfo = {
+  title: 'Frontman vs v0 (2026) — Open-Source Alternative for Real Codebases',
+  description:
+    'v0 generates new UI in a sandbox. Frontman edits your real codebase in the browser — free, open-source, BYOK. Feature matrix, pricing, and architecture compared.',
 }
 
-// Comparison data
-type Status = 'yes' | 'no' | 'partial'
-
-type Feature = {
-	name: string
-	frontman: Status
-	v0: Status
-	frontmanNote?: string
-	v0Note?: string
+const competitor: CompetitorInfo = {
+  name: 'v0',
+  slug: 'v0',
+  url: 'https://v0.dev',
+  category: 'DesignApplication',
+  description:
+    'AI-powered UI generation tool by Vercel for creating new apps/components from prompts, often in a sandboxed workflow.',
+  pricing: {
+    cost: '$0–$100/mo',
+    model: 'Credit-based, proprietary',
+    features: [
+      'Free: $5 credits/month, 7 messages/day',
+      'Premium: $20/month, $20 credits + $2 daily bonus',
+      'Team: $30/user/month, shared credits',
+      'Business: $100/user/month, training opt-out',
+      'Additional credits purchasable on-demand',
+    ],
+  },
 }
 
-const features: Feature[] = [
-	{ name: 'Edits your real codebase', frontman: 'yes', v0: 'no', frontmanNote: 'Edits actual source files in your project', v0Note: 'Generates code in a sandboxed environment' },
-	{ name: 'Sees live DOM & styles', frontman: 'yes', v0: 'partial', frontmanNote: 'Browser-side MCP server inspects your running app', v0Note: 'Sees its own sandbox preview, not your app' },
-	{ name: 'Click-to-select elements', frontman: 'yes', v0: 'yes', frontmanNote: 'In your running app', v0Note: 'In the sandbox preview (Design Mode)' },
-	{ name: 'Works with existing projects', frontman: 'yes', v0: 'partial', frontmanNote: 'Designed for existing codebases', v0Note: 'Can import repos via GitHub sync, but primary workflow is new generation' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', v0: 'yes', frontmanNote: 'Instant via your framework\'s HMR', v0Note: 'Instant in sandbox preview' },
-	{ name: 'Generate UI from scratch', frontman: 'no', v0: 'yes', v0Note: 'Core workflow: prompt to full UI' },
-	{ name: 'Deploy to production', frontman: 'no', v0: 'yes', v0Note: 'One-click deploy to Vercel' },
-	{ name: 'Figma import', frontman: 'no', v0: 'yes', v0Note: 'Import Figma designs and convert to code' },
-	{ name: 'Framework-aware middleware', frontman: 'yes', v0: 'no', frontmanNote: 'Hooks into Next.js, Astro, Vite runtime', v0Note: 'Generates framework code but doesn\'t integrate into your dev server' },
-	{ name: 'Server-side context', frontman: 'yes', v0: 'no', frontmanNote: 'Routes, server logs, query timing', v0Note: 'Client-side sandbox only' },
-	{ name: 'Component tree access', frontman: 'yes', v0: 'no', frontmanNote: 'React fiber, Vue reactivity, Svelte tree', v0Note: 'Generates components, doesn\'t inspect your existing tree' },
-	{ name: 'Computed CSS inspection', frontman: 'yes', v0: 'no', frontmanNote: 'Runtime values from your real app', v0Note: 'CSS in generated output only' },
-	{ name: 'Designer/PM friendly', frontman: 'yes', v0: 'yes', frontmanNote: 'No IDE needed — works in your browser', v0Note: 'No IDE needed — works in v0.dev' },
-	{ name: 'Open source', frontman: 'yes', v0: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', v0Note: 'Proprietary SaaS' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', v0: 'no', frontmanNote: 'Any LLM provider', v0Note: 'Uses Vercel\'s own models (v0 Mini, Pro, Max)' },
-	{ name: 'Self-hostable', frontman: 'yes', v0: 'no', frontmanNote: 'Everything runs locally', v0Note: 'Cloud service only' },
-	{ name: 'Works offline (with local LLM)', frontman: 'yes', v0: 'no', frontmanNote: 'BYOK includes local models via OpenRouter', v0Note: 'Requires internet' },
+const features: ComparisonFeature[] = [
+  { name: 'Edits your real codebase', frontman: 'yes', competitor: 'no', frontmanNote: 'Edits actual source files in your project', competitorNote: 'Generates code in a sandboxed environment' },
+  { name: 'Sees live DOM & styles', frontman: 'yes', competitor: 'partial', frontmanNote: 'Browser-side MCP server inspects your running app', competitorNote: 'Sees its own sandbox preview, not your app' },
+  { name: 'Click-to-select elements', frontman: 'yes', competitor: 'yes', frontmanNote: 'In your running app', competitorNote: 'In the sandbox preview (Design Mode)' },
+  { name: 'Works with existing projects', frontman: 'yes', competitor: 'partial', frontmanNote: 'Designed for existing codebases', competitorNote: 'Can import repos via GitHub sync, but primary workflow is new generation' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', competitor: 'yes', frontmanNote: 'Instant via your framework\'s HMR', competitorNote: 'Instant in sandbox preview' },
+  { name: 'Generate UI from scratch', frontman: 'no', competitor: 'yes', competitorNote: 'Core workflow: prompt to full UI' },
+  { name: 'Deploy to production', frontman: 'no', competitor: 'yes', competitorNote: 'One-click deploy to Vercel' },
+  { name: 'Figma import', frontman: 'no', competitor: 'yes', competitorNote: 'Import Figma designs and convert to code' },
+  { name: 'Framework-aware middleware', frontman: 'yes', competitor: 'no', frontmanNote: 'Hooks into Next.js, Astro, Vite runtime', competitorNote: 'Generates framework code but doesn\'t integrate into your dev server' },
+  { name: 'Server-side context', frontman: 'yes', competitor: 'no', frontmanNote: 'Routes, server logs, query timing', competitorNote: 'Client-side sandbox only' },
+  { name: 'Component tree access', frontman: 'yes', competitor: 'no', frontmanNote: 'React fiber, Vue reactivity, Svelte tree', competitorNote: 'Generates components, doesn\'t inspect your existing tree' },
+  { name: 'Computed CSS inspection', frontman: 'yes', competitor: 'no', frontmanNote: 'Runtime values from your real app', competitorNote: 'CSS in generated output only' },
+  { name: 'Designer/PM friendly', frontman: 'yes', competitor: 'yes', frontmanNote: 'No IDE needed — works in your browser', competitorNote: 'No IDE needed — works in v0.dev' },
+  { name: 'Open source', frontman: 'yes', competitor: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', competitorNote: 'Proprietary SaaS' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', competitor: 'no', frontmanNote: 'Any LLM provider', competitorNote: 'Uses Vercel\'s own models (v0 Mini, Pro, Max)' },
+  { name: 'Self-hostable', frontman: 'yes', competitor: 'no', frontmanNote: 'Everything runs locally', competitorNote: 'Cloud service only' },
+  { name: 'Works offline (with local LLM)', frontman: 'yes', competitor: 'no', frontmanNote: 'BYOK includes local models via OpenRouter', competitorNote: 'Requires internet' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
-
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'Is Frontman an open-source alternative to v0?',
-		answer: 'They solve different problems. v0 (v0.dev) is a generative UI tool — you describe what you want, it builds new UI in a sandbox, and you deploy it. Frontman (frontman.sh) is an AI coding agent for editing existing codebases — you click elements in your running app, describe changes, and it edits the actual source files. Frontman is open-source (Apache 2.0 client, AGPL-3.0 server) and free with BYOK. If you\'re starting from scratch, v0 is faster. If you\'re editing an existing app, Frontman is the right tool.'
-	},
-	{
-		question: 'Can Frontman generate UI from scratch like v0?',
-		answer: 'No. Frontman is designed for editing existing codebases, not generating new projects from prompts. Its strength is visual editing: click an element in your running app, describe what you want changed, and the AI edits the source code with full browser context. If you need to generate a landing page or component from a text description, v0 is the better tool. If you need to modify your existing Next.js app\'s UI with AI that can see the rendered result, Frontman is the better tool.'
-	},
-	{
-		question: 'Can I use v0 and Frontman together?',
-		answer: 'Yes, and this is a natural workflow. Use v0 to generate initial UI components or prototypes, then bring them into your real project. Once the code is in your codebase, use Frontman to iterate on it visually — clicking elements, adjusting styles, fixing responsive issues — with the AI seeing how your real app renders, not a sandbox preview.'
-	},
-	{
-		question: 'What does Frontman see that v0 does not?',
-		answer: 'Frontman integrates with your framework (Next.js, Astro, Vite) as middleware and runs a browser-side MCP server. It sees your real app\'s live DOM, computed CSS, component tree with props and state, server-side routes and logs, and actual viewport behavior. v0 works in a sandboxed environment — it sees its own generated preview but has no access to your existing codebase\'s runtime, component tree, or server-side context.'
-	},
-	{
-		question: 'Is Frontman really free compared to v0?',
-		answer: 'Yes. v0\'s free tier gives you $5 of credits per month with a 7-message daily limit. Premium is $20/month, Team is $30/user/month. Frontman is completely free to self-host — you bring your own API keys and pay your LLM provider directly. There are no message limits, no credit system, and no monthly subscription from Frontman itself.'
-	},
-	{
-		question: 'Which tool is better for designers?',
-		answer: 'It depends on the workflow. v0 is better for generating new UI from descriptions or Figma imports — designers can describe what they want and get working code. Frontman is better for iterating on existing UI — designers can click elements in the running app and describe visual changes without opening an IDE. v0 creates; Frontman refines.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an open-source alternative to v0?',
+    answer:
+      'They solve different problems. v0 (v0.dev) is a generative UI tool — you describe what you want, it builds new UI in a sandbox, and you deploy it. Frontman (frontman.sh) is an AI coding agent for editing existing codebases — you click elements in your running app, describe changes, and it edits the actual source files. Frontman is open-source (Apache 2.0 client, AGPL-3.0 server) and free with BYOK. If you\'re starting from scratch, v0 is faster. If you\'re editing an existing app, Frontman is the right tool.',
+  },
+  {
+    question: 'Can Frontman generate UI from scratch like v0?',
+    answer:
+      'No. Frontman is designed for editing existing codebases, not generating new projects from prompts. Its strength is visual editing: click an element in your running app, describe what you want changed, and the AI edits the source code with full browser context. If you need to generate a landing page or component from a text description, v0 is the better tool. If you need to modify your existing Next.js app\'s UI with AI that can see the rendered result, Frontman is the better tool.',
+  },
+  {
+    question: 'Can I use v0 and Frontman together?',
+    answer:
+      'Yes, and this is a natural workflow. Use v0 to generate initial UI components or prototypes, then bring them into your real project. Once the code is in your codebase, use Frontman to iterate on it visually — clicking elements, adjusting styles, fixing responsive issues — with the AI seeing how your real app renders, not a sandbox preview.',
+  },
+  {
+    question: 'What does Frontman see that v0 does not?',
+    answer:
+      'Frontman integrates with your framework (Next.js, Astro, Vite) as middleware and runs a browser-side MCP server. It sees your real app\'s live DOM, computed CSS, component tree with props and state, server-side routes and logs, and actual viewport behavior. v0 works in a sandboxed environment — it sees its own generated preview but has no access to your existing codebase\'s runtime, component tree, or server-side context.',
+  },
+  {
+    question: 'Is Frontman really free compared to v0?',
+    answer:
+      'Yes. v0\'s free tier gives you $5 of credits per month with a 7-message daily limit. Premium is $20/month, Team is $30/user/month. Frontman is completely free to self-host — you bring your own API keys and pay your LLM provider directly. There are no message limits, no credit system, and no monthly subscription from Frontman itself.',
+  },
+  {
+    question: 'Which tool is better for designers?',
+    answer:
+      'It depends on the workflow. v0 is better for generating new UI from descriptions or Figma imports — designers can describe what they want and get working code. Frontman is better for iterating on existing UI — designers can click elements in the running app and describe visual changes without opening an IDE. v0 creates; Frontman refines.',
+  },
 ]
 
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
+const alternatives: Alternative[] = [
+  { name: 'Frontman', slug: '', oneLiner: 'Visual editing in your real app with runtime context and source-level diffs.' },
+  { name: 'Bolt.new', slug: 'bolt', oneLiner: 'Prompt-to-app generation in a sandbox for rapid prototyping and greenfield starts.' },
+  { name: 'Lovable', slug: 'lovable', oneLiner: 'Generative app builder for non-coders with hosted infrastructure.' },
+  { name: 'Onlook', slug: 'onlook', oneLiner: 'Figma-like visual editor that outputs code in a sandbox workflow.' },
+  { name: 'Stagewise', slug: 'stagewise', oneLiner: 'Browser overlay to feed context into IDE agents.' },
+]
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
-	<!-- Hero / AI-Citable Summary (GEO Lead) -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs v0</h1>
-			<p class="hero-subtitle">Edit Your Real App vs Generate New UI</p>
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs v0"
+  heroSubtitle="Edit Your Real App vs Generate New UI"
+  features={features}
+  faqs={faqs}
+  alternatives={alternatives}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://v0.dev" class="text-link" rel="nofollow">v0</a> both use AI to help with frontend development, but they do opposite things. v0 generates new UI from text prompts in a sandboxed environment. Frontman edits your existing codebase by interacting with your running app in the browser.
+    </p>
+    <p>
+      <strong>Frontman</strong> is an open-source AI coding agent that hooks into your dev server as framework middleware (Next.js, Astro, Vite). It sees the live DOM, component tree, computed CSS, and server-side context. You click elements in your running app, describe changes in plain English, and Frontman edits the actual source files with hot reload. Free and unlimited — you bring your own API keys.
+    </p>
+    <p>
+      <strong>v0</strong> is Vercel's AI-powered UI generation tool. You describe what you want — or import a Figma design — and v0 generates a working app with React, Next.js, Tailwind, and shadcn/ui. It includes a visual Design Mode for clicking and editing generated output, GitHub sync, and one-click Vercel deploy. Credit-based pricing starting at $0/month (7 messages/day).
+    </p>
+    <p class="summary-emphasis">
+      The core difference: v0 creates new things. Frontman changes existing things. Use v0 to prototype, use Frontman to iterate on your real app.
+    </p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://v0.dev" class="text-link" rel="nofollow">v0</a> both use AI to help with frontend development, but they do opposite things. v0 generates new UI from text prompts in a sandboxed environment. Frontman edits your existing codebase by interacting with your running app in the browser.
-				</p>
-				<p>
-					<strong>Frontman</strong> is an open-source AI coding agent that hooks into your dev server as framework middleware (Next.js, Astro, Vite). It sees the live DOM, component tree, computed CSS, and server-side context. You click elements in your running app, describe changes in plain English, and Frontman edits the actual source files with hot reload. Free and unlimited — you bring your own API keys.
-				</p>
-				<p>
-					<strong>v0</strong> is Vercel's AI-powered UI generation tool. You describe what you want — or import a Figma design — and v0 generates a working app with React, Next.js, Tailwind, and shadcn/ui. It includes a visual Design Mode for clicking and editing generated output, GitHub sync, and one-click Vercel deploy. Credit-based pricing starting at $0/month (7 messages/day).
-				</p>
-				<p class="summary-emphasis">
-					The core difference: v0 creates new things. Frontman changes existing things. Use v0 to prototype, use Frontman to iterate on your real app.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="v0" />
-		</div>
-	</section>
+  <Fragment slot="competitor-strengths">
+    <p>v0 is the most popular generative UI tool right now, and the fastest way to go from an idea to a working frontend.</p>
+    <p><strong>Prompt-to-UI is fast.</strong> Describe what you want in plain English ("a dashboard with a sidebar, dark mode, and a chart showing monthly revenue") and v0 generates a complete, working React app. For prototyping and starting new projects, nothing is faster.</p>
+    <p><strong>Design Mode adds visual editing.</strong> v0's Design Mode lets you click elements in the generated preview and make visual changes. This is genuine click-to-edit functionality within the v0 sandbox. Frontman offers similar click-to-edit but for your actual running app, not a sandbox.</p>
+    <p>Import Figma designs and v0 generates working code that matches them. This helps designers hand off to developers on new projects. Frontman doesn't have Figma import.</p>
+    <p><strong>One-click deploy.</strong> Generated apps deploy to Vercel instantly. From idea to production URL in minutes. Frontman is a development tool, not a deployment platform.</p>
+    <p>v0 can sync with your GitHub repository, allowing generated code to flow into your existing project. This partially addresses the "sandbox vs real codebase" gap.</p>
+    <p><strong>Custom models.</strong> v0 runs its own model variants (v0 Mini, Pro, Max) optimized for UI generation. These are purpose-built for frontend code and outperform general-purpose models at that specific task.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="frontman-differentiators">
+    <p>v0 generates new UI from prompts. Frontman edits UI that already exists in your codebase. <strong>One creates. The other modifies.</strong></p>
+    <p><strong>Your real codebase, not a sandbox.</strong> When you use Frontman, you're editing the actual source files in your project. The AI sees the component tree, the CSS as the browser computed it, routing, and server state. Changes show up via hot module replacement in your actual dev server. With v0, you're working in a sandboxed environment that generates fresh code — which then needs to be integrated into your real project.</p>
+    <p><strong>Framework middleware integration.</strong> Frontman installs as a plugin into your dev server — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to your component tree at the framework level (React fiber nodes, Vue reactivity, Svelte components), computed CSS from your actual stylesheets, server-side routes and logs, and source map resolution to find the exact file and line for any rendered element.</p>
+    <p>v0's sandbox doesn't know about your design system, your existing component library, your server endpoints, or your real responsive behavior at different viewports. Frontman sees all of this because it's running inside your actual app. When you ask "make this card match the other cards on the page," Frontman can inspect the other cards' actual styles.</p>
+    <p><strong>Open source and BYOK.</strong> v0 is a proprietary SaaS with credit-based pricing. Frontman's client libraries are Apache 2.0 and the server is AGPL-3.0. You bring your own API keys — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API including local models. No credits, no message limits, no monthly fees from Frontman.</p>
+    <p><strong>Works with any component library.</strong> v0 is optimized for shadcn/ui and Tailwind. Frontman is component-library agnostic — it sees whatever your app actually renders, whether that's MUI, Chakra, Radix, custom components, or plain CSS. The browser doesn't care what library generated the DOM.</p>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">v0</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.v0)}>
-									<div class="status-content">
-										{feature.v0 === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.v0 === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.v0 === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.v0Note && <span class="status-note">{feature.v0Note}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-competitor">
+    <p>v0 is the better choice when you're creating something new from scratch:</p>
+    <ul>
+      <li><strong>Rapid prototyping</strong> — turning ideas or requirements into working UI as fast as possible</li>
+      <li><strong>Starting new projects</strong> — generating a complete app scaffold from a description</li>
+      <li><strong>Figma-to-code workflows</strong> — converting designs into working React components</li>
+      <li><strong>Non-developers building apps</strong> — product managers, designers, and founders who need working code without writing it</li>
+      <li><strong>Quick deploys</strong> — need a working URL to share with stakeholders immediately</li>
+      <li><strong>shadcn/ui and Tailwind projects</strong> — v0 is optimized for this stack</li>
+    </ul>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">v0</span>
-								<span>
-									{feature.v0 === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.v0 === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.v0 === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when you're working on an existing codebase:</p>
+    <ul>
+      <li><strong>Iterating on existing UI</strong> — adjusting styles, fixing responsive issues, refining layout on a real app</li>
+      <li><strong>Frontend developers on established projects</strong> — your app already exists and you need to edit it with AI that understands the context</li>
+      <li><strong>Teams where designers make UI changes</strong> — click elements in the running app, describe changes, review code diffs</li>
+      <li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
+      <li><strong>Open source and vendor-independent</strong> — no cloud dependency, no credit system, BYOK, self-hostable</li>
+      <li><strong>Server-side context matters</strong> — routes, server logs, and server-side state alongside visual editing</li>
+    </ul>
+    <p>A natural workflow: use v0 to generate initial UI, bring it into your project, then use Frontman to iterate and refine visually with full browser context.</p>
+  </Fragment>
 
-	<!-- What v0 Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What v0 Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>v0 is the most popular generative UI tool right now, and the fastest way to go from an idea to a working frontend.</p>
-				<p><strong>Prompt-to-UI is fast.</strong> Describe what you want in plain English ("a dashboard with a sidebar, dark mode, and a chart showing monthly revenue") and v0 generates a complete, working React app. For prototyping and starting new projects, nothing is faster.</p>
-				<p><strong>Design Mode adds visual editing.</strong> v0's Design Mode lets you click elements in the generated preview and make visual changes. This is genuine click-to-edit functionality within the v0 sandbox. Frontman offers similar click-to-edit but for your actual running app, not a sandbox.</p>
-				<p>Import Figma designs and v0 generates working code that matches them. This helps designers hand off to developers on new projects. Frontman doesn't have Figma import.</p>
-				<p><strong>One-click deploy.</strong> Generated apps deploy to Vercel instantly. From idea to production URL in minutes. Frontman is a development tool, not a deployment platform.</p>
-				<p>v0 can sync with your GitHub repository, allowing generated code to flow into your existing project. This partially addresses the "sandbox vs real codebase" gap.</p>
-				<p><strong>Custom models.</strong> v0 runs its own model variants (v0 Mini, Pro, Max) optimized for UI generation. These are purpose-built for frontend code and outperform general-purpose models at that specific task.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p>v0 generates new UI from prompts. Frontman edits UI that already exists in your codebase. <strong>One creates. The other modifies.</strong></p>
-
-				<p><strong>Your real codebase, not a sandbox.</strong> When you use Frontman, you're editing the actual source files in your project. The AI sees the component tree, the CSS as the browser computed it, routing, and server state. Changes show up via hot module replacement in your actual dev server. With v0, you're working in a sandboxed environment that generates fresh code — which then needs to be integrated into your real project.</p>
-
-				<p><strong>Framework middleware integration.</strong> Frontman installs as a plugin into your dev server — <code>@frontman-ai/nextjs</code>, <code>@frontman-ai/astro</code>, or <code>@frontman-ai/vite</code>. This gives it access to your component tree at the framework level (React fiber nodes, Vue reactivity, Svelte components), computed CSS from your actual stylesheets, server-side routes and logs, and source map resolution to find the exact file and line for any rendered element.</p>
-
-				<p>v0's sandbox doesn't know about your design system, your existing component library, your server endpoints, or your real responsive behavior at different viewports. Frontman sees all of this because it's running inside your actual app. When you ask "make this card match the other cards on the page," Frontman can inspect the other cards' actual styles.</p>
-
-				<p><strong>Open source and BYOK.</strong> v0 is a proprietary SaaS with credit-based pricing. Frontman's client libraries are Apache 2.0 and the server is AGPL-3.0. You bring your own API keys — Claude, ChatGPT, OpenRouter, or any OpenAI-compatible API including local models. No credits, no message limits, no monthly fees from Frontman.</p>
-
-				<p><strong>Works with any component library.</strong> v0 is optimized for shadcn/ui and Tailwind. Frontman is component-library agnostic — it sees whatever your app actually renders, whether that's MUI, Chakra, Radix, custom components, or plain CSS. The browser doesn't care what library generated the DOM.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use v0 -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Who Should Use v0</h2>
-			<div class="prose-content prose-content--dark">
-				<p>v0 is the better choice when you're creating something new from scratch:</p>
-				<ul>
-					<li><strong>Rapid prototyping</strong> — turning ideas or requirements into working UI as fast as possible</li>
-					<li><strong>Starting new projects</strong> — generating a complete app scaffold from a description</li>
-					<li><strong>Figma-to-code workflows</strong> — converting designs into working React components</li>
-					<li><strong>Non-developers building apps</strong> — product managers, designers, and founders who need working code without writing it</li>
-					<li><strong>Quick deploys</strong> — need a working URL to share with stakeholders immediately</li>
-					<li><strong>shadcn/ui and Tailwind projects</strong> — v0 is optimized for this stack</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Frontman -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use Frontman</h2>
-			<div class="prose-content">
-				<p>Frontman is the better choice when you're working on an existing codebase:</p>
-				<ul>
-					<li><strong>Iterating on existing UI</strong> — adjusting styles, fixing responsive issues, refining layout on a real app</li>
-					<li><strong>Frontend developers on established projects</strong> — your app already exists and you need to edit it with AI that understands the context</li>
-					<li><strong>Teams where designers make UI changes</strong> — click elements in the running app, describe changes, review code diffs</li>
-					<li><strong>Any component library or CSS approach</strong> — MUI, Chakra, Tailwind, CSS Modules, styled-components — Frontman sees what renders, not what you typed</li>
-					<li><strong>Open source and vendor-independent</strong> — no cloud dependency, no credit system, BYOK, self-hostable</li>
-					<li><strong>Server-side context matters</strong> — routes, server logs, and server-side state alongside visual editing</li>
-				</ul>
-				<p>A natural workflow: use v0 to generate initial UI, bring it into your project, then use Frontman to iterate and refine visually with full browser context.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Pricing -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Pricing Comparison</h2>
-			<div class="pricing-grid">
-				<div class="pricing-card pricing-card--highlighted">
-					<h3 class="pricing-name">Frontman</h3>
-					<div class="pricing-cost">Free</div>
-					<p class="pricing-model">Open source, BYOK</p>
-					<ul class="pricing-features">
-						<li>Unlimited usage, no caps or credits</li>
-						<li>Bring your own API keys (Claude, ChatGPT, OpenRouter)</li>
-						<li>Or sign in with Claude/ChatGPT subscription via OAuth</li>
-						<li>Apache 2.0 (client) / AGPL-3.0 (server)</li>
-						<li>You pay your LLM provider directly</li>
-					</ul>
-				</div>
-				<div class="pricing-card">
-					<h3 class="pricing-name">v0</h3>
-					<div class="pricing-cost">$0–$100/mo</div>
-					<p class="pricing-model">Credit-based, proprietary</p>
-					<ul class="pricing-features">
-						<li>Free: $5 credits/month, 7 messages/day</li>
-						<li>Premium: $20/month, $20 credits + $2 daily bonus</li>
-						<li>Team: $30/user/month, shared credits</li>
-						<li>Business: $100/user/month, training opt-out</li>
-						<li>Additional credits purchasable on-demand</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- Related -->
-	<section class="content-section">
-		<div class="content-container">
-			<p>Part of our <a href="/blog/best-open-source-ai-coding-tools-2026/" class="text-link">best open-source AI coding tools comparison</a> covering 12 tools across CLI, IDE, and browser categories.</p>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman</h2>
-			<p class="cta-description">One command. No account. No credit card. No prompt limits.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.hero-summary strong {
-		color: #fafafa;
-	}
-	.hero-summary code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-
-	/* Pricing */
-	.pricing-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
-	}
-	.pricing-card {
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid #e4e4e7;
-		background: white;
-	}
-	.pricing-card--highlighted {
-		border-color: #A259FF;
-		background: linear-gradient(135deg, rgba(162, 89, 255, 0.05), rgba(162, 89, 255, 0.02));
-		box-shadow: 0 0 0 1px rgba(162, 89, 255, 0.2);
-	}
-	.pricing-name {
-		font-size: 20px;
-		font-weight: 700;
-		color: #09090b;
-		margin-bottom: 8px;
-	}
-	.pricing-cost {
-		font-size: 36px;
-		font-weight: 800;
-		color: #09090b;
-		margin-bottom: 4px;
-		letter-spacing: -0.02em;
-	}
-	.pricing-card--highlighted .pricing-cost {
-		color: #A259FF;
-	}
-	.pricing-model {
-		font-size: 14px;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.pricing-features {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	.pricing-features li {
-		font-size: 15px;
-		color: #52525b;
-		padding: 6px 0;
-		padding-left: 20px;
-		position: relative;
-	}
-	.pricing-features li::before {
-		content: '\2192';
-		position: absolute;
-		left: 0;
-		color: #a1a1aa;
-	}
-
-	/* FAQ */
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-		cursor: pointer;
-	}
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.pricing-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="post-faq">
+    <section class="flex justify-center bg-zinc-950 px-6 py-16 text-zinc-50 max-md:px-5 max-md:py-10">
+      <div class="w-full max-w-[720px]">
+        <p class="text-[17px] leading-[1.7] text-zinc-300">
+          Part of our <a href="/blog/best-open-source-ai-coding-tools-2026/" class="text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-400">best open-source AI coding tools comparison</a> covering 12 tools across CLI, IDE, and browser categories.
+        </p>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>

--- a/apps/marketing/src/pages/vs/windsurf.astro
+++ b/apps/marketing/src/pages/vs/windsurf.astro
@@ -1,799 +1,197 @@
 ---
 // /vs/windsurf — Frontman vs Windsurf Comparison Page
 // Targets "windsurf alternative open source" and "windsurf vs" queries
-// Windsurf (by Cognition/formerly Codeium) is a VS Code fork with an embedded browser panel.
 
-// Components
-import Layout from '../../layouts/Layout.astro'
 import Button from '../../components/ui/Button.astro'
-import ComparisonDisclosure from '../../components/ui/ComparisonDisclosure.astro'
+import ComparisonLayout from '../../layouts/ComparisonLayout.astro'
+import type {
+  Alternative,
+  ComparisonFeature,
+  CompetitorInfo,
+  FAQ,
+  SEOInfo,
+} from '../../layouts/ComparisonLayout.astro'
 
-// SEO
-const SEO = {
-	title: 'Frontman vs Windsurf: Open-Source Alternative (2026)',
-	description:
-		'Frontman is browser middleware that sees your running app. Windsurf is a VS Code fork with preview. Free, open source. Compare features and pricing.'
+const seo: SEOInfo = {
+  title: 'Frontman vs Windsurf: Open-Source Alternative (2026)',
+  description:
+    'Frontman is browser middleware that sees your running app. Windsurf is a VS Code fork with preview. Free, open source. Compare features and pricing.',
 }
 
-// Comparison data
-type Status = 'yes' | 'no' | 'partial'
-
-type Feature = {
-	name: string
-	frontman: Status
-	windsurf: Status
-	frontmanNote?: string
-	windsurfNote?: string
+const competitor: CompetitorInfo = {
+  name: 'Windsurf',
+  slug: 'windsurf',
+  url: 'https://windsurf.com',
+  category: 'DeveloperApplication',
+  description:
+    'AI-powered IDE by Cognition with Cascade agent, autocomplete, embedded browser preview, terminal integration, and MCP support.',
+  pricing: {
+    cost: '$0–$30/mo',
+    model: 'Freemium, proprietary',
+    features: [
+      'Free: 25 Cascade credits/month, unlimited autocomplete',
+      'Pro: $15/month — 500 credits/month',
+      'Teams: $30/user/month — 500 credits/user, admin dashboard',
+      'Enterprise: custom pricing — 1,000+ credits, SSO, RBAC',
+      'Add-on: $10 for 250 extra credits',
+    ],
+  },
 }
 
-const features: Feature[] = [
-	{ name: 'Sees live DOM & styles', frontman: 'yes', windsurf: 'partial', frontmanNote: 'Browser-side MCP server inspects the live page', windsurfNote: 'Embedded preview panel — DOM only, no component tree' },
-	{ name: 'Sees computed CSS', frontman: 'yes', windsurf: 'partial', frontmanNote: 'Runtime values, not class names', windsurfNote: 'Preview panel shows rendered output; agent reads source files' },
-	{ name: 'Click-to-select elements', frontman: 'yes', windsurf: 'yes', frontmanNote: 'Visual component selection in your browser', windsurfNote: 'Click elements in embedded preview panel' },
-	{ name: 'Hot reload feedback loop', frontman: 'yes', windsurf: 'partial', frontmanNote: 'Instant in browser via HMR', windsurfNote: 'Edits files; preview refreshes on rebuild' },
-	{ name: 'Inline autocomplete', frontman: 'no', windsurf: 'yes', windsurfNote: 'Tab, Supercomplete, Tab-to-Jump, Tab-to-Import' },
-	{ name: 'Agent mode', frontman: 'yes', windsurf: 'yes', frontmanNote: 'Browser-context agent', windsurfNote: 'Cascade — Code and Chat modes with flow awareness' },
-	{ name: 'Multi-file refactoring', frontman: 'partial', windsurf: 'yes', frontmanNote: 'Can edit multiple files, not primary workflow', windsurfNote: 'Vibe and Replace — mass refactoring across hundreds of files' },
-	{ name: 'Terminal integration', frontman: 'no', windsurf: 'yes', windsurfNote: 'Built-in terminal, Turbo Mode auto-executes commands' },
-	{ name: 'Framework-aware', frontman: 'yes', windsurf: 'no', frontmanNote: 'Deep plugin for Next.js, Astro, Vite — sees component tree', windsurfNote: 'IDE-level file context, no framework runtime integration' },
-	{ name: 'Designer/PM friendly', frontman: 'yes', windsurf: 'no', frontmanNote: 'No IDE needed — works in the browser', windsurfNote: 'Requires IDE proficiency' },
-	{ name: 'Open source', frontman: 'yes', windsurf: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', windsurfNote: 'Proprietary (VS Code fork, closed-source AI features)' },
-	{ name: 'BYOK (bring your own key)', frontman: 'yes', windsurf: 'no', frontmanNote: 'Any LLM provider directly', windsurfNote: 'Uses Windsurf\'s model pool (GPT, Claude, Gemini, SWE-1.5)' },
-	{ name: 'Self-hostable', frontman: 'yes', windsurf: 'no', frontmanNote: 'Everything runs locally', windsurfNote: 'Cloud service; enterprise on-prem available' },
-	{ name: 'Works in the browser', frontman: 'yes', windsurf: 'no', frontmanNote: 'No IDE required', windsurfNote: 'Standalone VS Code fork' },
-	{ name: 'Backend coding', frontman: 'partial', windsurf: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', windsurfNote: 'Any language, any framework' },
-	{ name: 'MCP support', frontman: 'yes', windsurf: 'yes', frontmanNote: 'Browser-side MCP server', windsurfNote: 'Plugin Store with curated MCP servers' },
-	{ name: 'Proprietary models', frontman: 'no', windsurf: 'yes', windsurfNote: 'SWE-1.5 (claimed 13x faster than Sonnet 4.5)' },
+const features: ComparisonFeature[] = [
+  { name: 'Sees live DOM & styles', frontman: 'yes', competitor: 'partial', frontmanNote: 'Browser-side MCP server inspects the live page', competitorNote: 'Embedded preview panel — DOM only, no component tree' },
+  { name: 'Sees computed CSS', frontman: 'yes', competitor: 'partial', frontmanNote: 'Runtime values, not class names', competitorNote: 'Preview panel shows rendered output; agent reads source files' },
+  { name: 'Click-to-select elements', frontman: 'yes', competitor: 'yes', frontmanNote: 'Visual component selection in your browser', competitorNote: 'Click elements in embedded preview panel' },
+  { name: 'Hot reload feedback loop', frontman: 'yes', competitor: 'partial', frontmanNote: 'Instant in browser via HMR', competitorNote: 'Edits files; preview refreshes on rebuild' },
+  { name: 'Inline autocomplete', frontman: 'no', competitor: 'yes', competitorNote: 'Tab, Supercomplete, Tab-to-Jump, Tab-to-Import' },
+  { name: 'Agent mode', frontman: 'yes', competitor: 'yes', frontmanNote: 'Browser-context agent', competitorNote: 'Cascade — Code and Chat modes with flow awareness' },
+  { name: 'Multi-file refactoring', frontman: 'partial', competitor: 'yes', frontmanNote: 'Can edit multiple files, not primary workflow', competitorNote: 'Vibe and Replace — mass refactoring across hundreds of files' },
+  { name: 'Terminal integration', frontman: 'no', competitor: 'yes', competitorNote: 'Built-in terminal, Turbo Mode auto-executes commands' },
+  { name: 'Framework-aware', frontman: 'yes', competitor: 'no', frontmanNote: 'Deep plugin for Next.js, Astro, Vite — sees component tree', competitorNote: 'IDE-level file context, no framework runtime integration' },
+  { name: 'Designer/PM friendly', frontman: 'yes', competitor: 'no', frontmanNote: 'No IDE needed — works in the browser', competitorNote: 'Requires IDE proficiency' },
+  { name: 'Open source', frontman: 'yes', competitor: 'no', frontmanNote: 'Apache 2.0 (client) / AGPL-3.0 (server)', competitorNote: 'Proprietary (VS Code fork, closed-source AI features)' },
+  { name: 'BYOK (bring your own key)', frontman: 'yes', competitor: 'no', frontmanNote: 'Any LLM provider directly', competitorNote: 'Uses Windsurf\'s model pool (GPT, Claude, Gemini, SWE-1.5)' },
+  { name: 'Self-hostable', frontman: 'yes', competitor: 'no', frontmanNote: 'Everything runs locally', competitorNote: 'Cloud service; enterprise on-prem available' },
+  { name: 'Works in the browser', frontman: 'yes', competitor: 'no', frontmanNote: 'No IDE required', competitorNote: 'Standalone VS Code fork' },
+  { name: 'Backend coding', frontman: 'partial', competitor: 'yes', frontmanNote: 'Can read/write any file, but frontend-focused', competitorNote: 'Any language, any framework' },
+  { name: 'MCP support', frontman: 'yes', competitor: 'yes', frontmanNote: 'Browser-side MCP server', competitorNote: 'Plugin Store with curated MCP servers' },
+  { name: 'Proprietary models', frontman: 'no', competitor: 'yes', competitorNote: 'SWE-1.5 (claimed 13x faster than Sonnet 4.5)' },
 ]
 
-function statusLabel(status: Status): string {
-	switch (status) {
-		case 'yes': return 'Yes'
-		case 'no': return 'No'
-		case 'partial': return 'Partial'
-	}
-}
-
-// FAQ data for JSON-LD
-const faqs = [
-	{
-		question: 'Is Frontman an alternative to Windsurf?',
-		answer: 'They solve different problems. Windsurf is a VS Code fork with an AI agent (Cascade), autocomplete, and an embedded browser preview panel. It\'s a full IDE replacement. Frontman is browser middleware that integrates with your dev server (Next.js, Astro, Vite) and lets you click elements in your actual browser to edit code. For visual frontend editing where runtime context matters, Frontman is the open-source option. For general-purpose AI-assisted coding with a dedicated IDE, Windsurf is the more complete tool.'
-	},
-	{
-		question: 'How does Windsurf\'s browser preview compare to Frontman?',
-		answer: 'Windsurf has an embedded browser panel inside the IDE where you can click elements and send them to the Cascade agent. Frontman runs in your actual browser as framework middleware. The practical difference: Windsurf\'s preview shows the rendered DOM but doesn\'t know your React/Vue/Svelte component tree, props, state, or server-side context. Frontman\'s middleware integration sees the full component hierarchy, computed CSS, routes, and logs because it hooks into the framework itself.'
-	},
-	{
-		question: 'Can I use Frontman and Windsurf together?',
-		answer: 'Yes. Use Windsurf as your IDE for general coding, refactoring, and backend work. Use Frontman in the browser for visual frontend editing where you want to click UI elements and make changes with full runtime context. They edit the same source files and don\'t conflict.'
-	},
-	{
-		question: 'Is Frontman free compared to Windsurf?',
-		answer: 'Yes. Windsurf Free gives you 25 Cascade credits per month. Pro is $15/month for 500 credits. Frontman is free to self-host with no limits. You bring your own API keys to Claude, ChatGPT, or OpenRouter and pay those providers directly. No credit system, no monthly subscription from Frontman itself.'
-	},
-	{
-		question: 'What happened to Codeium / who owns Windsurf now?',
-		answer: 'Windsurf was originally built by Codeium. In mid-2025, Google acquihired the founders and key research staff. Cognition (the company behind Devin, the AI coding agent) then acquired the Windsurf product, IP, and remaining team. As of 2026, Windsurf is owned and operated by Cognition, Inc.'
-	}
+const faqs: FAQ[] = [
+  {
+    question: 'Is Frontman an alternative to Windsurf?',
+    answer:
+      'They solve different problems. Windsurf is a VS Code fork with an AI agent (Cascade), autocomplete, and an embedded browser preview panel. It\'s a full IDE replacement. Frontman is browser middleware that integrates with your dev server (Next.js, Astro, Vite) and lets you click elements in your actual browser to edit code. For visual frontend editing where runtime context matters, Frontman is the open-source option. For general-purpose AI-assisted coding with a dedicated IDE, Windsurf is the more complete tool.',
+  },
+  {
+    question: 'How does Windsurf\'s browser preview compare to Frontman?',
+    answer:
+      'Windsurf has an embedded browser panel inside the IDE where you can click elements and send them to the Cascade agent. Frontman runs in your actual browser as framework middleware. The practical difference: Windsurf\'s preview shows the rendered DOM but doesn\'t know your React/Vue/Svelte component tree, props, state, or server-side context. Frontman\'s middleware integration sees the full component hierarchy, computed CSS, routes, and logs because it hooks into the framework itself.',
+  },
+  {
+    question: 'Can I use Frontman and Windsurf together?',
+    answer:
+      'Yes. Use Windsurf as your IDE for general coding, refactoring, and backend work. Use Frontman in the browser for visual frontend editing where you want to click UI elements and make changes with full runtime context. They edit the same source files and don\'t conflict.',
+  },
+  {
+    question: 'Is Frontman free compared to Windsurf?',
+    answer:
+      'Yes. Windsurf Free gives you 25 Cascade credits per month. Pro is $15/month for 500 credits. Frontman is free to self-host with no limits. You bring your own API keys to Claude, ChatGPT, or OpenRouter and pay those providers directly. No credit system, no monthly subscription from Frontman itself.',
+  },
+  {
+    question: 'What happened to Codeium / who owns Windsurf now?',
+    answer:
+      'Windsurf was originally built by Codeium. In mid-2025, Google acquihired the founders and key research staff. Cognition (the company behind Devin, the AI coding agent) then acquired the Windsurf product, IP, and remaining team. As of 2026, Windsurf is owned and operated by Cognition, Inc.',
+  },
 ]
 
-// FAQPage JSON-LD
-const faqJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "FAQPage",
-	"mainEntity": faqs.map((faq) => ({
-		"@type": "Question",
-		"name": faq.question,
-		"acceptedAnswer": {
-			"@type": "Answer",
-			"text": faq.answer
-		}
-	}))
-}
+const alternatives: Alternative[] = [
+  { name: 'Frontman', slug: '', oneLiner: 'Open-source AI agent in your browser with runtime DOM/CSS awareness and click-to-edit workflows.' },
+  { name: 'Cursor', slug: 'cursor', oneLiner: 'AI IDE with strong autocomplete and agent mode for full-stack workflows.' },
+  { name: 'Claude Code', slug: 'claude-code', oneLiner: 'Terminal-native agent for multi-file coding, shell execution, and PR workflows.' },
+  { name: 'GitHub Copilot', slug: 'copilot', oneLiner: 'IDE-native assistant with autocomplete, chat, and GitHub integration.' },
+  { name: 'Stagewise', slug: 'stagewise', oneLiner: 'Browser overlay for visual context, especially useful with existing IDE agents.' },
+]
+
+const frontmanPricingFeatures = [
+  'Unlimited usage, no caps',
+  'Bring your own API keys (Claude, ChatGPT, OpenRouter)',
+  'Or sign in with Claude/ChatGPT subscription via OAuth',
+  'Apache 2.0 (client) / AGPL-3.0 (server)',
+  'You pay your LLM provider directly',
+]
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+<ComparisonLayout
+  seo={seo}
+  competitor={competitor}
+  heroTitle="Frontman vs Windsurf"
+  heroSubtitle="Browser Middleware vs AI IDE"
+  features={features}
+  faqs={faqs}
+  alternatives={alternatives}
+  frontmanPricing={{ features: frontmanPricingFeatures }}
+>
+  <Fragment slot="hero-summary">
+    <p>
+      <a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent that lives in your browser. It integrates with your framework (Next.js, Astro, or Vite) as a plugin that serves an overlay UI at <code>/frontman</code>. A browser-side MCP server handles DOM inspection, screenshots, computed CSS, and element selection. You click elements in your running app, describe changes in plain English, and Frontman edits the actual source files with hot reload.
+    </p>
+    <p>
+      <a href="https://windsurf.com" class="text-link" rel="nofollow">Windsurf</a> is a proprietary AI-powered IDE, a VS Code fork with a built-in agent called Cascade. It includes autocomplete (Tab), an embedded browser preview panel, MCP server support, and terminal integration. Originally built by Codeium, now owned by Cognition (the company behind Devin). Windsurf works across any language and framework through file-level context.
+    </p>
+    <p class="summary-emphasis">
+      The key distinction: Windsurf brings a preview browser into the IDE. Frontman puts the AI agent into your real browser. One adds browser context to an IDE workflow; the other works entirely from the browser.
+    </p>
+  </Fragment>
 
-	<!-- Hero / AI-Citable Summary -->
-	<section class="hero-section">
-		<div class="hero-container">
-			<p class="hero-label">Comparison</p>
-			<h1 class="hero-title">Frontman vs Windsurf</h1>
-			<p class="hero-subtitle">Browser Middleware vs AI IDE</p>
+  <Fragment slot="competitor-strengths">
+    <p>Windsurf has grown into a capable AI IDE with features worth understanding before you compare it to anything else.</p>
+    <p>Windsurf's agent mode, Cascade, monitors your file edits, terminal commands, and clipboard activity to infer what you're working on. This "flow awareness" means less manual context-providing compared to tools where you have to select files or explain your situation. It often picks up on your intent before you describe it.</p>
+    <p>Tab autocomplete goes beyond standard inline predictions. Supercomplete predicts your next action beyond single-token completion. Tab-to-Jump moves your cursor where you'll likely edit next. Tab-to-Import handles dependency imports automatically. For developers who rely on autocomplete, this is faster than most competitors.</p>
+    <p>The embedded browser panel lets you see your running app, click an element, and send it to Cascade. You can also forward console errors directly to the agent. This is closer to visual editing than any other IDE offers, though it works on raw DOM rather than the framework component tree.</p>
+    <p>Windsurf built its own coding model, SWE-1.5, which they claim runs 13x faster than Sonnet 4.5. Whether the claim holds in all scenarios, having a purpose-built model means some operations (like codebase search via Fast Context) are quicker than routing through general-purpose LLMs.</p>
+    <p>Windsurf also runs beyond VS Code. JetBrains gets native Cascade integration, and plugins exist for 40+ other editors. Cursor, by comparison, is VS Code-only.</p>
+    <p>On the enterprise side: SOC 2, HIPAA, FedRAMP/DOD, RBAC, SCIM. If your company has strict compliance requirements, Windsurf has certifications that most competitors lack.</p>
+  </Fragment>
 
-			<div class="hero-summary">
-				<p>
-					<a href="https://frontman.sh" class="text-link">Frontman</a> is an open-source AI coding agent that lives in your browser. It integrates with your framework (Next.js, Astro, or Vite) as a plugin that serves an overlay UI at <code>/frontman</code>. A browser-side MCP server handles DOM inspection, screenshots, computed CSS, and element selection. You click elements in your running app, describe changes in plain English, and Frontman edits the actual source files with hot reload.
-				</p>
-				<p>
-					<a href="https://windsurf.com" class="text-link" rel="nofollow">Windsurf</a> is a proprietary AI-powered IDE, a VS Code fork with a built-in agent called Cascade. It includes autocomplete (Tab), an embedded browser preview panel, MCP server support, and terminal integration. Originally built by Codeium, now owned by Cognition (the company behind Devin). Windsurf works across any language and framework through file-level context.
-				</p>
-				<p class="summary-emphasis">
-					The key distinction: Windsurf brings a preview browser into the IDE. Frontman puts the AI agent into your real browser. One adds browser context to an IDE workflow; the other works entirely from the browser.
-				</p>
-			</div>
-			<ComparisonDisclosure competitor="Windsurf" />
-		</div>
-	</section>
+  <Fragment slot="frontman-differentiators">
+    <p>Windsurf's embedded browser preview is a step toward visual editing. But there's a structural difference between putting a browser inside an IDE and putting an AI agent inside the browser.</p>
+    <p>Frontman installs as a plugin for Next.js, Astro, or Vite. It runs inside your dev server rather than alongside it. This means it has access to the component tree (React, Vue, Svelte), server-side routes and logs, compilation errors, and source maps that trace rendered elements back to exact file and line numbers. Windsurf's preview panel sees the rendered DOM, but it doesn't know that a particular <code>&lt;div&gt;</code> is a <code>&lt;ProductCard&gt;</code> component at line 47 of <code>ProductCard.tsx</code>.</p>
+    <p>Frontman also runs in your real browser, not an IDE panel. It serves at <code>/frontman</code> in Chrome, Firefox, or whatever you test with. You see the same page your users will see, at the same viewport width, with the same extensions and dev tools you always use. Windsurf's preview panel is a controlled embedded browser inside the IDE.</p>
+    <p>When you click an element in Frontman, the MCP server reads actual computed style values: real pixel dimensions, resolved colors, cascaded font sizes. It doesn't guess from class names. Windsurf's Cascade agent reads your source files and the preview's rendered output, but doesn't have direct access to the CSS cascade or computed values at the level Frontman's browser-side MCP server does.</p>
+    <p>On licensing: Frontman's client libraries are Apache 2.0, the server is AGPL-3.0, and you bring your own API keys to Claude, ChatGPT, OpenRouter, or any OpenAI-compatible provider. Windsurf is proprietary, uses its own model pool, and charges per-credit. You can't use your own LLM provider or self-host the AI features.</p>
+    <p>Frontman also doesn't require an IDE. Designers and product managers can open the app in a browser, click elements, and describe changes in plain English. The output is real source code edits for developer review. With Windsurf, you need the IDE installed and you need to know how to use it.</p>
+  </Fragment>
 
-	<!-- Comparison Table -->
-	<section class="comparison-section">
-		<div class="comparison-container">
-			<h2 class="section-title">Feature Comparison</h2>
+  <Fragment slot="who-should-use-competitor">
+    <p>Windsurf is the better choice when you want a full AI IDE that handles everything in one place:</p>
+    <ul>
+      <li><strong>Developers who want autocomplete, agent mode, and terminal in one tool.</strong> Cascade + Tab + terminal is a complete coding environment.</li>
+      <li><strong>Full-stack and backend developers.</strong> Any language, any framework, with purpose-built code search and refactoring.</li>
+      <li><strong>Teams on JetBrains IDEs.</strong> Windsurf has native JetBrains integration where Cursor does not.</li>
+      <li><strong>Enterprises with compliance requirements.</strong> SOC 2, HIPAA, FedRAMP certifications.</li>
+      <li><strong>Developers who want visual context without leaving the IDE.</strong> The embedded browser preview is a pragmatic middle ground.</li>
+    </ul>
+  </Fragment>
 
-			<!-- Desktop table -->
-			<div class="table-wrapper">
-				<table class="comparison-table" role="grid">
-					<thead>
-						<tr>
-							<th class="feature-header">Feature</th>
-							<th class="tool-header tool-header--highlighted">Frontman</th>
-							<th class="tool-header">Windsurf</th>
-						</tr>
-					</thead>
-					<tbody>
-						{features.map((feature) => (
-							<tr>
-								<td class="feature-cell">{feature.name}</td>
-								<td class={`status-cell status-cell--highlighted`} aria-label={statusLabel(feature.frontman)}>
-									<div class="status-content">
-										{feature.frontman === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.frontman === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.frontman === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.frontmanNote && <span class="status-note">{feature.frontmanNote}</span>}
-									</div>
-								</td>
-								<td class="status-cell" aria-label={statusLabel(feature.windsurf)}>
-									<div class="status-content">
-										{feature.windsurf === 'yes' && (
-											<svg class="status-icon status-icon--yes" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
-										)}
-										{feature.windsurf === 'no' && (
-											<svg class="status-icon status-icon--no" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-										)}
-										{feature.windsurf === 'partial' && (
-											<svg class="status-icon status-icon--partial" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-										)}
-										{feature.windsurfNote && <span class="status-note">{feature.windsurfNote}</span>}
-									</div>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+  <Fragment slot="who-should-use-frontman">
+    <p>Frontman is the better choice when you need deep browser context and visual editing:</p>
+    <ul>
+      <li><strong>Frontend developers who want the AI to see the actual rendered page.</strong> Computed styles, component tree, responsive behavior, and server logs in addition to source files.</li>
+      <li><strong>Teams where designers or PMs make UI changes.</strong> Click elements in the browser, describe changes, review code diffs. No IDE required.</li>
+      <li><strong>Next.js, Astro, or Vite projects</strong> where framework middleware gives the AI agent more context than file reading alone.</li>
+      <li><strong>Open-source and BYOK.</strong> Apache 2.0 client libs, AGPL-3.0 server, any LLM provider, self-hostable, no credit system.</li>
+      <li><strong>Developers who don't want to switch IDEs.</strong> Frontman works with whatever editor you already use. It only needs the browser.</li>
+    </ul>
+    <p>Many developers will use both. Windsurf (or Cursor, or your preferred IDE) for general coding, and Frontman in the browser for visual frontend work where the AI needs to see what's rendered.</p>
+    <p>See also: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a>, <a href="/vs/copilot/" class="text-link">Frontman vs GitHub Copilot</a>, <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a>.</p>
+  </Fragment>
 
-			<!-- Mobile cards -->
-			<div class="mobile-cards">
-				{features.map((feature) => (
-					<div class="mobile-card">
-						<h3 class="mobile-card-title">{feature.name}</h3>
-						<div class="mobile-card-grid">
-							<div class="mobile-card-item mobile-card-item--highlighted">
-								<span class="mobile-card-tool">Frontman</span>
-								<span>
-									{feature.frontman === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.frontman === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.frontman === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-							<div class="mobile-card-item">
-								<span class="mobile-card-tool">Windsurf</span>
-								<span>
-									{feature.windsurf === 'yes' && <svg class="status-icon status-icon--yes" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>}
-									{feature.windsurf === 'no' && <svg class="status-icon status-icon--no" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>}
-									{feature.windsurf === 'partial' && <svg class="status-icon status-icon--partial" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"></line></svg>}
-								</span>
-							</div>
-						</div>
-					</div>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- What Windsurf Does Well -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">What Windsurf Does Well</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Windsurf has grown into a capable AI IDE with features worth understanding before you compare it to anything else.</p>
-				<p>Windsurf's agent mode, Cascade, monitors your file edits, terminal commands, and clipboard activity to infer what you're working on. This "flow awareness" means less manual context-providing compared to tools where you have to select files or explain your situation. It often picks up on your intent before you describe it.</p>
-				<p>Tab autocomplete goes beyond standard inline predictions. Supercomplete predicts your next action beyond single-token completion. Tab-to-Jump moves your cursor where you'll likely edit next. Tab-to-Import handles dependency imports automatically. For developers who rely on autocomplete, this is faster than most competitors.</p>
-				<p>The embedded browser panel lets you see your running app, click an element, and send it to Cascade. You can also forward console errors directly to the agent. This is closer to visual editing than any other IDE offers, though it works on raw DOM rather than the framework component tree.</p>
-				<p>Windsurf built its own coding model, SWE-1.5, which they claim runs 13x faster than Sonnet 4.5. Whether the claim holds in all scenarios, having a purpose-built model means some operations (like codebase search via Fast Context) are quicker than routing through general-purpose LLMs.</p>
-				<p>Windsurf also runs beyond VS Code. JetBrains gets native Cascade integration, and plugins exist for 40+ other editors. Cursor, by comparison, is VS Code-only.</p>
-				<p>On the enterprise side: SOC 2, HIPAA, FedRAMP/DOD, RBAC, SCIM. If your company has strict compliance requirements, Windsurf has certifications that most competitors lack.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Where Frontman Is Different -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Where Frontman Is Different</h2>
-			<div class="prose-content">
-				<p>Windsurf's embedded browser preview is a step toward visual editing. But there's a structural difference between putting a browser inside an IDE and putting an AI agent inside the browser.</p>
-
-				<p>Frontman installs as a plugin for Next.js, Astro, or Vite. It runs inside your dev server rather than alongside it. This means it has access to the component tree (React, Vue, Svelte), server-side routes and logs, compilation errors, and source maps that trace rendered elements back to exact file and line numbers. Windsurf's preview panel sees the rendered DOM, but it doesn't know that a particular <code>&lt;div&gt;</code> is a <code>&lt;ProductCard&gt;</code> component at line 47 of <code>ProductCard.tsx</code>.</p>
-
-				<p>Frontman also runs in your real browser, not an IDE panel. It serves at <code>/frontman</code> in Chrome, Firefox, or whatever you test with. You see the same page your users will see, at the same viewport width, with the same extensions and dev tools you always use. Windsurf's preview panel is a controlled embedded browser inside the IDE.</p>
-
-				<p>When you click an element in Frontman, the MCP server reads actual computed style values: real pixel dimensions, resolved colors, cascaded font sizes. It doesn't guess from class names. Windsurf's Cascade agent reads your source files and the preview's rendered output, but doesn't have direct access to the CSS cascade or computed values at the level Frontman's browser-side MCP server does.</p>
-
-				<p>On licensing: Frontman's client libraries are Apache 2.0, the server is AGPL-3.0, and you bring your own API keys to Claude, ChatGPT, OpenRouter, or any OpenAI-compatible provider. Windsurf is proprietary, uses its own model pool, and charges per-credit. You can't use your own LLM provider or self-host the AI features.</p>
-
-				<p>Frontman also doesn't require an IDE. Designers and product managers can open the app in a browser, click elements, and describe changes in plain English. The output is real source code edits for developer review. With Windsurf, you need the IDE installed and you need to know how to use it.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Windsurf -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Who Should Use Windsurf</h2>
-			<div class="prose-content prose-content--dark">
-				<p>Windsurf is the better choice when you want a full AI IDE that handles everything in one place:</p>
-				<ul>
-					<li><strong>Developers who want autocomplete, agent mode, and terminal in one tool.</strong> Cascade + Tab + terminal is a complete coding environment.</li>
-					<li><strong>Full-stack and backend developers.</strong> Any language, any framework, with purpose-built code search and refactoring.</li>
-					<li><strong>Teams on JetBrains IDEs.</strong> Windsurf has native JetBrains integration where Cursor does not.</li>
-					<li><strong>Enterprises with compliance requirements.</strong> SOC 2, HIPAA, FedRAMP certifications.</li>
-					<li><strong>Developers who want visual context without leaving the IDE.</strong> The embedded browser preview is a pragmatic middle ground.</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	<!-- Who Should Use Frontman -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Who Should Use Frontman</h2>
-			<div class="prose-content">
-				<p>Frontman is the better choice when you need deep browser context and visual editing:</p>
-				<ul>
-					<li><strong>Frontend developers who want the AI to see the actual rendered page.</strong> Computed styles, component tree, responsive behavior, and server logs in addition to source files.</li>
-					<li><strong>Teams where designers or PMs make UI changes.</strong> Click elements in the browser, describe changes, review code diffs. No IDE required.</li>
-					<li><strong>Next.js, Astro, or Vite projects</strong> where framework middleware gives the AI agent more context than file reading alone.</li>
-					<li><strong>Open-source and BYOK.</strong> Apache 2.0 client libs, AGPL-3.0 server, any LLM provider, self-hostable, no credit system.</li>
-					<li><strong>Developers who don't want to switch IDEs.</strong> Frontman works with whatever editor you already use. It only needs the browser.</li>
-				</ul>
-				<p>Many developers will use both. Windsurf (or Cursor, or your preferred IDE) for general coding, and Frontman in the browser for visual frontend work where the AI needs to see what's rendered.</p>
-				<p>See also: <a href="/vs/cursor/" class="text-link">Frontman vs Cursor</a>, <a href="/vs/copilot/" class="text-link">Frontman vs GitHub Copilot</a>, <a href="/vs/stagewise/" class="text-link">Frontman vs Stagewise</a>.</p>
-			</div>
-		</div>
-	</section>
-
-	<!-- Pricing -->
-	<section class="content-section content-section--light">
-		<div class="content-container">
-			<h2 class="section-title section-title--dark">Pricing Comparison</h2>
-			<div class="pricing-grid">
-				<div class="pricing-card pricing-card--highlighted">
-					<h3 class="pricing-name">Frontman</h3>
-					<div class="pricing-cost">Free</div>
-					<p class="pricing-model">Open source, BYOK</p>
-					<ul class="pricing-features">
-						<li>Unlimited usage, no caps</li>
-						<li>Bring your own API keys (Claude, ChatGPT, OpenRouter)</li>
-						<li>Or sign in with Claude/ChatGPT subscription via OAuth</li>
-						<li>Apache 2.0 (client) / AGPL-3.0 (server)</li>
-						<li>You pay your LLM provider directly</li>
-					</ul>
-				</div>
-				<div class="pricing-card">
-					<h3 class="pricing-name">Windsurf</h3>
-					<div class="pricing-cost">$0–$30/mo</div>
-					<p class="pricing-model">Freemium, proprietary</p>
-					<ul class="pricing-features">
-						<li>Free: 25 Cascade credits/month, unlimited autocomplete</li>
-						<li>Pro: $15/month — 500 credits/month</li>
-						<li>Teams: $30/user/month — 500 credits/user, admin dashboard</li>
-						<li>Enterprise: custom pricing — 1,000+ credits, SSO, RBAC</li>
-						<li>Add-on: $10 for 250 extra credits</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- FAQ -->
-	<section class="content-section">
-		<div class="content-container">
-			<h2 class="section-title">Frequently Asked Questions</h2>
-			<div class="faq-list">
-				{faqs.map((faq) => (
-					<details class="faq-item group">
-						<summary class="faq-question">
-							<span>{faq.question}</span>
-							<span class="faq-icon">+</span>
-						</summary>
-						<div class="faq-answer">
-							<p>{faq.answer}</p>
-						</div>
-					</details>
-				))}
-			</div>
-		</div>
-	</section>
-
-	<!-- CTA -->
-	<section class="cta-section">
-		<div class="cta-container">
-			<h2 class="cta-title">Try Frontman</h2>
-			<p class="cta-description">One command. No account. No credit card. No credit limits.</p>
-			<div class="install-commands">
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/nextjs install</code>
-					<span class="command-label">Next.js</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> npx @frontman-ai/vite install</code>
-					<span class="command-label">Vite (React, Vue, Svelte, SolidJS)</span>
-				</div>
-				<div class="install-command">
-					<code><span class="command-prefix">$</span> astro add @frontman-ai/astro</code>
-					<span class="command-label">Astro</span>
-				</div>
-			</div>
-			<div class="cta-links">
-				<Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
-				<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="cta-discord">Join Discord</a>
-			</div>
-		</div>
-	</section>
-</Layout>
-
-<style>
-	@reference "../../styles/global.css";
-	/* Hero */
-	.hero-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 80px 24px 64px;
-		display: flex;
-		justify-content: center;
-	}
-	.hero-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.hero-label {
-		@apply font-mono;
-		font-size: 13px;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #A259FF;
-		margin-bottom: 12px;
-	}
-	.hero-title {
-		font-size: 48px;
-		font-weight: 700;
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-		color: #fafafa;
-		margin-bottom: 8px;
-	}
-	.hero-subtitle {
-		font-size: 20px;
-		color: #71717a;
-		margin-bottom: 40px;
-	}
-	.hero-summary p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.hero-summary code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.summary-emphasis {
-		color: #fafafa !important;
-		font-weight: 500;
-		border-left: 3px solid #A259FF;
-		padding-left: 16px;
-		margin-top: 24px !important;
-	}
-	.text-link {
-		color: #A259FF;
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
-	.text-link:hover {
-		color: #c084fc;
-	}
-
-	/* Comparison section */
-	.comparison-section {
-		background: #09090b;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.comparison-container {
-		max-width: 900px;
-		width: 100%;
-	}
-
-	/* Section titles */
-	.section-title {
-		font-size: 32px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 32px;
-		letter-spacing: -0.02em;
-	}
-	.section-title--dark {
-		color: #09090b;
-	}
-
-	/* Table */
-	.table-wrapper {
-		@apply hidden md:block;
-	}
-	.comparison-table {
-		@apply w-full;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-	.feature-header {
-		@apply text-left text-sm font-semibold uppercase tracking-wider py-4 px-6;
-		color: rgba(255, 255, 255, 0.4);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	}
-	.tool-header {
-		@apply text-center text-base font-bold py-4 px-6;
-		color: rgba(255, 255, 255, 0.7);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		width: 240px;
-	}
-	.tool-header--highlighted {
-		color: #A259FF;
-		background: rgba(162, 89, 255, 0.08);
-		border-top: 3px solid #A259FF;
-		border-bottom: 1px solid rgba(162, 89, 255, 0.2);
-	}
-	.feature-cell {
-		@apply text-left text-base py-4 px-6;
-		color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell {
-		@apply py-4 px-6;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-	}
-	.status-cell--highlighted {
-		background: rgba(162, 89, 255, 0.08);
-	}
-	.status-content {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: flex-start;
-	}
-	.status-note {
-		font-size: 13px;
-		color: rgba(255, 255, 255, 0.5);
-	}
-	tr:last-child .feature-cell,
-	tr:last-child .status-cell {
-		border-bottom: none;
-	}
-	.status-icon { @apply inline-block; }
-	.status-icon--yes { color: #22c55e; }
-	.status-icon--no { color: #ef4444; }
-	.status-icon--partial { color: #f59e0b; }
-
-	/* Mobile cards */
-	.mobile-cards {
-		@apply flex flex-col gap-3 md:hidden;
-	}
-	.mobile-card {
-		@apply p-4;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
-	}
-	.mobile-card-title {
-		@apply font-headings text-sm font-bold mb-3;
-		color: white;
-	}
-	.mobile-card-grid {
-		@apply grid grid-cols-2 gap-3;
-	}
-	.mobile-card-item {
-		@apply flex items-center justify-between py-2 px-3;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.03);
-	}
-	.mobile-card-item--highlighted {
-		background: rgba(162, 89, 255, 0.12);
-		border: 1px solid rgba(162, 89, 255, 0.25);
-	}
-	.mobile-card-tool {
-		@apply text-sm;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.mobile-card-item--highlighted .mobile-card-tool {
-		color: #A259FF;
-		font-weight: 600;
-	}
-
-	/* Content sections */
-	.content-section {
-		background: #09090b;
-		color: #fafafa;
-		padding: 64px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.content-section--light {
-		background: #fafafa;
-		color: #09090b;
-	}
-	.content-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.prose-content p {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		margin-bottom: 16px;
-	}
-	.prose-content--dark p {
-		color: #52525b;
-	}
-	.prose-content strong {
-		color: #fafafa;
-		font-weight: 600;
-	}
-	.prose-content--dark strong {
-		color: #09090b;
-	}
-	.prose-content code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 2px 6px;
-		border-radius: 4px;
-	}
-	.prose-content--dark code {
-		background: rgba(0, 0, 0, 0.06);
-	}
-	.prose-content ul {
-		list-style: none;
-		padding: 0;
-		margin: 16px 0;
-	}
-	.prose-content li {
-		font-size: 17px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding: 8px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-	.prose-content--dark li {
-		color: #52525b;
-	}
-	.prose-content li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 18px;
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		background: #A259FF;
-	}
-	.prose-content li strong {
-		color: #fafafa;
-	}
-	.prose-content--dark li strong {
-		color: #09090b;
-	}
-
-	/* Pricing */
-	.pricing-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
-	}
-	.pricing-card {
-		padding: 32px;
-		border-radius: 16px;
-		border: 1px solid #e4e4e7;
-		background: white;
-	}
-	.pricing-card--highlighted {
-		border-color: #A259FF;
-		background: linear-gradient(135deg, rgba(162, 89, 255, 0.05), rgba(162, 89, 255, 0.02));
-		box-shadow: 0 0 0 1px rgba(162, 89, 255, 0.2);
-	}
-	.pricing-name {
-		font-size: 20px;
-		font-weight: 700;
-		color: #09090b;
-		margin-bottom: 8px;
-	}
-	.pricing-cost {
-		font-size: 36px;
-		font-weight: 800;
-		color: #09090b;
-		margin-bottom: 4px;
-		letter-spacing: -0.02em;
-	}
-	.pricing-card--highlighted .pricing-cost {
-		color: #A259FF;
-	}
-	.pricing-model {
-		font-size: 14px;
-		color: #71717a;
-		margin-bottom: 24px;
-	}
-	.pricing-features {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	.pricing-features li {
-		font-size: 15px;
-		color: #52525b;
-		padding: 6px 0;
-		padding-left: 20px;
-		position: relative;
-	}
-	.pricing-features li::before {
-		content: '\2192';
-		position: absolute;
-		left: 0;
-		color: #a1a1aa;
-	}
-
-	/* FAQ */
-	.faq-list {
-		border-top: 1px solid #27272a;
-	}
-	.faq-item {
-		border-bottom: 1px solid #27272a;
-		cursor: pointer;
-	}
-	.faq-question {
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 24px 0;
-		color: #fafafa;
-		font-size: 17px;
-		font-weight: 500;
-		line-height: 1.4;
-		list-style: none;
-		transition: color 0.2s;
-	}
-	.faq-question::-webkit-details-marker { display: none; }
-	.faq-question:hover { color: #fff; }
-	.faq-question span:first-child { padding-right: 24px; }
-	.faq-icon {
-		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
-		border-radius: 50%;
-		border: 1px solid #3f3f46;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 18px;
-		font-weight: 300;
-		color: #71717a;
-		transition: all 0.3s ease;
-	}
-	.group[open] .faq-icon {
-		transform: rotate(45deg);
-		background: #27272a;
-	}
-	.faq-answer p {
-		font-size: 15px;
-		line-height: 1.7;
-		color: #a1a1aa;
-		padding-bottom: 24px;
-		margin: 0;
-		max-width: 620px;
-	}
-
-	/* CTA */
-	.cta-section {
-		background: #09090b;
-		border-top: 1px solid #27272a;
-		padding: 80px 24px;
-		display: flex;
-		justify-content: center;
-	}
-	.cta-container {
-		max-width: 720px;
-		width: 100%;
-	}
-	.cta-title {
-		font-size: 36px;
-		font-weight: 700;
-		color: #fafafa;
-		margin-bottom: 8px;
-		letter-spacing: -0.02em;
-	}
-	.cta-description {
-		font-size: 17px;
-		color: #71717a;
-		margin-bottom: 32px;
-	}
-	.install-commands {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		margin-bottom: 32px;
-	}
-	.install-command {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 12px 16px;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-	}
-	.install-command code {
-		font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-		font-size: 14px;
-		color: #fafafa;
-	}
-	.command-prefix {
-		color: #A259FF;
-		margin-right: 8px;
-	}
-	.command-label {
-		font-size: 13px;
-		color: #71717a;
-	}
-	.cta-links {
-		display: flex;
-		align-items: center;
-		gap: 24px;
-	}
-	.cta-discord {
-		color: #71717a;
-		font-size: 15px;
-		text-decoration: none;
-		transition: color 0.2s;
-	}
-	.cta-discord:hover {
-		color: #fafafa;
-	}
-
-	/* Responsive */
-	@media (max-width: 768px) {
-		.hero-section { padding: 48px 20px 40px; }
-		.hero-title { font-size: 32px; }
-		.hero-subtitle { font-size: 17px; margin-bottom: 24px; }
-		.section-title { font-size: 24px; }
-		.content-section { padding: 40px 20px; }
-		.comparison-section { padding: 40px 20px; }
-		.pricing-grid { grid-template-columns: 1fr; }
-		.cta-section { padding: 48px 20px; }
-		.cta-title { font-size: 28px; }
-		.cta-links { flex-direction: column; align-items: flex-start; gap: 12px; }
-		.install-command { flex-direction: column; align-items: flex-start; gap: 4px; }
-	}
-</style>
+  <Fragment slot="cta">
+    <section class="flex justify-center border-t border-zinc-800 bg-zinc-950 px-6 py-20 max-md:px-5 max-md:py-12">
+      <div class="w-full max-w-[720px]">
+        <h2 class="mb-2 text-4xl font-bold tracking-tight text-zinc-50 max-md:text-[28px]">Try Frontman</h2>
+        <p class="mb-8 text-[17px] text-zinc-300">One command. No account. No credit card. No credit limits.</p>
+        <div class="mb-8 flex flex-col gap-3">
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/nextjs install</code>
+            <span class="text-[13px] text-zinc-300">Next.js</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> npx @frontman-ai/vite install</code>
+            <span class="text-[13px] text-zinc-300">Vite (React, Vue, Svelte, SolidJS)</span>
+          </div>
+          <div class="flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 max-md:flex-col max-md:items-start max-md:gap-1">
+            <code class="font-mono text-sm text-zinc-50"><span class="mr-2 text-primary-500">$</span> astro add @frontman-ai/astro</code>
+            <span class="text-[13px] text-zinc-300">Astro</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-6 max-md:flex-col max-md:items-start max-md:gap-3">
+          <Button size="lg" style="primary" link="https://github.com/frontman-ai/frontman">Star on GitHub</Button>
+          <a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="text-[15px] text-zinc-300 transition-colors hover:text-zinc-50">Join Discord</a>
+        </div>
+      </div>
+    </section>
+  </Fragment>
+</ComparisonLayout>


### PR DESCRIPTION
## Summary
- Add two new marketing landing pages for SEO/AEO query coverage: `/use-cases/designers/` and `/use-cases/frontend-developers/`.
- Improve discovery for those pages by adding footer links and assigning `/use-cases/*` higher sitemap priority.
- Canonicalize the category article slug to `/blog/what-are-browser-aware-ai-coding-tools/`, add redirect from the old framework-aware slug, and update internal links accordingly.

## Validation
- `npm run build` (Astro check + build)
- Verified no broken links during build (`astro-broken-links-checker`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
