### PR TITLE
chore: disable hexpm elixir Docker updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,12 @@
       "groupName": "elixir-deps"
     },
     {
+      "description": "Disable hexpm/elixir Docker updates because Docker Hub tag listing times out",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["hexpm/elixir"],
+      "enabled": false
+    },
+    {
       "description": "Group ReScript-related packages",
       "matchPackageNames": [
         "rescript",


### PR DESCRIPTION
## Summary
- Disable Renovate updates for the `hexpm/elixir` Docker image because Docker Hub tag listing currently returns 504s.
- Keeps Mix/Hex dependency scanning available instead of letting the full Renovate run abort on Docker lookup.

## Verification
- `npx --yes -p renovate renovate-config-validator renovate.json`
- `npx --yes renovate --platform=local --dry-run=lookup`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frontman-ai/frontman/pull/952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
