### PR TITLE
Add agent comparison case study

### DIFF
--- a/apps/marketing/src/components/ui/cards/BlogCard.astro
+++ b/apps/marketing/src/components/ui/cards/BlogCard.astro
@@ -64,10 +64,10 @@ const {
 <style>
 	@reference "../../../styles/global.css";
 	.post-title {
-		@apply mb-0 text-xl;
+		@apply mb-3 text-xl;
 	}
 	.post-subtitle {
-		@apply mb-6 text-sm font-normal text-neutral-400 dark:text-neutral-400;
+		@apply mb-8 text-sm font-normal text-neutral-400 dark:text-neutral-400;
 	}
 	.post-tags {
 		@apply relative z-10 flex flex-wrap gap-2 border-t border-neutral-100 px-6 py-4 dark:border-neutral-800;

--- a/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
+++ b/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
@@ -1,0 +1,220 @@
+---
+title: 'What Happened When We Ran the Same Frontend Task in Frontman, OpenCode, and Claude Code'
+pubDate: 2026-05-05T05:00:00Z
+description: 'A single-task case study comparing Frontman, OpenCode, and Claude Code on the same Astro consent-banner integration. Same final code quality, very different iteration and token profiles.'
+author: 'Danni Fridland'
+authorRole: 'Co-founder, Frontman'
+image: '/blog/ai-coding-tools.png'
+tags: ['case-study', 'ai-agents', 'developer-tools', 'astro']
+faq:
+  - question: 'Did Frontman produce better code than OpenCode or Claude Code in this case study?'
+    answer: 'No. All three agents completed the task and produced roughly the same initial implementation. The interesting result was efficiency: Frontman required fewer model requests, fewer tokens, and less verification handoff because it already had runtime and framework context.'
+  - question: 'Is this a scientific benchmark?'
+    answer: 'No. This is a single-task internal case study on one real repo task. It is useful evidence for how architecture affects agent efficiency, not a universal claim that one agent is always better than another.'
+  - question: 'Why was Frontman more efficient?'
+    answer: 'Frontman is integrated into the running Astro dev server and browser preview. It already knew it was operating inside an Astro site, had access to the app structure through the integration, and could verify the banner visually through screenshots and browser-side JavaScript.'
+---
+
+We recently ran a small internal case study: give the same real frontend task to three coding agents and compare what happened.
+
+The agents were:
+
+- **Frontman**, running GPT-5.5 with medium thinking
+- **OpenCode**, running GPT-5.5 with medium thinking
+- **Claude Code**, running Claude Opus 4.7
+
+The task was deliberately mundane. No heroic refactor. No architecture rewrite. No contrived benchmark prompt. We wanted something that looked like real product work on our own marketing site.
+
+The task: integrate [`astro-consent`](https://github.com/velohost/astro-consent) into the Frontman marketing site, which already had Google Analytics configured.
+
+All three agents completed it. All three produced essentially the same first implementation. The difference was not code quality.
+
+The difference was how much work each agent needed to get there.
+
+## The Result
+
+| Agent | Requests | Prompt tokens | Completion tokens | Reasoning tokens | Total tokens | Cached prompt tokens | Non-cached prompt tokens | Cost |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Frontman | 18 | 1,388,944 | 8,114 | 2,073 | 1,399,131 | 1,296,384 | 92,560 | $1.354412 |
+| OpenCode | 56 | 3,625,774 | 13,497 | 4,401 | 3,643,672 | 3,345,408 | 280,366 | $3.472750 |
+| Claude Code | 86 | 5,223,274 | 21,127 | 6,021 | 5,250,422 | 5,145,408 | 105,014 | $5.472750 |
+
+On this task, Frontman used:
+
+- **68% fewer requests than OpenCode**
+- **79% fewer requests than Claude Code**
+- **62% fewer total tokens than OpenCode**
+- **73% fewer total tokens than Claude Code**
+- **61% lower reported cost than OpenCode**
+- **75% lower reported cost than Claude Code**
+
+Treat the cost numbers carefully. Model pricing, cache accounting, provider routing, and model choice can all change. Claude Code also used a different model. The more durable signal is the request and token profile: Frontman needed fewer agent turns to reach the same outcome.
+
+That is the point of the case study.
+
+## The Task
+
+The exact Frontman prompt was:
+
+```text
+help me integrate https://github.com/velohost/astro-consent to this page
+```
+
+For OpenCode and Claude Code, the prompt had to be slightly more explicit because they were operating from the monorepo rather than from the browser context of the marketing app:
+
+```text
+help me integrate https://github.com/velohost/astro-consent to @apps/marketing/
+```
+
+The site already had Google Analytics. The agents needed to install and configure `astro-consent`, adjust the analytics setup so consent mattered, add the banner styling, and make sure the site compiled and worked.
+
+The user-visible behavior was simple: a new visitor should see a consent banner until they accept or reject it. After that choice, the banner should not keep appearing.
+
+## The Important Part: All Three Finished
+
+This is not a dunk on OpenCode or Claude Code. Both completed the task. Claude Code was especially comprehensive and read broadly through the marketing app to understand the surrounding pages and conventions. OpenCode behaved similarly to Frontman once it had enough context.
+
+The first implementation quality was roughly the same across all three.
+
+That matters, because the honest conclusion is not:
+
+> Frontman wrote better code.
+
+The honest conclusion is:
+
+> Frontman reached and verified the same result with fewer agent turns because it started with more relevant runtime and framework context.
+
+For frontend work, that distinction is the product.
+
+## Why Frontman Needed Less Exploration
+
+OpenCode and Claude Code had to discover the application from the filesystem. They were dropped into a monorepo and needed to work out where the marketing app lived, what framework it used, where analytics was configured, how the Astro config was structured, and what build command should verify the result.
+
+Frontman already had a running browser session attached to the marketing app. More importantly, the Frontman Astro integration is not a generic file browser. It is installed inside the Astro dev server.
+
+In this repo, the marketing site uses the Frontman Astro integration directly in `apps/marketing/astro.config.mjs`:
+
+```js
+frontman({
+  projectRoot: appRoot,
+  sourceRoot: monorepoRoot,
+  basePath: "frontman",
+  serverName: "marketing",
+})
+```
+
+That gives the agent a much narrower starting point. It is not asking, "what is this repo?" It is operating inside a known Astro app with a live preview, framework tools, and browser tools already registered.
+
+The Astro integration itself is designed around that idea. It only activates in dev mode, installs middleware into Astro's Vite server, registers a Frontman dev toolbar app, captures source annotations, and exposes Astro-aware tools for routes and logs.
+
+From `libs/frontman-astro/src/FrontmanAstro__Integration.res`, the integration does several important things:
+
+- Registers Frontman middleware before Astro page routing, so `/frontman` and tool routes work inside the dev server.
+- Injects annotation capture into page heads, so selected DOM elements can be associated with source context where Astro exposes it.
+- Adds a Vite plugin that injects component props as HTML comments for richer agent context.
+- Initializes log capture, so the agent can see dev-server output and post-edit errors.
+- Uses Astro's resolved routes hook on Astro 5 and newer for route discovery.
+
+That is what we mean by "deep integration." It is not only a chat box next to an iframe. The dev server, browser, and agent loop are wired together.
+
+## Browser Verification Changed the Workflow
+
+The verification behavior differed too.
+
+OpenCode ran `make build` and stopped. Claude Code did the same. That is a valid baseline for many code tasks: if the build passes, the integration probably compiles.
+
+Frontman also verified through the browser. It checked that the consent banner was visible, then interacted with the banner using browser-side JavaScript to confirm the buttons worked.
+
+That verification path exists because Frontman registers browser-side tools in the client, including screenshots and JavaScript execution against the live preview iframe.
+
+The relevant tools are not abstract. In `libs/client/src/Client__ToolRegistry.res`, Frontman registers browser tools such as:
+
+- `take_screenshot`
+- `execute_js`
+- `set_device_mode`
+- `get_interactive_elements`
+- `interact_with_element`
+- `get_dom`
+- `search_text`
+- `question`
+
+For this task, the browser-specific value was straightforward: the acceptance criterion was not only "Astro builds." The acceptance criterion was "a new user sees a banner, can accept or reject it, and does not keep seeing it after making a choice."
+
+A build can tell you the first half only indirectly. A browser can tell you directly.
+
+## Why This Matters for Iteration
+
+The first implementation is only part of frontend work. The expensive part is often the loop after the implementation:
+
+```text
+try it -> look at it -> notice something off -> adjust -> verify again
+```
+
+We did not formally measure that second phase in this case study, so we are not including it in the table. But qualitatively, the same pattern held. Minor banner adjustments were faster in Frontman because the agent could operate from the rendered page and immediately verify the change in the browser.
+
+That is where browser-aware agents become interesting. The advantage is not that they are smarter. It is that they remove a pile of translation work.
+
+Without browser context, the user or the agent has to translate visual state into filesystem instructions:
+
+```text
+The banner is on the marketing site. It is Astro. The analytics script is over here. The config is over there. The consent package should wrap this. The banner should appear on first visit. Now run the build.
+```
+
+With Frontman, some of that context is already part of the harness. The agent starts closer to the task.
+
+## The Architecture Claim
+
+The result supports a specific architectural claim:
+
+> Runtime and framework context are efficiency features.
+
+They do not magically make the model more intelligent. They reduce the amount of exploration, prompting, and verification the model has to spend tokens on.
+
+This is especially visible in frontend work because the source code is not the only source of truth. The rendered DOM, computed CSS, viewport, local storage, cookies, client-side state, dev-server logs, and route table all matter.
+
+Frontman connects those surfaces through the browser and framework integration:
+
+```text
+Browser preview
+  -> screenshots, DOM, JavaScript execution, element interaction
+
+Astro dev server
+  -> routes, logs, file reads, file edits, source annotations
+
+Frontman server
+  -> agent loop, provider calls, tool routing, persisted task history
+```
+
+That architecture is more setup than a pure terminal agent. It is also less general. Frontman is not the tool we would choose for a deep backend refactor, a large migration, or a task where visual/runtime feedback does not matter.
+
+But for a frontend task whose correctness is visible in the browser, the integration pays for itself.
+
+## Caveats
+
+This was a case study, not a scientific benchmark.
+
+The caveats are real:
+
+- It was one task on one repo.
+- The repo was Frontman's own marketing app, which means the setup naturally favored Frontman's harness.
+- Frontman did not produce better first-pass code. All three agents produced roughly the same implementation.
+- Claude Code used a different model than Frontman and OpenCode.
+- We did not use wall-clock time as the metric because network conditions and inference speed make it noisy.
+- OpenCode had browser tooling available but did not use it during this run.
+- Browser context matters much less for backend work, pure refactors, or tasks where build/test output is the main source of truth.
+
+Those caveats do not make the result meaningless. They make the conclusion narrower and more useful.
+
+This case study does not prove that Frontman is universally better than OpenCode or Claude Code. It shows that, for a real visual/frontend integration task, deep browser and framework integration reduced the number of agent turns needed to reach and verify the same result.
+
+## The Takeaway
+
+The interesting result is not that Frontman completed the task. So did the other agents.
+
+The interesting result is that Frontman completed it with fewer requests, fewer tokens, and browser-level verification built into the workflow.
+
+That is what we are building Frontman around: not a bigger model, not a new prompting trick, but a better execution environment for frontend work.
+
+If the task is visual, the agent should be able to see it. If the app is running, the agent should be able to inspect it. If the result matters in the browser, verification should happen in the browser.
+
+[Try Frontman](https://frontman.sh/#install) on your own frontend task and compare the loop yourself.

--- a/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
+++ b/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
@@ -15,7 +15,7 @@ faq:
     answer: 'Frontman is integrated into the running Astro dev server and browser preview. It already knew it was operating inside an Astro site, had access to the app structure through the integration, and could verify the banner visually through screenshots and browser-side JavaScript.'
 ---
 
-We recently ran a small internal case study: give the same real frontend task to three coding agents and compare what happened.
+We recently ran the same real frontend task through three coding agents and compared the traces afterward.
 
 The agents were:
 
@@ -23,13 +23,11 @@ The agents were:
 - **OpenCode**, running GPT-5.5 with medium thinking
 - **Claude Code**, running Claude Opus 4.7
 
-The task was deliberately mundane. No heroic refactor. No architecture rewrite. No contrived benchmark prompt. We wanted something that looked like real product work on our own marketing site.
+The task was intentionally ordinary: install a consent-banner package on our marketing site and make it work with the analytics code already there. We wanted normal product work, not a benchmark stunt.
 
 The task: integrate [`astro-consent`](https://github.com/velohost/astro-consent) into the Frontman marketing site, which already had Google Analytics configured.
 
-All three agents completed it. All three produced essentially the same first implementation. The difference was not code quality.
-
-The difference was how much work each agent needed to get there.
+All three agents completed it. The first implementation was essentially the same in each run. The traces differed in how much exploration and verification happened before completion.
 
 ## The Result
 
@@ -48,9 +46,7 @@ On this task, Frontman used:
 - **61% lower reported cost than OpenCode**
 - **75% lower reported cost than Claude Code**
 
-Treat the cost numbers carefully. Model pricing, cache accounting, provider routing, and model choice can all change. Claude Code also used a different model. The more durable signal is the request and token profile: Frontman needed fewer agent turns to reach the same outcome.
-
-That is the point of the case study.
+Treat the cost numbers carefully. Model pricing, cache accounting, provider routing, and model choice can all change. Claude Code also used a different model. The request and token counts are the safer comparison: Frontman needed fewer agent turns to reach the same outcome.
 
 ## The Task
 
@@ -70,21 +66,19 @@ The site already had Google Analytics. The agents needed to install and configur
 
 The user-visible behavior was simple: a new visitor should see a consent banner until they accept or reject it. After that choice, the banner should not keep appearing.
 
-## The Important Part: All Three Finished
+## All Three Finished
 
 This is not a dunk on OpenCode or Claude Code. Both completed the task. Claude Code was especially comprehensive and read broadly through the marketing app to understand the surrounding pages and conventions. OpenCode behaved similarly to Frontman once it had enough context.
 
-The first implementation quality was roughly the same across all three.
-
-That matters, because the honest conclusion is not:
+The first implementation quality was roughly the same across all three. We would not summarize the run as:
 
 > Frontman wrote better code.
 
-The honest conclusion is:
+The more accurate summary is:
 
 > Frontman reached and verified the same result with fewer agent turns because it started with more relevant runtime and framework context.
 
-For frontend work, that distinction is the product.
+For frontend work, a lot of the cost is not typing the final diff. It is finding the right part of the app, checking the visible result, and iterating without losing context.
 
 ## Why Frontman Needed Less Exploration
 
@@ -92,7 +86,7 @@ OpenCode and Claude Code had to discover the application from the filesystem. Th
 
 Frontman already had a running browser session attached to the marketing app. More importantly, the Frontman Astro integration is not a generic file browser. It is installed inside the Astro dev server.
 
-In this repo, the marketing site uses the Frontman Astro integration directly in `apps/marketing/astro.config.mjs`:
+In this repo, the marketing site uses the Frontman Astro integration directly in [`apps/marketing/astro.config.mjs`](https://github.com/frontman-ai/frontman/blob/main/apps/marketing/astro.config.mjs):
 
 ```js
 frontman({
@@ -103,11 +97,11 @@ frontman({
 })
 ```
 
-That gives the agent a much narrower starting point. It is not asking, "what is this repo?" It is operating inside a known Astro app with a live preview, framework tools, and browser tools already registered.
+The agent starts from a narrower state. It is not starting with "what is this repo?" It is already inside a known Astro app, with a live preview and the relevant tool set registered.
 
-The Astro integration itself is designed around that idea. It only activates in dev mode, installs middleware into Astro's Vite server, registers a Frontman dev toolbar app, captures source annotations, and exposes Astro-aware tools for routes and logs.
+The Astro integration only activates in dev mode. It installs middleware into Astro's Vite server, registers a Frontman dev toolbar app, captures source annotations, and exposes Astro-aware tools for routes and logs.
 
-From `libs/frontman-astro/src/FrontmanAstro__Integration.res`, the integration does several important things:
+From [`libs/frontman-astro/src/FrontmanAstro__Integration.res`](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-astro/src/FrontmanAstro__Integration.res), the integration does several important things:
 
 - Registers Frontman middleware before Astro page routing, so `/frontman` and tool routes work inside the dev server.
 - Injects annotation capture into page heads, so selected DOM elements can be associated with source context where Astro exposes it.
@@ -115,19 +109,19 @@ From `libs/frontman-astro/src/FrontmanAstro__Integration.res`, the integration d
 - Initializes log capture, so the agent can see dev-server output and post-edit errors.
 - Uses Astro's resolved routes hook on Astro 5 and newer for route discovery.
 
-That is what we mean by "deep integration." It is not only a chat box next to an iframe. The dev server, browser, and agent loop are wired together.
+In this task, that wiring saved discovery work. Frontman did not need to infer from scratch that `apps/marketing` was an Astro app or where the browser-visible result should be checked.
 
 ## Browser Verification Changed the Workflow
 
-The verification behavior differed too.
+Verification differed too.
 
 OpenCode ran `make build` and stopped. Claude Code did the same. That is a valid baseline for many code tasks: if the build passes, the integration probably compiles.
 
 Frontman also verified through the browser. It checked that the consent banner was visible, then interacted with the banner using browser-side JavaScript to confirm the buttons worked.
 
-That verification path exists because Frontman registers browser-side tools in the client, including screenshots and JavaScript execution against the live preview iframe.
+Frontman can do that because it registers browser-side tools in the client, including screenshots and JavaScript execution against the live preview iframe.
 
-The relevant tools are not abstract. In `libs/client/src/Client__ToolRegistry.res`, Frontman registers browser tools such as:
+In [`libs/client/src/Client__ToolRegistry.res`](https://github.com/frontman-ai/frontman/blob/main/libs/client/src/Client__ToolRegistry.res), Frontman registers browser tools such as:
 
 - `take_screenshot`
 - `execute_js`
@@ -138,21 +132,19 @@ The relevant tools are not abstract. In `libs/client/src/Client__ToolRegistry.re
 - `search_text`
 - `question`
 
-For this task, the browser-specific value was straightforward: the acceptance criterion was not only "Astro builds." The acceptance criterion was "a new user sees a banner, can accept or reject it, and does not keep seeing it after making a choice."
+For this task, `make build` was necessary but incomplete. The visible behavior mattered: a new user sees the banner, can accept or reject it, and does not keep seeing it after making a choice. Frontman checked the first two pieces in the browser instead of stopping at compile success.
 
-A build can tell you the first half only indirectly. A browser can tell you directly.
+## Where the Extra Turns Went
 
-## Why This Matters for Iteration
-
-The first implementation is only part of frontend work. The expensive part is often the loop after the implementation:
+The first implementation is only part of frontend work. The slow part is often the loop after the code compiles:
 
 ```text
 try it -> look at it -> notice something off -> adjust -> verify again
 ```
 
-We did not formally measure that second phase in this case study, so we are not including it in the table. But qualitatively, the same pattern held. Minor banner adjustments were faster in Frontman because the agent could operate from the rendered page and immediately verify the change in the browser.
+We did not formally measure that second phase, so it is not in the table. During follow-up banner tweaks, though, the workflow difference was obvious: Frontman could look at the rendered banner and act on it directly. The other tools needed the operator to translate the visible issue back into file-oriented instructions.
 
-That is where browser-aware agents become interesting. The advantage is not that they are smarter. It is that they remove a pile of translation work.
+That is a smaller claim than "browser agents are better," and it fits the data better.
 
 Without browser context, the user or the agent has to translate visual state into filesystem instructions:
 
@@ -160,17 +152,15 @@ Without browser context, the user or the agent has to translate visual state int
 The banner is on the marketing site. It is Astro. The analytics script is over here. The config is over there. The consent package should wrap this. The banner should appear on first visit. Now run the build.
 ```
 
-With Frontman, some of that context is already part of the harness. The agent starts closer to the task.
+With Frontman, some of that context is already present before the first model call. The agent starts closer to the part of the problem that actually changed.
 
-## The Architecture Claim
+## What the Architecture Bought Us
 
-The result supports a specific architectural claim:
+The useful claim from this run is narrow: runtime and framework context reduced wasted turns.
 
-> Runtime and framework context are efficiency features.
+They did not make the model write a better consent integration. They reduced how much of the conversation was spent locating the app, understanding the framework setup, and checking whether the browser behavior matched the request.
 
-They do not magically make the model more intelligent. They reduce the amount of exploration, prompting, and verification the model has to spend tokens on.
-
-This is especially visible in frontend work because the source code is not the only source of truth. The rendered DOM, computed CSS, viewport, local storage, cookies, client-side state, dev-server logs, and route table all matter.
+Frontend tasks expose this quickly because the source code is not the only source of truth. The rendered DOM, computed CSS, viewport, local storage, cookies, client-side state, dev-server logs, and route table all matter.
 
 Frontman connects those surfaces through the browser and framework integration:
 
@@ -185,15 +175,13 @@ Frontman server
   -> agent loop, provider calls, tool routing, persisted task history
 ```
 
-That architecture is more setup than a pure terminal agent. It is also less general. Frontman is not the tool we would choose for a deep backend refactor, a large migration, or a task where visual/runtime feedback does not matter.
+This architecture costs more setup than a pure terminal agent and it is less general. Frontman is not the tool we would choose for a deep backend refactor, a large migration, or a task where visual/runtime feedback does not matter.
 
-But for a frontend task whose correctness is visible in the browser, the integration pays for itself.
+For this task, though, the extra wiring removed work that the other agents had to do through exploration.
 
-## Caveats
+## What This Does Not Prove
 
-This was a case study, not a scientific benchmark.
-
-The caveats are real:
+This was a case study, not a scientific benchmark:
 
 - It was one task on one repo.
 - The repo was Frontman's own marketing app, which means the setup naturally favored Frontman's harness.
@@ -203,18 +191,14 @@ The caveats are real:
 - OpenCode had browser tooling available but did not use it during this run.
 - Browser context matters much less for backend work, pure refactors, or tasks where build/test output is the main source of truth.
 
-Those caveats do not make the result meaningless. They make the conclusion narrower and more useful.
+We would call it evidence for one narrow thing: on a real frontend integration task, browser and framework context reduced the number of agent turns needed to reach and verify the same result.
 
-This case study does not prove that Frontman is universally better than OpenCode or Claude Code. It shows that, for a real visual/frontend integration task, deep browser and framework integration reduced the number of agent turns needed to reach and verify the same result.
+## What We Took From The Run
 
-## The Takeaway
+The result changed how we talk about Frontman internally. We should not claim that browser context automatically produces better code. This run did not show that.
 
-The interesting result is not that Frontman completed the task. So did the other agents.
+It showed something more practical: when the task depends on a running frontend, the agent wastes fewer turns if the running frontend is part of its normal working environment.
 
-The interesting result is that Frontman completed it with fewer requests, fewer tokens, and browser-level verification built into the workflow.
-
-That is what we are building Frontman around: not a bigger model, not a new prompting trick, but a better execution environment for frontend work.
-
-If the task is visual, the agent should be able to see it. If the app is running, the agent should be able to inspect it. If the result matters in the browser, verification should happen in the browser.
+The model still matters. The prompt still matters. For frontend work, this run suggests the environment around the model matters too.
 
 [Try Frontman](https://frontman.sh/#install) on your own frontend task and compare the loop yourself.

--- a/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
+++ b/apps/marketing/src/content/blog/frontman-vs-opencode-claude-code-case-study.md
@@ -1,5 +1,5 @@
 ---
-title: 'What Happened When We Ran the Same Frontend Task in Frontman, OpenCode, and Claude Code'
+title: 'Frontman vs OpenCode vs Claude Code: AI Coding Agent Case Study'
 pubDate: 2026-05-05T05:00:00Z
 description: 'A single-task case study comparing Frontman, OpenCode, and Claude Code on the same Astro consent-banner integration. Same final code quality, very different iteration and token profiles.'
 author: 'Danni Fridland'

--- a/apps/marketing/src/layouts/PostLayout.astro
+++ b/apps/marketing/src/layouts/PostLayout.astro
@@ -148,6 +148,113 @@ const videoJsonLd = frontmatter.video
 		@apply mx-auto max-w-3xl px-6 py-12 lg:py-24;
 	}
 
+	.post-body :global(table) {
+		@apply block max-w-full overflow-x-auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.post-body :global(.metric-comparison) {
+		margin: 32px 0;
+		padding: 22px;
+		border: 1px solid #27272a;
+		border-radius: 24px;
+		background: linear-gradient(180deg, rgba(39, 39, 42, 0.5), rgba(24, 24, 27, 0.35));
+		display: grid;
+		gap: 22px;
+	}
+	.post-body :global(.metric-comparison__header) {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 16px;
+		padding-bottom: 18px;
+		border-bottom: 1px solid rgba(63, 63, 70, 0.72);
+	}
+	.post-body :global(.metric-comparison__title) {
+		margin: 0;
+		color: #fafafa;
+		font-size: 20px;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+	}
+	.post-body :global(.metric-comparison__note) {
+		margin: 6px 0 0;
+		color: #a1a1aa;
+		font-size: 13px;
+		line-height: 1.5;
+	}
+	.post-body :global(.metric-comparison__winner-key) {
+		flex: 0 0 auto;
+		border: 1px solid rgba(16, 185, 129, 0.35);
+		border-radius: 999px;
+		padding: 6px 10px;
+		background: rgba(16, 185, 129, 0.12);
+		color: #6ee7b7;
+		font-size: 12px;
+		font-weight: 700;
+	}
+	.post-body :global(.metric-comparison__grid) {
+		display: grid;
+		gap: 18px;
+	}
+	.post-body :global(.metric-comparison__category) {
+		display: grid;
+		gap: 12px;
+	}
+	.post-body :global(.metric-comparison__category-title) {
+		margin: 0;
+		color: #fafafa;
+		font-size: 15px;
+		font-weight: 800;
+		letter-spacing: -0.01em;
+	}
+	.post-body :global(.metric-comparison__agents) {
+		display: grid;
+		gap: 10px;
+	}
+	.post-body :global(.metric-comparison__agent) {
+		--bar-width: 0%;
+		--bar-color: rgba(113, 113, 122, 0.38);
+		position: relative;
+		isolation: isolate;
+		overflow: hidden;
+		padding: 12px 14px;
+		border: 1px solid rgba(63, 63, 70, 0.75);
+		border-radius: 14px;
+		background: rgba(9, 9, 11, 0.72);
+		display: grid;
+		grid-template-columns: minmax(120px, 1fr) auto;
+		align-items: center;
+		gap: 12px;
+	}
+	.post-body :global(.metric-comparison__agent::before) {
+		content: "";
+		position: absolute;
+		inset: 0 auto 0 0;
+		z-index: -1;
+		width: var(--bar-width);
+		background: linear-gradient(90deg, var(--bar-color), transparent);
+	}
+	.post-body :global(.metric-comparison__agent--winner) {
+		--bar-color: rgba(16, 185, 129, 0.42);
+		border-color: rgba(16, 185, 129, 0.5);
+		box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.12) inset;
+	}
+	.post-body :global(.metric-comparison__agent-name) {
+		color: #e4e4e7;
+		font-size: 14px;
+		font-weight: 700;
+	}
+	.post-body :global(.metric-comparison__agent--winner .metric-comparison__agent-name) {
+		color: #6ee7b7;
+	}
+	.post-body :global(.metric-comparison__agent-value) {
+		color: #fafafa;
+		font-size: 15px;
+		font-weight: 800;
+		font-variant-numeric: tabular-nums;
+	}
+
 	.post-faq {
 		background: #09090b;
 		color: #fafafa;
@@ -217,12 +324,111 @@ const videoJsonLd = frontmatter.video
 	}
 
 	@media (max-width: 768px) {
+		.post-body :global(.metric-comparison) {
+			padding: 16px;
+			border-radius: 20px;
+		}
+		.post-body :global(.metric-comparison__header) {
+			flex-direction: column;
+		}
+		.post-body :global(.metric-comparison__winner-key) {
+			align-self: flex-start;
+		}
+		.post-body :global(.metric-comparison__agent) {
+			grid-template-columns: 1fr;
+			gap: 6px;
+		}
+		.post-body :global(.metric-comparison__agent-value) {
+			font-size: 17px;
+		}
 		.post-faq { padding: 40px 20px; }
 		.post-faq__title { font-size: 24px; }
 	}
 </style>
 
 <script>
+	function initMetricComparisons() {
+		document.querySelectorAll<HTMLUListElement>('.post-body ul').forEach((list) => {
+			const items = Array.from(list.querySelectorAll<HTMLLIElement>(':scope > li'));
+			const isMetricSummaryList = items.length > 0 && items.every((item) => {
+				const text = item.textContent ?? '';
+				return /^\s*\d+%/.test(text) && /\b(fewer|lower)\b/i.test(text);
+			});
+			if (!isMetricSummaryList || list.dataset.metricComparisonRendered === 'true') return;
+
+			const table = list.previousElementSibling?.matches('table')
+				? list.previousElementSibling as HTMLTableElement
+				: list.parentElement?.querySelector<HTMLTableElement>('table');
+			if (!table) return;
+
+			const rows = Array.from(table.querySelectorAll<HTMLTableRowElement>('tbody tr')).map((row) => {
+				const cells = Array.from(row.querySelectorAll<HTMLTableCellElement>('td')).map((cell) => cell.textContent?.trim() ?? '');
+				return {
+					agent: cells[0],
+					requests: Number(cells[1]?.replace(/,/g, '')),
+					totalTokens: Number(cells[5]?.replace(/,/g, '')),
+					cost: Number(cells[8]?.replace(/[$,]/g, '')),
+					costLabel: cells[8],
+				};
+			}).filter((row) => row.agent && Number.isFinite(row.requests) && Number.isFinite(row.totalTokens) && Number.isFinite(row.cost));
+			if (rows.length === 0) return;
+
+			const categories = [
+				{ title: 'Number of requests', key: 'requests', format: (value: number) => value.toLocaleString() },
+				{ title: 'Total tokens', key: 'totalTokens', format: (value: number) => value.toLocaleString() },
+				{ title: 'Cost', key: 'cost', format: (_value: number, row: typeof rows[number]) => row.costLabel },
+			] as const;
+
+			const card = document.createElement('section');
+			card.className = 'metric-comparison';
+			card.setAttribute('aria-label', 'Agent efficiency comparison');
+			card.innerHTML = `
+				<div class="metric-comparison__header">
+					<div>
+						<h3 class="metric-comparison__title">Efficiency comparison</h3>
+						<p class="metric-comparison__note">Lower is better. Each category shows Frontman, OpenCode, and Claude Code side by side.</p>
+					</div>
+					<span class="metric-comparison__winner-key">Winner highlighted</span>
+				</div>
+				<div class="metric-comparison__grid"></div>
+			`;
+
+			const grid = card.querySelector<HTMLDivElement>('.metric-comparison__grid');
+			if (!grid) return;
+
+			categories.forEach((category) => {
+				const values = rows.map((row) => row[category.key]);
+				const minValue = Math.min(...values);
+				const maxValue = Math.max(...values);
+				const section = document.createElement('section');
+				section.className = 'metric-comparison__category';
+				section.innerHTML = `<h4 class="metric-comparison__category-title">${category.title}</h4>`;
+
+				const agents = document.createElement('div');
+				agents.className = 'metric-comparison__agents';
+				rows.forEach((row) => {
+					const value = row[category.key];
+					const barWidth = maxValue > 0 ? Math.max(8, (value / maxValue) * 100) : 0;
+					const isWinner = value === minValue;
+					const agent = document.createElement('div');
+					agent.className = `metric-comparison__agent${isWinner ? ' metric-comparison__agent--winner' : ''}`;
+					agent.style.setProperty('--bar-width', `${barWidth}%`);
+					agent.innerHTML = `
+						<span class="metric-comparison__agent-name">${row.agent}</span>
+						<span class="metric-comparison__agent-value">${category.format(value, row)}</span>
+					`;
+					agents.appendChild(agent);
+				});
+
+				section.appendChild(agents);
+				grid.appendChild(section);
+			});
+
+			list.dataset.metricComparisonRendered = 'true';
+			list.replaceWith(card);
+		});
+	}
+
 	function initCodeCopyButtons() {
 		document.querySelectorAll<HTMLPreElement>('pre.astro-code').forEach((pre) => {
 			if (pre.querySelector('.code-copy-btn')) return;
@@ -249,6 +455,10 @@ const videoJsonLd = frontmatter.video
 		});
 	}
 
+	initMetricComparisons();
 	initCodeCopyButtons();
-	document.addEventListener('astro:after-swap', initCodeCopyButtons);
+	document.addEventListener('astro:after-swap', () => {
+		initMetricComparisons();
+		initCodeCopyButtons();
+	});
 </script>


### PR DESCRIPTION
## Summary
- Adds a Frontman vs OpenCode vs Claude Code case-study blog post for the marketing site
- Frames the result around request/token efficiency and browser verification rather than implementation quality
- Includes caveats for the single-task methodology and links to relevant Frontman source files

## Verification
- `make build` from `apps/marketing`

## Notes
- There are unrelated uncommitted local changes in `apps/marketing/src/layouts/PostLayout.astro`, `pricing.md`, and `scripts/calc-openrouter-tokens.js`; they were not included in this PR.