### PR TITLE
Remove dead task helpers

### DIFF
--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -13,7 +13,6 @@ module ACPTypes = Client__Task__Types.ACPTypes
 let stripFileUriPrefix = Client__Task__Types.stripFileUriPrefix
 let makeAnnotationMeta = Client__Task__Types.makeAnnotationMeta
 let annotationToContentBlocks = Client__Task__Types.annotationToContentBlocks
-let taskToContentBlocks = Client__Task__Types.taskToContentBlocks
 let taskToPageContextBlocks = Client__Task__Types.taskToPageContextBlocks
 let messageAnnotationsToContentBlocks = Client__Task__Types.messageAnnotationsToContentBlocks
 

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -12,21 +12,6 @@ module Message = Client__Message
 
 module Annotation = Client__Annotation__Types
 
-module FigmaNode = {
-  // Selected node with DSL representation or full node data, and image
-  type selectedNodeData = {
-    nodeId: string,
-    nodeData: string, // DSL representation OR full JSON node data
-    image: option<string>, // Base64 data URL (data:image/jpeg;base64,... or data:image/png;base64,...)
-    isDsl: bool, // true if nodeData is DSL text, false if full JSON data
-  }
-
-  type t =
-    | NoSelection
-    | WaitingForSelection
-    | SelectedNode(selectedNodeData)
-}
-
 // Todo - single source of truth for todo state (updated by reducer)
 module Todo = {
   type status =
@@ -350,32 +335,6 @@ module Task = {
     })
   }
 
-  // Transition Unloaded -> Loading
-  let startLoading = (task: t, ~previewUrl: string): t =>
-    switch task {
-    | Unloaded({id, title, createdAt, updatedAt}) =>
-      Loading({
-        id,
-        title,
-        createdAt,
-        updatedAt,
-        messages: Client__MessageStore.make(),
-        previewFrame: {
-          url: previewUrl,
-          contentDocument: None,
-          contentWindow: None,
-          deviceMode: Client__DeviceMode.defaultDeviceMode,
-          orientation: Client__DeviceMode.defaultOrientation,
-        },
-        annotationMode: Annotation.Off,
-        annotations: [],
-        activePopupAnnotationId: None,
-        isAnimationFrozen: false,
-      })
-    | New(_) => failwith("[Task.startLoading] Cannot load a New task - it has no server session")
-    | Loading(_) | Loaded(_) => task
-    }
-
   // Atomic transition: New → Loaded (promotion when first message is sent)
   // Message insertion is handled separately by the task reducer's AddUserMessage
   // Preserves clientId for stable React keying (prevents iframe remount)
@@ -414,46 +373,6 @@ module Task = {
     }
   }
 
-  // Create a Loaded task directly (for new tasks with known session ID)
-  let makeLoaded = (
-    ~id: string,
-    ~title: string,
-    ~previewUrl: string,
-    ~createdAt: float,
-    ~messages: array<Message.t>=[],
-    ~isAgentRunning: bool=false,
-  ): t => {
-    Loaded({
-      id,
-      clientId: None,
-      title: normalizeTitle(title),
-      createdAt,
-      updatedAt: createdAt,
-      messages: Client__MessageStore.fromArray(messages),
-      previewFrame: {
-        url: previewUrl,
-        contentDocument: None,
-        contentWindow: None,
-        deviceMode: Client__DeviceMode.defaultDeviceMode,
-        orientation: Client__DeviceMode.defaultOrientation,
-      },
-      annotationMode: Annotation.Off,
-      annotations: [],
-      activePopupAnnotationId: None,
-      isAnimationFrozen: false,
-      isAgentRunning,
-      planEntries: [],
-      turnError: None,
-      retryStatus: None,
-      imageAttachments: Dict.make(),
-      pendingQuestion: None,
-    })
-  }
-
-  // ============================================================================
-  // Helper types and convenience constructors
-  // ============================================================================
-
   type loadedData = {
     messages: array<Message.t>,
     annotationMode: Annotation.annotationMode,
@@ -466,28 +385,6 @@ module Task = {
     pendingQuestion: option<Client__Question__Types.pendingQuestion>,
   }
 
-  type loadState =
-    | NotLoaded
-    | Loading(loadedData)
-    | Loaded(loadedData)
-
-  let makeLoadedData = (~messages=[]): loadedData => {
-    messages,
-    annotationMode: Annotation.Off,
-    annotations: [],
-    activePopupAnnotationId: None,
-    isAnimationFrozen: false,
-    isAgentRunning: false,
-    planEntries: [],
-    turnError: None,
-    pendingQuestion: None,
-  }
-
-  let make = (~title: string, ~previewUrl: string, ~messages=[]): t => {
-    let newId = WebAPI.Global.crypto->WebAPI.Crypto.randomUUID
-    makeLoaded(~id=newId, ~title, ~previewUrl, ~createdAt=Date.now(), ~messages)
-  }
-
   let makeWithId = (
     ~id: string,
     ~title: string,
@@ -497,73 +394,6 @@ module Task = {
   ): t => {
     let _ = previewUrl
     makeUnloaded(~id, ~title, ~createdAt, ~updatedAt=updatedAt->Option.getOr(createdAt))
-  }
-
-  let makeWithIdLoaded = (
-    ~id: string,
-    ~title: string,
-    ~previewUrl: string,
-    ~createdAt: float,
-  ): t => {
-    makeLoaded(~id, ~title, ~previewUrl, ~createdAt)
-  }
-
-  let getLoadedData = (task: t): option<loadedData> => {
-    switch task {
-    | Loaded({
-        messages,
-        annotationMode,
-        annotations,
-        activePopupAnnotationId,
-        isAnimationFrozen,
-        isAgentRunning,
-        planEntries,
-        turnError,
-        pendingQuestion,
-      }) =>
-      Some({
-        messages: Client__MessageStore.toArray(messages),
-        annotationMode,
-        annotations,
-        activePopupAnnotationId,
-        isAnimationFrozen,
-        isAgentRunning,
-        planEntries,
-        turnError,
-        pendingQuestion,
-      })
-    | Loading({
-        messages,
-        annotationMode,
-        annotations,
-        activePopupAnnotationId,
-        isAnimationFrozen,
-      }) =>
-      Some({
-        messages: Client__MessageStore.toArray(messages),
-        annotationMode,
-        annotations,
-        activePopupAnnotationId,
-        isAnimationFrozen,
-        isAgentRunning: false,
-        planEntries: [],
-        turnError: None,
-        pendingQuestion: None,
-      })
-    | New({annotationMode, annotations, activePopupAnnotationId, isAnimationFrozen}) =>
-      Some({
-        messages: [],
-        annotationMode,
-        annotations,
-        activePopupAnnotationId,
-        isAnimationFrozen,
-        isAgentRunning: false,
-        planEntries: [],
-        turnError: None,
-        pendingQuestion: None,
-      })
-    | Unloaded(_) => None
-    }
   }
 
   let updateLoadedData = (task: t, fn: loadedData => loadedData): t => {
@@ -1010,72 +840,6 @@ let annotationToContentBlocks = (annotation: Annotation.t, ~index: int): array<
   [Some(resourceBlock), screenshotBlock]->Array.filterMap(x => x)
 }
 
-// Helper to create _meta JSON for figma node with nodeId and is_dsl flag
-let makeFigmaNodeMeta: (string, bool) => JSON.t = %raw(`
-  function(nodeId, isDsl) {
-    return {
-      "figma_node": true,
-      "node_id": nodeId,
-      "is_dsl": isDsl
-    };
-  }
-`)
-
-// Build a Resource ContentBlock from FigmaNode data
-// Contains the Figma node as DSL string (compact, token-efficient format) or full JSON data
-let figmaNodeToContentBlock = (
-  nodeId: string,
-  nodeData: string,
-  isDsl: bool,
-): ACPTypes.contentBlock => {
-  let textResource: ACPTypes.textResourceContents = {
-    uri: nodeId,
-    mimeType: Some("text/plain"),
-    text: nodeData,
-  }
-
-  // Create _meta with figma_node annotation, nodeId, and is_dsl flag
-  let _meta = makeFigmaNodeMeta(nodeId, isDsl)
-  let embeddedResource: ACPTypes.embeddedResource = {
-    _meta: Some(_meta),
-    annotations: None,
-    resource: ACPTypes.TextResourceContents(textResource),
-  }
-
-  ACPTypes.EmbeddedResource({
-    resource: embeddedResource,
-    _meta: None,
-    annotations: None,
-  })
-}
-
-// Build an Image ContentBlock from FigmaNode image data
-// Uses resource type with mimeType extracted from the data URL
-let figmaImageToContentBlock = (imageDataUrl: string): ACPTypes.contentBlock => {
-  let (mimeType, base64Data) = parseDataUrl(imageDataUrl)
-
-  let blobResource: ACPTypes.blobResourceContents = {
-    uri: "figma://node/image",
-    mimeType: Some(mimeType),
-    blob: base64Data,
-  }
-
-  // Create _meta with figma_image annotation
-  let _meta: JSON.t = %raw(`{"figma_image": true}`)
-
-  let embeddedResource: ACPTypes.embeddedResource = {
-    _meta: Some(_meta),
-    annotations: None,
-    resource: ACPTypes.BlobResourceContents(blobResource),
-  }
-
-  ACPTypes.EmbeddedResource({
-    resource: embeddedResource,
-    _meta: None,
-    annotations: None,
-  })
-}
-
 // Helper: read document.title from a document reference
 let getDocumentTitle: WebAPI.DOMAPI.document => string = %raw(`
   function(doc) { return doc.title || ""; }
@@ -1254,32 +1018,6 @@ let currentPageToContentBlock = (previewFrame: Task.previewFrame): ACPTypes.cont
     _meta: None,
     annotations: None,
   })
-}
-
-// Build ContentBlocks array from Task
-// Returns array of ContentBlocks to be added to the prompt
-// Each annotation produces 1-2 blocks (resource + optional screenshot)
-let taskToContentBlocks = (task: Task.t): array<ACPTypes.contentBlock> => {
-  switch task {
-  | Task.Unloaded(_) => []
-  | Task.New({annotations, previewFrame})
-  | Task.Loading({annotations, previewFrame})
-  | Task.Loaded({annotations, previewFrame}) => {
-      let blocks = []
-
-      // Add current page context (always included — implicit context)
-      let blocks = Array.concat(blocks, [currentPageToContentBlock(previewFrame)])
-
-      // Add annotation content blocks
-      let annotationBlocks =
-        annotations->Array.flatMapWithIndex((annotation, index) =>
-          annotationToContentBlocks(annotation, ~index)
-        )
-      let blocks = Array.concat(blocks, annotationBlocks)
-
-      blocks
-    }
-  }
 }
 
 // ============================================================================

--- a/libs/client/test/Client__HistoryReplay.test.res
+++ b/libs/client/test/Client__HistoryReplay.test.res
@@ -33,7 +33,7 @@ module TestHelpers = {
       ~createdAt=Date.now(),
       ~updatedAt=Date.now(),
     )
-    Task.startLoading(unloaded, ~previewUrl="http://localhost:3000")
+    TaskReducer.next(unloaded, LoadStarted({previewUrl: "http://localhost:3000"}))->Pair.first
   }
 
   let getMessages = (task: Task.t): array<Message.t> => {

--- a/libs/client/test/Client__LoadSessionFlow.test.res
+++ b/libs/client/test/Client__LoadSessionFlow.test.res
@@ -30,13 +30,10 @@ describe("Load Session Then Stream", () => {
     ->Expect.toBe(Some(taskId))
 
     // 2. State: create a loaded task directly (simulates task creation via AddUserMessage)
-    let loadedTask = Task.makeLoaded(
-      ~id=taskId,
-      ~title="Loaded Task",
-      ~previewUrl="http://localhost:3000",
-      ~createdAt=Date.now(),
-      ~isAgentRunning=true,
-    )
+    let loadedTask =
+      Task.makeNew(~previewUrl="http://localhost:3000")
+      ->Task.newToLoaded(~id=taskId, ~title="Loaded Task")
+      ->Task.updateLoadedData(data => {...data, isAgentRunning: true})
     let tasks = Dict.make()
     tasks->Dict.set(taskId, loadedTask)
     let appState: State.state = {
@@ -59,7 +56,7 @@ describe("Load Session Then Stream", () => {
     )
 
     let task = finalState.tasks->Dict.get(taskId)->Option.getOrThrow
-    let messages = Task.getLoadedData(task)->Option.mapOr([], d => d.messages)
+    let messages = Task.getMessages(task)
     t->expect(messages->Array.length)->Expect.toBe(1)
   })
 })

--- a/libs/client/test/Client__State__ConcurrentTasks.test.res
+++ b/libs/client/test/Client__State__ConcurrentTasks.test.res
@@ -17,13 +17,10 @@ module TestSetup = {
   ): StateReducer.state => {
     let tasks = Dict.make()
     taskIds->Array.forEach(id => {
-      let task = Task.makeLoaded(
-        ~id,
-        ~title=`Task ${id}`,
-        ~previewUrl="http://localhost:3000",
-        ~createdAt=Date.now(),
-        ~isAgentRunning,
-      )
+      let task =
+        Task.makeNew(~previewUrl="http://localhost:3000")
+        ->Task.newToLoaded(~id, ~title=`Task ${id}`)
+        ->Task.updateLoadedData(data => {...data, isAgentRunning})
       tasks->Dict.set(id, task)
     })
 
@@ -42,7 +39,7 @@ module TestSetup = {
 
 // Helper to get messages from a task's loadedData
 let getTaskMessages = (task: Task.t) => {
-  Task.getLoadedData(task)->Option.mapOr([], data => data.messages)
+  Task.getMessages(task)
 }
 
 // Helper to get current task ID

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -1,11 +1,24 @@
 open Vitest
 
 module Reducer = Client__State__StateReducer
+module TaskReducer = Client__Task__Reducer
 module Task = Client__State__Types.Task
 module UserContentPart = Client__State__Types.UserContentPart
 module AssistantContentPart = Client__State__Types.AssistantContentPart
 
 module TestHelpers = {
+  let makeLoadedTask = (
+    ~id,
+    ~title,
+    ~previewUrl,
+    ~createdAt as _,
+    ~messages=[],
+    ~isAgentRunning=false,
+  ) =>
+    Task.makeNew(~previewUrl)
+    ->Task.newToLoaded(~id, ~title)
+    ->Task.updateLoadedData(data => {...data, messages, isAgentRunning})
+
   let makeStateWithTask = (
     ~taskId="test-task-1",
     ~messages=[],
@@ -13,7 +26,7 @@ module TestHelpers = {
     ~previewUrl="http://localhost:3000",
     ~isAgentRunning=false,
   ) => {
-    let task = Task.makeLoaded(
+    let task = makeLoadedTask(
       ~id=taskId,
       ~title="Test Task",
       ~previewUrl,
@@ -695,7 +708,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
 
 describe("Client State Reducer - Task Management Actions", () => {
   test("SwitchTask restores task messages", t => {
-    let task1 = Task.makeLoaded(
+    let task1 = TestHelpers.makeLoadedTask(
       ~id="task-1",
       ~title="Task 1",
       ~previewUrl="http://localhost:3000",
@@ -710,7 +723,7 @@ describe("Client State Reducer - Task Management Actions", () => {
       ],
     )
 
-    let task2 = Task.makeLoaded(
+    let task2 = TestHelpers.makeLoadedTask(
       ~id="task-2",
       ~title="Task 2",
       ~previewUrl="http://localhost:3000",
@@ -792,7 +805,7 @@ describe("Client State Reducer - Task Management Actions", () => {
   })
 
   test("DeleteTask switches to New when deleting only task", t => {
-    let task1 = Task.makeLoaded(
+    let task1 = TestHelpers.makeLoadedTask(
       ~id="task-1",
       ~title="Task 1",
       ~previewUrl="http://localhost:3000",
@@ -844,7 +857,7 @@ describe("Client State Reducer - Task Management Actions", () => {
 
   test("AddUserMessage after deleting last task creates new task", t => {
     // Start with a single task
-    let task1 = Task.makeLoaded(
+    let task1 = TestHelpers.makeLoadedTask(
       ~id="task-1",
       ~title="Task 1",
       ~previewUrl="http://localhost:3000",
@@ -934,7 +947,7 @@ describe("Client State Reducer - Task Management Actions", () => {
   })
 
   test("Tasks maintain independent state across switches", t => {
-    let task1 = Task.makeLoaded(
+    let task1 = TestHelpers.makeLoadedTask(
       ~id="task-1",
       ~title="Task 1",
       ~previewUrl="http://localhost:3000",
@@ -1056,7 +1069,7 @@ describe("Client State Reducer - Session Loading Actions", () => {
 
   test("SessionsLoadSuccess does not overwrite existing tasks", t => {
     // Create state with an existing task
-    let existingTask = Task.makeLoaded(
+    let existingTask = TestHelpers.makeLoadedTask(
       ~id="session-1",
       ~title="Existing Task",
       ~previewUrl="http://localhost:3000",
@@ -1171,7 +1184,8 @@ describe("Client State Reducer - Session Loading Actions", () => {
       ~createdAt=1000.0,
       ~updatedAt=1000.0,
     )
-    let loadingTask = Task.startLoading(task, ~previewUrl="http://localhost:3000")
+    let loadingTask =
+      TaskReducer.next(task, LoadStarted({previewUrl: "http://localhost:3000"}))->Pair.first
 
     let tasks = Dict.make()
     tasks->Dict.set("task-123", loadingTask)

--- a/libs/client/test/Client__State__Types.test.res
+++ b/libs/client/test/Client__State__Types.test.res
@@ -102,14 +102,6 @@ let getMetaObject = (meta: JSON.t, field: string): Dict.t<JSON.t> =>
   ->Option.flatMap(JSON.Decode.object)
   ->Option.getOrThrow
 
-// Helper to create a New task with custom annotations
-let makeNewTaskWithAnnotations = (annotations: array<Annotation.t>): Types.Task.t => {
-  switch Types.Task.makeNew(~previewUrl="http://localhost:3000") {
-  | Types.Task.New(data) => Types.Task.New({...data, annotations})
-  | other => other
-  }
-}
-
 describe("Client__State__Types", () => {
   describe("annotationToContentBlocks", () => {
     test(
@@ -398,73 +390,6 @@ describe("Client__State__Types", () => {
 
         let metaObj = meta->JSON.Decode.object->Option.getOrThrow
         t->expect(metaObj->Dict.get("bounding_box")->Option.isNone)->Expect.toBe(true)
-      },
-    )
-  })
-
-  describe("taskToContentBlocks", () => {
-    test(
-      "returns empty array for Unloaded task",
-      t => {
-        let task = Types.Task.Unloaded({
-          id: "test",
-          title: "test",
-          createdAt: 0.0,
-          updatedAt: 0.0,
-        })
-
-        let blocks = Types.taskToContentBlocks(task)
-        t->expect(blocks->Array.length)->Expect.toBe(0)
-      },
-    )
-
-    test(
-      "returns annotation blocks for New task with annotations",
-      t => {
-        let annotation = makeTestAnnotation(
-          ~file="file:///home/user/project/src/Component.tsx",
-          ~line=42,
-          ~column=5,
-          ~screenshot="data:image/jpeg;base64,/9j/4AAQ",
-        )
-
-        let task = makeNewTaskWithAnnotations([annotation])
-
-        let blocks = Types.taskToContentBlocks(task)
-        // 1 current_page block + 1 annotation with screenshot (2 blocks) = 3 blocks
-        t->expect(blocks->Array.length)->Expect.toBe(3)
-      },
-    )
-
-    test(
-      "returns blocks for multiple annotations",
-      t => {
-        let ann1 = makeTestAnnotation(
-          ~file="file:///home/user/project/src/A.tsx",
-          ~line=1,
-          ~column=1,
-        )
-        let ann2 = makeTestAnnotation(
-          ~file="file:///home/user/project/src/B.tsx",
-          ~line=2,
-          ~column=2,
-          ~screenshot="data:image/png;base64,iVBORw0K",
-        )
-
-        let task = makeNewTaskWithAnnotations([ann1, ann2])
-
-        let blocks = Types.taskToContentBlocks(task)
-        // 1 current_page block + ann1: 1 block (no screenshot) + ann2: 2 blocks (with screenshot) = 4 total
-        t->expect(blocks->Array.length)->Expect.toBe(4)
-
-        // blocks[0] is current_page; annotation blocks start at index 1
-        // Verify first annotation has index 0
-        let meta0 = getMeta(blocks->Array.getUnsafe(1))
-        t->expect(getMetaFloat(meta0, "annotation_index"))->Expect.toBe(0.0)
-
-        // Verify second annotation has index 1
-        let meta1 = getMeta(blocks->Array.getUnsafe(2))
-        t->expect(getMetaFloat(meta1, "annotation_index"))->Expect.toBe(1.0)
       },
     )
   })

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -6,7 +6,9 @@ module TaskReducer = Client__Task__Reducer
 
 module TestHelpers = {
   let makeLoadedTask = (~id="test-task-1", ~messages=[], ~previewUrl="http://localhost:3000") => {
-    Task.makeLoaded(~id, ~title="Test Task", ~previewUrl, ~createdAt=Date.now(), ~messages)
+    Task.makeNew(~previewUrl)
+    ->Task.newToLoaded(~id, ~title="Test Task")
+    ->Task.updateLoadedData(data => {...data, messages})
   }
 
   let makeUnloadedTask = (~id="test-task-1") => {
@@ -20,7 +22,7 @@ module TestHelpers = {
       ~createdAt=Date.now(),
       ~updatedAt=Date.now(),
     )
-    Task.startLoading(unloaded, ~previewUrl)
+    TaskReducer.next(unloaded, LoadStarted({previewUrl: previewUrl}))->Pair.first
   }
 
   // Helper to get messages from loaded tasks (unwraps the option)


### PR DESCRIPTION
## Summary
- Remove unused task constructors/load-state helpers and stale Figma content-block helpers.
- Drop the obsolete `taskToContentBlocks` API now that page context and message annotations are built separately.
- Update tests to use live task transitions/reducer actions instead of removed helper APIs.

## Review Notes
- PR diff is limited to client task types/state type re-exports and related tests.
- Existing unrelated dirty worktree files were not committed.
- Net PR diff: 36 insertions, 364 deletions.

## Tests
- `make test` in `libs/client`.