### PR TITLE
Simplify task execution setup

### DIFF
--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -27,7 +27,6 @@ defmodule FrontmanServer.Tasks.Execution do
   alias FrontmanServer.Image
   alias FrontmanServer.Observability.TelemetryEvents
   alias FrontmanServer.Providers
-  alias FrontmanServer.Providers.ResolvedKey
   alias FrontmanServer.Tasks.Execution.{Framework, RootAgent, ToolExecutor}
   alias FrontmanServer.Tasks.{Interaction, Task}
   alias FrontmanServer.Tools
@@ -75,8 +74,16 @@ defmodule FrontmanServer.Tasks.Execution do
     # Resolve API key at the domain layer (earliest point)
     case Providers.prepare_api_key(scope, model) do
       {:ok, api_key_info} ->
+        max_tokens = Application.fetch_env!(:frontman_server, :llm_max_tokens)
+        {model_spec, llm_opts} = Providers.to_llm_args(api_key_info, max_tokens: max_tokens)
+
+        llm_opts =
+          llm_opts
+          |> maybe_enable_prompt_cache(api_key_info.provider)
+          |> maybe_disable_parallel_tool_calls(task.framework)
+
         task_id = task.task_id
-        agent = build_agent(task, tools, opts, api_key_info, task.framework)
+        agent = build_agent(task, tools, model_spec, llm_opts, task.framework)
 
         messages =
           task.interactions
@@ -89,13 +96,39 @@ defmodule FrontmanServer.Tasks.Execution do
         backend_tool_modules =
           Keyword.get(opts, :backend_tool_modules, Tools.backend_tool_modules())
 
-        submit_to_runtime(scope, agent, task_id, messages,
-          api_key_info: api_key_info,
-          mcp_tool_defs: mcp_tool_defs,
-          backend_tool_modules: backend_tool_modules,
-          execution_framework: task.framework,
-          interaction_id: Keyword.get(opts, :interaction_id)
-        )
+        tool_executor =
+          ToolExecutor.make_executor(scope, task_id,
+            backend_tool_modules: backend_tool_modules,
+            mcp_tools: tools,
+            mcp_tool_defs: mcp_tool_defs,
+            llm_opts: Keyword.put(llm_opts, :model, model_spec)
+          )
+
+        # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
+        # in event handlers — the agent may complete before this line returns.
+        TelemetryEvents.task_start(task_id)
+
+        case SwarmAi.Runtime.run(FrontmanServer.AgentRuntime, task_id, agent, messages,
+               metadata: %{
+                 task_id: task_id,
+                 resolved_key: api_key_info,
+                 scope: scope,
+                 interaction_id: Keyword.get(opts, :interaction_id)
+               },
+               tool_executor: tool_executor,
+               tool_execution_mode: tool_execution_mode(task.framework)
+             ) do
+          {:ok, pid} ->
+            {:ok, pid}
+
+          {:error, :already_running} ->
+            TelemetryEvents.task_stop(task_id)
+            {:ok, :already_running}
+
+          error ->
+            TelemetryEvents.task_stop(task_id)
+            error
+        end
 
       {:error, reason} ->
         {:error, reason}
@@ -126,110 +159,47 @@ defmodule FrontmanServer.Tasks.Execution do
 
   # --- Private ---
 
-  # Dialyzer warning suppressed: protocol dispatch on Agent can't be statically proven.
-  @dialyzer {:nowarn_function, submit_to_runtime: 5}
-  defp submit_to_runtime(scope, agent, task_id, messages, opts) do
-    %ResolvedKey{} = resolved_key = Keyword.fetch!(opts, :api_key_info)
-    execution_framework = Keyword.fetch!(opts, :execution_framework)
-
-    mcp_tools = Map.get(agent, :tools, [])
-    mcp_tool_defs = Keyword.get(opts, :mcp_tool_defs, [])
-    backend_tool_modules = Keyword.fetch!(opts, :backend_tool_modules)
-
-    llm_opts =
-      [api_key: resolved_key.api_key, model: resolved_key.model]
-      |> maybe_enable_prompt_cache(resolved_key.provider)
-
-    llm_opts = maybe_disable_parallel_tool_calls(execution_framework, llm_opts)
-
-    tool_executor =
-      ToolExecutor.make_executor(scope, task_id,
-        backend_tool_modules: backend_tool_modules,
-        mcp_tools: mcp_tools,
-        mcp_tool_defs: mcp_tool_defs,
-        llm_opts: llm_opts
-      )
-
-    # Emit task start telemetry BEFORE Runtime.run to avoid race with task_stop
-    # in event handlers — the agent may complete before this line returns.
-    TelemetryEvents.task_start(task_id)
-
-    interaction_id = Keyword.get(opts, :interaction_id)
-
-    case SwarmAi.Runtime.run(FrontmanServer.AgentRuntime, task_id, agent, messages,
-           metadata: %{
-             task_id: task_id,
-             resolved_key: resolved_key,
-             scope: scope,
-             interaction_id: interaction_id
-           },
-           tool_executor: tool_executor,
-           tool_execution_mode: tool_execution_mode(execution_framework)
-         ) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      {:error, :already_running} ->
-        TelemetryEvents.task_stop(task_id)
-        {:ok, :already_running}
-
-      error ->
-        TelemetryEvents.task_stop(task_id)
-        error
-    end
-  end
-
   defp maybe_enable_prompt_cache(opts, "anthropic"),
     do: Keyword.put(opts, :anthropic_prompt_cache, true)
 
   defp maybe_enable_prompt_cache(opts, _provider), do: opts
 
-  defp maybe_disable_parallel_tool_calls(%Framework{id: :wordpress}, llm_opts) do
+  defp maybe_disable_parallel_tool_calls(llm_opts, %Framework{id: :wordpress}) do
     # WordPress tools mutate external state; serial calls avoid stale Elementor rollback races.
     Keyword.put(llm_opts, :parallel_tool_calls, false)
   end
 
-  defp maybe_disable_parallel_tool_calls(_framework, llm_opts), do: llm_opts
+  defp maybe_disable_parallel_tool_calls(llm_opts, _framework), do: llm_opts
 
   defp tool_execution_mode(%Framework{id: :wordpress}), do: :serial
   defp tool_execution_mode(_framework), do: :parallel
 
-  defp build_agent(%Task{} = task, tools, opts, %ResolvedKey{} = resolved_key, %Framework{} = fw) do
-    case Keyword.get(opts, :agent) do
-      nil ->
-        has_typescript_react = Framework.has_typescript_react?(fw)
+  defp build_agent(%Task{} = task, tools, model_spec, llm_opts, %Framework{} = fw) do
+    has_typescript_react = Framework.has_typescript_react?(fw)
 
-        # Derive prompt data from task interactions
-        project_rules =
-          task.interactions
-          |> Enum.filter(&match?(%Interaction.DiscoveredProjectRule{}, &1))
+    # Derive prompt data from task interactions
+    project_rules =
+      task.interactions
+      |> Enum.filter(&match?(%Interaction.DiscoveredProjectRule{}, &1))
 
-        project_structure =
-          task.interactions
-          |> Enum.find(&match?(%Interaction.DiscoveredProjectStructure{}, &1))
-          |> case do
-            nil -> nil
-            struct -> struct.summary
-          end
+    project_structure =
+      task.interactions
+      |> Enum.find(&match?(%Interaction.DiscoveredProjectStructure{}, &1))
+      |> case do
+        nil -> nil
+        struct -> struct.summary
+      end
 
-        max_tokens = Application.fetch_env!(:frontman_server, :llm_max_tokens)
-        {model_spec, llm_opts} = Providers.to_llm_args(resolved_key, max_tokens: max_tokens)
-        llm_opts = maybe_disable_parallel_tool_calls(fw, llm_opts)
-
-        RootAgent.new(
-          tools: tools,
-          has_annotations: Interaction.has_annotations?(task.interactions),
-          has_typescript_react: has_typescript_react,
-          framework: fw,
-          model: model_spec,
-          llm_opts: llm_opts,
-          project_rules: project_rules,
-          project_structure: project_structure
-        )
-
-      custom_agent ->
-        custom_agent
-    end
+    RootAgent.new(
+      tools: tools,
+      has_annotations: Interaction.has_annotations?(task.interactions),
+      has_typescript_react: has_typescript_react,
+      framework: fw,
+      model: model_spec,
+      llm_opts: llm_opts,
+      project_rules: project_rules,
+      project_structure: project_structure
+    )
   end
 
   # Providers that declare a max_image_dimension hard-reject images exceeding


### PR DESCRIPTION
## Summary
- Inline task turn runtime submission into `Execution.run/3`
- Remove the stale custom `:agent` override path
- Build provider/framework LLM options once and share them with the root agent and tool executor

## Verification
- `mix test test/frontman_server/tasks/execution_test.exs`
- `mix test test/frontman_server/tasks/execution`