### PR TITLE
Exclude blog starter from dependency and security scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
       default-days: 30
     exclude-paths:
       - "libs/frontman-nextjs/test/cli/fixtures/**"
+      - "test/sites/blog-starter/**"
     groups:
       rescript:
         patterns:

--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "test/sites/blog-starter/**"


### PR DESCRIPTION
## Summary
- Exclude `test/sites/blog-starter/**` from root npm Dependabot scans.
- Add GitHub Secret Scanning path ignore for `test/sites/blog-starter/**`.

## Notes
- GitHub dependency/security alerts have limited repo-file path exclusion controls; secret scanning supports this path ignore.

## Tests
- `git diff --check origin/main...HEAD`