### PR TITLE
fix(wordpress): preserve duplicated page metadata

### DIFF
--- a/.changeset/fix-wordpress-duplicate-pages-nav-items.md
+++ b/.changeset/fix-wordpress-duplicate-pages-nav-items.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Fix WordPress page duplication to copy Elementor/page metadata and preserve post-backed navigation item metadata during menu updates.

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
@@ -297,6 +297,7 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
 
     **Pages and menus**:
     - Use `wp_duplicate_post` to clone existing WordPress pages/posts so Elementor data and safe post metadata are copied.
+    - After `wp_create_post` or `wp_duplicate_post` creates a page draft, navigate the preview to the returned permalink with `execute_js` instead of reloading the previous page, then continue editing or verifying the returned `post_id`.
     - When adding a WordPress page/post to a navigation menu, pass `post_id` to `wp_create_menu_item` instead of creating a custom URL item.
 
     **For design questions**:

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
@@ -295,6 +295,10 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
     **Attachments**:
     Use `wp_upload_media` with `image_ref` only when the user asks to use an attachment; then use the returned `attachment_id`/`url`. Do not upload unused attachments.
 
+    **Pages and menus**:
+    - Use `wp_duplicate_post` to clone existing WordPress pages/posts so Elementor data and safe post metadata are copied.
+    - When adding a WordPress page/post to a navigation menu, pass `post_id` to `wp_create_menu_item` instead of creating a custom URL item.
+
     **For design questions**:
     First check which theme is active with WordPress tools.
     Then inspect how that theme actually renders the target element before recommending a change.

--- a/apps/frontman_server/test/frontman_server/tasks/execution/prompts_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/prompts_test.exs
@@ -40,6 +40,7 @@ defmodule FrontmanServer.Tasks.Execution.PromptsTest do
       assert prompt =~ "already a child theme"
       refute prompt =~ "selection_scope"
       assert prompt =~ "Restore Elementor rollbacks one at a time"
+      assert prompt =~ "navigate the preview to the returned permalink"
       refute prompt =~ "use `write_file` with the attachment's `image_ref`"
 
       assert prompt =~ "Do not upload unused attachments"

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -3,6 +3,7 @@
 define( 'ABSPATH', sys_get_temp_dir() . '/frontman-wordpress-mutation-tests/' );
 
 $GLOBALS['frontman_test_posts'] = [];
+$GLOBALS['frontman_test_meta'] = [];
 $GLOBALS['frontman_test_options'] = [];
 $GLOBALS['frontman_test_menu_terms'] = [];
 $GLOBALS['frontman_test_menu_item_to_term'] = [];
@@ -188,6 +189,24 @@ if ( ! function_exists( 'wp_delete_post' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( int $post_id, string $key = '', bool $single = false ) {
+		$meta = $GLOBALS['frontman_test_meta'][ $post_id ] ?? [];
+		if ( '' === $key ) {
+			return $meta;
+		}
+
+		return $single ? ( $meta[ $key ][0] ?? '' ) : ( $meta[ $key ] ?? [] );
+	}
+}
+
+if ( ! function_exists( 'add_post_meta' ) ) {
+	function add_post_meta( int $post_id, string $key, $value ): bool {
+		$GLOBALS['frontman_test_meta'][ $post_id ][ $key ][] = wp_unslash( $value );
+		return true;
+	}
+}
+
 if ( ! function_exists( 'parse_blocks' ) ) {
 	function parse_blocks( string $content ): array {
 		$parts = array_values( array_filter( explode( "\n\n", $content ) ) );
@@ -326,15 +345,16 @@ if ( ! function_exists( 'wp_update_nav_menu_item' ) ) {
 	function wp_update_nav_menu_item( int $term_id, int $menu_item_id, array $menu_data ) {
 		$menu_data = wp_unslash( $menu_data );
 		if ( 0 === $menu_item_id ) {
-			$menu_item_id = count( $GLOBALS['frontman_test_posts'] ) + 1;
+			$menu_item_id = empty( $GLOBALS['frontman_test_posts'] ) ? 1 : max( array_keys( $GLOBALS['frontman_test_posts'] ) ) + 1;
 			$item = new WP_Post();
 			$item->ID = $menu_item_id;
 			$item->post_type = 'nav_menu_item';
+			$item->post_status = $menu_data['menu-item-status'] ?? 'publish';
 			$item->title = $menu_data['menu-item-title'] ?? '';
 			$item->url = $menu_data['menu-item-url'] ?? '';
-			$item->type = 'custom';
-			$item->object = 'custom';
-			$item->object_id = 0;
+			$item->type = $menu_data['menu-item-type'] ?? 'custom';
+			$item->object = $menu_data['menu-item-object'] ?? 'custom';
+			$item->object_id = $menu_data['menu-item-object-id'] ?? 0;
 			$item->menu_item_parent = $menu_data['menu-item-parent-id'] ?? 0;
 			$item->menu_order = $menu_data['menu-item-position'] ?? ( count( wp_get_nav_menu_items( $term_id ) ) + 1 );
 		} else {
@@ -346,6 +366,18 @@ if ( ! function_exists( 'wp_update_nav_menu_item' ) ) {
 		}
 		if ( isset( $menu_data['menu-item-url'] ) ) {
 			$item->url = $menu_data['menu-item-url'];
+		}
+		if ( isset( $menu_data['menu-item-type'] ) ) {
+			$item->type = $menu_data['menu-item-type'];
+		}
+		if ( isset( $menu_data['menu-item-object'] ) ) {
+			$item->object = $menu_data['menu-item-object'];
+		}
+		if ( isset( $menu_data['menu-item-object-id'] ) ) {
+			$item->object_id = $menu_data['menu-item-object-id'];
+		}
+		if ( isset( $menu_data['menu-item-parent-id'] ) ) {
+			$item->menu_item_parent = $menu_data['menu-item-parent-id'];
 		}
 		if ( isset( $menu_data['menu-item-position'] ) ) {
 			$item->menu_order = $menu_data['menu-item-position'];
@@ -440,9 +472,11 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->test_posts_include_before_snapshots();
 		$this->test_blocks_include_before_snapshots();
 		$this->test_block_move_and_delete_snapshots();
+		$this->test_duplicate_post_copies_page_metadata();
 		$this->test_menu_management_snapshots();
 		$this->test_menu_item_creation_includes_before_snapshot();
 		$this->test_menu_option_and_widget_updates_include_before_snapshots();
+		$this->test_post_backed_menu_items_preserve_metadata();
 		$this->test_widget_management_snapshots();
 		$this->test_template_update_snapshot();
 		$this->test_cache_tools();
@@ -462,6 +496,13 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$post->post_author = 1;
 		$post->post_name = 'before';
 		$GLOBALS['frontman_test_posts'][10] = $post;
+		$GLOBALS['frontman_test_meta'][10] = [
+			'_elementor_edit_mode' => [ 'builder' ],
+			'_elementor_data' => [ '[{"id":"root10","elType":"container","elements":[]}]' ],
+			'_wp_page_template' => [ 'elementor_header_footer' ],
+			'_frontman_elementor_rollbacks' => [ 'do-not-copy' ],
+			'_edit_lock' => [ 'do-not-copy' ],
+		];
 
 		$slash_post = new WP_Post();
 		$slash_post->ID = 11;
@@ -620,6 +661,21 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_true( false !== strpos( $deleted['after']['post_content'], 'C:\\tmp\\file' ), 'wp_delete_block preserves existing backslash-sensitive block markup' );
 	}
 
+	private function test_duplicate_post_copies_page_metadata(): void {
+		$tool = new Frontman_Tool_Posts();
+		$duplicated = $tool->duplicate_post( [
+			'source_id' => 10,
+			'title' => 'Duplicated Home',
+		] );
+
+		$duplicate_id = $duplicated['id'];
+		$this->assert_same( 'Duplicated Home', $duplicated['after']['title'], 'wp_duplicate_post returns the duplicated post snapshot' );
+		$this->assert_same( 'draft', $duplicated['after']['status'], 'wp_duplicate_post creates duplicate drafts' );
+		$this->assert_same( '[{"id":"root10","elType":"container","elements":[]}]', $GLOBALS['frontman_test_meta'][ $duplicate_id ]['_elementor_data'][0], 'wp_duplicate_post copies Elementor data' );
+		$this->assert_true( ! isset( $GLOBALS['frontman_test_meta'][ $duplicate_id ]['_frontman_elementor_rollbacks'] ), 'wp_duplicate_post does not copy Frontman rollback snapshots' );
+		$this->assert_true( ! isset( $GLOBALS['frontman_test_meta'][ $duplicate_id ]['_edit_lock'] ), 'wp_duplicate_post does not copy edit locks' );
+	}
+
 	private function test_menu_management_snapshots(): void {
 		$tool = new Frontman_Tool_Menus();
 		$locations = $tool->list_menu_locations( [] );
@@ -700,6 +756,34 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( 1, count( $created['before']['items'] ), 'wp_create_menu_item returns menu state before insertion' );
 		$this->assert_same( 2, count( $created['after']['items'] ), 'wp_create_menu_item returns menu state after insertion' );
 		$this->assert_same( "Awesome C:\\Tools", $created['item']['title'], 'wp_create_menu_item returns the created menu item and preserves backslashes' );
+	}
+
+	private function test_post_backed_menu_items_preserve_metadata(): void {
+		$menu_tool = new Frontman_Tool_Menus();
+		$created = $menu_tool->create_menu_item( [
+			'menu_id' => 7,
+			'post_id' => 10,
+		] );
+
+		$this->assert_same( 'post_type', $created['item']['type'], 'wp_create_menu_item can create post-backed menu items' );
+		$this->assert_same( 'page', $created['item']['object'], 'post-backed menu item records the source post type' );
+		$this->assert_same( 10, $created['item']['object_id'], 'post-backed menu item records the source post ID' );
+
+		$updated = $menu_tool->update_menu_item( [
+			'menu_item_id' => $created['menu_item_id'],
+			'title' => 'Home Link',
+		] );
+
+		$this->assert_same( 'post_type', $updated['after']['type'], 'wp_update_menu_item preserves post-backed menu item type when changing title' );
+		$this->assert_same( 'page', $updated['after']['object'], 'wp_update_menu_item preserves post-backed menu item object when changing title' );
+		$this->assert_same( 10, $updated['after']['object_id'], 'wp_update_menu_item preserves post-backed menu item object_id when changing title' );
+		$this->assert_error_contains(
+			static function() use ( $menu_tool, $created ) {
+				$menu_tool->update_menu_item( [ 'menu_item_id' => $created['menu_item_id'], 'url' => 'https://example.com/custom' ] );
+			},
+			'post-backed menu item',
+			'wp_update_menu_item rejects URL-only updates on post-backed menu items'
+		);
 	}
 
 	private function test_widget_management_snapshots(): void {

--- a/libs/frontman-wordpress/tools/class-tool-menus.php
+++ b/libs/frontman-wordpress/tools/class-tool-menus.php
@@ -122,7 +122,7 @@ class Frontman_Tool_Menus {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_create_menu_item',
-			'Creates a new custom-link menu item in a navigation menu.',
+			'Creates a new custom-link or post/page-backed menu item in a navigation menu. Use post_id for WordPress pages/posts so the menu item keeps proper object metadata.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -137,7 +137,11 @@ class Frontman_Tool_Menus {
 					],
 					'url'       => [
 						'type'        => 'string',
-						'description' => 'URL for the new custom link.',
+						'description' => 'URL for a custom-link menu item. Do not use with post_id.',
+					],
+					'post_id'   => [
+						'type'        => 'integer',
+						'description' => 'Optional WordPress post/page ID for a post-backed menu item.',
 					],
 					'parent_id' => [
 						'type'        => 'integer',
@@ -148,14 +152,14 @@ class Frontman_Tool_Menus {
 						'description' => 'Optional 1-based menu position.',
 					],
 				],
-				'required' => [ 'menu_id', 'title', 'url' ],
+				'required' => [ 'menu_id' ],
 			],
 			[ $this, 'create_menu_item' ]
 		) );
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_update_menu_item',
-			'Updates a menu item\'s title, URL, or position. Only the fields you provide will be changed.',
+			'Updates a menu item\'s title, URL, or position while preserving its existing WordPress menu item metadata.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -170,7 +174,7 @@ class Frontman_Tool_Menus {
 					],
 					'url'          => [
 						'type'        => 'string',
-						'description' => 'New URL for custom link menu items.',
+						'description' => 'New URL for custom link menu items. Post-backed menu items keep their post permalink.',
 					],
 					'position'     => [
 						'type'        => 'integer',
@@ -249,7 +253,7 @@ class Frontman_Tool_Menus {
 		foreach ( $menus as $menu ) {
 			$items      = wp_get_nav_menu_items( $menu->term_id ) ?: [];
 			$locations  = get_nav_menu_locations();
-			$assigned   = array_keys( array_filter( $locations, function( $id ) use ( $menu ) { return $id === $menu->term_id; } ) );
+			$assigned   = array_keys( array_filter( $locations, function( $id ) use ( $menu ) { return (int) $id === (int) $menu->term_id; } ) );
 
 			$result[] = [
 				'id'        => $menu->term_id,
@@ -406,19 +410,45 @@ class Frontman_Tool_Menus {
 
 		$before = $this->read_menu( [ 'id' => $menu_id ] );
 
-		$menu_data = [
-			'menu-item-title'     => sanitize_text_field( $input['title'] ?? '' ),
-			'menu-item-url'       => esc_url_raw( $input['url'] ?? '' ),
-			'menu-item-type'      => 'custom',
-			'menu-item-object'    => 'custom',
-			'menu-item-object-id' => 0,
-			'menu-item-status'    => 'publish',
-		];
+		if ( isset( $input['post_id'] ) && absint( $input['post_id'] ) > 0 ) {
+			$post_id = absint( $input['post_id'] );
+			$post    = get_post( $post_id );
+			if ( ! $post ) {
+				throw new Frontman_Tool_Error( "Post not found: {$post_id}" );
+			}
+
+			$menu_data = [
+				'menu-item-title'     => isset( $input['title'] ) ? sanitize_text_field( $input['title'] ) : $post->post_title,
+				'menu-item-url'       => get_permalink( $post_id ),
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => sanitize_key( $post->post_type ),
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+			];
+		} else {
+			$title = sanitize_text_field( $input['title'] ?? '' );
+			$url   = esc_url_raw( $input['url'] ?? '' );
+
+			if ( '' === $title ) {
+				throw new Frontman_Tool_Error( 'title is required for custom-link menu items.' );
+			}
+			if ( '' === $url ) {
+				throw new Frontman_Tool_Error( 'url is required for custom-link menu items. Use post_id for WordPress pages/posts.' );
+			}
+
+			$menu_data = [
+				'menu-item-title'     => $title,
+				'menu-item-url'       => $url,
+				'menu-item-type'      => 'custom',
+				'menu-item-object'    => 'custom',
+				'menu-item-object-id' => 0,
+				'menu-item-status'    => 'publish',
+			];
+		}
 
 		if ( isset( $input['parent_id'] ) ) {
 			$menu_data['menu-item-parent-id'] = absint( $input['parent_id'] );
 		}
-
 		if ( isset( $input['position'] ) ) {
 			$menu_data['menu-item-position'] = absint( $input['position'] );
 		}
@@ -454,16 +484,39 @@ class Frontman_Tool_Menus {
 			throw new Frontman_Tool_Error( "Menu item not found: {$menu_item_id}" );
 		}
 
-		$menu_data = [];
+		$setup_item = wp_setup_nav_menu_item( $item );
+		$status     = (string) ( $setup_item->post_status ?? 'publish' );
+		$menu_data  = [
+			'menu-item-db-id'     => (int) $setup_item->ID,
+			'menu-item-title'     => (string) $setup_item->title,
+			'menu-item-url'       => (string) $setup_item->url,
+			'menu-item-type'      => (string) $setup_item->type,
+			'menu-item-object'    => (string) $setup_item->object,
+			'menu-item-object-id' => (int) $setup_item->object_id,
+			'menu-item-parent-id' => (int) $setup_item->menu_item_parent,
+			'menu-item-position'  => (int) $setup_item->menu_order,
+			'menu-item-status'    => '' === $status ? 'publish' : $status,
+		];
+		$changed    = false;
 
 		if ( isset( $input['title'] ) ) {
 			$menu_data['menu-item-title'] = sanitize_text_field( $input['title'] );
+			$changed = true;
 		}
 		if ( isset( $input['url'] ) ) {
+			if ( 'custom' !== (string) ( $setup_item->type ?? '' ) ) {
+				throw new Frontman_Tool_Error( 'Cannot set url on a post-backed menu item. Create a custom-link menu item for arbitrary URLs.' );
+			}
 			$menu_data['menu-item-url'] = esc_url_raw( $input['url'] );
+			$changed = true;
 		}
 		if ( isset( $input['position'] ) ) {
 			$menu_data['menu-item-position'] = absint( $input['position'] );
+			$changed = true;
+		}
+
+		if ( ! $changed ) {
+			throw new Frontman_Tool_Error( 'Provide title, url, or position to update a menu item.' );
 		}
 
 		// Get the menu this item belongs to.

--- a/libs/frontman-wordpress/tools/class-tool-posts.php
+++ b/libs/frontman-wordpress/tools/class-tool-posts.php
@@ -2,7 +2,7 @@
 /**
  * WordPress Post tools — CRUD operations on posts/pages/CPTs.
  *
- * Tools: wp_list_posts, wp_read_post, wp_create_post, wp_update_post, wp_delete_post
+ * Tools: wp_list_posts, wp_read_post, wp_create_post, wp_duplicate_post, wp_update_post, wp_delete_post
  *
  * Handlers return plain data arrays on success, throw Frontman_Tool_Error on failure.
  * The registry (Frontman_Tools::call) wraps results into MCP format with _meta.
@@ -89,7 +89,7 @@ class Frontman_Tool_Posts {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_create_post',
-			'Creates a new post or page. Returns the new post ID and permalink.',
+			'Creates a new post or page. Returns the new post ID and permalink. Use wp_duplicate_post when the user asks to duplicate or clone an existing page so Elementor/post metadata is copied.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -117,6 +117,27 @@ class Frontman_Tool_Posts {
 				'required' => [ 'title', 'content' ],
 			],
 			[ $this, 'create_post' ]
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_duplicate_post',
+			'Duplicates an existing post or page as a draft, copying content and Elementor/page metadata. Use this instead of wp_create_post when cloning a page.',
+			[
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'source_id' => [
+						'type'        => 'integer',
+						'description' => 'The post/page ID to duplicate.',
+					],
+					'title'     => [
+						'type'        => 'string',
+						'description' => 'Optional title for the duplicated post. Defaults to "{source title} Copy".',
+					],
+				],
+				'required' => [ 'source_id' ],
+			],
+			[ $this, 'duplicate_post' ]
 		) );
 
 		$tools->add( new Frontman_Tool_Definition(
@@ -274,6 +295,48 @@ class Frontman_Tool_Posts {
 	}
 
 	/**
+	 * wp_duplicate_post handler.
+	 */
+	public function duplicate_post( array $input ): array {
+		$source_id = absint( $input['source_id'] ?? 0 );
+		$source    = get_post( $source_id );
+
+		if ( ! $source ) {
+			throw new Frontman_Tool_Error( "Post not found: {$source_id}" );
+		}
+
+		$title  = isset( $input['title'] ) ? sanitize_text_field( $input['title'] ) : trim( (string) $source->post_title ) . ' Copy';
+
+		$post_data = [
+			'post_title'   => $title,
+			'post_content' => (string) ( $source->post_content ?? '' ),
+			'post_excerpt' => (string) ( $source->post_excerpt ?? '' ),
+			'post_type'    => sanitize_key( $source->post_type ?? 'post' ),
+			'post_status'  => 'draft',
+		];
+
+		$post_id = wp_insert_post( wp_slash( $post_data ), true );
+
+		if ( is_wp_error( $post_id ) ) {
+			throw new Frontman_Tool_Error( $post_id->get_error_message() );
+		}
+
+		foreach ( [ '_elementor_edit_mode', '_elementor_data', '_elementor_template_type', '_elementor_version', '_elementor_page_settings', '_wp_page_template' ] as $key ) {
+			foreach ( get_post_meta( $source_id, $key, false ) as $value ) {
+				add_post_meta( (int) $post_id, $key, wp_slash( $value ) );
+			}
+		}
+
+		return [
+			'duplicated'       => true,
+			'id'               => (int) $post_id,
+			'source'           => $this->read_post( [ 'id' => $source_id ] ),
+			'after'            => $this->read_post( [ 'id' => (int) $post_id ] ),
+			'permalink'        => get_permalink( $post_id ),
+		];
+	}
+
+	/**
 	 * wp_update_post handler.
 	 */
 	public function update_post( array $input ): array {
@@ -347,6 +410,7 @@ class Frontman_Tool_Posts {
 			'trashed' => ! $force,
 		];
 	}
+
 }
 
 // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped


### PR DESCRIPTION
## Summary
- Add `wp_duplicate_post` to clone posts/pages as drafts while copying Elementor/page metadata.
- Support `post_id` menu items and preserve existing nav item metadata on updates.
- Add regression tests, prompt guidance, and a patch changeset for duplicate pages and post-backed menu links.

## Verification
- `make test-wordpress-core-tools`
- `mix format --check-formatted`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
