### PR TITLE
Trim client CLI noise

### DIFF
--- a/.changeset/trim-client-cli-noise.md
+++ b/.changeset/trim-client-cli-noise.md
@@ -1,0 +1,8 @@
+---
+"@frontman-ai/frontman-core": patch
+"@frontman-ai/nextjs": patch
+"@frontman-ai/vite": patch
+"@frontman-ai/client": patch
+---
+
+Trim duplicated CLI package-manager helpers and remove stale client tool summary helpers.

--- a/libs/client/src/Client__ToolRegistry.res
+++ b/libs/client/src/Client__ToolRegistry.res
@@ -9,41 +9,16 @@ type tool = module(Tool.Tool)
 
 type t = {tools: array<tool>}
 
-// Create empty registry
-let make = (): t => {
-  tools: [],
-}
-
-let coreBrowserTools = (): t => {
-  tools: [
-    module(Client__Tool__TakeScreenshot),
-    module(Client__Tool__ExecuteJs),
-    module(Client__Tool__SetDeviceMode),
-    module(Client__Tool__GetInteractiveElements),
-    module(Client__Tool__InteractWithElement),
-    module(Client__Tool__GetDom),
-    module(Client__Tool__SearchText),
-    module(Client__Tool__Question),
-  ],
-}
-
-// Add tools to registry
-let addTools = (registry: t, newTools: array<tool>): t => {
-  tools: Array.concat(registry.tools, newTools),
-}
-
-// Merge two registries
-let merge = (a: t, b: t): t => {
-  tools: Array.concat(a.tools, b.tools),
-}
-
-// Get tool by name
-let getToolByName = (registry: t, name: string): option<tool> => {
-  registry.tools->Array.find(m => {
-    module T = unpack(m)
-    T.name == name
-  })
-}
+let coreBrowserTools: array<tool> = [
+  module(Client__Tool__TakeScreenshot),
+  module(Client__Tool__ExecuteJs),
+  module(Client__Tool__SetDeviceMode),
+  module(Client__Tool__GetInteractiveElements),
+  module(Client__Tool__InteractWithElement),
+  module(Client__Tool__GetDom),
+  module(Client__Tool__SearchText),
+  module(Client__Tool__Question),
+]
 
 // Register all tools from registry into an MCP server
 let registerAll = (registry: t, mcpServer: MCPServer.t): MCPServer.t => {
@@ -52,20 +27,16 @@ let registerAll = (registry: t, mcpServer: MCPServer.t): MCPServer.t => {
   )
 }
 
-// Get count of tools
-let count = (registry: t): int => {
-  registry.tools->Array.length
-}
-
 // Build a registry with core browser tools + framework-specific tools
 let forFramework = (framework: Client__RuntimeConfig.frameworkId): t => {
-  let base = coreBrowserTools()
-  switch framework {
+  let tools = switch framework {
   | Astro =>
     let getPreviewDoc = Client__Tool__ElementResolver.getPreviewDoc
-    base->addTools(
+    Array.concat(
+      coreBrowserTools,
       FrontmanAiAstroBrowser.FrontmanAstroBrowser__Registry.browserTools(~getPreviewDoc),
     )
-  | Nextjs | Vite | Wordpress => base
+  | Nextjs | Vite | Wordpress => coreBrowserTools
   }
+  {tools: tools}
 }

--- a/libs/client/src/components/frontman/Client__ToolGroupTypes.res
+++ b/libs/client/src/components/frontman/Client__ToolGroupTypes.res
@@ -6,14 +6,6 @@
  */
 module Message = Client__State__Types.Message
 
-// Tool categories for grouping purposes
-type toolCategory =
-  | Exploration // read, list, search, grep, go-to-definition
-  | Action // edit, write, terminal, browser actions
-  | Todo // todo operations
-  | Task // subagent/nested tasks
-  | Other
-
 // Summary statistics for grouped tools
 type toolsSummary = {
   files: array<string>, // Files read
@@ -22,12 +14,6 @@ type toolsSummary = {
   definitions: int, // Definitions found
   browserSnapshots: int, // Browser snapshots taken
   tools: array<string>, // All tool names in group
-  // Todo tracking
-  todos: int, // Total todos in result
-  todosNewlyCreated: int, // Todos created in this group
-  todosNewlyCompleted: int, // Todos marked complete in this group
-  todosNewlyStarted: int, // Todos started (in_progress) in this group
-  todosNewlyCancelled: int, // Todos cancelled in this group
 }
 
 // Empty summary for initialization
@@ -38,17 +24,7 @@ let emptySummary: toolsSummary = {
   definitions: 0,
   browserSnapshots: 0,
   tools: [],
-  todos: 0,
-  todosNewlyCreated: 0,
-  todosNewlyCompleted: 0,
-  todosNewlyStarted: 0,
-  todosNewlyCancelled: 0,
 }
-
-// Group visual state
-type toolGroupState =
-  | Collapsed
-  | Expanded
 
 // Group type determines the prefix label
 type groupType =

--- a/libs/client/src/components/frontman/Client__ToolGroupUtils.res
+++ b/libs/client/src/components/frontman/Client__ToolGroupUtils.res
@@ -152,57 +152,6 @@ let incrementIf = (count, condition) =>
   }
 
 /**
- * Extract todo statistics from a todo_write tool's input
- * The input contains the todos array with status changes
- */
-let extractTodoStatsFromInput = (input: option<JSON.t>): (int, int, int, int, int) => {
-  // Returns: (total, created, completed, started, cancelled)
-  switch input {
-  | Some(json) =>
-    switch JSON.Decode.object(json) {
-    | Some(obj) =>
-      // Check for "todos" array in input
-      let todosField = obj->Dict.get("todos")
-      switch todosField {
-      | Some(todosJson) =>
-        switch JSON.Decode.array(todosJson) {
-        | Some(arr) =>
-          let (created, completed, started, cancelled) = arr->Array.reduce((0, 0, 0, 0), (
-            (c, comp, s, can),
-            item,
-          ) => {
-            switch JSON.Decode.object(item) {
-            | Some(itemObj) =>
-              let status =
-                itemObj
-                ->Dict.get("status")
-                ->Option.flatMap(JSON.Decode.string)
-                ->Option.getOr("")
-                ->String.toLowerCase
-
-              // Count by status
-              switch status {
-              | "completed" | "complete" | "done" => (c, comp + 1, s, can)
-              | "in_progress" | "in-progress" | "started" | "running" => (c, comp, s + 1, can)
-              | "cancelled" | "canceled" | "removed" => (c, comp, s, can + 1)
-              | "pending" => (c + 1, comp, s, can) // New pending = created
-              | _ => (c, comp, s, can)
-              }
-            | None => (c, comp, s, can)
-            }
-          })
-          (Array.length(arr), created, completed, started, cancelled)
-        | None => (0, 0, 0, 0, 0)
-        }
-      | None => (0, 0, 0, 0, 0)
-      }
-    | None => (0, 0, 0, 0, 0)
-    }
-  | None => (0, 0, 0, 0, 0)
-  }
-}
-
-/**
  * Calculate summary statistics from grouped tool calls
  */
 let calculateSummary = (tools: array<Message.toolCall>): Types.toolsSummary => {
@@ -236,32 +185,6 @@ let calculateSummary = (tools: array<Message.toolCall>): Types.toolsSummary => {
       includesAny(name, browserSnapshotNeedles),
     )
 
-    // Todo operations
-    let (
-      todos,
-      todosNewlyCreated,
-      todosNewlyCompleted,
-      todosNewlyStarted,
-      todosNewlyCancelled,
-    ) = if TodoUtils.isTodoTool(tool.toolName) {
-      let (total, created, completed, started, cancelled) = extractTodoStatsFromInput(tool.input)
-      (
-        acc.todos + total,
-        acc.todosNewlyCreated + created,
-        acc.todosNewlyCompleted + completed,
-        acc.todosNewlyStarted + started,
-        acc.todosNewlyCancelled + cancelled,
-      )
-    } else {
-      (
-        acc.todos,
-        acc.todosNewlyCreated,
-        acc.todosNewlyCompleted,
-        acc.todosNewlyStarted,
-        acc.todosNewlyCancelled,
-      )
-    }
-
     {
       files,
       directories,
@@ -269,11 +192,6 @@ let calculateSummary = (tools: array<Message.toolCall>): Types.toolsSummary => {
       definitions,
       browserSnapshots,
       tools: Array.concat(acc.tools, [tool.toolName]),
-      todos,
-      todosNewlyCreated,
-      todosNewlyCompleted,
-      todosNewlyStarted,
-      todosNewlyCancelled,
     }
   })
 }
@@ -296,61 +214,6 @@ let unique = (arr: array<string>): array<string> => {
 }
 
 /**
- * Generate a nice label for todo changes
- * Returns labels like:
- * - "completed 2 to-dos"
- * - "started 1 to-do"
- * - "created 3 to-dos, completed 2"
- */
-let generateTodoLabel = (summary: Types.toolsSummary): option<string> => {
-  let parts = []
-
-  // Created todos
-  let parts = if summary.todosNewlyCreated > 0 {
-    let label = `created ${Int.toString(
-        summary.todosNewlyCreated,
-      )} to-do${summary.todosNewlyCreated == 1 ? "" : "s"}`
-    Array.concat(parts, [label])
-  } else {
-    parts
-  }
-
-  // Completed todos
-  let parts = if summary.todosNewlyCompleted > 0 {
-    let label = `completed ${Int.toString(summary.todosNewlyCompleted)}`
-    Array.concat(parts, [label])
-  } else {
-    parts
-  }
-
-  // Started todos (in_progress)
-  let parts = if summary.todosNewlyStarted > 0 {
-    let label = `started ${Int.toString(summary.todosNewlyStarted)}`
-    Array.concat(parts, [label])
-  } else {
-    parts
-  }
-
-  // Cancelled todos
-  let parts = if summary.todosNewlyCancelled > 0 {
-    let label = `cancelled ${Int.toString(summary.todosNewlyCancelled)}`
-    Array.concat(parts, [label])
-  } else {
-    parts
-  }
-
-  // If we have any parts, join them
-  if Array.length(parts) > 0 {
-    Some(Array.join(parts, ", "))
-  } else if summary.todos > 0 {
-    // Fallback: just show total count if we have todos but no specific actions
-    Some(`${Int.toString(summary.todos)} to-do${summary.todos == 1 ? "" : "s"}`)
-  } else {
-    None
-  }
-}
-
-/**
  * Generate summary labels from statistics
  * Returns an array like ["1 directory", "2 files", "3 searches"]
  * 
@@ -359,8 +222,7 @@ let generateTodoLabel = (summary: Types.toolsSummary): option<string> => {
  * 2. file → "N file(s)"  
  * 3. search → "N search(es)"
  * 4. definition → "found N definition(s)"
- * 5. todo → "completed N to-dos, started N"
- * 6. snapshot → "N snapshot(s)"
+ * 5. snapshot → "N snapshot(s)"
  */
 let generateSummaryLabels = (summary: Types.toolsSummary): array<string> => {
   let labels = []
@@ -405,13 +267,7 @@ let generateSummaryLabels = (summary: Types.toolsSummary): array<string> => {
     labels
   }
 
-  // 5. Todos
-  let labels = switch generateTodoLabel(summary) {
-  | Some(todoLabel) => Array.concat(labels, [todoLabel])
-  | None => labels
-  }
-
-  // 6. Browser snapshots
+  // 5. Browser snapshots
   let labels = if summary.browserSnapshots > 0 {
     let label = `${Int.toString(summary.browserSnapshots)} snapshot${summary.browserSnapshots == 1
         ? ""

--- a/libs/client/src/utils/Client__TodoUtils.res
+++ b/libs/client/src/utils/Client__TodoUtils.res
@@ -133,52 +133,6 @@ let extractTodosFromToolResult = (resultJson: JSON.t): option<array<todoItem>> =
 }
 
 /**
- * Calculate summary stats for a TODO list
- */
-type todoStats = {
-  total: int,
-  pending: int,
-  inProgress: int,
-  completed: int,
-  cancelled: int,
-}
-
-let calculateStats = (todos: array<todoItem>): todoStats => {
-  let initial = {total: 0, pending: 0, inProgress: 0, completed: 0, cancelled: 0}
-
-  todos->Array.reduce(initial, (acc, todo) => {
-    let base = {...acc, total: acc.total + 1}
-    switch todo.status {
-    | #pending => {...base, pending: base.pending + 1}
-    | #in_progress => {...base, inProgress: base.inProgress + 1}
-    | #completed => {...base, completed: base.completed + 1}
-    | #cancelled => {...base, cancelled: base.cancelled + 1}
-    }
-  })
-}
-
-/**
- * Generate a summary label for TODO stats
- * e.g., "Completed 2 of 5 to-dos"
- */
-let generateSummaryLabel = (stats: todoStats): string => {
-  if stats.total == 0 {
-    // No todos - return empty, caller should use operation label
-    ""
-  } else if stats.completed > 0 && stats.completed < stats.total {
-    `Completed ${Int.toString(stats.completed)} of ${Int.toString(stats.total)} to-dos`
-  } else if stats.completed == stats.total && stats.total > 0 {
-    `Completed all ${Int.toString(stats.total)} to-dos`
-  } else if stats.inProgress > 0 {
-    `${Int.toString(stats.inProgress)} to-do${stats.inProgress > 1 ? "s" : ""} in progress`
-  } else if stats.pending > 0 {
-    `${Int.toString(stats.pending)} to-do${stats.pending > 1 ? "s" : ""} pending`
-  } else {
-    `${Int.toString(stats.total)} to-do${stats.total != 1 ? "s" : ""}`
-  }
-}
-
-/**
  * Extract TODO items from tool INPUT (for todo_write)
  * The input contains the todos array being written
  */

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -1,94 +1,49 @@
 open Vitest
 
 module ToolRegistry = Client__ToolRegistry
+module FrontmanClient = FrontmanAiFrontmanClient
+module Relay = FrontmanClient.FrontmanClient__Relay
+module MCPServer = FrontmanClient.FrontmanClient__MCP__Server
+
+let toolNames = (framework): array<string> => {
+  let registry = ToolRegistry.forFramework(framework)
+  let relay = Relay.make(~baseUrl="http://localhost:3000")
+  let server = ToolRegistry.registerAll(registry, MCPServer.make(~relay))
+
+  server
+  ->MCPServer.getToolsJson
+  ->Array.filterMap(json =>
+    json
+    ->JSON.Decode.object
+    ->Option.flatMap(obj => obj->Dict.get("name"))
+    ->Option.flatMap(JSON.Decode.string)
+  )
+}
 
 describe("ToolRegistry", _t => {
-  test("make creates empty registry", t => {
-    let registry = ToolRegistry.make()
+  test("registers core browser tools for non-Astro frameworks", t => {
+    let names = toolNames(Client__RuntimeConfig.Nextjs)
 
-    t->expect(registry->ToolRegistry.count)->Expect.toBe(0)
+    t->expect(names->Array.length)->Expect.toBe(8)
+    t->expect(names->Array.includes("take_screenshot"))->Expect.toBe(true)
+    t->expect(names->Array.includes("execute_js"))->Expect.toBe(true)
+    t->expect(names->Array.includes("set_device_mode"))->Expect.toBe(true)
+    t->expect(names->Array.includes("get_interactive_elements"))->Expect.toBe(true)
+    t->expect(names->Array.includes("interact_with_element"))->Expect.toBe(true)
+    t->expect(names->Array.includes("get_dom"))->Expect.toBe(true)
+    t->expect(names->Array.includes("search_text"))->Expect.toBe(true)
   })
 
-  test("coreBrowserTools returns all browser tools", t => {
-    let registry = ToolRegistry.coreBrowserTools()
+  test("adds Astro browser tools only for Astro", t => {
+    let astroNames = toolNames(Client__RuntimeConfig.Astro)
+    let viteNames = toolNames(Client__RuntimeConfig.Vite)
+    let wordpressNames = toolNames(Client__RuntimeConfig.Wordpress)
 
-    t->expect(registry->ToolRegistry.count)->Expect.toBe(8)
-  })
-
-  test("finds tool by name", t => {
-    let registry = ToolRegistry.coreBrowserTools()
-
-    t
-    ->expect(registry->ToolRegistry.getToolByName("take_screenshot")->Option.isSome)
-    ->Expect.toBe(true)
-    t->expect(registry->ToolRegistry.getToolByName("execute_js")->Option.isSome)->Expect.toBe(true)
-    t
-    ->expect(registry->ToolRegistry.getToolByName("set_device_mode")->Option.isSome)
-    ->Expect.toBe(true)
-    t
-    ->expect(registry->ToolRegistry.getToolByName("get_interactive_elements")->Option.isSome)
-    ->Expect.toBe(true)
-    t
-    ->expect(registry->ToolRegistry.getToolByName("interact_with_element")->Option.isSome)
-    ->Expect.toBe(true)
-    t->expect(registry->ToolRegistry.getToolByName("get_dom")->Option.isSome)->Expect.toBe(true)
-    t->expect(registry->ToolRegistry.getToolByName("search_text")->Option.isSome)->Expect.toBe(true)
-    t
-    ->expect(registry->ToolRegistry.getToolByName("nonexistent")->Option.isSome)
-    ->Expect.toBe(false)
-  })
-
-  test("addTools extends registry", t => {
-    let registry = ToolRegistry.make()
-    let extended = registry->ToolRegistry.addTools([module(Client__Tool__ExecuteJs)])
-
-    t->expect(registry->ToolRegistry.count)->Expect.toBe(0) // original unchanged
-    t->expect(extended->ToolRegistry.count)->Expect.toBe(1)
-  })
-
-  test("merge combines two registries", t => {
-    let a = ToolRegistry.make()->ToolRegistry.addTools([module(Client__Tool__ExecuteJs)])
-    let b = ToolRegistry.make()->ToolRegistry.addTools([module(Client__Tool__TakeScreenshot)])
-    let merged = ToolRegistry.merge(a, b)
-
-    t->expect(merged->ToolRegistry.count)->Expect.toBe(2)
-    t->expect(merged->ToolRegistry.getToolByName("execute_js")->Option.isSome)->Expect.toBe(true)
-    t
-    ->expect(merged->ToolRegistry.getToolByName("take_screenshot")->Option.isSome)
-    ->Expect.toBe(true)
-  })
-
-  describe("forFramework", _t => {
-    test(
-      "Astro returns core browser tools count",
-      t => {
-        let registry = ToolRegistry.forFramework(Client__RuntimeConfig.Astro)
-        t->expect(registry->ToolRegistry.count)->Expect.toBe(9)
-      },
-    )
-
-    test(
-      "Nextjs returns core browser tools count",
-      t => {
-        let registry = ToolRegistry.forFramework(Client__RuntimeConfig.Nextjs)
-        t->expect(registry->ToolRegistry.count)->Expect.toBe(8)
-      },
-    )
-
-    test(
-      "Vite returns core browser tools count",
-      t => {
-        let registry = ToolRegistry.forFramework(Client__RuntimeConfig.Vite)
-        t->expect(registry->ToolRegistry.count)->Expect.toBe(8)
-      },
-    )
-
-    test(
-      "Wordpress returns core browser tools count",
-      t => {
-        let registry = ToolRegistry.forFramework(Client__RuntimeConfig.Wordpress)
-        t->expect(registry->ToolRegistry.count)->Expect.toBe(8)
-      },
-    )
+    t->expect(astroNames->Array.length)->Expect.toBe(9)
+    t->expect(astroNames->Array.includes("get_astro_audit"))->Expect.toBe(true)
+    t->expect(viteNames->Array.length)->Expect.toBe(8)
+    t->expect(viteNames->Array.includes("get_astro_audit"))->Expect.toBe(false)
+    t->expect(wordpressNames->Array.length)->Expect.toBe(8)
+    t->expect(wordpressNames->Array.includes("get_astro_audit"))->Expect.toBe(false)
   })
 })

--- a/libs/frontman-core/src/cli/FrontmanCore__Cli__PackageManager.res
+++ b/libs/frontman-core/src/cli/FrontmanCore__Cli__PackageManager.res
@@ -1,0 +1,94 @@
+module Path = FrontmanBindings.Path
+module FsUtils = FrontmanCore__FsUtils
+
+type t =
+  | Npm
+  | Yarn
+  | Pnpm
+  | Bun
+  | Deno
+
+let checkDir = async (dir: string): option<t> => {
+  let bunLockb = Path.join([dir, "bun.lockb"])
+  let bunLock = Path.join([dir, "bun.lock"])
+  let denoLock = Path.join([dir, "deno.lock"])
+  let pnpmLock = Path.join([dir, "pnpm-lock.yaml"])
+  let yarnLock = Path.join([dir, "yarn.lock"])
+  let npmLock = Path.join([dir, "package-lock.json"])
+
+  if (await FsUtils.pathExists(bunLockb)) || (await FsUtils.pathExists(bunLock)) {
+    Some(Bun)
+  } else if await FsUtils.pathExists(denoLock) {
+    Some(Deno)
+  } else if await FsUtils.pathExists(pnpmLock) {
+    Some(Pnpm)
+  } else if await FsUtils.pathExists(yarnLock) {
+    Some(Yarn)
+  } else if await FsUtils.pathExists(npmLock) {
+    Some(Npm)
+  } else {
+    None
+  }
+}
+
+let detect = async (projectDir: string): t => {
+  switch await checkDir(projectDir) {
+  | Some(pm) => pm
+  | None =>
+    let parentDir = Path.dirname(projectDir)
+    if parentDir != projectDir {
+      switch await checkDir(parentDir) {
+      | Some(pm) => pm
+      | None =>
+        let grandparentDir = Path.dirname(parentDir)
+        if grandparentDir != parentDir {
+          switch await checkDir(grandparentDir) {
+          | Some(pm) => pm
+          | None => Npm
+          }
+        } else {
+          Npm
+        }
+      }
+    } else {
+      Npm
+    }
+  }
+}
+
+let command = (pm: t): string => {
+  switch pm {
+  | Npm => "npm"
+  | Yarn => "npx yarn"
+  | Pnpm => "npx pnpm"
+  | Bun => "bun"
+  | Deno => "deno"
+  }
+}
+
+let devCommand = (pm: t): string => {
+  switch pm {
+  | Npm => "npm run dev"
+  | Yarn => "yarn dev"
+  | Pnpm => "pnpm dev"
+  | Bun => "bun dev"
+  | Deno => "deno task dev"
+  }
+}
+
+let devInstallArgs = (pm: t): array<string> => {
+  switch pm {
+  | Npm => ["install", "-D"]
+  | Yarn => ["add", "-D"]
+  | Pnpm => ["add", "--save-dev"]
+  | Bun => ["add", "--dev"]
+  | Deno => ["add", "--dev"]
+  }
+}
+
+let npmPackages = (pm: t, packages: array<string>): array<string> => {
+  switch pm {
+  | Deno => packages->Array.map(packageName => "npm:" ++ packageName)
+  | Npm | Yarn | Pnpm | Bun => packages
+  }
+}

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Detect.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Detect.res
@@ -6,6 +6,7 @@ module Process = Bindings.Process
 module FsUtils = FrontmanAiFrontmanCore.FrontmanCore__FsUtils
 module ExnUtils = FrontmanAiFrontmanCore.FrontmanCore__ExnUtils
 module Semver = FrontmanAiFrontmanCore.FrontmanCore__Semver
+module PackageManager = FrontmanAiFrontmanCore.FrontmanCore__Cli__PackageManager
 
 // Node.js module resolution — handles monorepo hoisting, pnpm virtual store,
 // Yarn PnP, and all standard node_modules layouts.
@@ -19,7 +20,7 @@ type nextVersion = {
   raw: string,
 }
 
-type packageManager =
+type packageManager = PackageManager.t =
   | Npm
   | Yarn
   | Pnpm
@@ -128,59 +129,7 @@ let detectNextVersion = async (projectDir: string): result<nextVersion, string> 
   }
 }
 
-// Detect package manager from lock files
-// Checks current directory and parent directories (for monorepo setups)
-let detectPackageManager = async (projectDir: string): packageManager => {
-  // Check a directory for lock files
-  let checkDir = async (dir: string): option<packageManager> => {
-    let bunLockb = Path.join([dir, "bun.lockb"])
-    let bunLock = Path.join([dir, "bun.lock"])
-    let denoLock = Path.join([dir, "deno.lock"])
-    let pnpmLock = Path.join([dir, "pnpm-lock.yaml"])
-    let yarnLock = Path.join([dir, "yarn.lock"])
-    let npmLock = Path.join([dir, "package-lock.json"])
-
-    if (await FsUtils.pathExists(bunLockb)) || (await FsUtils.pathExists(bunLock)) {
-      Some(Bun)
-    } else if await FsUtils.pathExists(denoLock) {
-      Some(Deno)
-    } else if await FsUtils.pathExists(pnpmLock) {
-      Some(Pnpm)
-    } else if await FsUtils.pathExists(yarnLock) {
-      Some(Yarn)
-    } else if await FsUtils.pathExists(npmLock) {
-      Some(Npm)
-    } else {
-      None
-    }
-  }
-
-  // First check the project directory
-  switch await checkDir(projectDir) {
-  | Some(pm) => pm
-  | None =>
-    // Check parent directory (for monorepo setups)
-    let parentDir = Path.dirname(projectDir)
-    if parentDir != projectDir {
-      switch await checkDir(parentDir) {
-      | Some(pm) => pm
-      | None =>
-        // Check grandparent (for deeply nested monorepos)
-        let grandparentDir = Path.dirname(parentDir)
-        if grandparentDir != parentDir {
-          switch await checkDir(grandparentDir) {
-          | Some(pm) => pm
-          | None => Npm // Default to npm
-          }
-        } else {
-          Npm
-        }
-      }
-    } else {
-      Npm // Default to npm
-    }
-  }
-}
+let detectPackageManager = PackageManager.detect
 
 // Pattern to detect @frontman-ai/nextjs import
 let frontmanImportPattern = /@frontman-ai\/nextjs/
@@ -271,40 +220,8 @@ let isNextJs16Plus = (info: projectInfo): bool => {
   info.nextVersion.major >= 16
 }
 
-// Get package manager command
-// Uses npx to ensure the package manager is available even if not in PATH
-let getPackageManagerCommand = (pm: packageManager): string => {
-  switch pm {
-  | Npm => "npm"
-  | Yarn => "npx yarn"
-  | Pnpm => "npx pnpm"
-  | Bun => "bun"
-  | Deno => "deno"
-  }
-}
+let getPackageManagerCommand = PackageManager.command
 
-// Get the dev server command for display in success messages
-let getDevCommand = (pm: packageManager): string => {
-  switch pm {
-  | Npm => "npm run dev"
-  | Yarn => "yarn dev"
-  | Pnpm => "pnpm dev"
-  | Bun => "bun dev"
-  | Deno => "deno task dev"
-  }
-}
+let getDevCommand = PackageManager.devCommand
 
-// Get install command args for each package manager
-// Installs as devDependencies: Next.js bundles all imports at build time (both
-// middleware on Edge and instrumentation on Node.js), so these packages only need
-// to exist during `next build`, not at runtime. Every deployment platform runs
-// `npm install` (all deps) before `next build`, then prunes devDeps afterward.
-let getInstallArgs = (pm: packageManager): array<string> => {
-  switch pm {
-  | Npm => ["install", "-D"]
-  | Yarn => ["add", "-D"]
-  | Pnpm => ["add", "--save-dev"]
-  | Bun => ["add", "--dev"]
-  | Deno => ["add", "--dev"]
-  }
-}
+let getInstallArgs = PackageManager.devInstallArgs

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Install.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Install.res
@@ -9,6 +9,7 @@ module Detect = FrontmanNextjs__Cli__Detect
 module Files = FrontmanNextjs__Cli__Files
 module Templates = FrontmanNextjs__Cli__Templates
 module Style = FrontmanNextjs__Cli__Style
+module PackageManager = FrontmanAiFrontmanCore.FrontmanCore__Cli__PackageManager
 
 type installOptions = {
   server: string,
@@ -31,11 +32,7 @@ let installDependencies = async (
   let pm = Detect.getPackageManagerCommand(packageManager)
   let args = Detect.getInstallArgs(packageManager)
   let packages = ["@frontman-ai/nextjs", "@opentelemetry/sdk-node"]
-  // Deno requires npm: prefix for npm packages (otherwise it looks them up on JSR)
-  let packages = switch packageManager {
-  | Deno => packages->Array.map(p => "npm:" ++ p)
-  | _ => packages
-  }
+  let packages = PackageManager.npmPackages(packageManager, packages)
   let cmd = `${pm} ${args->Array.join(" ")} ${packages->Array.join(" ")}`
 
   switch dryRun {

--- a/libs/frontman-vite/src/cli/FrontmanVite__Cli__Detect.res
+++ b/libs/frontman-vite/src/cli/FrontmanVite__Cli__Detect.res
@@ -3,8 +3,9 @@ module Bindings = FrontmanBindings
 module Fs = Bindings.Fs
 module Path = Bindings.Path
 module FsUtils = FrontmanAiFrontmanCore.FrontmanCore__FsUtils
+module PackageManager = FrontmanAiFrontmanCore.FrontmanCore__Cli__PackageManager
 
-type packageManager =
+type packageManager = PackageManager.t =
   | Npm
   | Yarn
   | Pnpm
@@ -32,54 +33,7 @@ let readFile = async (path: string): option<string> => {
   }
 }
 
-// Detect package manager from lock files
-let detectPackageManager = async (projectDir: string): packageManager => {
-  let checkDir = async (dir: string): option<packageManager> => {
-    let bunLockb = Path.join([dir, "bun.lockb"])
-    let bunLock = Path.join([dir, "bun.lock"])
-    let denoLock = Path.join([dir, "deno.lock"])
-    let pnpmLock = Path.join([dir, "pnpm-lock.yaml"])
-    let yarnLock = Path.join([dir, "yarn.lock"])
-    let npmLock = Path.join([dir, "package-lock.json"])
-
-    if (await FsUtils.pathExists(bunLockb)) || (await FsUtils.pathExists(bunLock)) {
-      Some(Bun)
-    } else if await FsUtils.pathExists(denoLock) {
-      Some(Deno)
-    } else if await FsUtils.pathExists(pnpmLock) {
-      Some(Pnpm)
-    } else if await FsUtils.pathExists(yarnLock) {
-      Some(Yarn)
-    } else if await FsUtils.pathExists(npmLock) {
-      Some(Npm)
-    } else {
-      None
-    }
-  }
-
-  switch await checkDir(projectDir) {
-  | Some(pm) => pm
-  | None =>
-    let parentDir = Path.dirname(projectDir)
-    if parentDir != projectDir {
-      switch await checkDir(parentDir) {
-      | Some(pm) => pm
-      | None =>
-        let grandparentDir = Path.dirname(parentDir)
-        if grandparentDir != parentDir {
-          switch await checkDir(grandparentDir) {
-          | Some(pm) => pm
-          | None => Npm
-          }
-        } else {
-          Npm
-        }
-      }
-    } else {
-      Npm
-    }
-  }
-}
+let detectPackageManager = PackageManager.detect
 
 // Pattern to detect frontman plugin import
 let frontmanImportPattern = /@frontman-ai\/vite|frontman-vite|frontmanPlugin/
@@ -170,35 +124,8 @@ let detect = async (projectDir: string): result<projectInfo, string> => {
   }
 }
 
-// Get package manager command
-let getPackageManagerCommand = (pm: packageManager): string => {
-  switch pm {
-  | Npm => "npm"
-  | Yarn => "npx yarn"
-  | Pnpm => "npx pnpm"
-  | Bun => "bun"
-  | Deno => "deno"
-  }
-}
+let getPackageManagerCommand = PackageManager.command
 
-// Get the dev server command
-let getDevCommand = (pm: packageManager): string => {
-  switch pm {
-  | Npm => "npm run dev"
-  | Yarn => "yarn dev"
-  | Pnpm => "pnpm dev"
-  | Bun => "bun dev"
-  | Deno => "deno task dev"
-  }
-}
+let getDevCommand = PackageManager.devCommand
 
-// Get install command args
-let getInstallArgs = (pm: packageManager): array<string> => {
-  switch pm {
-  | Npm => ["install", "-D"]
-  | Yarn => ["add", "-D"]
-  | Pnpm => ["add", "--save-dev"]
-  | Bun => ["add", "--dev"]
-  | Deno => ["add", "--dev"]
-  }
-}
+let getInstallArgs = PackageManager.devInstallArgs

--- a/libs/frontman-vite/src/cli/FrontmanVite__Cli__Install.res
+++ b/libs/frontman-vite/src/cli/FrontmanVite__Cli__Install.res
@@ -8,6 +8,7 @@ module Process = Bindings.Process
 module Detect = FrontmanVite__Cli__Detect
 module Templates = FrontmanVite__Cli__Templates
 module Style = FrontmanVite__Cli__Style
+module PackageManager = FrontmanAiFrontmanCore.FrontmanCore__Cli__PackageManager
 
 type installOptions = {
   server: string,
@@ -30,10 +31,7 @@ let installDependencies = async (
   let pm = Detect.getPackageManagerCommand(packageManager)
   let args = Detect.getInstallArgs(packageManager)
   let packages = ["@frontman-ai/vite"]
-  let packages = switch packageManager {
-  | Deno => packages->Array.map(p => "npm:" ++ p)
-  | _ => packages
-  }
+  let packages = PackageManager.npmPackages(packageManager, packages)
   let cmd = `${pm} ${args->Array.join(" ")} ${packages->Array.join(" ")}`
 
   switch dryRun {


### PR DESCRIPTION
## Summary
- Extract shared CLI package-manager detection/command helpers into frontman-core and reuse them from Next.js and Vite installers.
- Remove unused client tool registry helpers and rewrite tests around actual MCP registration behavior.
- Drop stale TODO summary fields/label generation that were no longer consumed.

## Verification
- yarn rescript build (`libs/frontman-core`)
- yarn build:rescript (`libs/frontman-vite`)
- make test (`libs/frontman-nextjs`)
- make test (`libs/client`)
- npx @rescript/tools@0.6.6 reanalyze -config (`libs/client`, `libs/frontman-core`, `libs/frontman-nextjs`, `libs/frontman-vite`)
- git diff --check
- pre-push reanalyze across all ReScript libs