### PR TITLE
Fix marketing Ahrefs audit issues

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -128,6 +128,7 @@ export default defineConfig({
       disable404Route: true,
       logo: {
         src: "./src/assets/logo.svg",
+        alt: "Frontman logo",
       },
       social: [
         {
@@ -290,7 +291,7 @@ export default defineConfig({
         if (/\/vs\//.test(item.url)) return item;
       },
       integrations: (item) => {
-        if (/\/integrations\//.test(item.url)) return item;
+        if (/(?<!\/docs)\/integrations\//.test(item.url)) return item;
       },
       docs: (item) => {
         if (/\/docs\//.test(item.url)) return item;

--- a/apps/marketing/src/components/blocks/comparison/ComparisonStructuredData.astro
+++ b/apps/marketing/src/components/blocks/comparison/ComparisonStructuredData.astro
@@ -1,8 +1,8 @@
 ---
 // ComparisonStructuredData
 // ------------------------
-// Emits all JSON-LD structured data for a /vs/ comparison page.
-// Blocks: FAQPage, SoftwareApplication (Frontman), SoftwareApplication (competitor), WebPage.
+// Emits JSON-LD structured data for a /vs/ comparison page.
+// Blocks: FAQPage and WebPage. Software-app rich results require real ratings or reviews, so avoid emitting incomplete SoftwareApplication markup.
 
 type FAQ = {
   question: string
@@ -31,7 +31,7 @@ type Props = {
   seo: SEOInfo
 }
 
-const { competitor, faqs, seo } = Astro.props
+const { faqs, seo } = Astro.props
 const pageUrl = Astro.url.href
 
 // FAQPage
@@ -46,44 +46,6 @@ const faqJsonLd = {
       "text": faq.answer,
     },
   })),
-}
-
-// SoftwareApplication — Frontman
-const frontmanAppJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Frontman",
-  "url": "https://frontman.sh/",
-  "applicationCategory": "DesignApplication",
-  "operatingSystem": "Web",
-  "description": "An open-source AI agent that lets designers and product managers edit a running app in the browser. Point at any element, describe the change, get real code.",
-  "license": "https://github.com/frontman-ai/frontman/blob/main/LICENSE",
-  "codeRepository": "https://github.com/frontman-ai/frontman",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD",
-    "description": "Free and open source — bring your own API key",
-  },
-  "isSimilarTo": {
-    "@type": "SoftwareApplication",
-    "name": competitor.name,
-    "url": competitor.url,
-  },
-}
-
-// SoftwareApplication — Competitor
-const competitorAppJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": competitor.name,
-  "url": competitor.url,
-  "applicationCategory": competitor.category,
-  "description": competitor.description,
-  "offers": {
-    "@type": "Offer",
-    "description": `${competitor.pricing.cost} — ${competitor.pricing.model}`,
-  },
 }
 
 // WebPage
@@ -102,6 +64,4 @@ const webPageJsonLd = {
 ---
 
 <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
-<script is:inline type="application/ld+json" set:html={JSON.stringify(frontmanAppJsonLd)} />
-<script is:inline type="application/ld+json" set:html={JSON.stringify(competitorAppJsonLd)} />
 <script is:inline type="application/ld+json" set:html={JSON.stringify(webPageJsonLd)} />

--- a/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
+++ b/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
@@ -1,7 +1,7 @@
 ---
 // Structured Data (JSON-LD)
 // ------------
-// Description: Injects Organization, SoftwareApplication (homepage only), and BreadcrumbList schema markup for SEO.
+// Description: Injects Organization and BreadcrumbList schema markup for SEO.
 
 type BreadcrumbItem = {
 	name: string
@@ -19,7 +19,6 @@ const { noindex = false, breadcrumbs } = Astro.props
 const url = new URL(Astro.request.url)
 const pathname = url.pathname
 const segments = pathname.split('/').filter(Boolean)
-const isHomepage = segments.length === 0
 
 const defaultBreadcrumbItems = [
 	{ name: 'Home', url: 'https://frontman.sh/' },
@@ -68,30 +67,6 @@ const breadcrumbJsonLd = {
 		"http://www.wikidata.org/entity/Q138753470"
 	]
 })} />
-
-{/* SoftwareApplication - only on homepage where it's contextually relevant */}
-{isHomepage && (
-	<script is:inline type="application/ld+json" set:html={JSON.stringify({
-		"@context": "https://schema.org",
-		"@type": "SoftwareApplication",
-		"name": "Frontman",
-		"url": "https://frontman.sh/",
-		"applicationCategory": "DesignApplication",
-		"operatingSystem": "Web",
-		"description": "Point at any element in your running app, describe what you want in plain English, and get real code edits. Frontman lets designers and product managers work on a running application the way they work in Figma. Supports Next.js, Astro, and Vite.",
-		"author": {
-			"@type": "Organization",
-			"name": "Frontman",
-			"url": "https://frontman.sh/"
-		},
-		"license": "https://github.com/frontman-ai/frontman/blob/main/LICENSE",
-		"codeRepository": "https://github.com/frontman-ai/frontman",
-		"downloadUrl": "https://github.com/frontman-ai/frontman",
-		"screenshot": "https://frontman.sh/og-image.png",
-		"featureList": "Click-to-select UI elements, Live DOM context, AI-powered code edits, Framework-aware (Next.js, Astro, Vite), BYOK (Bring Your Own Key), Open-source core",
-		"softwareRequirements": "Next.js, Astro, or Vite development project"
-	})} />
-)}
 
 {/* BreadcrumbList - helps Google show breadcrumb trails in search results */}
 {shouldEmitBreadcrumbs && (

--- a/apps/marketing/src/content/docs/docs/api-keys.md
+++ b/apps/marketing/src/content/docs/docs/api-keys.md
@@ -1,6 +1,6 @@
 ---
 title: API Keys & Providers
-description: Configure your AI model provider — use the free tier, bring your own key, or connect via OAuth.
+description: Configure AI model access in Frontman, choose a provider, bring your own API key, connect OAuth, and control model selection and usage costs.
 ---
 
 Frontman needs access to a large language model (LLM) to power the coding agent. You have three options for connecting a provider.

--- a/apps/marketing/src/content/docs/docs/installation.md
+++ b/apps/marketing/src/content/docs/docs/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: How to install Frontman in your project.
+description: Install Frontman in Astro, Next.js, or Vite projects with the right package command, then open the browser agent in your local dev server.
 ---
 
 Frontman ships as a framework-specific integration — pick the guide that matches your project.

--- a/apps/marketing/src/content/docs/docs/integrations/astro.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/astro.mdx
@@ -1,6 +1,6 @@
 ---
 title: Astro
-description: Complete reference for the @frontman-ai/astro integration — installation, configuration options, dev server hooks, element source detection, and troubleshooting.
+description: Install and configure @frontman-ai/astro, including integration options, dev server hooks, element source detection, and troubleshooting.
 ---
 
 import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js Integration
-description: Install @frontman-ai/nextjs with App Router, Pages Router, Next.js 16 proxy.ts, middleware matchers, Turbopack HMR, and OpenTelemetry troubleshooting.
+description: Install @frontman-ai/nextjs for App Router, Pages Router, Next.js proxy or middleware setup, Turbopack HMR, and OpenTelemetry troubleshooting.
 ---
 
 import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';

--- a/apps/marketing/src/content/docs/docs/integrations/vite.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/vite.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vite Integration
-description: Install and configure the @frontman-ai/vite plugin for React, Vue, Svelte, SolidJS, and SvelteKit apps, including options, source mapping, logs, and troubleshooting.
+description: Install and configure @frontman-ai/vite for React, Vue, Svelte, SolidJS, and SvelteKit apps, with source mapping, logs, and troubleshooting.
 ---
 
 import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';

--- a/apps/marketing/src/content/docs/docs/integrations/wordpress.md
+++ b/apps/marketing/src/content/docs/docs/integrations/wordpress.md
@@ -1,6 +1,6 @@
 ---
 title: WordPress (Beta)
-description: Install the Frontman WordPress plugin to edit posts, blocks, Elementor pages, menus, templates, widgets, and site settings through a conversational AI interface.
+description: Install the Frontman WordPress plugin to edit posts, blocks, Elementor pages, menus, templates, widgets, and settings through an AI interface.
 ---
 
 The Frontman WordPress plugin adds an AI agent directly to your WordPress site. Navigate to `/frontman`, describe what you want to change, and the agent handles the supported workflow inside the site preview — no code editor or terminal required for those supported changes.

--- a/apps/marketing/src/content/docs/docs/reference/compatibility.md
+++ b/apps/marketing/src/content/docs/docs/reference/compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Frameworks
-description: What Frontman supports today across Next.js, Astro, Vite-based apps, and WordPress, including requirements, limits, and what each integration exposes to the agent.
+description: See what Frontman supports across Next.js, Astro, Vite-based apps, and WordPress, including version requirements and integration limits.
 ---
 
 Frontman has two compatibility layers:

--- a/apps/marketing/src/content/docs/docs/reference/index.md
+++ b/apps/marketing/src/content/docs/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-description: Technical reference for Frontman — configuration options, environment variables, architecture internals, supported models, framework compatibility, self-hosting, and troubleshooting.
+description: Technical reference for Frontman configuration, environment variables, architecture, supported models, compatibility, self-hosting, and troubleshooting.
 ---
 
 The reference section covers everything under the hood: how Frontman is structured, how to configure it, and what to do when something goes wrong. If you're looking for step-by-step workflows, head to [Using Frontman](/docs/using/how-the-agent-works/) instead.

--- a/apps/marketing/src/content/docs/docs/reference/troubleshooting.md
+++ b/apps/marketing/src/content/docs/docs/reference/troubleshooting.md
@@ -3,8 +3,6 @@ title: Troubleshooting
 description: Fix common Frontman issues — UI not loading, agent timeouts, tool failures, WebSocket connection problems, and more.
 ---
 
-# Frontman Troubleshooting Guide
-
 This guide helps you diagnose and fix common Frontman issues quickly: Frontman not loading, agent timeouts, tool call failures, WebSocket disconnects, and code edits that do not apply.
 
 If you are looking for setup docs, start with [Reference](/docs/reference/). You can also check [Compatibility](/docs/reference/compatibility/), [Configuration](/docs/reference/configuration/), [Environment Variables](/docs/reference/env-vars/), [Models](/docs/reference/models/), and [Architecture](/docs/reference/architecture/).

--- a/apps/marketing/src/content/docs/docs/using/how-the-agent-works.md
+++ b/apps/marketing/src/content/docs/docs/using/how-the-agent-works.md
@@ -1,6 +1,6 @@
 ---
 title: How the Agent Works
-description: Understand the Frontman agent loop — how it sees your page, reads your code, and makes changes.
+description: Understand the Frontman agent loop, from browser context and source-code reads to file edits, verification, and live preview feedback.
 ---
 
 Frontman is an AI agent that sits between your browser and your source code. You describe a change in natural language, and it executes that change by looking at your running app, reading relevant files, and editing them — all without you leaving the browser.

--- a/apps/marketing/src/content/docs/docs/using/plans-and-todos.md
+++ b/apps/marketing/src/content/docs/docs/using/plans-and-todos.md
@@ -1,6 +1,6 @@
 ---
 title: Plans & Todo Lists
-description: How Frontman uses structured plans to track progress on complex tasks.
+description: See how Frontman creates visible task plans and todo lists for complex edits, tracks progress step by step, and keeps one active item at a time.
 ---
 
 For complex tasks, Frontman creates a structured plan — a visible todo list that tracks each step of the work. This gives you real-time insight into what the agent is doing, what's done, and what's next.

--- a/apps/marketing/src/content/docs/docs/using/question-flow.md
+++ b/apps/marketing/src/content/docs/docs/using/question-flow.md
@@ -1,6 +1,6 @@
 ---
 title: The Question Flow
-description: How the Frontman agent asks you questions, how to answer, and what happens when you decline.
+description: Learn how Frontman pauses to ask structured questions, when the agent needs your input, how to answer, and what happens when you decline.
 ---
 
 Most of the time, the Frontman agent works autonomously — it reads your prompt, looks at the page, edits code, and verifies the result. But sometimes it doesn't have enough information to proceed confidently. When that happens, it uses the **question tool** to pause the agent loop and ask you directly.

--- a/apps/marketing/src/data/legalInfo.ts
+++ b/apps/marketing/src/data/legalInfo.ts
@@ -11,6 +11,7 @@ export const legalInfo = {
 	registerNumber: 'HRB 273526 B',
 	managingDirector: 'Fridland Dimitri',
 	supportEmail: 'support@frontman.sh',
+	supportEmailDisplay: 'support [at] frontman.sh',
 	vatId: 'not yet issued'
 } as const
 
@@ -27,7 +28,7 @@ export const legalPlaceholders = {
 	'{{company.registerNumber}}': legalInfo.registerNumber,
 	'{{company.managingDirector}}': legalInfo.managingDirector,
 	'{{company.supportEmail}}': legalInfo.supportEmail,
-	'{{company.supportMailto}}': `[${legalInfo.supportEmail}](mailto:${legalInfo.supportEmail})`,
+	'{{company.supportMailto}}': legalInfo.supportEmailDisplay,
 	'{{company.vatId}}': legalInfo.vatId,
 	'{{company.fullAddress}}': `${legalInfo.streetAddress}, ${legalInfo.postalCode} ${legalInfo.city}, ${legalInfo.country}`
 } as const

--- a/apps/marketing/src/layouts/PostLayout.astro
+++ b/apps/marketing/src/layouts/PostLayout.astro
@@ -87,63 +87,13 @@ const itemListJsonLd = frontmatter.comparisonItems?.length
 					"@type": "ListItem",
 					"position": index + 1,
 					"item": {
-						"@type": "SoftwareApplication",
+						"@type": "Thing",
 						"name": item.name,
 						"url": item.url,
-						"applicationCategory": "DeveloperApplication",
 						...(item.description ? { "description": item.description } : {})
 					}
 				})
 			)
-		}
-	: null
-
-// SoftwareApplication JSON-LD (optional, driven by frontmatter.softwareApplication)
-const softwareApplicationJsonLd = frontmatter.softwareApplication
-	? {
-			"@context": "https://schema.org",
-			"@type": "SoftwareApplication",
-			"name": frontmatter.softwareApplication.name,
-			"url": frontmatter.softwareApplication.url,
-			"applicationCategory": frontmatter.softwareApplication.applicationCategory,
-			"operatingSystem": frontmatter.softwareApplication.operatingSystem,
-			"description": frontmatter.softwareApplication.description,
-			"author": {
-				"@type": "Organization",
-				"name": "Frontman",
-				"url": "https://frontman.sh/"
-			},
-			...(frontmatter.softwareApplication.license
-				? { "license": frontmatter.softwareApplication.license }
-				: {}),
-			...(frontmatter.softwareApplication.codeRepository
-				? { "codeRepository": frontmatter.softwareApplication.codeRepository }
-				: {}),
-			...(frontmatter.softwareApplication.featureList?.length
-				? { "featureList": frontmatter.softwareApplication.featureList }
-				: {}),
-			...(frontmatter.softwareApplication.offers?.length
-				? {
-						"offers": frontmatter.softwareApplication.offers.map(
-							(offer: {
-								name: string
-								price: string
-								priceCurrency: string
-								url: string
-								category?: string
-								description?: string
-							}) => ({
-								"@type": "Offer",
-								"name": offer.name,
-								"price": offer.price,
-								"priceCurrency": offer.priceCurrency,
-								"url": offer.url,
-								...(offer.category ? { "category": offer.category } : {}),
-								...(offer.description ? { "description": offer.description } : {})
-							})
-						)
-					}
-				: {})
 		}
 	: null
 
@@ -181,7 +131,6 @@ const videoJsonLd = frontmatter.video
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(blogPostJsonLd)} />
 	{faqJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
 	{itemListJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(itemListJsonLd)} />}
-	{softwareApplicationJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(softwareApplicationJsonLd)} />}
 	{videoJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} />}
 	<BlogPostHero
 		tags={frontmatter.tags}

--- a/apps/marketing/src/pages/about.astro
+++ b/apps/marketing/src/pages/about.astro
@@ -9,7 +9,7 @@ import Layout from '../layouts/Layout.astro'
 
 // Content
 const SEO = {
-	title: 'About Frontman',
+	title: 'About Frontman: Visual AI Editing for Frontend Teams',
 	description:
 		'Frontman is built by Danni Friedland and Itay Adler — two co-founders who believe AI coding tools should see what developers see.'
 }

--- a/apps/marketing/src/pages/changelog.astro
+++ b/apps/marketing/src/pages/changelog.astro
@@ -14,7 +14,7 @@ const feedData = parseChangelog()
 const SEO = {
 	title: 'Changelog | Frontman',
 	description:
-		'Track every update, new feature, and improvement shipped in Frontman.'
+		'Track every Frontman release, product update, bug fix, integration improvement, and documentation change as the AI frontend editing platform evolves.'
 }
 ---
 

--- a/apps/marketing/src/pages/contact.astro
+++ b/apps/marketing/src/pages/contact.astro
@@ -13,8 +13,8 @@ const contactOptions = [
 		title: 'Email support',
 		description:
 			'Best for installation help, account questions, self-hosting questions, and anything you want to send privately.',
-		href: `mailto:${legalInfo.supportEmail}`,
-		label: legalInfo.supportEmail
+		href: '#email-support',
+		label: legalInfo.supportEmailDisplay
 	},
 	{
 		title: 'Read the docs',
@@ -42,7 +42,7 @@ const contactOptions = [
 const faqs = [
 	{
 		question: 'Where should I report a bug?',
-		answer: `If you can share reproduction steps publicly, GitHub is the best place. If the issue includes private project details, email ${legalInfo.supportEmail} instead.`
+		answer: `If you can share reproduction steps publicly, GitHub is the best place. If the issue includes private project details, email ${legalInfo.supportEmailDisplay} instead.`
 	},
 	{
 		question: 'What should I include when asking for help?',
@@ -51,7 +51,7 @@ const faqs = [
 	},
 	{
 		question: 'Can I ask about self-hosting or team rollout?',
-		answer: `Yes. Email ${legalInfo.supportEmail} with your environment details and goals, and include links to any docs pages you already checked so the conversation starts with context.`
+		answer: `Yes. Email ${legalInfo.supportEmailDisplay} with your environment details and goals, and include links to any docs pages you already checked so the conversation starts with context.`
 	}
 ]
 
@@ -102,6 +102,7 @@ const jsonLd = {
 			<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
 				{contactOptions.map((option) => (
 					<a
+						id={option.href === '#email-support' ? 'email-support' : undefined}
 						href={option.href}
 						class="rounded-3xl border border-neutral-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:border-primary-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-primary-600"
 					>

--- a/apps/marketing/src/pages/dpa.astro
+++ b/apps/marketing/src/pages/dpa.astro
@@ -4,7 +4,7 @@ import LegalDocument from '../components/legal/LegalDocument.astro'
 
 const SEO = {
 	title: 'Data Processing Agreement | Frontman',
-	description: 'Data Processing Agreement for business customers using the hosted Frontman service.'
+	description: 'Read Frontman\'s Data Processing Agreement for hosted customers, including processor obligations, security terms, subprocessors, and privacy contacts.'
 }
 ---
 

--- a/apps/marketing/src/pages/faq.astro
+++ b/apps/marketing/src/pages/faq.astro
@@ -27,7 +27,7 @@ const categories = [
 // Content
 // - SEO
 const SEO = {
-	title: 'Frontman FAQ',
+	title: 'Frontman FAQ: AI Frontend Editing Questions Answered',
 	description:
 		'Get answers to common questions about Frontman — the AI agent that lives inside your app. Learn about features, frameworks, safety, and more.'
 }

--- a/apps/marketing/src/pages/impressum.astro
+++ b/apps/marketing/src/pages/impressum.astro
@@ -5,7 +5,7 @@ import { legalInfo } from '../data/legalInfo'
 
 const SEO = {
 	title: 'Impressum | Frontman',
-	description: `Legal provider information for ${legalInfo.brandName} and ${legalInfo.companyNameAscii}.`
+	description: `Legal provider details for ${legalInfo.brandName}, including ${legalInfo.companyNameAscii}, registered office, court registration, and responsible management.`
 }
 ---
 

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -16,7 +16,7 @@ import faqData from '../data/json-files/faqData.json'
 // Content
 // - SEO
 const SEO = {
-	title: 'Visual AI Frontend Editing | Frontman',
+	title: 'Frontman: Visual AI Frontend Editing',
 	description:
 		'Click any element, describe changes in plain English, get real code edits. Frontman sees your live DOM and running app. Open-source core with BYOK model support.'
 }

--- a/apps/marketing/src/pages/pricing.astro
+++ b/apps/marketing/src/pages/pricing.astro
@@ -144,18 +144,16 @@ const pricingJsonLd = {
 	'@context': 'https://schema.org',
 	'@graph': [
 		{
-			'@type': 'SoftwareApplication',
-			name: 'Frontman Pro',
-			url: 'https://frontman.sh/pricing/',
-			applicationCategory: 'DeveloperApplication',
-			operatingSystem: 'Web',
+			'@type': 'WebPage',
+			name: SEO.title,
 			description: SEO.description,
-			author: {
-				'@type': 'Organization',
-				name: 'Frontman',
-				url: 'https://frontman.sh/'
-			},
-			offers: [
+			url: 'https://frontman.sh/pricing/'
+		},
+		{
+			'@type': 'OfferCatalog',
+			name: 'Frontman Pro pricing',
+			url: 'https://frontman.sh/pricing/',
+			itemListElement: [
 				{
 					'@type': 'Offer',
 					name: 'Frontman Pro monthly seat',
@@ -176,8 +174,7 @@ const pricingJsonLd = {
 					category: 'subscription',
 					description: 'Hosted Frontman Pro seat billed yearly. AI provider usage is billed separately.'
 				}
-			],
-			featureList: planFeatures
+			]
 		},
 		{
 			'@type': 'FAQPage',

--- a/apps/marketing/src/pages/subprocessors.astro
+++ b/apps/marketing/src/pages/subprocessors.astro
@@ -4,7 +4,7 @@ import LegalDocument from '../components/legal/LegalDocument.astro'
 
 const SEO = {
 	title: 'Subprocessors | Frontman',
-	description: 'Current subprocessors and service providers used by Frontman.'
+	description: 'Review the third-party subprocessors and service providers Frontman uses to host the product, run analytics, support customers, and process data.'
 }
 ---
 

--- a/apps/marketing/src/pages/toms.astro
+++ b/apps/marketing/src/pages/toms.astro
@@ -4,7 +4,7 @@ import LegalDocument from '../components/legal/LegalDocument.astro'
 
 const SEO = {
 	title: 'Technical and Organizational Measures | Frontman',
-	description: 'Technical and organizational security measures used by Frontman.'
+	description: 'Review the technical and organizational security measures Frontman uses for access control, encryption, availability, monitoring, and incident response.'
 }
 ---
 


### PR DESCRIPTION
## Summary
- Tune marketing page titles and meta descriptions flagged by Ahrefs
- Remove incomplete SoftwareApplication JSON-LD instead of fabricating ratings or reviews
- Avoid crawler-visible mailto output and fix sitemap/docs integration grouping

## Verification
- make build in apps/marketing
- git diff --check -- apps/marketing
- Generated-output checks for mailto, Cloudflare email protection links, SoftwareApplication markup, and sampled H1/image alt coverage