### PR TITLE
chore: make npm publish retries idempotent

### DIFF
--- a/libs/frontman-astro/Makefile
+++ b/libs/frontman-astro/Makefile
@@ -10,8 +10,8 @@ build: ## Build ReScript + bundle with tsup
 publish: build ## Build and publish to npm (pass OTP=<code> for 2FA)
 	@PKG=$$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
 	if npm view "$$PKG" version >/dev/null 2>&1; then \
-		echo "Error: $$PKG already published — bump the version first"; \
-		exit 1; \
+		echo "Skipping $$PKG — already published"; \
+		exit 0; \
 	fi; \
 	npm publish $(if $(OTP),--otp=$(OTP))
 

--- a/libs/frontman-nextjs/Makefile
+++ b/libs/frontman-nextjs/Makefile
@@ -10,8 +10,8 @@ build: ## Build ReScript + bundle
 publish: build ## Build and publish to npm (pass OTP=<code> for 2FA)
 	@PKG=$$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
 	if npm view "$$PKG" version >/dev/null 2>&1; then \
-		echo "Error: $$PKG already published — bump the version first"; \
-		exit 1; \
+		echo "Skipping $$PKG — already published"; \
+		exit 0; \
 	fi; \
 	npm publish $(if $(OTP),--otp=$(OTP))
 

--- a/libs/frontman-vite/Makefile
+++ b/libs/frontman-vite/Makefile
@@ -10,8 +10,8 @@ build: ## Build ReScript + bundle with tsup
 publish: build ## Build and publish to npm (pass OTP=<code> for 2FA)
 	@PKG=$$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
 	if npm view "$$PKG" version >/dev/null 2>&1; then \
-		echo "Error: $$PKG already published — bump the version first"; \
-		exit 1; \
+		echo "Skipping $$PKG — already published"; \
+		exit 0; \
 	fi; \
 	npm publish $(if $(OTP),--otp=$(OTP))
 

--- a/libs/react-statestore/Makefile
+++ b/libs/react-statestore/Makefile
@@ -36,7 +36,7 @@ check: lint test ## Run all checks (lint + test)
 publish: build ## Build and publish to npm (pass OTP=<code> for 2FA)
 	@PKG=$$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
 	if npm view "$$PKG" version >/dev/null 2>&1; then \
-		echo "Error: $$PKG already published — bump the version first"; \
-		exit 1; \
+		echo "Skipping $$PKG — already published"; \
+		exit 0; \
 	fi; \
 	npm publish $(if $(OTP),--otp=$(OTP))


### PR DESCRIPTION
## Summary
- Skip npm publish when the exact package version already exists on npm
- Allow partial release retries to continue across Astro, Vite, Next.js, and react-statestore packages

## Validation
- Ran `make publish` locally after versions were already published; all four packages built and skipped successfully