### PR TITLE
Move title generation enqueueing into tasks context

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -297,7 +297,18 @@ defmodule FrontmanServer.Tasks do
          {:ok, interaction} <- add_user_message(scope, task_id, content_blocks) do
       opts = Keyword.put(opts, :interaction_id, interaction.id)
       maybe_start_execution(scope, task_id, tools, opts)
+      maybe_enqueue_title_from_submit(scope, task_id, opts)
       {:ok, interaction}
+    end
+  end
+
+  defp maybe_enqueue_title_from_submit(scope, task_id, opts) do
+    case Keyword.fetch(opts, :title_prompt_text) do
+      {:ok, prompt_text} ->
+        maybe_enqueue_initial_title_generation(scope, task_id, prompt_text, model: opts[:model])
+
+      :error ->
+        :ok
     end
   end
 
@@ -463,6 +474,28 @@ defmodule FrontmanServer.Tasks do
 
     GenerateTitle.new_job(scope, task_id, user_prompt_text, model)
     |> Oban.insert()
+  end
+
+  @doc """
+  Enqueues title generation only for the task's first user message while the
+  task is still using its default title.
+  """
+  @spec maybe_enqueue_initial_title_generation(Accounts.scope(), String.t(), String.t(), keyword()) ::
+          {:ok, Oban.Job.t()} | {:ok, :skipped} | {:error, :not_found | Oban.Job.changeset()}
+  def maybe_enqueue_initial_title_generation(scope, task_id, user_prompt_text, opts \\ []) do
+    with {:ok, schema} <- get_task_by_id(scope, task_id) do
+      interactions = load_interactions(task_id)
+
+      if schema.short_desc == Task.short_description(task_id) and first_user_message?(interactions) do
+        enqueue_title_generation(scope, task_id, user_prompt_text, opts)
+      else
+        {:ok, :skipped}
+      end
+    end
+  end
+
+  defp first_user_message?(interactions) do
+    Enum.count(interactions, &match?(%Interaction.UserMessage{}, &1)) == 1
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -463,7 +463,8 @@ defmodule FrontmanServerWeb.TaskChannel do
     opts =
       build_execution_opts(socket,
         model: model,
-        mcp_tool_defs: mcp_tools
+        mcp_tool_defs: mcp_tools,
+        title_prompt_text: prompt.text_summary
       )
 
     case Tasks.submit_user_message(scope, task_id, prompt.content, all_tools, opts) do
@@ -483,8 +484,6 @@ defmodule FrontmanServerWeb.TaskChannel do
         socket = assign(socket, :last_execution_opts, opts)
 
         Logger.info("User message added, agent spawned for task #{task_id}")
-
-        Tasks.enqueue_title_generation(scope, task_id, prompt.text_summary, model: model)
 
         {:noreply, socket}
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -317,10 +317,9 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Build me a login page"), [],
-          agent: agent
+          agent: agent,
+          title_prompt_text: "Build me a login page"
         )
-
-      Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
 
       assert_enqueued(worker: GenerateTitle, args: %{task_id: task_id})
     end
@@ -332,36 +331,31 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       agent1 = test_agent(mock_llm("First response"), "TitleAgent1")
       agent2 = test_agent(mock_llm("Second response"), "TitleAgent2")
 
-      # First message + title enqueue
+      # First message enqueues the task title from the task context.
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Build me a login page"), [],
-          agent: agent1
+          agent: agent1,
+          title_prompt_text: "Build me a login page"
         )
 
-      {:ok, first_job} =
-        Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
+      assert [%{id: first_job_id}] = all_enqueued(worker: GenerateTitle)
 
       assert_receive {:interaction, %Interaction.AgentCompleted{}}, 5_000
 
-      # Second message + title enqueue (should be deduplicated by Oban unique constraint)
+      # Second message does not enqueue another title job.
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Now add a signup form"), [],
-          agent: agent2
+          agent: agent2,
+          title_prompt_text: "Now add a signup form"
         )
 
-      {:ok, second_job} =
-        Tasks.enqueue_title_generation(scope, task_id, "Now add a signup form")
-
-      # Oban unique constraint returns the existing job — same ID means no new job was inserted
-      assert first_job.id == second_job.id
-
-      # Only one title generation job should exist for this task
+      # Only one title generation job should exist for this task.
       enqueued = all_enqueued(worker: GenerateTitle)
 
       title_jobs_for_task =
         Enum.filter(enqueued, fn job -> job.args["task_id"] == task_id end)
 
-      assert length(title_jobs_for_task) == 1
+      assert [%{id: ^first_job_id}] = title_jobs_for_task
     end
   end
 


### PR DESCRIPTION
## Summary
Fixes #934

Moves first-message title generation into the Tasks context instead of enqueueing from TaskChannel after every successful prompt.

## Changes
- Add task-domain gating for initial title generation based on default title + first user message
- Pass the prompt summary through submit opts from TaskChannel
- Update title enqueue tests to assert the context enqueues once and skips later prompts

## Test Plan
- Attempted: `mix test test/frontman_server/tasks/execution_test.exs:312 test/frontman_server_web/channels/task_channel_test.exs:115` (blocked: `mix` not installed in cron host)
- Attempted: `./bin/pod-exec mix test apps/frontman_server/test/frontman_server/tasks/execution_test.exs:312 apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs:115` (blocked: no running worktree container for branch `main`)

---
🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
