### PR TITLE
Fix title generation overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- Keep generated task titles stable after the first user prompt instead of regenerating them on every prompt.
+
 ## [0.17.0] - 2026-05-12
 
 

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -41,6 +41,8 @@ defmodule FrontmanServer.Tasks do
       {MessageOptimizer, []}
     ]
 
+  import Ecto.Query, only: [where: 3]
+
   alias FrontmanServer.Accounts
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
@@ -146,11 +148,15 @@ defmodule FrontmanServer.Tasks do
           :ok | {:error, :not_found | Ecto.Changeset.t()}
   def set_generated_title(scope, task_id, title) do
     with {:ok, schema} <- get_task_by_id(scope, task_id),
+         true <- generated_title_missing?(schema),
          {:ok, _updated} <-
            schema
            |> TaskSchema.update_changeset(%{short_desc: title})
            |> Repo.update() do
       broadcast_task(task_id, {:title_updated, task_id, title})
+    else
+      false -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -456,12 +462,32 @@ defmodule FrontmanServer.Tasks do
   Enqueues an Oban job to generate a title for a task from the user's prompt.
   """
   @spec enqueue_title_generation(Accounts.scope(), String.t(), String.t(), keyword()) ::
-          {:ok, Oban.Job.t()} | {:error, Oban.Job.changeset()}
+          :ok | {:error, :not_found | Oban.Job.changeset()}
   def enqueue_title_generation(scope, task_id, user_prompt_text, opts \\ []) do
     model = opts |> Keyword.get(:model) |> Providers.resolve_model_string()
 
-    GenerateTitle.new_job(scope, task_id, user_prompt_text, model)
-    |> Oban.insert()
+    with {:ok, schema} <- get_task_by_id(scope, task_id),
+         true <- generated_title_missing?(schema),
+         true <- first_user_message?(task_id),
+         {:ok, _job} <-
+           GenerateTitle.new_job(scope, task_id, user_prompt_text, model) |> Oban.insert() do
+      :ok
+    else
+      false -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp first_user_message?(task_id) do
+    InteractionSchema
+    |> InteractionSchema.for_task(task_id)
+    |> where([interaction], interaction.type == "user_message")
+    |> Repo.aggregate(:count, :id)
+    |> Kernel.==(1)
+  end
+
+  defp generated_title_missing?(%TaskSchema{id: task_id, short_desc: short_desc}) do
+    short_desc == Task.short_description(task_id)
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -41,8 +41,6 @@ defmodule FrontmanServer.Tasks do
       {MessageOptimizer, []}
     ]
 
-  import Ecto.Query, only: [where: 3]
-
   alias FrontmanServer.Accounts
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
@@ -148,7 +146,7 @@ defmodule FrontmanServer.Tasks do
           :ok | {:error, :not_found | Ecto.Changeset.t()}
   def set_generated_title(scope, task_id, title) do
     with {:ok, schema} <- get_task_by_id(scope, task_id),
-         true <- generated_title_missing?(schema),
+         true <- schema.short_desc == Task.short_description(task_id),
          {:ok, _updated} <-
            schema
            |> TaskSchema.update_changeset(%{short_desc: title})
@@ -462,32 +460,12 @@ defmodule FrontmanServer.Tasks do
   Enqueues an Oban job to generate a title for a task from the user's prompt.
   """
   @spec enqueue_title_generation(Accounts.scope(), String.t(), String.t(), keyword()) ::
-          :ok | {:error, :not_found | Oban.Job.changeset()}
+          {:ok, Oban.Job.t()} | {:error, Oban.Job.changeset()}
   def enqueue_title_generation(scope, task_id, user_prompt_text, opts \\ []) do
     model = opts |> Keyword.get(:model) |> Providers.resolve_model_string()
 
-    with {:ok, schema} <- get_task_by_id(scope, task_id),
-         true <- generated_title_missing?(schema),
-         true <- first_user_message?(task_id),
-         {:ok, _job} <-
-           GenerateTitle.new_job(scope, task_id, user_prompt_text, model) |> Oban.insert() do
-      :ok
-    else
-      false -> :ok
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp first_user_message?(task_id) do
-    InteractionSchema
-    |> InteractionSchema.for_task(task_id)
-    |> where([interaction], interaction.type == "user_message")
-    |> Repo.aggregate(:count, :id)
-    |> Kernel.==(1)
-  end
-
-  defp generated_title_missing?(%TaskSchema{id: task_id, short_desc: short_desc}) do
-    short_desc == Task.short_description(task_id)
+    GenerateTitle.new_job(scope, task_id, user_prompt_text, model)
+    |> Oban.insert()
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -145,15 +145,16 @@ defmodule FrontmanServer.Tasks do
   @spec set_generated_title(Accounts.scope(), String.t(), String.t()) ::
           :ok | {:error, :not_found | Ecto.Changeset.t()}
   def set_generated_title(scope, task_id, title) do
-    with {:ok, schema} <- get_task_by_id(scope, task_id),
-         true <- schema.short_desc == Task.short_description(task_id),
+    default_title = Task.short_description(task_id)
+
+    with {:ok, %TaskSchema{short_desc: ^default_title} = schema} <- get_task_by_id(scope, task_id),
          {:ok, _updated} <-
            schema
            |> TaskSchema.update_changeset(%{short_desc: title})
            |> Repo.update() do
       broadcast_task(task_id, {:title_updated, task_id, title})
     else
-      false -> :ok
+      {:ok, %TaskSchema{}} -> :ok
       {:error, reason} -> {:error, reason}
     end
   end

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -19,7 +19,7 @@ defmodule FrontmanServer.Workers.GenerateTitle do
     unique: [
       keys: [:task_id],
       period: :infinity,
-      states: [:available, :scheduled, :executing, :retryable]
+      states: [:available, :scheduled, :executing, :retryable, :completed]
     ]
 
   require Logger

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -314,7 +314,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive {:interaction, %Interaction.AgentCompleted{}}, 5_000
 
-      Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
+      :ok = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
 
       assert_enqueued(worker: GenerateTitle, args: %{task_id: task_id})
     end
@@ -329,20 +329,15 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Build me a login page"), [])
 
-      {:ok, first_job} =
-        Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
+      :ok = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
 
       assert_receive {:interaction, %Interaction.AgentCompleted{}}, 5_000
 
-      # Second message + title enqueue (should be deduplicated by Oban unique constraint)
+      # Second message should not enqueue a new title job.
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Now add a signup form"), [])
 
-      {:ok, second_job} =
-        Tasks.enqueue_title_generation(scope, task_id, "Now add a signup form")
-
-      # Oban unique constraint returns the existing job — same ID means no new job was inserted
-      assert first_job.id == second_job.id
+      :ok = Tasks.enqueue_title_generation(scope, task_id, "Now add a signup form")
 
       # Only one title generation job should exist for this task
       enqueued = all_enqueued(worker: GenerateTitle)

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -314,7 +314,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive {:interaction, %Interaction.AgentCompleted{}}, 5_000
 
-      :ok = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
+      {:ok, _job} = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
 
       assert_enqueued(worker: GenerateTitle, args: %{task_id: task_id})
     end
@@ -329,7 +329,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Build me a login page"), [])
 
-      :ok = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
+      {:ok, _job} = Tasks.enqueue_title_generation(scope, task_id, "Build me a login page")
 
       assert_receive {:interaction, %Interaction.AgentCompleted{}}, 5_000
 
@@ -337,7 +337,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       {:ok, _} =
         Tasks.submit_user_message(scope, task_id, user_content("Now add a signup form"), [])
 
-      :ok = Tasks.enqueue_title_generation(scope, task_id, "Now add a signup form")
+      {:ok, _job} = Tasks.enqueue_title_generation(scope, task_id, "Now add a signup form")
 
       # Only one title generation job should exist for this task
       enqueued = all_enqueued(worker: GenerateTitle)

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -47,6 +47,15 @@ defmodule FrontmanServer.TasksTest do
       assert {:ok, "My Custom Title"} = Tasks.get_short_desc(scope, task_id)
     end
 
+    test "does not overwrite an existing generated title", %{scope: scope} do
+      task_id = task_fixture(scope)
+
+      :ok = Tasks.set_generated_title(scope, task_id, "First Title")
+      :ok = Tasks.set_generated_title(scope, task_id, "Second Title")
+
+      assert {:ok, "First Title"} = Tasks.get_short_desc(scope, task_id)
+    end
+
     test "returns not_found for non-existent task", %{scope: scope} do
       assert {:error, :not_found} = Tasks.get_short_desc(scope, Ecto.UUID.generate())
     end

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -4,9 +4,11 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
 
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
+  import Ecto.Query, only: [where: 3]
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers.Model
+  alias FrontmanServer.Repo
   alias FrontmanServer.Tasks
   alias FrontmanServer.Workers.GenerateTitle
 
@@ -56,10 +58,7 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
 
       task_id = task_fixture(scope)
 
-      {:ok, _message} =
-        Tasks.add_user_message(scope, task_id, user_content("Help me build a login page"))
-
-      :ok =
+      {:ok, _job} =
         Tasks.enqueue_title_generation(scope, task_id, "Help me build a login page",
           model: Model.new("openrouter", "openai/gpt-5.5")
         )
@@ -74,17 +73,19 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
       )
     end
 
-    test "does not enqueue after the first user message title is generated", %{user: user} do
+    test "completed title jobs remain unique", %{user: user} do
       scope = Scope.for_user(user)
-      task_id = task_fixture(scope)
+      task_id = Ecto.UUID.generate()
 
-      {:ok, _message} = Tasks.add_user_message(scope, task_id, user_content("Build a login page"))
-      :ok = Tasks.set_generated_title(scope, task_id, "Login Page")
-      {:ok, _message} = Tasks.add_user_message(scope, task_id, user_content("Now add signup"))
+      {:ok, first_job} = Tasks.enqueue_title_generation(scope, task_id, "Build a login page")
 
-      :ok = Tasks.enqueue_title_generation(scope, task_id, "Now add signup")
+      Oban.Job
+      |> where([job], job.id == ^first_job.id)
+      |> Repo.update_all(set: [state: "completed"])
 
-      refute_enqueued(worker: GenerateTitle, args: %{task_id: task_id})
+      {:ok, second_job} = Tasks.enqueue_title_generation(scope, task_id, "Now add signup")
+
+      assert first_job.id == second_job.id
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -56,7 +56,10 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
 
       task_id = task_fixture(scope)
 
-      {:ok, _job} =
+      {:ok, _message} =
+        Tasks.add_user_message(scope, task_id, user_content("Help me build a login page"))
+
+      :ok =
         Tasks.enqueue_title_generation(scope, task_id, "Help me build a login page",
           model: Model.new("openrouter", "openai/gpt-5.5")
         )
@@ -69,6 +72,19 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
           model: "openrouter:openai/gpt-5.5"
         }
       )
+    end
+
+    test "does not enqueue after the first user message title is generated", %{user: user} do
+      scope = Scope.for_user(user)
+      task_id = task_fixture(scope)
+
+      {:ok, _message} = Tasks.add_user_message(scope, task_id, user_content("Build a login page"))
+      :ok = Tasks.set_generated_title(scope, task_id, "Login Page")
+      {:ok, _message} = Tasks.add_user_message(scope, task_id, user_content("Now add signup"))
+
+      :ok = Tasks.enqueue_title_generation(scope, task_id, "Now add signup")
+
+      refute_enqueued(worker: GenerateTitle, args: %{task_id: task_id})
     end
   end
 end


### PR DESCRIPTION
## Summary
- Keep title generation jobs unique even after completion so later prompts do not create replacement title jobs.
- Make generated title persistence idempotent so stale jobs cannot overwrite an existing title.
- Add regressions for completed-job uniqueness and stable generated titles.

## Verification
- `mix format --check-formatted lib/frontman_server/tasks.ex lib/frontman_server/workers/generate_title.ex test/frontman_server/tasks/execution_test.exs test/frontman_server/tasks_test.exs test/frontman_server/workers/generate_title_test.exs`
- `mix test test/frontman_server/tasks_test.exs test/frontman_server/workers/generate_title_test.exs test/frontman_server/tasks/execution_test.exs`
- `mix test test/frontman_server_web/channels/task_channel_test.exs`