### PR TITLE
Remove unused client component wrappers

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,7 @@ pre-commit:
   parallel: true
   commands:
     biome-lint:
+      root: "libs/client/"
       glob: "libs/client/**/*.{ts,tsx,js,jsx,mjs}"
       run: npx biome check --no-errors-on-unmatched {staged_files}
 

--- a/libs/client/src/bindings/Bindings__UI__AlertDialog.res
+++ b/libs/client/src/bindings/Bindings__UI__AlertDialog.res
@@ -1,9 +1,6 @@
 // UI AlertDialog component bindings
 // Usage:
 // <UI__AlertDialog open={isOpen} onOpenChange={setIsOpen}>
-//   <UI__AlertDialogTrigger asChild=true>
-//     <UI__Button variant=#destructive>{React.string("Delete")}</UI__Button>
-//   </UI__AlertDialogTrigger>
 //   <UI__AlertDialogContent>
 //     <UI__AlertDialogHeader>
 //       <UI__AlertDialogTitle>{React.string("Are you sure?")}</UI__AlertDialogTitle>
@@ -28,29 +25,6 @@ module AlertDialog = {
     ~onOpenChange: bool => unit=?,
     ~children: React.element=?,
   ) => React.element = "AlertDialog"
-}
-
-module AlertDialogTrigger = {
-  @module("@/components/ui/alert-dialog") @react.component
-  external make: (
-    ~className: string=?,
-    ~asChild: bool=?,
-    ~onClick: ReactEvent.Mouse.t => unit=?,
-    ~disabled: bool=?,
-    ~children: React.element=?,
-  ) => React.element = "AlertDialogTrigger"
-}
-
-module AlertDialogPortal = {
-  @module("@/components/ui/alert-dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "AlertDialogPortal"
-}
-
-module AlertDialogOverlay = {
-  @module("@/components/ui/alert-dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "AlertDialogOverlay"
 }
 
 module AlertDialogContent = {

--- a/libs/client/src/bindings/Bindings__UI__Dialog.res
+++ b/libs/client/src/bindings/Bindings__UI__Dialog.res
@@ -2,12 +2,10 @@
 // Usage:
 // <UI__Dialog open={isOpen} onOpenChange={setIsOpen}>
 //   <UI__DialogContent>
-//     <UI__DialogHeader>
-//       <UI__DialogTitle>{React.string("Title")}</UI__DialogTitle>
-//       <UI__DialogDescription>
-//         {React.string("Description")}
-//       </UI__DialogDescription>
-//     </UI__DialogHeader>
+//     <UI__DialogTitle>{React.string("Title")}</UI__DialogTitle>
+//     <UI__DialogDescription>
+//       {React.string("Description")}
+//     </UI__DialogDescription>
 //   </UI__DialogContent>
 // </UI__Dialog>
 
@@ -21,23 +19,6 @@ module Dialog = {
   ) => React.element = "Dialog"
 }
 
-module DialogTrigger = {
-  @module("@/components/ui/dialog") @react.component
-  external make: (
-    ~className: string=?,
-    ~asChild: bool=?,
-    ~onClick: ReactEvent.Mouse.t => unit=?,
-    ~disabled: bool=?,
-    ~children: React.element=?,
-  ) => React.element = "DialogTrigger"
-}
-
-module DialogPortal = {
-  @module("@/components/ui/dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "DialogPortal"
-}
-
 module DialogClose = {
   @module("@/components/ui/dialog") @react.component
   external make: (
@@ -49,12 +30,6 @@ module DialogClose = {
   ) => React.element = "DialogClose"
 }
 
-module DialogOverlay = {
-  @module("@/components/ui/dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "DialogOverlay"
-}
-
 module DialogContent = {
   @module("@/components/ui/dialog") @react.component
   external make: (
@@ -64,18 +39,6 @@ module DialogContent = {
     ~onPointerDownOutside: {..} => unit=?,
     ~children: React.element=?,
   ) => React.element = "DialogContent"
-}
-
-module DialogHeader = {
-  @module("@/components/ui/dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "DialogHeader"
-}
-
-module DialogFooter = {
-  @module("@/components/ui/dialog") @react.component
-  external make: (~className: string=?, ~children: React.element=?) => React.element =
-    "DialogFooter"
 }
 
 module DialogTitle = {

--- a/libs/client/src/components/frontman/Client__ToolGroupUtils.res
+++ b/libs/client/src/components/frontman/Client__ToolGroupUtils.res
@@ -432,14 +432,6 @@ let generateSummaryLabels = (summary: Types.toolsSummary): array<string> => {
   }
 }
 
-/**
- * Generate a single combined summary label
- * e.g., "1 directory · 2 files · 3 searches"
- */
-let generateSummaryLabel = (summary: Types.toolsSummary): string => {
-  generateSummaryLabels(summary)->Array.join(" · ")
-}
-
 // ============================================================================
 // Grouping Logic
 // ============================================================================
@@ -593,29 +585,6 @@ let groupToolCalls = (
   flushGroup()
 
   result
-}
-
-/**
- * Check if a sequence of messages should potentially be grouped
- * This is useful for determining if grouping UI is relevant
- */
-let shouldGroupMessages = (messages: array<Message.t>, ~minConsecutive: int=2): bool => {
-  let consecutiveGroupable = ref(0)
-  let maxConsecutive = ref(0)
-
-  messages->Array.forEach(msg => {
-    switch msg {
-    | Message.ToolCall(tc) if isGroupableTool(tc.toolName) && !hasError(tc) => {
-        consecutiveGroupable := consecutiveGroupable.contents + 1
-        if consecutiveGroupable.contents > maxConsecutive.contents {
-          maxConsecutive := consecutiveGroupable.contents
-        }
-      }
-    | _ => consecutiveGroupable := 0
-    }
-  })
-
-  maxConsecutive.contents >= minConsecutive
 }
 
 /**

--- a/libs/client/src/components/ui/alert-dialog.tsx
+++ b/libs/client/src/components/ui/alert-dialog.tsx
@@ -9,14 +9,6 @@ function AlertDialog({
 	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
-function AlertDialogTrigger({
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-	return (
-		<AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-	);
-}
-
 function AlertDialogPortal({
 	...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
@@ -141,9 +133,6 @@ function AlertDialogCancel({
 
 export {
 	AlertDialog,
-	AlertDialogPortal,
-	AlertDialogOverlay,
-	AlertDialogTrigger,
 	AlertDialogContent,
 	AlertDialogHeader,
 	AlertDialogFooter,

--- a/libs/client/src/components/ui/dialog.tsx
+++ b/libs/client/src/components/ui/dialog.tsx
@@ -10,12 +10,6 @@ function Dialog({
 	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
-}
-
 function DialogPortal({
 	...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
@@ -78,29 +72,6 @@ function DialogContent({
 	);
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="dialog-header"
-			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
-			{...props}
-		/>
-	);
-}
-
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="dialog-footer"
-			className={cn(
-				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
 function DialogTitle({
 	className,
 	...props
@@ -127,15 +98,4 @@ function DialogDescription({
 	);
 }
 
-export {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogOverlay,
-	DialogPortal,
-	DialogTitle,
-	DialogTrigger,
-};
+export { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle };

--- a/libs/client/src/components/ui/dropdown-menu.tsx
+++ b/libs/client/src/components/ui/dropdown-menu.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -10,14 +9,6 @@ function DropdownMenu({
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
 	return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
-}
-
-function DropdownMenuPortal({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-	return (
-		<DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-	);
 }
 
 function DropdownMenuTrigger({
@@ -51,14 +42,6 @@ function DropdownMenuContent({
 	);
 }
 
-function DropdownMenuGroup({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-	return (
-		<DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-	);
-}
-
 function DropdownMenuItem({
 	className,
 	inset,
@@ -79,67 +62,6 @@ function DropdownMenuItem({
 			)}
 			{...props}
 		/>
-	);
-}
-
-function DropdownMenuCheckboxItem({
-	className,
-	children,
-	checked,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
-	return (
-		<DropdownMenuPrimitive.CheckboxItem
-			data-slot="dropdown-menu-checkbox-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			checked={checked}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</DropdownMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</DropdownMenuPrimitive.CheckboxItem>
-	);
-}
-
-function DropdownMenuRadioGroup({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-	return (
-		<DropdownMenuPrimitive.RadioGroup
-			data-slot="dropdown-menu-radio-group"
-			{...props}
-		/>
-	);
-}
-
-function DropdownMenuRadioItem({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
-	return (
-		<DropdownMenuPrimitive.RadioItem
-			data-slot="dropdown-menu-radio-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
-					<CircleIcon className="size-2 fill-current" />
-				</DropdownMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</DropdownMenuPrimitive.RadioItem>
 	);
 }
 
@@ -176,82 +98,11 @@ function DropdownMenuSeparator({
 	);
 }
 
-function DropdownMenuShortcut({
-	className,
-	...props
-}: React.ComponentProps<"span">) {
-	return (
-		<span
-			data-slot="dropdown-menu-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
-function DropdownMenuSub({
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
-}
-
-function DropdownMenuSubTrigger({
-	className,
-	inset,
-	children,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-	inset?: boolean;
-}) {
-	return (
-		<DropdownMenuPrimitive.SubTrigger
-			data-slot="dropdown-menu-sub-trigger"
-			data-inset={inset}
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-			<ChevronRightIcon className="ml-auto size-4" />
-		</DropdownMenuPrimitive.SubTrigger>
-	);
-}
-
-function DropdownMenuSubContent({
-	className,
-	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-	return (
-		<DropdownMenuPrimitive.SubContent
-			data-slot="dropdown-menu-sub-content"
-			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
 export {
 	DropdownMenu,
-	DropdownMenuPortal,
 	DropdownMenuTrigger,
 	DropdownMenuContent,
-	DropdownMenuGroup,
 	DropdownMenuLabel,
 	DropdownMenuItem,
-	DropdownMenuCheckboxItem,
-	DropdownMenuRadioGroup,
-	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
-	DropdownMenuShortcut,
-	DropdownMenuSub,
-	DropdownMenuSubTrigger,
-	DropdownMenuSubContent,
 };

--- a/libs/client/src/webpreview/Client__BrowserUrl.res
+++ b/libs/client/src/webpreview/Client__BrowserUrl.res
@@ -37,9 +37,6 @@ let _getBasePath: unit => string = {
     }
 }
 
-// Returns the URL suffix including the leading slash (e.g. "/frontman").
-let suffix = () => `/${_getBasePath()}`
-
 // Strip a single trailing slash from a URL or pathname, unless it's just "/".
 // Used to normalize trailing-slash variants (e.g. /en and /en/) so they are
 // treated as the same destination for comparison and URL building purposes.


### PR DESCRIPTION
## Summary
- Remove unused client UI wrapper exports and matching ReScript bindings.
- Drop unused tool-group/browser-url helper functions found during the component audit.
- Scope the client Biome pre-commit hook to `libs/client`, matching package lint behavior.

## Testing
- `make -C libs/client test`
- `make -C libs/client build-lib`
- `make -C libs/client lint`
- `git diff --check`