### PR TITLE
fix(client): restore replayed image attachments

### DIFF
--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -544,6 +544,31 @@ let extractAttachmentsFromUserContent = (content: array<UserContentPart.t>): arr
   })
 }
 
+let attachmentUri = (att: Message.fileAttachmentData): string => `attachment://${att.id}/${att.filename}`
+
+let accumulateImageAttachments = (
+  imageAttachments: Dict.t<Message.fileAttachmentData>,
+  attachments: array<Message.fileAttachmentData>,
+): Dict.t<Message.fileAttachmentData> => {
+  let updated = imageAttachments->Dict.copy
+  attachments->Array.forEach(att => updated->Dict.set(attachmentUri(att), att))
+  updated
+}
+
+let collectImageAttachmentsFromMessages = (
+  messages: Client__MessageStore.t,
+): Dict.t<Message.fileAttachmentData> => {
+  messages
+  ->MessageStore.toArray
+  ->Array.reduce(Dict.make(), (imageAttachments, msg) =>
+    switch msg {
+    | Message.User({content}) =>
+      accumulateImageAttachments(imageAttachments, extractAttachmentsFromUserContent(content))
+    | _ => imageAttachments
+    }
+  )
+}
+
 // Helper to get task ID for error messages
 let getTaskIdForError = (task: Task.t): string => Task.getId(task)->Option.getOr("(no id)")
 
@@ -993,11 +1018,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     let message = Message.User({id, content, annotations, createdAt: Date.now()})
 
     // Accumulate image attachments keyed by URI for write_file image_ref resolution
-    let updatedImageAttachments = data.imageAttachments->Dict.copy
-    attachments->Array.forEach(att => {
-      let uri = `attachment://${att.id}/${att.filename}`
-      updatedImageAttachments->Dict.set(uri, att)
-    })
+    let updatedImageAttachments = accumulateImageAttachments(data.imageAttachments, attachments)
 
     (
       Task.Loaded({
@@ -1178,6 +1199,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
       let sortedMessages = MessageStore.toSorted(messages, (a, b) =>
         Selectors.getMessageCreatedAt(a) -. Selectors.getMessageCreatedAt(b)
       )
+      let imageAttachments = collectImageAttachmentsFromMessages(sortedMessages)
       (
         Task.Loaded({
           id,
@@ -1195,7 +1217,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
           planEntries: [],
           turnError: None,
           retryStatus: None,
-          imageAttachments: Dict.make(),
+          imageAttachments,
           pendingQuestion: None,
         }),
         [],

--- a/libs/client/test/Client__HistoryReplay.test.res
+++ b/libs/client/test/Client__HistoryReplay.test.res
@@ -156,6 +156,36 @@ describe("History Replay - Reducer level (direct dispatch)", () => {
     ->Expect.toBe("Still BlueHotDog")
   })
 
+  test("LoadComplete rebuilds image_ref resolver store from replayed user images", t => {
+    let task = TestHelpers.makeLoadingTask()
+    let imageDataUrl = "data:image/png;base64,aGVsbG8="
+    let imageUri = "attachment://att-history/screenshot.png"
+
+    let (task, _) = TaskReducer.next(
+      task,
+      UserMessageReceived({
+        id: "user-with-image",
+        content: [
+          UserContentPart.text("please use this screenshot"),
+          UserContentPart.Image({
+            id: Some("att-history"),
+            image: imageDataUrl,
+            mediaType: Some("image/png"),
+            name: Some("screenshot.png"),
+          }),
+        ],
+        annotations: [],
+        timestamp: "2026-04-27T16:59:45Z",
+      }),
+    )
+
+    let (loaded, _) = TaskReducer.next(task, LoadComplete)
+    let imageAttachments = Task.getImageAttachments(loaded)
+    let resolved = imageAttachments->Dict.get(imageUri)->Option.map(Message.resolveAttachmentImage)
+
+    t->expect(resolved)->Expect.toEqual(Some({Message.base64: "aGVsbG8=", mediaType: "image/png"}))
+  })
+
   test("all agent messages are Completed (not Streaming) after LoadComplete", t => {
     let task = TestHelpers.makeLoadingTask()
 


### PR DESCRIPTION
## Summary
Fixes #941

Rebuilds the client-side image attachment resolver store from replayed user messages when a saved task finishes loading. This keeps historical `attachment://...` image refs usable after reload/reconnect instead of advertising refs that `image_ref` cannot resolve.

## Changes
- Shared the live-message attachment accumulation logic for both new messages and replayed history.
- Rehydrates `imageAttachments` during `LoadComplete` from replayed user image content parts.
- Added coverage for resolving a replayed image attachment after load completion.

## Test Plan
- `make rescript-build`
- `yarn vitest run --config vitest.temp.config.mjs -t 'LoadComplete rebuilds image_ref resolver store'` (temporary local config used only to target the generated ReScript test file)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
