### PR TITLE
Support image URLs in web_fetch

### DIFF
--- a/.changeset/support-web-fetch-images.md
+++ b/.changeset/support-web-fetch-images.md
@@ -1,0 +1,4 @@
+---
+---
+
+Support public image URLs in web_fetch so fetched images can be passed to the LLM with source URL context.

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -61,6 +61,11 @@ config :frontman_server,
   # Test key for Cloak encryption (generated with :crypto.strong_rand_bytes(32) |> Base.encode64())
   cloak_key: "dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleTEyMzQ="
 
+config :frontman_server, :web_fetch_req_options,
+  plug: {Req.Test, :web_fetch},
+  retry_delay: fn _ -> 0 end,
+  retry_log_level: false
+
 # OpenTelemetry - disable in tests
 config :opentelemetry,
   span_processor: :simple,

--- a/apps/frontman_server/lib/frontman_server/image.ex
+++ b/apps/frontman_server/lib/frontman_server/image.ex
@@ -24,8 +24,15 @@ defmodule FrontmanServer.Image do
   # Tools whose results contain base64-encoded images.
   # {image_field, extra_text_fields} per canonical tool name (without mcp_ prefix).
   @image_tool_configs %{
-    "take_screenshot" => {:screenshot, []}
+    "take_screenshot" => {:screenshot, []},
+    "web_fetch" => {:image, [:url, :content_type]}
   }
+
+  @type decoded_tool_image :: %{
+          required(:data) => binary(),
+          required(:media_type) => String.t(),
+          required(:context) => String.t() | nil
+        }
 
   # ── Public API ──────────────────────────────────────────────────────
 
@@ -48,6 +55,29 @@ defmodule FrontmanServer.Image do
   def image_tool_config(tool_name) when is_binary(tool_name) do
     canonical = String.replace_prefix(tool_name, "mcp_", "")
     Map.get(@image_tool_configs, canonical)
+  end
+
+  @doc """
+  Decodes a configured tool image result into runtime LLM image input data.
+
+  The returned binary payload is for constructing LLM content parts only. Do
+  not persist it; persisted interactions should keep the original JSON-safe
+  tool result with its base64 data URL.
+  """
+  @spec decode_tool_image_for_llm(String.t(), map()) :: {:ok, decoded_tool_image()} | :no_image
+  def decode_tool_image_for_llm(tool_name, result) when is_binary(tool_name) and is_map(result) do
+    with {image_field, context_fields} <- image_tool_config(tool_name),
+         data_url when is_binary(data_url) <- get_configured_field(result, image_field),
+         {:ok, data, media_type} <- decode_data_url(data_url) do
+      {:ok,
+       %{
+         data: data,
+         media_type: media_type,
+         context: build_context(result, context_fields)
+       }}
+    else
+      _ -> :no_image
+    end
   end
 
   @doc """
@@ -143,6 +173,30 @@ defmodule FrontmanServer.Image do
   def parse_dimensions(_), do: :unknown
 
   # ── Private ─────────────────────────────────────────────────────────
+
+  defp build_context(result, fields) do
+    fields
+    |> Enum.flat_map(fn field ->
+      case get_configured_field(result, field) do
+        nil -> []
+        value -> ["#{field}: #{encode_context_value(value)}"]
+      end
+    end)
+    |> case do
+      [] -> nil
+      parts -> Enum.join(parts, "\n\n")
+    end
+  end
+
+  defp get_configured_field(map, field) when is_atom(field) do
+    case Map.fetch(map, Atom.to_string(field)) do
+      {:ok, value} -> value
+      :error -> Map.get(map, field)
+    end
+  end
+
+  defp encode_context_value(value) when is_binary(value), do: value
+  defp encode_context_value(value), do: Jason.encode!(value)
 
   # Scan JPEG markers looking for any SOFn (Start of Frame) marker.
   # SOFn markers are 0xFFC0-0xFFCF except 0xFFC4 (DHT), 0xFFC8 (JPG extension),

--- a/apps/frontman_server/lib/frontman_server/image.ex
+++ b/apps/frontman_server/lib/frontman_server/image.ex
@@ -21,64 +21,30 @@ defmodule FrontmanServer.Image do
   # Other providers (OpenAI, OpenRouter, Google) auto-resize.
   @max_dimension 7680
 
-  # Tools whose results contain base64-encoded images.
-  # {image_field, extra_text_fields} per canonical tool name (without mcp_ prefix).
-  @image_tool_configs %{
-    "take_screenshot" => {:screenshot, []},
-    "web_fetch" => {:image, [:url, :content_type]}
-  }
-
   @type decoded_tool_image :: %{
           required(:data) => binary(),
-          required(:media_type) => String.t(),
-          required(:context) => String.t() | nil
+          required(:media_type) => String.t()
         }
 
   # ── Public API ──────────────────────────────────────────────────────
 
   @doc """
-  Returns the image extraction config for a tool, or `nil` if the tool
-  does not produce images.
-
-  The canonical name is used (the `mcp_` prefix is stripped automatically).
-
-      iex> FrontmanServer.Image.image_tool_config("take_screenshot")
-      {:screenshot, []}
-
-      iex> FrontmanServer.Image.image_tool_config("mcp_take_screenshot")
-      {:screenshot, []}
-
-      iex> FrontmanServer.Image.image_tool_config("read_file")
-      nil
-  """
-  @spec image_tool_config(String.t()) :: {atom(), [atom()]} | nil
-  def image_tool_config(tool_name) when is_binary(tool_name) do
-    canonical = String.replace_prefix(tool_name, "mcp_", "")
-    Map.get(@image_tool_configs, canonical)
-  end
-
-  @doc """
-  Decodes a configured tool image result into runtime LLM image input data.
+  Decodes image-producing tool results into runtime LLM image input data.
 
   The returned binary payload is for constructing LLM content parts only. Do
   not persist it; persisted interactions should keep the original JSON-safe
   tool result with its base64 data URL.
   """
   @spec decode_tool_image_for_llm(String.t(), map()) :: {:ok, decoded_tool_image()} | :no_image
-  def decode_tool_image_for_llm(tool_name, result) when is_binary(tool_name) and is_map(result) do
-    with {image_field, context_fields} <- image_tool_config(tool_name),
-         data_url when is_binary(data_url) <- get_configured_field(result, image_field),
-         {:ok, data, media_type} <- decode_data_url(data_url) do
-      {:ok,
-       %{
-         data: data,
-         media_type: media_type,
-         context: build_context(result, context_fields)
-       }}
-    else
-      _ -> :no_image
-    end
-  end
+  def decode_tool_image_for_llm("take_screenshot", %{"screenshot" => data_url})
+      when is_binary(data_url),
+      do: decode_tool_data_url(data_url)
+
+  def decode_tool_image_for_llm("web_fetch", %{"image" => data_url})
+      when is_binary(data_url),
+      do: decode_tool_data_url(data_url)
+
+  def decode_tool_image_for_llm(_tool_name, _result), do: :no_image
 
   @doc """
   Checks whether a binary image exceeds a dimension limit on either axis.
@@ -174,29 +140,12 @@ defmodule FrontmanServer.Image do
 
   # ── Private ─────────────────────────────────────────────────────────
 
-  defp build_context(result, fields) do
-    fields
-    |> Enum.flat_map(fn field ->
-      case get_configured_field(result, field) do
-        nil -> []
-        value -> ["#{field}: #{encode_context_value(value)}"]
-      end
-    end)
-    |> case do
-      [] -> nil
-      parts -> Enum.join(parts, "\n\n")
+  defp decode_tool_data_url(data_url) do
+    case decode_data_url(data_url) do
+      {:ok, data, media_type} -> {:ok, %{data: data, media_type: media_type}}
+      :error -> :no_image
     end
   end
-
-  defp get_configured_field(map, field) when is_atom(field) do
-    case Map.fetch(map, Atom.to_string(field)) do
-      {:ok, value} -> value
-      :error -> Map.get(map, field)
-    end
-  end
-
-  defp encode_context_value(value) when is_binary(value), do: value
-  defp encode_context_value(value), do: Jason.encode!(value)
 
   # Scan JPEG markers looking for any SOFn (Start of Frame) marker.
   # SOFn markers are 0xFFC0-0xFFCF except 0xFFC4 (DHT), 0xFFC8 (JPG extension),

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -416,18 +416,11 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   defp extract_image_content(tool_name, json_string) do
     with {:ok, decoded} when is_map(decoded) <- Jason.decode(json_string),
-         {:ok, image} <- Image.decode_tool_image_for_llm(tool_name, decoded) do
-      {:ok, swarm_content_parts(image)}
+         {:ok, %{data: data, media_type: media_type}} <-
+           Image.decode_tool_image_for_llm(tool_name, decoded) do
+      {:ok, [ContentPart.image(data, media_type)]}
     else
       _ -> :no_image
     end
-  end
-
-  defp swarm_content_parts(%{data: data, media_type: media_type, context: nil}) do
-    [ContentPart.image(data, media_type)]
-  end
-
-  defp swarm_content_parts(%{data: data, media_type: media_type, context: context}) do
-    [ContentPart.text(context), ContentPart.image(data, media_type)]
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -406,33 +406,28 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   # content parts. This mirrors the same extraction logic in Interaction.to_llm_message.
 
   defp maybe_enrich_with_images(tool_name, {:ok, content} = result) when is_binary(content) do
-    case Image.image_tool_config(tool_name) do
-      nil ->
-        result
-
-      {image_field, _text_fields} ->
-        case extract_image_content(content, image_field) do
-          {:ok, content_parts} -> {:ok, content_parts}
-          :no_image -> result
-        end
+    case extract_image_content(tool_name, content) do
+      {:ok, content_parts} -> {:ok, content_parts}
+      :no_image -> result
     end
   end
 
   defp maybe_enrich_with_images(_tool_name, result), do: result
 
-  defp extract_image_content(json_string, image_field) do
-    field_name = Atom.to_string(image_field)
-
+  defp extract_image_content(tool_name, json_string) do
     with {:ok, decoded} when is_map(decoded) <- Jason.decode(json_string),
-         data_url when is_binary(data_url) <- Map.get(decoded, field_name),
-         {:ok, binary, mime} <- Image.decode_data_url(data_url) do
-      {:ok, [ContentPart.image(binary, mime)]}
+         {:ok, image} <- Image.decode_tool_image_for_llm(tool_name, decoded) do
+      {:ok, swarm_content_parts(image)}
     else
-      {:error, _json_error} -> :no_image
-      {:ok, _not_a_map} -> :no_image
-      nil -> :no_image
-      # Image field present but not a string (e.g. integer, list).
-      _non_string_field -> :no_image
+      _ -> :no_image
     end
+  end
+
+  defp swarm_content_parts(%{data: data, media_type: media_type, context: nil}) do
+    [ContentPart.image(data, media_type)]
+  end
+
+  defp swarm_content_parts(%{data: data, media_type: media_type, context: context}) do
+    [ContentPart.text(context), ContentPart.image(data, media_type)]
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -1272,11 +1272,11 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defp to_llm_message(%ToolResult{tool_name: name, tool_call_id: id, result: result}) do
     # Check if this tool result contains an image that should be sent as image content
-    case extract_image_from_result(name, result) do
-      {image_binary, mime_type, text_content} ->
-        build_tool_message_with_image(name, id, image_binary, mime_type, text_content)
+    case decode_tool_result_image(name, result) do
+      {:ok, image} ->
+        build_tool_message_with_image(name, id, image)
 
-      nil ->
+      :no_image ->
         json_result = if is_binary(result), do: result, else: Jason.encode!(result)
         ReqLLM.Context.tool_result_message(name, id, json_result)
     end
@@ -1566,55 +1566,26 @@ defmodule FrontmanServer.Tasks.Interaction do
     end
   end
 
-  defp extract_image_from_result(tool_name, result) when is_map(result) do
-    with {image_field, text_fields} <- Image.image_tool_config(tool_name),
-         data_url when is_binary(data_url) <- get_field(result, image_field),
-         {:ok, binary, mime} <- Image.decode_data_url(data_url) do
-      text_content = build_text_content(result, text_fields)
-      {binary, mime, text_content}
-    else
-      _ -> nil
-    end
-  end
+  defp decode_tool_result_image(tool_name, result) when is_map(result),
+    do: Image.decode_tool_image_for_llm(tool_name, result)
 
-  defp extract_image_from_result(_tool_name, _result), do: nil
+  defp decode_tool_result_image(_tool_name, _result), do: :no_image
 
-  defp build_tool_message_with_image(name, id, image_binary, mime_type, text_content) do
+  defp build_tool_message_with_image(name, id, %{data: data, media_type: media_type} = image) do
     content =
-      case text_content do
-        "" ->
-          [ContentPart.image(image_binary, mime_type)]
+      case image.context do
+        nil ->
+          [ContentPart.image(data, media_type)]
 
-        text ->
+        context ->
           [
-            ContentPart.text(text),
-            ContentPart.image(image_binary, mime_type)
+            ContentPart.text(context),
+            ContentPart.image(data, media_type)
           ]
       end
 
     %ReqLLM.Message{role: :tool, name: name, tool_call_id: id, content: content}
   end
-
-  defp build_text_content(result, fields) do
-    text_parts =
-      Enum.flat_map(fields, fn field ->
-        case get_field(result, field) do
-          nil -> []
-          value -> [format_field(field, value)]
-        end
-      end)
-
-    error = get_field(result, :error)
-    text_parts = if error, do: text_parts ++ ["Error: #{error}"], else: text_parts
-
-    Enum.join(text_parts, "\n\n")
-  end
-
-  defp format_field(:node, value), do: "Node data:\n#{encode_json(value)}"
-  defp format_field(field, value), do: "#{field}: #{encode_json(value)}"
-
-  defp encode_json(value) when is_binary(value), do: value
-  defp encode_json(value), do: Jason.encode!(value)
 
   # Get field from map, supporting both string and atom keys.
   # This is needed because metadata from DB has string keys, but in-memory uses atoms.

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -1571,20 +1571,13 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defp decode_tool_result_image(_tool_name, _result), do: :no_image
 
-  defp build_tool_message_with_image(name, id, %{data: data, media_type: media_type} = image) do
-    content =
-      case image.context do
-        nil ->
-          [ContentPart.image(data, media_type)]
-
-        context ->
-          [
-            ContentPart.text(context),
-            ContentPart.image(data, media_type)
-          ]
-      end
-
-    %ReqLLM.Message{role: :tool, name: name, tool_call_id: id, content: content}
+  defp build_tool_message_with_image(name, id, %{data: data, media_type: media_type}) do
+    %ReqLLM.Message{
+      role: :tool,
+      name: name,
+      tool_call_id: id,
+      content: [ContentPart.image(data, media_type)]
+    }
   end
 
   # Get field from map, supporting both string and atom keys.

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -21,6 +21,16 @@ defmodule FrontmanServer.Tools.WebFetch do
   @max_response_bytes 5_242_880
   @max_redirects 10
   @max_retries 5
+  @image_media_types ["image/png", "image/jpeg", "image/gif", "image/webp"]
+  @accept_header Enum.join(
+                   [
+                     "application/json",
+                     "text/markdown;q=0.9",
+                     "text/html;q=0.8",
+                     "text/plain;q=0.7"
+                   ] ++ Enum.map(@image_media_types, &"#{&1};q=0.8"),
+                   ", "
+                 )
 
   @impl true
   @spec name() :: String.t()
@@ -109,7 +119,7 @@ defmodule FrontmanServer.Tools.WebFetch do
 
   defp fetch(url, [user_agent | remaining_agents], redirects) do
     headers = [
-      {"accept", "application/json, text/markdown;q=0.9, text/html;q=0.8, text/plain;q=0.7"},
+      {"accept", @accept_header},
       {"user-agent", user_agent}
     ]
 
@@ -229,7 +239,6 @@ defmodule FrontmanServer.Tools.WebFetch do
   # -- Content-type guard ------------------------------------------------------
 
   @text_prefixes ["text/", "application/json", "application/xml", "application/javascript"]
-  @image_media_types ["image/png", "image/jpeg", "image/gif", "image/webp"]
 
   defp text_content?(content_type) do
     ct = String.downcase(content_type)

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -30,15 +30,17 @@ defmodule FrontmanServer.Tools.WebFetch do
   @spec description() :: String.t()
   def description do
     """
-    Fetch a public external web page and return its content as markdown.
+    Fetch a public external text page or image URL.
 
-    Use this to retrieve content from known public internet URLs. Do not use this
-    for the current app page, localhost, private networks, .local, .internal, or
-    other development-server URLs. For the current web preview page, use the
-    available browser or framework-specific page inspection tools instead.
+    Use this to retrieve content from known public internet URLs, including
+    public image URLs for visual analysis. Do not use this for the current app
+    page, localhost, private networks, .local, .internal, or other
+    development-server URLs. For the current web preview page, use the available
+    browser or framework-specific page inspection tools instead.
 
     HTML pages are automatically converted to markdown. Results are paginated by
-    lines — use offset and limit to read through large pages.
+    lines — use offset and limit to read through large pages. Image responses are
+    returned as image content and include the source URL.
 
     If total_lines > start_line + lines_returned, there is more content available.
     Call again with a higher offset to continue reading.
@@ -81,15 +83,12 @@ defmodule FrontmanServer.Tools.WebFetch do
   @spec execute(map(), FrontmanServer.Tools.Backend.Context.t()) ::
           FrontmanServer.Tools.Backend.result()
   def execute(args, _context) do
-    with {:ok, url} <- validate_url(args) do
-      offset = clamp(Map.get(args, "offset", 0), 0, :infinity)
-      limit = clamp(Map.get(args, "limit", 500), 1, 2000)
+    offset = clamp(Map.get(args, "offset", 0), 0, :infinity)
+    limit = clamp(Map.get(args, "limit", 500), 1, 2000)
 
-      with {:ok, content_type, body} <- fetch(url),
-           :ok <- require_text_content(content_type) do
-        markdown = convert_to_markdown(body, content_type)
-        paginate(markdown, url, content_type, offset, limit)
-      end
+    with {:ok, url} <- validate_url(args),
+         {:ok, content_type, body} <- fetch(url) do
+      content_result(url, content_type, body, offset, limit)
     end
   end
 
@@ -230,21 +229,63 @@ defmodule FrontmanServer.Tools.WebFetch do
   # -- Content-type guard ------------------------------------------------------
 
   @text_prefixes ["text/", "application/json", "application/xml", "application/javascript"]
+  @image_media_types ["image/png", "image/jpeg", "image/gif", "image/webp"]
 
-  defp require_text_content(content_type) do
+  defp text_content?(content_type) do
     ct = String.downcase(content_type)
+    Enum.any?(@text_prefixes, &String.contains?(ct, &1))
+  end
 
-    case Enum.any?(@text_prefixes, &String.contains?(ct, &1)) do
-      true ->
-        :ok
+  defp image_content?(content_type) do
+    content_type
+    |> media_type()
+    |> then(&(&1 in @image_media_types))
+  end
 
-      false ->
-        {:error,
-         "Cannot fetch non-text content (#{content_type}). This tool only supports text-based URLs."}
-    end
+  defp media_type(content_type) do
+    content_type
+    |> String.split(";", parts: 2)
+    |> hd()
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp unsupported_content_error(content_type) do
+    {:error,
+     "Cannot fetch non-text content (#{content_type}). This tool only supports text-based URLs and supported image URLs."}
   end
 
   # -- Content conversion -----------------------------------------------------
+
+  defp content_result(url, content_type, body, offset, limit) do
+    cond do
+      image_content?(content_type) ->
+        image_result(url, content_type, body)
+
+      text_content?(content_type) ->
+        text_result(url, content_type, body, offset, limit)
+
+      true ->
+        unsupported_content_error(content_type)
+    end
+  end
+
+  defp text_result(url, content_type, body, offset, limit) do
+    markdown = convert_to_markdown(body, content_type)
+    paginate(markdown, url, content_type, offset, limit)
+  end
+
+  defp image_result(url, content_type, body) do
+    mime = media_type(content_type)
+
+    {:ok,
+     %{
+       "type" => "image",
+       "url" => url,
+       "content_type" => content_type,
+       "image" => "data:#{mime};base64,#{Base.encode64(body)}"
+     }}
+  end
 
   defp convert_to_markdown(body, content_type) do
     case String.contains?(content_type, "text/html") do

--- a/apps/frontman_server/test/frontman_server/image_test.exs
+++ b/apps/frontman_server/test/frontman_server/image_test.exs
@@ -260,23 +260,35 @@ defmodule FrontmanServer.ImageTest do
     end
   end
 
-  # ── image_tool_config/1 ─────────────────────────────────────────────
+  # ── decode_tool_image_for_llm/2 ─────────────────────────────────────
 
-  describe "image_tool_config/1" do
-    test "returns config for take_screenshot" do
-      assert {:screenshot, []} = Image.image_tool_config("take_screenshot")
+  describe "decode_tool_image_for_llm/2" do
+    test "decodes take_screenshot image" do
+      image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
+
+      result = %{
+        "screenshot" => "data:image/jpeg;base64,#{Base.encode64(image_bytes)}"
+      }
+
+      assert {:ok, %{data: ^image_bytes, media_type: "image/jpeg"}} =
+               Image.decode_tool_image_for_llm("take_screenshot", result)
     end
 
-    test "strips mcp_ prefix and returns config" do
-      assert {:screenshot, []} = Image.image_tool_config("mcp_take_screenshot")
+    test "decodes web_fetch image" do
+      image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
+
+      result = %{
+        "url" => "https://example.com/cat.jpg",
+        "content_type" => "image/jpeg",
+        "image" => "data:image/jpeg;base64,#{Base.encode64(image_bytes)}"
+      }
+
+      assert {:ok, %{data: ^image_bytes, media_type: "image/jpeg"}} =
+               Image.decode_tool_image_for_llm("web_fetch", result)
     end
 
-    test "returns nil for unknown tool" do
-      assert nil == Image.image_tool_config("read_file")
-    end
-
-    test "returns nil for unknown mcp_ tool" do
-      assert nil == Image.image_tool_config("mcp_read_file")
+    test "returns :no_image for non-image tools" do
+      assert :no_image = Image.decode_tool_image_for_llm("read_file", %{"content" => "hello"})
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -1,7 +1,6 @@
 defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
   @moduledoc """
-  Tests for ToolExecutor public API: make_executor/3, run_backend_tool/5,
-  start_mcp_tool/3, and handle_timeout/5.
+  Focused tests for ToolExecutor callback shaping and result enrichment.
   """
 
   use ExUnit.Case, async: false
@@ -15,22 +14,6 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
   alias FrontmanServer.Tools.Backend
 
   # --- Fake backend tools ---
-
-  # A backend tool that invokes context.tool_executor to simulate sub-agent use.
-  defmodule SubAgentTool do
-    @behaviour Backend
-
-    def name, do: "sub_agent_tool"
-    def description, do: "Invokes context.tool_executor"
-    def parameter_schema, do: %{"type" => "object", "properties" => %{}}
-    def timeout_ms, do: 30_000
-    def on_timeout, do: :error
-
-    def execute(_args, context) do
-      _results = context.tool_executor.([])
-      {:ok, "executor is callable"}
-    end
-  end
 
   # A backend tool that declares on_timeout: :pause_agent.
   defmodule PauseOnTimeoutTool do
@@ -65,96 +48,16 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     {:ok, scope: scope, task_id: task_id, llm_opts: llm_opts}
   end
 
-  describe "run_backend_tool/5 — sub-agent spawning" do
-    @tag :capture_log
-    test "backend tool can call context.tool_executor without crashing", %{
-      scope: scope,
-      task_id: task_id,
-      llm_opts: llm_opts
-    } do
-      exec_opts = %{
-        backend_tool_modules: [SubAgentTool],
-        backend_module_map: %{SubAgentTool.name() => SubAgentTool},
-        mcp_tools: [],
-        mcp_tool_defs: [],
-        llm_opts: llm_opts
-      }
-
-      tool_call = %SwarmAi.ToolCall{
-        id: "tc_#{System.unique_integer([:positive])}",
-        name: SubAgentTool.name(),
-        arguments: "{}"
-      }
-
-      result = ToolExecutor.run_backend_tool(scope, SubAgentTool, task_id, exec_opts, tool_call)
-
-      # SubAgentTool calls context.tool_executor.([]) and returns {:ok, "executor is callable"}.
-      assert %SwarmAi.ToolResult{is_error: false} = result
-    end
+  defp tool_results(task, tool_call_id) do
+    Enum.filter(task.interactions, fn
+      %Interaction.ToolResult{tool_call_id: ^tool_call_id} -> true
+      _ -> false
+    end)
   end
 
-  describe "start_mcp_tool/3 — MCP tool routing" do
+  describe "handle_timeout/5 — cancelled tools" do
     @tag :capture_log
-    test "registers caller's pid in ToolCallRegistry before returning", %{
-      scope: scope,
-      task_id: task_id
-    } do
-      tool_call_id = "tc_mcp_#{System.unique_integer([:positive])}"
-
-      tool_call = %SwarmAi.ToolCall{
-        id: tool_call_id,
-        name: "some_mcp_tool",
-        arguments: "{}"
-      }
-
-      # start_mcp_tool is meant to be called in PE's own process (self() = PE).
-      # Here, test process acts as PE.
-      ToolExecutor.start_mcp_tool(scope, task_id, tool_call)
-
-      # Verify registry registration with test process pid.
-      assert [{test_pid, _}] =
-               Registry.lookup(FrontmanServer.ToolCallRegistry, {:tool_call, tool_call_id})
-
-      assert test_pid == self()
-
-      # Verify tool call interaction was published so the client can execute it.
-      {:ok, task} = Tasks.get_task(scope, task_id)
-
-      tool_calls =
-        Enum.filter(task.interactions, fn
-          %Tasks.Interaction.ToolCall{tool_call_id: ^tool_call_id} -> true
-          _ -> false
-        end)
-
-      assert length(tool_calls) == 1,
-             "start_mcp_tool/3 did not publish ToolCall interaction"
-    end
-  end
-
-  describe "handle_timeout/5 — :error policy" do
-    @tag :capture_log
-    test "persists error ToolResult and is a no-op for :triggered reason", %{
-      scope: scope,
-      task_id: task_id
-    } do
-      tc = %SwarmAi.ToolCall{id: "tc-to-1", name: "pause_on_timeout_tool", arguments: "{}"}
-      ToolExecutor.handle_timeout(scope, task_id, :error, tc, :triggered)
-
-      {:ok, task} = Tasks.get_task(scope, task_id)
-
-      result =
-        Enum.find(task.interactions, fn
-          %Interaction.ToolResult{tool_call_id: "tc-to-1"} -> true
-          _ -> false
-        end)
-
-      assert result != nil
-      assert result.is_error == true
-      assert result.result =~ "timed out"
-    end
-
-    @tag :capture_log
-    test "persists error ToolResult for :cancelled reason", %{
+    test "persists error ToolResult for :error policy", %{
       scope: scope,
       task_id: task_id
     } do
@@ -162,44 +65,11 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       ToolExecutor.handle_timeout(scope, task_id, :error, tc, :cancelled)
 
       {:ok, task} = Tasks.get_task(scope, task_id)
-
-      result =
-        Enum.find(task.interactions, fn
-          %Interaction.ToolResult{tool_call_id: "tc-to-2"} -> true
-          _ -> false
-        end)
-
-      assert result != nil
-      assert result.is_error == true
-    end
-  end
-
-  describe "handle_timeout/5 — :pause_agent policy" do
-    @tag :capture_log
-    test "handle_timeout(:triggered) is a no-op for :pause_agent — SwarmDispatcher owns persistence",
-         %{scope: scope, task_id: task_id} do
-      tc = %SwarmAi.ToolCall{
-        id: "tc_#{System.unique_integer([:positive])}",
-        name: PauseOnTimeoutTool.name(),
-        arguments: "{}"
-      }
-
-      ToolExecutor.handle_timeout(scope, task_id, :pause_agent, tc, :triggered)
-
-      {:ok, task} = Tasks.get_task(scope, task_id)
-
-      tool_results =
-        Enum.filter(task.interactions, fn
-          %Interaction.ToolResult{tool_call_id: tc_id} -> tc_id == tc.id
-          _ -> false
-        end)
-
-      assert tool_results == [],
-             "Expected no ToolResult for :pause_agent/:triggered, got #{length(tool_results)}"
+      assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end
 
     @tag :capture_log
-    test "handle_timeout(:cancelled) persists a ToolResult for sibling tool", %{
+    test "persists ToolResult for :pause_agent policy", %{
       scope: scope,
       task_id: task_id
     } do
@@ -212,15 +82,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       ToolExecutor.handle_timeout(scope, task_id, :pause_agent, tc, :cancelled)
 
       {:ok, task} = Tasks.get_task(scope, task_id)
-
-      tool_results =
-        Enum.filter(task.interactions, fn
-          %Interaction.ToolResult{tool_call_id: tc_id} -> tc_id == tc.id
-          _ -> false
-        end)
-
-      assert length(tool_results) == 1,
-             "Expected a ToolResult for :pause_agent/:cancelled, got #{length(tool_results)}"
+      assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end
   end
 
@@ -267,19 +129,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     end
   end
 
-  describe "make_executor/3 — returns single function" do
-    test "returns a function, not a tuple", %{scope: scope, task_id: task_id, llm_opts: llm_opts} do
-      result =
-        ToolExecutor.make_executor(scope, task_id,
-          backend_tool_modules: [SubAgentTool],
-          mcp_tools: [],
-          mcp_tool_defs: [],
-          llm_opts: llm_opts
-        )
-
-      assert is_function(result, 1)
-    end
-
+  describe "make_executor/3 — execution descriptors" do
     test "executor returns ToolExecution.Sync for backend tools", %{
       scope: scope,
       task_id: task_id,
@@ -343,61 +193,41 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
              } = execution
 
       assert tc_id == tc.id
-    end
 
-    test "MCP tool Await has process_result set to make_mcp_tool_result MFA", %{
-      scope: scope,
-      task_id: task_id,
-      llm_opts: llm_opts
-    } do
-      tool_name = "some_mcp_tool"
-
-      mcp_def = %FrontmanServer.Tools.MCP{
-        name: tool_name,
-        description: "test",
-        input_schema: %{},
-        on_timeout: :error,
-        timeout_ms: 60_000
-      }
-
-      executor =
-        ToolExecutor.make_executor(scope, task_id,
-          backend_tool_modules: [],
-          mcp_tools: [],
-          mcp_tool_defs: [mcp_def],
-          llm_opts: llm_opts
-        )
-
-      tc = %SwarmAi.ToolCall{
-        id: "tc_#{System.unique_integer([:positive])}",
-        name: tool_name,
-        arguments: "{}"
-      }
-
-      [execution] = executor.([tc])
-
-      assert %SwarmAi.ToolExecution.Await{
-               process_result: {ToolExecutor, :make_mcp_tool_result, [^tool_name]}
-             } = execution
+      assert execution.process_result == {ToolExecutor, :make_mcp_tool_result, [tc.name]}
     end
   end
 
   describe "make_mcp_tool_result/4" do
-    test "enriches screenshot tool result with image content parts" do
-      data_url = "data:image/jpeg;base64,#{Base.encode64("fake-jpeg-bytes")}"
-      json_content = Jason.encode!(%{"screenshot" => data_url})
+    test "enriches web_fetch image result with source text and image content parts" do
+      image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
+      image_url = "https://example.com/cat.jpg"
 
-      tool_call = %SwarmAi.ToolCall{
-        id: "tc_screenshot",
-        name: "mcp_take_screenshot",
-        arguments: "{}"
-      }
+      json_content =
+        Jason.encode!(%{
+          "type" => "image",
+          "url" => image_url,
+          "content_type" => "image/jpeg",
+          "image" => "data:image/jpeg;base64,#{Base.encode64(image_bytes)}"
+        })
 
-      result =
-        ToolExecutor.make_mcp_tool_result("mcp_take_screenshot", tool_call, json_content, false)
+      tool_call = %SwarmAi.ToolCall{id: "tc_web_fetch", name: "web_fetch", arguments: "{}"}
 
-      assert %SwarmAi.ToolResult{id: "tc_screenshot", is_error: false} = result
-      assert [%SwarmAi.Message.ContentPart{type: :image}] = result.content
+      result = ToolExecutor.make_mcp_tool_result("web_fetch", tool_call, json_content, false)
+
+      assert %SwarmAi.ToolResult{id: "tc_web_fetch", is_error: false} = result
+
+      assert [
+               %SwarmAi.Message.ContentPart{type: :text, text: text},
+               %SwarmAi.Message.ContentPart{
+                 type: :image,
+                 data: ^image_bytes,
+                 media_type: "image/jpeg"
+               }
+             ] = result.content
+
+      assert text =~ image_url
+      assert text =~ "image/jpeg"
     end
 
     test "returns plain text ToolResult for non-image tool" do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -199,7 +199,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
   end
 
   describe "make_mcp_tool_result/4" do
-    test "enriches web_fetch image result with source text and image content parts" do
+    test "enriches web_fetch image result with image content part" do
       image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
       image_url = "https://example.com/cat.jpg"
 
@@ -218,16 +218,12 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       assert %SwarmAi.ToolResult{id: "tc_web_fetch", is_error: false} = result
 
       assert [
-               %SwarmAi.Message.ContentPart{type: :text, text: text},
                %SwarmAi.Message.ContentPart{
                  type: :image,
                  data: ^image_bytes,
                  media_type: "image/jpeg"
                }
              ] = result.content
-
-      assert text =~ image_url
-      assert text =~ "image/jpeg"
     end
 
     test "returns plain text ToolResult for non-image tool" do

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -244,6 +244,80 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     end
   end
 
+  # -- web_fetch image results ------------------------------------------------
+
+  describe "web_fetch image results" do
+    setup [:setup_sandbox, :setup_user, :setup_task]
+
+    test "fetched image URL is persisted and converts back to LLM image content with source URL",
+         %{
+           task_id: task_id,
+           scope: scope
+         } do
+      image_url = "https://example.com/cat.jpg"
+      image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
+      tool_call_id = "tc_web_fetch_image_#{System.unique_integer([:positive])}"
+
+      web_fetch_call =
+        tool_call("web_fetch", %{"url" => image_url}, id: tool_call_id)
+
+      Req.Test.stub(:web_fetch, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("image/jpeg")
+        |> Plug.Conn.send_resp(200, image_bytes)
+      end)
+
+      expect_llm_responses([
+        {:tool_calls, [web_fetch_call], "I'll fetch the image."},
+        "I can inspect the image."
+      ])
+
+      scope = Scope.with_env_api_keys(scope, %{"nvidia" => "sk-test"})
+
+      {:ok, _interaction} =
+        Tasks.submit_user_message(
+          scope,
+          task_id,
+          user_content("What is in #{image_url}?"),
+          [],
+          model: "nvidia:moonshotai/kimi-k2.6"
+        )
+
+      assert_receive {:execution_event, %ExecutionEvent{type: :completed}}, 5_000
+
+      {:ok, task} = Tasks.get_task(scope, task_id)
+
+      tool_result =
+        Enum.find(task.interactions, fn
+          %Interaction.ToolResult{tool_call_id: ^tool_call_id} -> true
+          _ -> false
+        end)
+
+      assert %Interaction.ToolResult{is_error: false, result: result} = tool_result
+      assert result["type"] == "image"
+      assert result["url"] == image_url
+      assert result["content_type"] =~ "image/jpeg"
+      assert result["image"] == "data:image/jpeg;base64,#{Base.encode64(image_bytes)}"
+
+      tool_message =
+        task.interactions
+        |> Interaction.to_llm_messages()
+        |> Enum.find(fn message ->
+          message.role == :tool && message.tool_call_id == tool_call_id
+        end)
+
+      assert tool_message != nil
+
+      assert [
+               %{type: :text, text: tool_context},
+               %{type: :image, data: ^image_bytes, media_type: "image/jpeg"}
+             ] = tool_message.content
+
+      assert tool_context =~ image_url
+      assert tool_context =~ "image/jpeg"
+    end
+  end
+
   # -- Interactive tool (question) with blocking receive ----------------------
 
   describe "interactive tool (question) blocking" do

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -249,7 +249,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   describe "web_fetch image results" do
     setup [:setup_sandbox, :setup_user, :setup_task]
 
-    test "fetched image URL is persisted and converts back to LLM image content with source URL",
+    test "fetched image URL is persisted and converts back to LLM image content",
          %{
            task_id: task_id,
            scope: scope
@@ -309,12 +309,8 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert tool_message != nil
 
       assert [
-               %{type: :text, text: tool_context},
                %{type: :image, data: ^image_bytes, media_type: "image/jpeg"}
              ] = tool_message.content
-
-      assert tool_context =~ image_url
-      assert tool_context =~ "image/jpeg"
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
@@ -4,16 +4,6 @@ defmodule FrontmanServer.Tools.WebFetchTest do
   alias FrontmanServer.Tools.WebFetch
 
   setup do
-    Application.put_env(:frontman_server, :web_fetch_req_options,
-      plug: {Req.Test, :web_fetch},
-      retry_delay: fn _ -> 0 end,
-      retry_log_level: false
-    )
-
-    on_exit(fn ->
-      Application.delete_env(:frontman_server, :web_fetch_req_options)
-    end)
-
     context = %FrontmanServer.Tools.Backend.Context{
       scope: nil,
       task: nil,
@@ -349,21 +339,35 @@ defmodule FrontmanServer.Tools.WebFetchTest do
     end
   end
 
-  describe "execute/2 — non-text content rejection" do
-    test "rejects image/png responses", %{context: ctx} do
-      # PNG header bytes
-      stub_resp(200, "image/png", <<137, 80, 78, 71, 13, 10, 26, 10>>)
+  describe "execute/2 — image support and non-text rejection" do
+    test "returns image/png responses as image results", %{context: ctx} do
+      image_bytes = <<137, 80, 78, 71, 13, 10, 26, 10>>
+      url = "https://example.com/logo.png"
 
-      assert {:error, msg} = execute("https://example.com/logo.png", ctx)
-      assert msg =~ "non-text"
-      assert msg =~ "image/png"
+      stub_resp(200, "image/png", image_bytes)
+
+      assert {:ok, result} = execute(url, ctx)
+      assert result["type"] == "image"
+      assert result["url"] == url
+      assert result["content_type"] =~ "image/png"
+      assert result["image"] == "data:image/png;base64,#{Base.encode64(image_bytes)}"
     end
 
-    test "rejects image/jpeg responses", %{context: ctx} do
-      stub_resp(200, "image/jpeg", <<255, 216, 255, 224>>)
+    test "returns image/jpeg responses with normalized data URL media type", %{context: ctx} do
+      image_bytes = <<255, 216, 255, 224, "fake-jpeg">>
+      url = "https://example.com/photo.jpg"
 
-      assert {:error, msg} = execute("https://example.com/photo.jpg", ctx)
-      assert msg =~ "non-text"
+      Req.Test.stub(:web_fetch, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "image/jpeg; charset=binary")
+        |> Plug.Conn.send_resp(200, image_bytes)
+      end)
+
+      assert {:ok, result} = execute(url, ctx)
+      assert result["type"] == "image"
+      assert result["url"] == url
+      assert result["content_type"] == "image/jpeg; charset=binary"
+      assert result["image"] == "data:image/jpeg;base64,#{Base.encode64(image_bytes)}"
     end
 
     test "rejects application/octet-stream responses", %{context: ctx} do
@@ -378,6 +382,14 @@ defmodule FrontmanServer.Tools.WebFetchTest do
 
       assert {:error, msg} = execute("https://example.com/doc.pdf", ctx)
       assert msg =~ "non-text"
+    end
+
+    test "rejects image/svg+xml responses", %{context: ctx} do
+      stub_resp(200, "image/svg+xml", "<svg></svg>")
+
+      assert {:error, msg} = execute("https://example.com/vector.svg", ctx)
+      assert msg =~ "non-text"
+      assert msg =~ "image/svg+xml"
     end
 
     test "allows text/html responses", %{context: ctx} do

--- a/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
@@ -344,7 +344,17 @@ defmodule FrontmanServer.Tools.WebFetchTest do
       image_bytes = <<137, 80, 78, 71, 13, 10, 26, 10>>
       url = "https://example.com/logo.png"
 
-      stub_resp(200, "image/png", image_bytes)
+      Req.Test.stub(:web_fetch, fn conn ->
+        accept = Plug.Conn.get_req_header(conn, "accept") |> List.first("")
+        assert accept =~ "image/png"
+        assert accept =~ "image/jpeg"
+        assert accept =~ "image/gif"
+        assert accept =~ "image/webp"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("image/png")
+        |> Plug.Conn.send_resp(200, image_bytes)
+      end)
 
       assert {:ok, result} = execute(url, ctx)
       assert result["type"] == "image"


### PR DESCRIPTION
## Summary
- Add supported image MIME handling to web_fetch with data URL results
- Reuse shared tool-image decoding for live and replay LLM content
- Add image enrichment coverage plus changeset

## Verification
- mix format --check-formatted lib/frontman_server/tools/web_fetch.ex lib/frontman_server/image.ex lib/frontman_server/tasks/execution/tool_executor.ex lib/frontman_server/tasks/interaction.ex test/frontman_server/tools/web_fetch_test.exs test/frontman_server/tasks/execution/tool_executor_test.exs test/frontman_server/tasks/execution_test.exs
- mix test test/frontman_server/tools/web_fetch_test.exs
- mix test test/frontman_server/tasks/execution/tool_executor_test.exs
- mix test test/frontman_server/tasks/execution_test.exs
- make precommit