### PR TITLE
docs(wordpress): align tool guidance

### DIFF
--- a/.changeset/remove-wordpress-file-mutation-tools.md
+++ b/.changeset/remove-wordpress-file-mutation-tools.md
@@ -2,4 +2,4 @@
 "marketing": patch
 ---
 
-Update the WordPress integration docs and marketing copy to reflect the new Frontman-managed child-theme workflow: live theme and plugin files stay read-only, while safe CSS, HTML, and JSON edits happen only inside the managed child theme.
+Update the WordPress integration docs and marketing copy to match the tools currently exposed by the plugin.

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex
@@ -269,7 +269,7 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
     You are working with a WordPress site. Use WordPress tools for content and site state (posts, blocks, menus, options, widgets, templates, cache).
 
     **Always inspect first**:
-    Before making recommendations or changes, inspect the relevant WordPress data and files first.
+    Before making recommendations or changes, inspect the relevant WordPress data first using available WordPress tools.
 
     **Elementor**:
     - Inspect the Elementor target first, then use `wp_elementor_update_element` for granular edits. It inspects the actual Elementor element and handles normal settings updates vs HTML-widget fragment updates from `old_html`/`new_html`.
@@ -287,7 +287,8 @@ defmodule FrontmanServer.Tasks.Execution.Prompts do
     **For design questions**:
     First check which theme is active with WordPress tools.
     Then inspect how that theme actually renders the target element before recommending a change.
-    Read the relevant template, partial, stylesheet, block template, menu, widget area, or option that controls the element.
+    Use WordPress tools to read the relevant block template, template part, menu, widget area, or option that controls the element.
+    Use browser inspection for rendered structure and styling.
     Base design recommendations on the real theme structure, not guesses.
 
     **For recommendations**:

--- a/apps/marketing/src/data/json-files/faqData.json
+++ b/apps/marketing/src/data/json-files/faqData.json
@@ -43,13 +43,13 @@
 	},
 	{
 		"question": "Which frameworks are supported?",
-		"reply": "Frontman supports Next.js, Astro, Vite, and WordPress. For JavaScript frameworks it integrates as middleware, turning your local dev server into an MCP server. For WordPress it installs as a plugin that exposes WordPress-specific tools alongside PHP-native read-only file inspection and Frontman-managed child-theme editing tools.",
+		"reply": "Frontman supports Next.js, Astro, Vite, and WordPress. For JavaScript frameworks it integrates as middleware, turning your local dev server into an MCP server. For WordPress it installs as a plugin that exposes WordPress-specific tools for posts, pages, blocks, Elementor content, menus, templates, widgets, settings, and WooCommerce when active.",
 		"category": "technical",
 		"open": true
 	},
 	{
 		"question": "How does it get context about my app?",
-		"reply": "Frontman gets context from the runtime it is installed into. For JavaScript frameworks, it hooks into your local dev server and browser tools. For WordPress, the plugin exposes WordPress-native tools and read-only site inspection directly from the running site. In both cases, the agent queries live runtime context instead of relying only on static files.",
+		"reply": "Frontman gets context from the runtime it is installed into. For JavaScript frameworks, it hooks into your local dev server and browser tools. For WordPress, the plugin exposes WordPress-native content, template, menu, widget, option, Elementor, and WooCommerce tools directly from the running site. In both cases, the agent queries live runtime context instead of relying only on static files.",
 		"category": "technical",
 		"open": false
 	},


### PR DESCRIPTION
Summary:
- Remove remaining public FAQ claims for WordPress filesystem inspection and managed child-theme editing tools.
- Update WordPress agent guidance to inspect supported WordPress data and browser-rendered output instead of unavailable files.
- Correct the changeset wording to match current plugin capabilities.

Verification:
- jq empty apps/marketing/src/data/json-files/faqData.json
- git diff --check -- .changeset/remove-wordpress-file-mutation-tools.md apps/frontman_server/lib/frontman_server/tasks/execution/prompts.ex apps/marketing/src/data/json-files/faqData.json
- pre-commit hooks passed during commit after installing server Mix deps

Closes #1026