### PR TITLE
Add Bazel ReScript package graph

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --lockfile_mode=off

--- a/.changeset/migrate-rescript-bazel.md
+++ b/.changeset/migrate-rescript-bazel.md
@@ -1,0 +1,11 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-core": patch
+"@frontman-ai/frontman-protocol": patch
+"@frontman-ai/react-statestore": patch
+"@frontman/bindings": patch
+"@frontman/logs": patch
+---
+
+Add Bazel build and test targets for the ReScript package graph.

--- a/.changeset/protocol-schemas-bazel.md
+++ b/.changeset/protocol-schemas-bazel.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-protocol": patch
+---
+
+Add Bazel schema export and schema check targets for protocol schemas.

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ lib/
 # Node
 node_modules/
 
+# Bazel convenience symlinks
+bazel-*
+
 # Environment variables
 .env.local
 test/e2e/.env

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+module(name = "frontman", version = "0.0.0")

--- a/libs/bindings/BUILD.bazel
+++ b/libs/bindings/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "bindings",
+    package_name = "@frontman/bindings",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    deps = ["//libs/experimental-rescript-webapi"],
+)

--- a/libs/bindings/BUILD.bazel
+++ b/libs/bindings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,8 +8,7 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = ["//libs/experimental-rescript-webapi"],
 )

--- a/libs/client/BUILD.bazel
+++ b/libs/client/BUILD.bazel
@@ -11,11 +11,13 @@ rescript_package(
         "src/**/*.css",
         "src/**/*.res",
         "src/**/*.resi",
+        "src/**/*.ts",
         "src/**/*.tsx",
     ], allow_empty = True),
     dev_srcs = glob([
         "test/**/*.js",
         "test/**/*.json",
+        "test/**/*.mjs",
         "test/**/*.res",
         "test/**/*.resi",
         "test/**/*.ts",

--- a/libs/client/BUILD.bazel
+++ b/libs/client/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,21 +8,12 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.css",
-        "src/**/*.res",
-        "src/**/*.resi",
-        "src/**/*.ts",
-        "src/**/*.tsx",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES + ["src/.gitignore"], allow_empty = True),
     dev_srcs = glob([
-        "test/**/*.js",
-        "test/**/*.json",
-        "test/**/*.mjs",
-        "test/**/*.res",
-        "test/**/*.resi",
-        "test/**/*.ts",
+        "test/**",
         "vitest.config.*",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",

--- a/libs/client/BUILD.bazel
+++ b/libs/client/BUILD.bazel
@@ -1,0 +1,34 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "client",
+    package_name = "@frontman-ai/client",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.css",
+        "src/**/*.res",
+        "src/**/*.resi",
+        "src/**/*.tsx",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**/*.js",
+        "test/**/*.json",
+        "test/**/*.res",
+        "test/**/*.resi",
+        "test/**/*.ts",
+        "vitest.config.*",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+        "//libs/frontman-astro-browser",
+        "//libs/frontman-client",
+        "//libs/frontman-protocol",
+        "//libs/logs",
+        "//libs/react-statestore",
+    ],
+    test_runner = "vitest",
+)

--- a/libs/experimental-rescript-webapi/BUILD.bazel
+++ b/libs/experimental-rescript-webapi/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "experimental-rescript-webapi",
+    package_name = "@rescript/webapi",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "tests/**/*.res",
+    ], allow_empty = True),
+    test_runner = "compile",
+)

--- a/libs/frontman-astro-browser/BUILD.bazel
+++ b/libs/frontman-astro-browser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,14 +8,12 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     dev_srcs = glob([
-        "test/**/*.res",
-        "test/**/*.resi",
+        "test/**",
         "vitest.config.*",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/experimental-rescript-webapi",
         "//libs/frontman-protocol",

--- a/libs/frontman-astro-browser/BUILD.bazel
+++ b/libs/frontman-astro-browser/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "frontman-astro-browser",
+    package_name = "@frontman-ai/astro-browser",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**/*.res",
+        "test/**/*.resi",
+        "vitest.config.*",
+    ], allow_empty = True),
+    deps = [
+        "//libs/experimental-rescript-webapi",
+        "//libs/frontman-protocol",
+    ],
+    test_runner = "vitest",
+)

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Registry.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Registry.test.res
@@ -1,6 +1,6 @@
 open Vitest
 
-module Registry = FrontmanAiAstroBrowser.FrontmanAstroBrowser__Registry
+module Registry = FrontmanAstroBrowser__Registry
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let unpackName = (toolModule: module(Tool.BrowserTool)): string => {

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Tool__GetAstroAudit.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Tool__GetAstroAudit.test.res
@@ -2,8 +2,7 @@ open Vitest
 
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
-let makeTool = (~getPreviewDoc) =>
-  FrontmanAiAstroBrowser.FrontmanAstroBrowser__Tool__GetAstroAudit.make(~getPreviewDoc)
+let makeTool = (~getPreviewDoc) => FrontmanAstroBrowser__Tool__GetAstroAudit.make(~getPreviewDoc)
 
 let unpackName = (toolModule: module(Tool.BrowserTool)): string => {
   module T = unpack(toolModule)
@@ -14,7 +13,7 @@ let unpackExecute = (toolModule: module(Tool.BrowserTool)) => {
   module T = unpack(toolModule)
   (input, ~taskId, ~toolCallId) =>
     T.execute(Obj.magic(input), ~taskId, ~toolCallId)->Promise.thenResolve((r): Tool.toolResult<
-      FrontmanAiAstroBrowser.FrontmanAstroBrowser__Tool__GetAstroAudit.output,
+      FrontmanAstroBrowser__Tool__GetAstroAudit.output,
     > => Obj.magic(r))
 }
 
@@ -28,7 +27,7 @@ describe("FrontmanAstroBrowser__Tool__GetAstroAudit", _t => {
     let tool = makeTool(~getPreviewDoc=() => None)
     let execute = unpackExecute(tool)
     let result = await execute(
-      ({}: FrontmanAiAstroBrowser.FrontmanAstroBrowser__Tool__GetAstroAudit.input),
+      ({}: FrontmanAstroBrowser__Tool__GetAstroAudit.input),
       ~taskId="t1",
       ~toolCallId="tc1",
     )

--- a/libs/frontman-client/BUILD.bazel
+++ b/libs/frontman-client/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "frontman-client",
+    package_name = "@frontman-ai/frontman-client",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**/*.res",
+        "test/**/*.resi",
+        "vitest.config.*",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+        "//libs/frontman-protocol",
+        "//libs/logs",
+    ],
+    test_runner = "vitest",
+)

--- a/libs/frontman-client/BUILD.bazel
+++ b/libs/frontman-client/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,14 +8,12 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     dev_srcs = glob([
-        "test/**/*.res",
-        "test/**/*.resi",
+        "test/**",
         "vitest.config.*",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",

--- a/libs/frontman-core/BUILD.bazel
+++ b/libs/frontman-core/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "frontman-core",
+    package_name = "@frontman-ai/frontman-core",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**",
+        "vitest.config.*",
+    ], exclude = [
+        "test/**/*.res.mjs",
+        "test/**/*.res.mjs.map",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+        "//libs/frontman-protocol",
+    ],
+    test_runner = "vitest",
+)

--- a/libs/frontman-core/BUILD.bazel
+++ b/libs/frontman-core/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,16 +8,12 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     dev_srcs = glob([
         "test/**",
         "vitest.config.*",
-    ], exclude = [
-        "test/**/*.res.mjs",
-        "test/**/*.res.mjs.map",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",

--- a/libs/frontman-protocol/BUILD.bazel
+++ b/libs/frontman-protocol/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "frontman-protocol",
+    package_name = "@frontman-ai/frontman-protocol",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "schemas/**/*.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+    ],
+)

--- a/libs/frontman-protocol/BUILD.bazel
+++ b/libs/frontman-protocol/BUILD.bazel
@@ -1,4 +1,9 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load(
+    "//tools/bazel/rescript:defs.bzl",
+    "rescript_package",
+    "rescript_schema_export",
+    "schema_check_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,4 +21,35 @@ rescript_package(
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",
     ],
+)
+
+rescript_package(
+    name = "frontman-protocol_schemas_pkg",
+    package_name = "@frontman-ai/frontman-protocol",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "scripts/**/*.res",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+rescript_schema_export(
+    name = "schemas",
+    package = ":frontman-protocol_schemas_pkg",
+    script = "scripts/ExportSchemas.res.mjs",
+    static_schema_files = ["schemas/acp/contentBlock.json"],
+)
+
+schema_check_test(
+    name = "check_schemas",
+    generated = ":schemas",
+    schema_files = glob(["schemas/**/*.json"]),
+    tags = ["local", "no-remote", "no-sandbox"],
 )

--- a/libs/frontman-protocol/BUILD.bazel
+++ b/libs/frontman-protocol/BUILD.bazel
@@ -1,5 +1,6 @@
 load(
     "//tools/bazel/rescript:defs.bzl",
+    "RESCRIPT_OUTPUT_EXCLUDES",
     "rescript_package",
     "rescript_schema_export",
     "schema_check_test",
@@ -13,10 +14,9 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "schemas/**/*.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "schemas/**",
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",
@@ -29,10 +29,9 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "scripts/**/*.res",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "scripts/**",
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     deps = [
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",

--- a/libs/logs/BUILD.bazel
+++ b/libs/logs/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "logs",
+    package_name = "@frontman/logs",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**/*.res",
+        "test/**/*.resi",
+        "vitest.config.*",
+    ], allow_empty = True),
+    test_runner = "vitest",
+)

--- a/libs/logs/BUILD.bazel
+++ b/libs/logs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,13 +8,11 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     dev_srcs = glob([
-        "test/**/*.res",
-        "test/**/*.resi",
+        "test/**",
         "vitest.config.*",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     test_runner = "vitest",
 )

--- a/libs/react-statestore/BUILD.bazel
+++ b/libs/react-statestore/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load("//tools/bazel/rescript:defs.bzl", "RESCRIPT_OUTPUT_EXCLUDES", "rescript_package")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,14 +8,11 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "src/**/*.res",
-        "src/**/*.resi",
-    ], allow_empty = True),
+        "src/**",
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     dev_srcs = glob([
-        "test/**/*.res",
-        "test/**/*.resi",
-        "test/**/*.ts",
+        "test/**",
         "vitest.config.*",
-    ], allow_empty = True),
+    ], exclude = RESCRIPT_OUTPUT_EXCLUDES, allow_empty = True),
     test_runner = "vitest",
 )

--- a/libs/react-statestore/BUILD.bazel
+++ b/libs/react-statestore/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+
+package(default_visibility = ["//visibility:public"])
+
+rescript_package(
+    name = "react-statestore",
+    package_name = "@frontman-ai/react-statestore",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    dev_srcs = glob([
+        "test/**/*.res",
+        "test/**/*.resi",
+        "test/**/*.ts",
+        "vitest.config.*",
+    ], allow_empty = True),
+    test_runner = "vitest",
+)

--- a/tools/bazel/rescript/BUILD.bazel
+++ b/tools/bazel/rescript/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["defs.bzl"])

--- a/tools/bazel/rescript/defs.bzl
+++ b/tools/bazel/rescript/defs.bzl
@@ -1,0 +1,355 @@
+RescriptPackageInfo = provider(
+    fields = {
+        "package_name": "npm package name exported by this target",
+        "output": "compiled package directory",
+        "direct_deps": "direct ReScript package deps used by this build mode",
+    },
+)
+
+_MIGRATED_PACKAGES = [
+    "@rescript/webapi",
+    "@frontman/bindings",
+    "@frontman-ai/react-statestore",
+    "@frontman/logs",
+    "@frontman-ai/frontman-protocol",
+    "@frontman-ai/frontman-client",
+    "@frontman-ai/frontman-core",
+    "@frontman-ai/astro-browser",
+    "@frontman-ai/client",
+]
+
+def _copy_manifest_lines(files, package_path):
+    lines = []
+    prefix = package_path + "/" if package_path else ""
+
+    for src in files:
+        rel = src.short_path
+        if prefix and rel.startswith(prefix):
+            rel = rel[len(prefix):]
+        lines.append("%s\t%s" % (src.path, rel))
+
+    return "\n".join(lines) + "\n"
+
+def _setup_node_modules_script():
+    migrated = " ".join(["'%s'" % package for package in _MIGRATED_PACKAGES])
+
+    return """
+setup_node_modules() {
+  local pkg_dir="$1"
+  local root_nm="$2"
+
+  if [ ! -d "$root_nm" ]; then
+    echo "missing node_modules at $root_nm" >&2
+    exit 1
+  fi
+
+  mkdir -p "$pkg_dir/node_modules"
+
+  for entry in "$root_nm"/*; do
+    [ -e "$entry" ] || continue
+    local base
+    base="$(basename "$entry")"
+
+    if [ "$base" = ".bin" ]; then
+      ln -s "$entry" "$pkg_dir/node_modules/.bin"
+    elif [ "${base#@}" != "$base" ]; then
+      mkdir -p "$pkg_dir/node_modules/$base"
+      for scoped in "$entry"/*; do
+        [ -e "$scoped" ] || continue
+        ln -s "$scoped" "$pkg_dir/node_modules/$base/$(basename "$scoped")"
+      done
+    else
+      ln -s "$entry" "$pkg_dir/node_modules/$base"
+    fi
+  done
+
+  for package in __MIGRATED_PACKAGES__; do
+    rm -rf "$pkg_dir/node_modules/$package"
+  done
+}
+
+link_package_dep() {
+  local pkg_dir="$1"
+  local package_name="$2"
+  local package_path="$3"
+  local dest="$pkg_dir/node_modules/$package_name"
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$dest"
+  ln -s "$package_path" "$dest"
+}
+
+copy_package_dep() {
+  local pkg_dir="$1"
+  local package_name="$2"
+  local package_path="$3"
+  local dest="$pkg_dir/node_modules/$package_name"
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$dest"
+  cp -a "$package_path" "$dest"
+  chmod -R u+w "$dest"
+}
+""".replace("__MIGRATED_PACKAGES__", migrated)
+
+def _ensure_node_script():
+    return """
+ensure_node() {
+  if command -v node >/dev/null 2>&1; then
+    return
+  fi
+
+  for node_bin in "${HOME:-}/.local/share/mise/installs/node"/*/bin /home/*/.local/share/mise/installs/node/*/bin /usr/local/bin /usr/bin; do
+    if [ -x "$node_bin/node" ]; then
+      export PATH="$node_bin:$PATH"
+      return
+    fi
+  done
+
+  echo "missing node executable on PATH" >&2
+  exit 1
+}
+"""
+
+def _build_command(manifest, out, dep_infos, dev):
+    dep_links = []
+    for dep in dep_infos:
+        dep_links.append("copy_package_dep \"$pkg\" %s \"$execroot/%s\"" % (
+            _shell_quote(dep.package_name),
+            dep.output.path,
+        ))
+
+    build_args = "build"
+
+    return """
+set -euo pipefail
+
+execroot="$PWD"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+pkg="$tmp/package"
+mkdir -p "$pkg"
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  mkdir -p "$pkg/$(dirname "$rel")"
+  cp "$src" "$pkg/$rel"
+done < "$execroot/__MANIFEST__"
+
+mkdir -p "$pkg/src" "$pkg/test" "$pkg/tests" "$pkg/scripts"
+
+__SETUP_NODE_MODULES__
+__ENSURE_NODE__
+
+ensure_node
+setup_node_modules "$pkg" "$execroot/node_modules"
+__DEP_LINKS__
+
+cd "$pkg"
+"$execroot/node_modules/.bin/rescript" __BUILD_ARGS__
+
+rm -rf "$pkg/node_modules"
+rm -rf "$execroot/__OUT__"
+mkdir -p "$execroot/__OUT__"
+cp -a "$pkg/." "$execroot/__OUT__/"
+""".replace("__MANIFEST__", manifest.path).replace(
+        "__SETUP_NODE_MODULES__",
+        _setup_node_modules_script(),
+    ).replace(
+        "__ENSURE_NODE__",
+        _ensure_node_script(),
+    ).replace(
+        "__DEP_LINKS__",
+        "\n".join(dep_links),
+    ).replace(
+        "__BUILD_ARGS__",
+        build_args,
+    ).replace(
+        "__OUT__",
+        out.path,
+    )
+
+def _shell_quote(value):
+    return "'" + value.replace("'", "'\\''") + "'"
+
+def _rescript_package_impl(ctx):
+    out = ctx.actions.declare_directory(ctx.label.name + "_pkg")
+    manifest = ctx.actions.declare_file(ctx.label.name + "_sources.txt")
+    srcs = ctx.files.srcs
+    dep_infos = [dep[RescriptPackageInfo] for dep in ctx.attr.deps]
+
+    ctx.actions.write(
+        output = manifest,
+        content = _copy_manifest_lines(srcs, ctx.label.package),
+    )
+
+    ctx.actions.run_shell(
+        inputs = depset(srcs + [manifest] + [dep.output for dep in dep_infos]),
+        outputs = [out],
+        command = _build_command(manifest, out, dep_infos, ctx.attr.dev),
+        execution_requirements = {
+            "local": "1",
+            "no-remote": "1",
+            "no-sandbox": "1",
+        },
+        use_default_shell_env = True,
+        mnemonic = "ReScriptBuild",
+        progress_message = "Building ReScript package %s" % ctx.attr.package_name,
+    )
+
+    return [
+        DefaultInfo(files = depset([out])),
+        RescriptPackageInfo(
+            package_name = ctx.attr.package_name,
+            output = out,
+            direct_deps = dep_infos,
+        ),
+    ]
+
+_rescript_package = rule(
+    implementation = _rescript_package_impl,
+    attrs = {
+        "package_name": attr.string(mandatory = True),
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [RescriptPackageInfo]),
+        "dev": attr.bool(default = False),
+    },
+)
+
+def _test_script(package, runner):
+    dep_links = []
+    for dep in package.direct_deps:
+        dep_links.append("link_package_dep \"$pkg\" %s \"$dep_root/%s\"" % (
+            _shell_quote(dep.package_name),
+            dep.output.short_path,
+        ))
+
+    if runner == "vitest":
+        run = """
+cd "$pkg"
+export NODE_OPTIONS="${NODE_OPTIONS:-} --preserve-symlinks"
+"$root_nm/.bin/vitest" run
+"""
+    elif runner == "compile":
+        run = """
+test -d "$pkg/lib"
+"""
+    else:
+        fail("unknown ReScript test runner: %s" % runner)
+
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+runfiles="${RUNFILES_DIR:-$0.runfiles}"
+workspace="${TEST_WORKSPACE:-frontman}"
+test_cwd="$PWD"
+execroot="$PWD"
+root_nm="$test_cwd/node_modules"
+
+if [ ! -d "$root_nm" ] && [[ "$test_cwd" == */bazel-out/* ]]; then
+  execroot="${test_cwd%%/bazel-out/*}"
+  root_nm="$execroot/node_modules"
+fi
+
+if [ ! -d "$root_nm" ] && [ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]; then
+  root_nm="$BUILD_WORKSPACE_DIRECTORY/node_modules"
+fi
+
+pkg_src="$runfiles/$workspace/__PACKAGE_SHORT_PATH__"
+dep_root="$runfiles/$workspace"
+
+if [ ! -d "$pkg_src" ]; then
+  pkg_src="$execroot/__PACKAGE_PATH__"
+  dep_root="$execroot"
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel-test.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+pkg="$tmp/package"
+mkdir -p "$pkg"
+cp -a "$pkg_src/." "$pkg/"
+chmod -R u+w "$pkg"
+
+__SETUP_NODE_MODULES__
+__ENSURE_NODE__
+
+ensure_node
+setup_node_modules "$pkg" "$root_nm"
+__DEP_LINKS__
+
+__RUN__
+""".replace("__PACKAGE_SHORT_PATH__", package.output.short_path).replace(
+        "__PACKAGE_PATH__",
+        package.output.path,
+    ).replace(
+        "__SETUP_NODE_MODULES__",
+        _setup_node_modules_script(),
+    ).replace(
+        "__ENSURE_NODE__",
+        _ensure_node_script(),
+    ).replace(
+        "__DEP_LINKS__",
+        "\n".join(dep_links),
+    ).replace(
+        "__RUN__",
+        run,
+    )
+
+def _rescript_package_test_impl(ctx):
+    package = ctx.attr.package[RescriptPackageInfo]
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.write(
+        output = executable,
+        content = _test_script(package, ctx.attr.runner),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [package.output] + [dep.output for dep in package.direct_deps])
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = runfiles,
+        ),
+    ]
+
+_rescript_package_test = rule(
+    implementation = _rescript_package_test_impl,
+    attrs = {
+        "package": attr.label(mandatory = True, providers = [RescriptPackageInfo]),
+        "runner": attr.string(default = "vitest", values = ["compile", "vitest"]),
+    },
+    test = True,
+)
+
+def rescript_package(name, package_name, srcs, dev_srcs = [], deps = [], dev_deps = [], test_runner = None, visibility = None):
+    kwargs = {}
+    if visibility != None:
+        kwargs["visibility"] = visibility
+
+    _rescript_package(
+        name = name,
+        package_name = package_name,
+        srcs = srcs,
+        deps = deps,
+        **kwargs
+    )
+
+    if test_runner != None:
+        _rescript_package(
+            name = name + "_dev",
+            package_name = package_name,
+            srcs = srcs + dev_srcs,
+            deps = deps + dev_deps,
+            dev = True,
+            visibility = ["//visibility:private"],
+        )
+
+        _rescript_package_test(
+            name = "test",
+            package = ":" + name + "_dev",
+            runner = test_runner,
+            tags = ["local", "no-remote", "no-sandbox"],
+            **kwargs
+        )

--- a/tools/bazel/rescript/defs.bzl
+++ b/tools/bazel/rescript/defs.bzl
@@ -323,6 +323,247 @@ _rescript_package_test = rule(
     test = True,
 )
 
+def _schema_export_command(package, script, schemas_dir, static_manifest, out):
+    dep_links = []
+    for dep in package.direct_deps:
+        dep_links.append("copy_package_dep \"$pkg\" %s \"$execroot/%s\"" % (
+            _shell_quote(dep.package_name),
+            dep.output.path,
+        ))
+
+    return """
+set -euo pipefail
+
+execroot="$PWD"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel-schemas.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+pkg="$tmp/package"
+mkdir -p "$pkg"
+cp -a "$execroot/__PACKAGE_PATH__/." "$pkg/"
+chmod -R u+w "$pkg"
+
+__SETUP_NODE_MODULES__
+__ENSURE_NODE__
+
+ensure_node
+setup_node_modules "$pkg" "$execroot/node_modules"
+__DEP_LINKS__
+
+rm -rf "$pkg/__SCHEMAS_DIR__"
+mkdir -p "$pkg/__SCHEMAS_DIR__"
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  mkdir -p "$pkg/$(dirname "$rel")"
+  cp "$src" "$pkg/$rel"
+done < "$execroot/__STATIC_MANIFEST__"
+
+cd "$pkg"
+node "__SCRIPT__"
+
+rm -rf "$execroot/__OUT__"
+mkdir -p "$execroot/__OUT__"
+cp -a "$pkg/__SCHEMAS_DIR__/." "$execroot/__OUT__/"
+""".replace("__PACKAGE_PATH__", package.output.path).replace(
+        "__SETUP_NODE_MODULES__",
+        _setup_node_modules_script(),
+    ).replace(
+        "__ENSURE_NODE__",
+        _ensure_node_script(),
+    ).replace(
+        "__DEP_LINKS__",
+        "\n".join(dep_links),
+    ).replace(
+        "__STATIC_MANIFEST__",
+        static_manifest.path,
+    ).replace(
+        "__SCHEMAS_DIR__",
+        schemas_dir,
+    ).replace(
+        "__SCRIPT__",
+        script,
+    ).replace(
+        "__OUT__",
+        out.path,
+    )
+
+def _rescript_schema_export_impl(ctx):
+    package = ctx.attr.package[RescriptPackageInfo]
+    out = ctx.actions.declare_directory(ctx.label.name + "_out")
+    static_manifest = ctx.actions.declare_file(ctx.label.name + "_static_schemas.txt")
+
+    ctx.actions.write(
+        output = static_manifest,
+        content = _copy_manifest_lines(ctx.files.static_schema_files, ctx.label.package),
+    )
+
+    ctx.actions.run_shell(
+        inputs = depset(
+            [package.output, static_manifest] +
+            ctx.files.static_schema_files +
+            [dep.output for dep in package.direct_deps],
+        ),
+        outputs = [out],
+        command = _schema_export_command(package, ctx.attr.script, ctx.attr.schemas_dir, static_manifest, out),
+        execution_requirements = {
+            "local": "1",
+            "no-remote": "1",
+            "no-sandbox": "1",
+        },
+        use_default_shell_env = True,
+        mnemonic = "ReScriptSchemaExport",
+        progress_message = "Exporting ReScript schemas %s" % ctx.label,
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+rescript_schema_export = rule(
+    implementation = _rescript_schema_export_impl,
+    attrs = {
+        "package": attr.label(mandatory = True, providers = [RescriptPackageInfo]),
+        "script": attr.string(mandatory = True),
+        "schemas_dir": attr.string(default = "schemas"),
+        "static_schema_files": attr.label_list(allow_files = True),
+    },
+)
+
+def _schema_manifest_lines(files, package_path, schemas_dir):
+    lines = []
+    prefix = package_path + "/" + schemas_dir + "/" if package_path else schemas_dir + "/"
+
+    for src in files:
+        rel = src.short_path
+        if rel.startswith(prefix):
+            rel = rel[len(prefix):]
+        lines.append("%s\t%s" % (src.short_path, rel))
+
+    return "\n".join(lines) + "\n"
+
+def _schema_check_script(generated, manifest):
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+runfiles="${RUNFILES_DIR:-$0.runfiles}"
+workspace="${TEST_WORKSPACE:-}"
+execroot="$PWD"
+
+generated=""
+manifest=""
+runfiles_workspace=""
+
+for candidate_workspace in "$workspace" _main frontman; do
+  [ -n "$candidate_workspace" ] || continue
+  candidate_generated="$runfiles/$candidate_workspace/__GENERATED_SHORT_PATH__"
+  candidate_manifest="$runfiles/$candidate_workspace/__MANIFEST_SHORT_PATH__"
+  if [ -d "$candidate_generated" ] && [ -f "$candidate_manifest" ]; then
+    generated="$candidate_generated"
+    manifest="$candidate_manifest"
+    runfiles_workspace="$candidate_workspace"
+    break
+  fi
+done
+
+if [ -z "$generated" ]; then
+  generated="$execroot/__GENERATED_PATH__"
+fi
+
+if [ -z "$manifest" ]; then
+  manifest="$execroot/__MANIFEST_PATH__"
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel-check-schemas.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+expected="$tmp/expected.txt"
+actual="$tmp/actual.txt"
+: > "$expected"
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  printf '%s\n' "$rel" >> "$expected"
+done < "$manifest"
+
+sort -o "$expected" "$expected"
+(cd "$generated" && find . -type f -name '*.json' -print | while read -r file; do printf '%s\n' "${file#./}"; done | sort) > "$actual"
+
+failed=0
+if ! diff -u "$expected" "$actual"; then
+  echo "Generated schema file list differs from committed schemas" >&2
+  failed=1
+fi
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  committed="$runfiles/$runfiles_workspace/$src"
+  if [ ! -f "$committed" ]; then
+    committed="$execroot/$src"
+  fi
+
+  generated_file="$generated/$rel"
+  if [ ! -f "$generated_file" ]; then
+    echo "Missing generated schema: $rel" >&2
+    failed=1
+    continue
+  fi
+
+  if ! cmp -s "$committed" "$generated_file"; then
+    echo "Schema mismatch: $rel" >&2
+    diff -u "$committed" "$generated_file" || true
+    failed=1
+  fi
+done < "$manifest"
+
+exit "$failed"
+""".replace("__GENERATED_SHORT_PATH__", generated.short_path).replace(
+        "__GENERATED_PATH__",
+        generated.path,
+    ).replace(
+        "__MANIFEST_SHORT_PATH__",
+        manifest.short_path,
+    ).replace(
+        "__MANIFEST_PATH__",
+        manifest.path,
+    )
+
+def _schema_check_test_impl(ctx):
+    generated = ctx.files.generated
+    if len(generated) != 1:
+        fail("schema_check_test generated attr must have exactly one output")
+
+    manifest = ctx.actions.declare_file(ctx.label.name + "_schemas.txt")
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.write(
+        output = manifest,
+        content = _schema_manifest_lines(ctx.files.schema_files, ctx.label.package, ctx.attr.schemas_dir),
+    )
+
+    ctx.actions.write(
+        output = executable,
+        content = _schema_check_script(generated[0], manifest),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = ctx.files.schema_files + generated + [manifest])
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = runfiles,
+        ),
+    ]
+
+schema_check_test = rule(
+    implementation = _schema_check_test_impl,
+    attrs = {
+        "generated": attr.label(mandatory = True),
+        "schema_files": attr.label_list(allow_files = True, mandatory = True),
+        "schemas_dir": attr.string(default = "schemas"),
+    },
+    test = True,
+)
+
 def rescript_package(name, package_name, srcs, dev_srcs = [], deps = [], dev_deps = [], test_runner = None, visibility = None):
     kwargs = {}
     if visibility != None:

--- a/tools/bazel/rescript/defs.bzl
+++ b/tools/bazel/rescript/defs.bzl
@@ -6,6 +6,15 @@ RescriptPackageInfo = provider(
     },
 )
 
+RESCRIPT_OUTPUT_EXCLUDES = [
+    "**/*.gen.tsx",
+    "**/*.res.d.ts",
+    "**/*.res.js",
+    "**/*.res.js.map",
+    "**/*.res.mjs",
+    "**/*.res.mjs.map",
+]
+
 _MIGRATED_PACKAGES = [
     "@rescript/webapi",
     "@frontman/bindings",


### PR DESCRIPTION
## Summary
- Add ReScript Bazel package rule/macro and minimal Bazel workspace setup.
- Add Bazel build/test targets across the migrated ReScript package graph.
- Fix Astro browser test imports for package-local Bazel execution.

## Tracking issues
- Closes #1098
- Closes #1099
- Part of #1096

## Verification
- `./bin/pod-exec mise exec -- make rescript-build`
- `./bin/pod-exec mise exec -- make -C libs/frontman-astro-browser test`
- Pre-commit hook: `rescript-format`
- Pre-push hook: `reanalyze`

Not run:
- `bazel test ...`: `bazel` and `bazelisk` are not installed in local/container PATH.