### PR TITLE
Add Bazel protocol schema checks

### DIFF
--- a/.changeset/protocol-schemas-bazel.md
+++ b/.changeset/protocol-schemas-bazel.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-protocol": patch
+---
+
+Add Bazel schema export and schema check targets for protocol schemas.

--- a/libs/client/BUILD.bazel
+++ b/libs/client/BUILD.bazel
@@ -11,11 +11,13 @@ rescript_package(
         "src/**/*.css",
         "src/**/*.res",
         "src/**/*.resi",
+        "src/**/*.ts",
         "src/**/*.tsx",
     ], allow_empty = True),
     dev_srcs = glob([
         "test/**/*.js",
         "test/**/*.json",
+        "test/**/*.mjs",
         "test/**/*.res",
         "test/**/*.resi",
         "test/**/*.ts",

--- a/libs/frontman-protocol/BUILD.bazel
+++ b/libs/frontman-protocol/BUILD.bazel
@@ -29,7 +29,6 @@ rescript_package(
     srcs = glob([
         "package.json",
         "rescript.json",
-        "schemas/**/*.json",
         "scripts/**/*.res",
         "src/**/*.res",
         "src/**/*.resi",
@@ -45,6 +44,7 @@ rescript_schema_export(
     name = "schemas",
     package = ":frontman-protocol_schemas_pkg",
     script = "scripts/ExportSchemas.res.mjs",
+    static_schema_files = ["schemas/acp/contentBlock.json"],
 )
 
 schema_check_test(

--- a/libs/frontman-protocol/BUILD.bazel
+++ b/libs/frontman-protocol/BUILD.bazel
@@ -1,4 +1,9 @@
-load("//tools/bazel/rescript:defs.bzl", "rescript_package")
+load(
+    "//tools/bazel/rescript:defs.bzl",
+    "rescript_package",
+    "rescript_schema_export",
+    "schema_check_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,4 +21,35 @@ rescript_package(
         "//libs/bindings",
         "//libs/experimental-rescript-webapi",
     ],
+)
+
+rescript_package(
+    name = "frontman-protocol_schemas_pkg",
+    package_name = "@frontman-ai/frontman-protocol",
+    srcs = glob([
+        "package.json",
+        "rescript.json",
+        "schemas/**/*.json",
+        "scripts/**/*.res",
+        "src/**/*.res",
+        "src/**/*.resi",
+    ], allow_empty = True),
+    deps = [
+        "//libs/bindings",
+        "//libs/experimental-rescript-webapi",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+rescript_schema_export(
+    name = "schemas",
+    package = ":frontman-protocol_schemas_pkg",
+    script = "scripts/ExportSchemas.res.mjs",
+)
+
+schema_check_test(
+    name = "check_schemas",
+    generated = ":schemas",
+    schema_files = glob(["schemas/**/*.json"]),
+    tags = ["local", "no-remote", "no-sandbox"],
 )

--- a/tools/bazel/rescript/defs.bzl
+++ b/tools/bazel/rescript/defs.bzl
@@ -323,6 +323,226 @@ _rescript_package_test = rule(
     test = True,
 )
 
+def _schema_export_command(package, script, schemas_dir, out):
+    dep_links = []
+    for dep in package.direct_deps:
+        dep_links.append("copy_package_dep \"$pkg\" %s \"$execroot/%s\"" % (
+            _shell_quote(dep.package_name),
+            dep.output.path,
+        ))
+
+    return """
+set -euo pipefail
+
+execroot="$PWD"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel-schemas.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+pkg="$tmp/package"
+mkdir -p "$pkg"
+cp -a "$execroot/__PACKAGE_PATH__/." "$pkg/"
+chmod -R u+w "$pkg"
+
+__SETUP_NODE_MODULES__
+__ENSURE_NODE__
+
+ensure_node
+setup_node_modules "$pkg" "$execroot/node_modules"
+__DEP_LINKS__
+
+mkdir -p "$pkg/__SCHEMAS_DIR__"
+
+cd "$pkg"
+node "__SCRIPT__"
+
+rm -rf "$execroot/__OUT__"
+mkdir -p "$execroot/__OUT__"
+cp -a "$pkg/__SCHEMAS_DIR__/." "$execroot/__OUT__/"
+""".replace("__PACKAGE_PATH__", package.output.path).replace(
+        "__SETUP_NODE_MODULES__",
+        _setup_node_modules_script(),
+    ).replace(
+        "__ENSURE_NODE__",
+        _ensure_node_script(),
+    ).replace(
+        "__DEP_LINKS__",
+        "\n".join(dep_links),
+    ).replace(
+        "__SCHEMAS_DIR__",
+        schemas_dir,
+    ).replace(
+        "__SCRIPT__",
+        script,
+    ).replace(
+        "__OUT__",
+        out.path,
+    )
+
+def _rescript_schema_export_impl(ctx):
+    package = ctx.attr.package[RescriptPackageInfo]
+    out = ctx.actions.declare_directory(ctx.label.name + "_out")
+
+    ctx.actions.run_shell(
+        inputs = depset([package.output] + [dep.output for dep in package.direct_deps]),
+        outputs = [out],
+        command = _schema_export_command(package, ctx.attr.script, ctx.attr.schemas_dir, out),
+        execution_requirements = {
+            "local": "1",
+            "no-remote": "1",
+            "no-sandbox": "1",
+        },
+        use_default_shell_env = True,
+        mnemonic = "ReScriptSchemaExport",
+        progress_message = "Exporting ReScript schemas %s" % ctx.label,
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+rescript_schema_export = rule(
+    implementation = _rescript_schema_export_impl,
+    attrs = {
+        "package": attr.label(mandatory = True, providers = [RescriptPackageInfo]),
+        "script": attr.string(mandatory = True),
+        "schemas_dir": attr.string(default = "schemas"),
+    },
+)
+
+def _schema_manifest_lines(files, package_path, schemas_dir):
+    lines = []
+    prefix = package_path + "/" + schemas_dir + "/" if package_path else schemas_dir + "/"
+
+    for src in files:
+        rel = src.short_path
+        if rel.startswith(prefix):
+            rel = rel[len(prefix):]
+        lines.append("%s\t%s" % (src.short_path, rel))
+
+    return "\n".join(lines) + "\n"
+
+def _schema_check_script(generated, manifest):
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+runfiles="${RUNFILES_DIR:-$0.runfiles}"
+workspace="${TEST_WORKSPACE:-}"
+execroot="$PWD"
+
+generated=""
+manifest=""
+runfiles_workspace=""
+
+for candidate_workspace in "$workspace" _main frontman; do
+  [ -n "$candidate_workspace" ] || continue
+  candidate_generated="$runfiles/$candidate_workspace/__GENERATED_SHORT_PATH__"
+  candidate_manifest="$runfiles/$candidate_workspace/__MANIFEST_SHORT_PATH__"
+  if [ -d "$candidate_generated" ] && [ -f "$candidate_manifest" ]; then
+    generated="$candidate_generated"
+    manifest="$candidate_manifest"
+    runfiles_workspace="$candidate_workspace"
+    break
+  fi
+done
+
+if [ -z "$generated" ]; then
+  generated="$execroot/__GENERATED_PATH__"
+fi
+
+if [ -z "$manifest" ]; then
+  manifest="$execroot/__MANIFEST_PATH__"
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/rescript-bazel-check-schemas.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+expected="$tmp/expected.txt"
+actual="$tmp/actual.txt"
+: > "$expected"
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  printf '%s\n' "$rel" >> "$expected"
+done < "$manifest"
+
+sort -o "$expected" "$expected"
+(cd "$generated" && find . -type f -name '*.json' -print | while read -r file; do printf '%s\n' "${file#./}"; done | sort) > "$actual"
+
+failed=0
+if ! diff -u "$expected" "$actual"; then
+  echo "Generated schema file list differs from committed schemas" >&2
+  failed=1
+fi
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  committed="$runfiles/$runfiles_workspace/$src"
+  if [ ! -f "$committed" ]; then
+    committed="$execroot/$src"
+  fi
+
+  generated_file="$generated/$rel"
+  if [ ! -f "$generated_file" ]; then
+    echo "Missing generated schema: $rel" >&2
+    failed=1
+    continue
+  fi
+
+  if ! cmp -s "$committed" "$generated_file"; then
+    echo "Schema mismatch: $rel" >&2
+    diff -u "$committed" "$generated_file" || true
+    failed=1
+  fi
+done < "$manifest"
+
+exit "$failed"
+""".replace("__GENERATED_SHORT_PATH__", generated.short_path).replace(
+        "__GENERATED_PATH__",
+        generated.path,
+    ).replace(
+        "__MANIFEST_SHORT_PATH__",
+        manifest.short_path,
+    ).replace(
+        "__MANIFEST_PATH__",
+        manifest.path,
+    )
+
+def _schema_check_test_impl(ctx):
+    generated = ctx.files.generated
+    if len(generated) != 1:
+        fail("schema_check_test generated attr must have exactly one output")
+
+    manifest = ctx.actions.declare_file(ctx.label.name + "_schemas.txt")
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.write(
+        output = manifest,
+        content = _schema_manifest_lines(ctx.files.schema_files, ctx.label.package, ctx.attr.schemas_dir),
+    )
+
+    ctx.actions.write(
+        output = executable,
+        content = _schema_check_script(generated[0], manifest),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = ctx.files.schema_files + generated + [manifest])
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = runfiles,
+        ),
+    ]
+
+schema_check_test = rule(
+    implementation = _schema_check_test_impl,
+    attrs = {
+        "generated": attr.label(mandatory = True),
+        "schema_files": attr.label_list(allow_files = True, mandatory = True),
+        "schemas_dir": attr.string(default = "schemas"),
+    },
+    test = True,
+)
+
 def rescript_package(name, package_name, srcs, dev_srcs = [], deps = [], dev_deps = [], test_runner = None, visibility = None):
     kwargs = {}
     if visibility != None:

--- a/tools/bazel/rescript/defs.bzl
+++ b/tools/bazel/rescript/defs.bzl
@@ -323,7 +323,7 @@ _rescript_package_test = rule(
     test = True,
 )
 
-def _schema_export_command(package, script, schemas_dir, out):
+def _schema_export_command(package, script, schemas_dir, static_manifest, out):
     dep_links = []
     for dep in package.direct_deps:
         dep_links.append("copy_package_dep \"$pkg\" %s \"$execroot/%s\"" % (
@@ -350,7 +350,14 @@ ensure_node
 setup_node_modules "$pkg" "$execroot/node_modules"
 __DEP_LINKS__
 
+rm -rf "$pkg/__SCHEMAS_DIR__"
 mkdir -p "$pkg/__SCHEMAS_DIR__"
+
+while IFS=$'\t' read -r src rel; do
+  [ -n "$src" ] || continue
+  mkdir -p "$pkg/$(dirname "$rel")"
+  cp "$src" "$pkg/$rel"
+done < "$execroot/__STATIC_MANIFEST__"
 
 cd "$pkg"
 node "__SCRIPT__"
@@ -368,6 +375,9 @@ cp -a "$pkg/__SCHEMAS_DIR__/." "$execroot/__OUT__/"
         "__DEP_LINKS__",
         "\n".join(dep_links),
     ).replace(
+        "__STATIC_MANIFEST__",
+        static_manifest.path,
+    ).replace(
         "__SCHEMAS_DIR__",
         schemas_dir,
     ).replace(
@@ -381,11 +391,21 @@ cp -a "$pkg/__SCHEMAS_DIR__/." "$execroot/__OUT__/"
 def _rescript_schema_export_impl(ctx):
     package = ctx.attr.package[RescriptPackageInfo]
     out = ctx.actions.declare_directory(ctx.label.name + "_out")
+    static_manifest = ctx.actions.declare_file(ctx.label.name + "_static_schemas.txt")
+
+    ctx.actions.write(
+        output = static_manifest,
+        content = _copy_manifest_lines(ctx.files.static_schema_files, ctx.label.package),
+    )
 
     ctx.actions.run_shell(
-        inputs = depset([package.output] + [dep.output for dep in package.direct_deps]),
+        inputs = depset(
+            [package.output, static_manifest] +
+            ctx.files.static_schema_files +
+            [dep.output for dep in package.direct_deps],
+        ),
         outputs = [out],
-        command = _schema_export_command(package, ctx.attr.script, ctx.attr.schemas_dir, out),
+        command = _schema_export_command(package, ctx.attr.script, ctx.attr.schemas_dir, static_manifest, out),
         execution_requirements = {
             "local": "1",
             "no-remote": "1",
@@ -404,6 +424,7 @@ rescript_schema_export = rule(
         "package": attr.label(mandatory = True, providers = [RescriptPackageInfo]),
         "script": attr.string(mandatory = True),
         "schemas_dir": attr.string(default = "schemas"),
+        "static_schema_files": attr.label_list(allow_files = True),
     },
 )
 


### PR DESCRIPTION
## Summary
- Add Bazel schema export target for `frontman-protocol` into a declared output tree.
- Add Bazel schema check test that compares generated schemas to committed `schemas/**/*.json` without `git diff` or source mutation.
- Include client `.ts` source and handwritten `.mjs` test globs from #1109 review feedback.

## Stacking
- Base branch: `issue-1099-migrate-rescript-package-graph`
- This PR is stacked on #1109 and should merge into that branch.

## Tracking issues
- Closes #1100
- Part of #1096
- Builds on #1109 / #1099

## Verification
- `npx --yes @bazel/bazelisk query //...`
- `npx --yes @bazel/bazelisk build //libs/frontman-protocol:schemas`
- `npx --yes @bazel/bazelisk test //libs/frontman-protocol:check_schemas`
- `npx --yes @bazel/bazelisk test //libs/client:test`
- `aquery` no-yarn check for protocol schema targets and client test
- `git diff --check`
- Pre-push hook: `reanalyze`