### PR TITLE
Remove backend model defaults

### DIFF
--- a/.changeset/remove-backend-model-defaults.md
+++ b/.changeset/remove-backend-model-defaults.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-protocol": patch
+---
+
+Remove backend default model selection and let the client choose the first available model option.

--- a/apps/frontman_server/config/providers.exs
+++ b/apps/frontman_server/config/providers.exs
@@ -13,7 +13,6 @@ providers = [
      display_name: "OpenAI",
      max_image_dimension: nil,
      llm_db_provider: [],
-     default_model: "gpt-5.5",
      models: [
        {"GPT-5.5", "gpt-5.5", :packaged},
        {"GPT-5.4", "gpt-5.4", :packaged},
@@ -27,7 +26,6 @@ providers = [
      # Anthropic hard-rejects images > 8000px per side; 7680 leaves margin.
      max_image_dimension: 7680,
      llm_db_provider: [],
-     default_model: "claude-sonnet-4-6",
      models: [
        {"Claude Opus 4.8", "claude-opus-4-8", :packaged},
        {"Claude Opus 4.7", "claude-opus-4-7", :packaged},
@@ -44,7 +42,6 @@ providers = [
      display_name: "OpenRouter",
      max_image_dimension: nil,
      llm_db_provider: [],
-     default_model: "google/gemini-3-flash-preview",
      models: [
        {"GPT-5.5", "openai/gpt-5.5", :packaged},
        {"GPT-5.5 Pro", "openai/gpt-5.5-pro", :packaged},
@@ -71,7 +68,6 @@ providers = [
      display_name: "Fireworks AI",
      max_image_dimension: nil,
      llm_db_provider: [],
-     default_model: "accounts/fireworks/routers/kimi-k2p6-turbo",
      models: [
        {"Kimi K2.6 Turbo", "accounts/fireworks/routers/kimi-k2p6-turbo", :packaged}
      ]
@@ -81,7 +77,6 @@ providers = [
      display_name: "NVIDIA",
      max_image_dimension: nil,
      llm_db_provider: [],
-     default_model: "moonshotai/kimi-k2.6",
      models: [
        {"Kimi K2.6", "moonshotai/kimi-k2.6",
         %{

--- a/apps/frontman_server/lib/agent_client_protocol.ex
+++ b/apps/frontman_server/lib/agent_client_protocol.ex
@@ -136,19 +136,18 @@ defmodule AgentClientProtocol do
   @doc """
   Translates domain model config data into ACP SessionConfigOption format.
 
-  Receives the output of `Providers.model_config_data/2` — a domain DTO
-  containing model groups and a default model — and serializes it into
-  the ACP wire format.  This function has no knowledge of provider
+  Receives the output of `Providers.model_config_data/1` — a domain DTO
+  containing model groups — and serializes it into the ACP wire format.
+  This function has no knowledge of provider
   internals; all domain logic is encapsulated in the Providers context.
   """
-  def build_model_config_options(%{groups: groups, default_model: default_model}) do
+  def build_model_config_options(%{groups: groups}) do
     [
       %{
         "type" => "select",
         "id" => "model",
         "name" => "Model",
         "category" => "model",
-        "currentValue" => default_model,
         "options" =>
           Enum.map(groups, fn %{id: id, name: name, options: options} ->
             %{

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -38,14 +38,17 @@ defmodule FrontmanServer.Providers do
 
   ## Parameters
     - scope: The user scope (or nil for anonymous).
-    - model: The model string (e.g., "openrouter:openai/gpt-4"), or nil for default
+    - model: The model string (e.g., "openrouter:openai/gpt-4")
 
   ## Returns
     - `{:ok, {model_spec, llm_opts}}` - Ready to use for LLM calls
     - `{:error, :no_api_key}` - No API key available
   """
-  def prepare_llm_args(scope, model, opts \\ []) do
-    model = model || default_model()
+  def prepare_llm_args(scope, model, opts \\ [])
+
+  def prepare_llm_args(_scope, nil, _opts), do: {:error, :missing_model}
+
+  def prepare_llm_args(scope, model, opts) when is_binary(model) and model != "" do
     provider = model_provider_name(model)
 
     case oauth_llm_opts(provider, resolve_oauth_token(scope, provider)) do
@@ -54,6 +57,8 @@ defmodule FrontmanServer.Providers do
       :use_api_key -> api_key_llm_args(scope, provider, model, opts)
     end
   end
+
+  def prepare_llm_args(_scope, _model, _opts), do: {:error, :missing_model}
 
   defp oauth_llm_opts("anthropic", %OAuthToken{access_token: access_token}) do
     {:ok,
@@ -96,10 +101,14 @@ defmodule FrontmanServer.Providers do
     {:ok, model_string(provider, value)}
   end
 
-  def model_from_client_params(params) do
-    {provider, name} = model_parts(params)
-    {:ok, model_string(provider, name)}
+  def model_from_client_params(params) when is_binary(params) do
+    case String.split(params, ":", parts: 2) do
+      [provider, name] when provider != "" and name != "" -> {:ok, model_string(provider, name)}
+      _invalid -> :error
+    end
   end
+
+  def model_from_client_params(_params), do: :error
 
   def start_anthropic_oauth do
     {verifier, challenge} = AnthropicOAuth.generate_pkce()
@@ -422,9 +431,8 @@ defmodule FrontmanServer.Providers do
   @doc """
   Returns model selection data for a user, ready for ACP serialization.
 
-  Resolves which providers the user can access, then builds model groups and
-  picks the best default. Returns a domain DTO that ACP
-  translates to `SessionConfigOption` wire format.
+  Resolves which providers the user can access, then builds model groups.
+  Returns a domain DTO that ACP translates to `SessionConfigOption` wire format.
 
   ## Parameters
 
@@ -436,7 +444,6 @@ defmodule FrontmanServer.Providers do
     * `:groups` – list of model group maps, each with `:id`, `:name`, and
       `:options` (list of `%{name: name, value: value}` maps where
       `value` is a serialized `"provider:model"` string)
-    * `:default_model` – serialized `"provider:model"` string for the best default
   """
   def model_config_data(scope) do
     api_key_providers = list_api_key_providers(scope)
@@ -470,30 +477,11 @@ defmodule FrontmanServer.Providers do
         %{id: provider, name: config.display_name, options: options}
       end)
 
-    default_model = pick_default_model(provider_configs)
-
-    %{groups: groups, default_model: default_model}
+    %{groups: groups}
   end
 
   defp provider_config(provider) do
     Map.fetch!(@provider_configs, String.downcase(provider))
-  end
-
-  defp default_model do
-    default_model_for("openrouter", provider_config("openrouter"))
-  end
-
-  defp default_model_for(provider, config) do
-    model_string(String.downcase(provider), config.default_model)
-  end
-
-  defp pick_default_model([]) do
-    default_model_for("openrouter", provider_config("openrouter"))
-  end
-
-  defp pick_default_model(provider_configs) do
-    [{provider, config} | _] = provider_configs
-    default_model_for(provider, config)
   end
 
   defp model_parts(model) when is_binary(model) do

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -501,9 +501,9 @@ defmodule FrontmanServer.Tasks do
           project_traits: project_traits
         }
       )
-      when is_binary(task_id) and is_list(mcp_tools) and is_list(project_traits) do
-    user_message_interaction = Interaction.UserMessage.new(content_blocks)
-
+      when is_binary(task_id) and is_binary(model) and model != "" and is_list(mcp_tools) and
+             is_list(project_traits) do
+    user_message_interaction = Interaction.UserMessage.new(content_blocks, model)
     execution = %{model: model, mcp_tools: mcp_tools, project_traits: project_traits}
 
     case insert_user_turn_for_locked_task(scope, task_id, user_message_interaction) do
@@ -525,6 +525,10 @@ defmodule FrontmanServer.Tasks do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  def submit_user_message(%Scope{}, %{model: _model}) do
+    {:error, :missing_model}
   end
 
   defp insert_user_turn_for_locked_task(%Scope{} = scope, task_id, user_message_interaction) do
@@ -698,6 +702,7 @@ defmodule FrontmanServer.Tasks do
          rows = load_interaction_rows(task_id),
          {:ok, turn_number} <- retry_turn_number(task_id, retried_error_id),
          :ok <- ensure_latest_retry_turn(turn_number, rows),
+         {:ok, execution} <- ensure_execution_model(task_id, turn_number, execution),
          {:ok, _retry} <-
            record_interaction(schema, Interaction.AgentRetry.new(retried_error_id), turn_number) do
       run_execution(scope, schema, turn_number, execution)
@@ -720,23 +725,40 @@ defmodule FrontmanServer.Tasks do
 
   @doc "Resumes execution for the active agent run."
   def resume_execution(scope, task_id, execution) do
-    case get_task(scope, task_id) do
-      {:ok, task} ->
-        rows = load_interaction_rows(task_id)
+    with {:ok, task} <- get_task(scope, task_id),
+         rows = load_interaction_rows(task_id),
+         {:ok, turn_number} when is_integer(turn_number) <- active_agent_run_turn_number(rows),
+         {:ok, execution} <- ensure_execution_model(task_id, turn_number, execution) do
+      run_execution(scope, task, turn_number, execution)
+    else
+      {:ok, nil} -> {:error, :not_running}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-        case active_agent_run_turn_number(rows) do
-          {:ok, turn_number} when is_integer(turn_number) ->
-            run_execution(scope, task, turn_number, execution)
+  defp ensure_execution_model(_task_id, _turn_number, %{model: model} = execution)
+       when is_binary(model) and model != "" do
+    {:ok, execution}
+  end
 
-          {:ok, nil} ->
-            {:error, :not_running}
+  defp ensure_execution_model(task_id, turn_number, execution) do
+    case model_for_turn(task_id, turn_number) do
+      {:ok, model} -> {:ok, Map.put(execution, :model, model)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-          {:error, reason} ->
-            {:error, reason}
-        end
+  defp model_for_turn(task_id, turn_number) do
+    InteractionSchema.for_task(task_id)
+    |> InteractionSchema.for_turn(turn_number)
+    |> InteractionSchema.of_type(Interaction.UserMessage)
+    |> Repo.one()
+    |> case do
+      %InteractionSchema{data: %{"model" => model}} when is_binary(model) and model != "" ->
+        {:ok, model}
 
-      {:error, :not_found} ->
-        {:error, :not_found}
+      _missing ->
+        {:error, :missing_model}
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -35,7 +35,7 @@ defmodule FrontmanServer.Tasks.Execution do
   and submits the agent to SwarmAi.
 
   ## Params
-  - `:model` - LLM model spec (nil uses provider default)
+  - `:model` - LLM model spec
   - `:mcp_tools` - client MCP tool definitions for this turn
   - `:project_traits` - client/framework traits used for system prompt guidance
 
@@ -219,6 +219,9 @@ defmodule FrontmanServer.Tasks.Execution do
 
   def error_message(%Scope{}, :registration_timeout),
     do: "Agent failed to start. Please try again."
+
+  def error_message(%Scope{}, :missing_model),
+    do: "Model is required for this request."
 
   def error_message(%Scope{}, reason),
     do: inspect(reason)

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -377,6 +377,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     embedded_schema do
       field :id, :string
       field :timestamp, :utc_datetime_usec
+      field :model, :string
       field :messages, {:array, :string}, default: []
       embeds_many :annotations, Annotation
       embeds_one :selected_figma_node, FigmaNode
@@ -384,10 +385,11 @@ defmodule FrontmanServer.Tasks.Interaction do
       embeds_one :current_page, CurrentPage
     end
 
-    def new(content_blocks) do
+    def new(content_blocks, model \\ nil) do
       %__MODULE__{
         id: Interaction.new_id(),
         timestamp: Interaction.now(),
+        model: model,
         messages: extract_messages(content_blocks),
         annotations: extract_annotations(content_blocks),
         selected_figma_node: extract_selected_figma_node(content_blocks),
@@ -809,6 +811,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     %{
       type: type_for(value),
       id: value.id,
+      model: value.model,
       messages: value.messages,
       timestamp: DateTime.to_iso8601(value.timestamp),
       annotations: Enum.map(value.annotations, &annotation_json_map/1),

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -65,6 +65,10 @@ defmodule FrontmanServer.Workers.GenerateTitle do
          :ok <- Tasks.apply_title_suggestion(scope, task_id, title) do
       :ok
     else
+      {:error, :missing_model} ->
+        Logger.debug("GenerateTitle: Missing model, cancelling")
+        {:cancel, :missing_model}
+
       {:error, :no_api_key} ->
         Logger.debug("GenerateTitle: No API key available, cancelling")
         {:cancel, :no_api_key}

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -60,7 +60,6 @@ defmodule FrontmanServerWeb.TaskChannel do
           |> assign(:mcp_tools, [])
           |> assign(:mcp_status, :pending)
           |> assign(:pending_mcp_tool_requests, %{})
-          |> assign(:last_execution, nil)
 
         send(self(), {:start_mcp_init, init_actions})
 
@@ -696,11 +695,11 @@ defmodule FrontmanServerWeb.TaskChannel do
 
           {:ok, _interaction, turn_number} ->
             socket =
-              assign(socket, :pending_prompt, %{
+              socket
+              |> assign(:pending_prompt, %{
                 turn_number: turn_number,
                 jsonrpc_id: id
               })
-              |> assign(:last_execution, execution)
 
             Logger.info("User message added, agent spawned for task #{task_id}")
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -676,17 +676,11 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     case Providers.model_from_client_params(meta["model"]) do
       {:ok, model} ->
-        execution = %{
-          model: model,
-          mcp_tools: socket.assigns.mcp_tools,
-          project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
-        }
-
         Logger.info("process_prompt", %{task_id: task_id, model: model})
 
         case Tasks.submit_user_message(
                scope,
-               Map.merge(execution, %{task_id: task_id, message: content_blocks})
+               prompt_submission_params(socket, content_blocks, model, meta)
              ) do
           {:error, :already_running} ->
             Logger.info("Rejected prompt — agent already running for task #{task_id}")
@@ -717,6 +711,16 @@ defmodule FrontmanServerWeb.TaskChannel do
 
         {:reply, {:ok, %{@acp_message => error_response}}, socket}
     end
+  end
+
+  defp prompt_submission_params(socket, content_blocks, model, meta) do
+    %{
+      task_id: socket.assigns.task_id,
+      message: content_blocks,
+      model: model,
+      mcp_tools: socket.assigns.mcp_tools,
+      project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
+    }
   end
 
   defp handle_execution_chunk(socket, %{type: :content, text: text})

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -680,7 +680,14 @@ defmodule FrontmanServerWeb.TaskChannel do
 
         case Tasks.submit_user_message(
                scope,
-               prompt_submission_params(socket, content_blocks, model, meta)
+               %{
+                 task_id: task_id,
+                 message: content_blocks,
+                 model: model,
+                 mcp_tools: socket.assigns.mcp_tools,
+                 project_traits:
+                   Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
+               }
              ) do
           {:error, :already_running} ->
             Logger.info("Rejected prompt — agent already running for task #{task_id}")
@@ -711,16 +718,6 @@ defmodule FrontmanServerWeb.TaskChannel do
 
         {:reply, {:ok, %{@acp_message => error_response}}, socket}
     end
-  end
-
-  defp prompt_submission_params(socket, content_blocks, model, meta) do
-    %{
-      task_id: socket.assigns.task_id,
-      message: content_blocks,
-      model: model,
-      mcp_tools: socket.assigns.mcp_tools,
-      project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
-    }
   end
 
   defp handle_execution_chunk(socket, %{type: :content, text: text})

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -546,7 +546,7 @@ defmodule FrontmanServerWeb.TaskChannel do
     # Store error result and notify agent.
     # :no_executor means the agent is dead (e.g. server restart). Unlike the
     # success path in handle_tool_call_response/4, we don't auto-resume here because MCP
-    # error responses don't carry _meta (env API keys + model) needed to restart.
+    # error responses don't carry _meta with the model needed to restart.
     # The error is persisted; the user can retry via a new prompt.
     case Tasks.resolve_tool_request(
            scope,

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -674,40 +674,48 @@ defmodule FrontmanServerWeb.TaskChannel do
        when is_map(meta) do
     task_id = socket.assigns.task_id
     scope = socket.assigns.scope
-    {:ok, model} = Providers.model_from_client_params(meta["model"])
 
-    execution = %{
-      model: model,
-      mcp_tools: socket.assigns.mcp_tools,
-      project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
-    }
+    case Providers.model_from_client_params(meta["model"]) do
+      {:ok, model} ->
+        execution = %{
+          model: model,
+          mcp_tools: socket.assigns.mcp_tools,
+          project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
+        }
 
-    Logger.info("process_prompt", %{task_id: task_id, model: model})
+        Logger.info("process_prompt", %{task_id: task_id, model: model})
 
-    case Tasks.submit_user_message(
-           scope,
-           Map.merge(execution, %{task_id: task_id, message: content_blocks})
-         ) do
-      {:error, :already_running} ->
-        Logger.info("Rejected prompt — agent already running for task #{task_id}")
-        error_response = JsonRpc.error_response(id, -32_000, "Agent already running")
-        {:reply, {:ok, %{@acp_message => error_response}}, socket}
+        case Tasks.submit_user_message(
+               scope,
+               Map.merge(execution, %{task_id: task_id, message: content_blocks})
+             ) do
+          {:error, :already_running} ->
+            Logger.info("Rejected prompt — agent already running for task #{task_id}")
+            error_response = JsonRpc.error_response(id, -32_000, "Agent already running")
+            {:reply, {:ok, %{@acp_message => error_response}}, socket}
 
-      {:ok, _interaction, turn_number} ->
-        socket =
-          assign(socket, :pending_prompt, %{
-            turn_number: turn_number,
-            jsonrpc_id: id
-          })
-          |> assign(:last_execution, execution)
+          {:ok, _interaction, turn_number} ->
+            socket =
+              assign(socket, :pending_prompt, %{
+                turn_number: turn_number,
+                jsonrpc_id: id
+              })
+              |> assign(:last_execution, execution)
 
-        Logger.info("User message added, agent spawned for task #{task_id}")
+            Logger.info("User message added, agent spawned for task #{task_id}")
 
-        {:noreply, socket}
+            {:noreply, socket}
 
-      {:error, reason} ->
-        Logger.error("Failed to add user message: #{inspect(reason)}")
-        error_response = JsonRpc.error_response(id, -32_000, to_string(reason))
+          {:error, reason} ->
+            Logger.error("Failed to add user message: #{inspect(reason)}")
+            error_response = JsonRpc.error_response(id, -32_000, to_string(reason))
+            {:reply, {:ok, %{@acp_message => error_response}}, socket}
+        end
+
+      :error ->
+        error_response =
+          JsonRpc.error_response(id, JsonRpc.error_invalid_params(), "Model is required")
+
         {:reply, {:ok, %{@acp_message => error_response}}, socket}
     end
   end

--- a/apps/frontman_server/priv/repo/migrations/20260618000000_backfill_user_message_models.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260618000000_backfill_user_message_models.exs
@@ -1,0 +1,18 @@
+defmodule FrontmanServer.Repo.Migrations.BackfillUserMessageModels do
+  use Ecto.Migration
+
+  @legacy_default_model "openrouter:google/gemini-3-flash-preview"
+
+  def up do
+    execute("""
+    UPDATE interactions
+    SET data = jsonb_set(data, '{model}', to_jsonb('#{@legacy_default_model}'::text), true)
+    WHERE type = 'user_message'
+      AND NOT (data ? 'model')
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/apps/frontman_server/test/agent_client_protocol_test.exs
+++ b/apps/frontman_server/test/agent_client_protocol_test.exs
@@ -64,8 +64,8 @@ defmodule AgentClientProtocolTest do
   end
 
   describe "build_model_config_options/1" do
-    defp config_data(groups, default_model \\ "anthropic:claude-sonnet-4-5") do
-      %{groups: groups, default_model: default_model}
+    defp config_data(groups) do
+      %{groups: groups}
     end
 
     defp model_group(id, name, options) do
@@ -126,12 +126,12 @@ defmodule AgentClientProtocolTest do
       assert Enum.all?(values, &String.starts_with?(&1, "anthropic:"))
     end
 
-    test "currentValue uses provided default" do
-      data = config_data([], "anthropic:claude-sonnet-4-5")
+    test "does not set currentValue" do
+      data = config_data([])
 
       [option] = ACP.build_model_config_options(data)
 
-      assert option["currentValue"] == "anthropic:claude-sonnet-4-5"
+      refute Map.has_key?(option, "currentValue")
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -51,6 +51,10 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
                Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
     end
 
+    test "returns :missing_model when no model is provided", %{scope: scope} do
+      assert {:error, :missing_model} = Providers.prepare_llm_args(scope, nil)
+    end
+
     test "openrouter user key resolves correctly", %{scope: scope} do
       {:ok, _} = Providers.upsert_api_key(scope, "openrouter", "sk-or-user-test")
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -5,7 +5,7 @@ defmodule FrontmanServer.TasksTest do
   import FrontmanServer.Test.Fixtures.Tasks
 
   alias Ecto.Migration.Runner
-  alias FrontmanServer.Repo.Migrations.BackfillInteractionTurnNumbers
+  alias FrontmanServer.Repo.Migrations.{BackfillInteractionTurnNumbers, BackfillUserMessageModels}
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tasks.InteractionSchema
@@ -192,6 +192,35 @@ defmodule FrontmanServer.TasksTest do
                {Interaction.ToolCall, 2},
                {Interaction.ToolResult, 2}
              ] = db_type_turns(task_id)
+    end
+  end
+
+  describe "user-message model backfill migration" do
+    test "sets the legacy default model on old user messages", %{scope: scope} do
+      task_id = task_fixture(scope).id
+
+      insert_interaction_row(task_id, Interaction.UserMessage, 1, %{"messages" => ["hello"]})
+      run_user_message_model_backfill_migration()
+
+      assert [%{data: %{"model" => "openrouter:google/gemini-3-flash-preview"}}] =
+               InteractionSchema.for_task(task_id)
+               |> InteractionSchema.of_type(Interaction.UserMessage)
+               |> Repo.all()
+    end
+
+    test "leaves explicit models untouched", %{scope: scope} do
+      task_id = task_fixture(scope).id
+
+      insert_interaction_row(task_id, Interaction.UserMessage, 1, %{
+        "model" => "anthropic:claude-sonnet-4-6"
+      })
+
+      run_user_message_model_backfill_migration()
+
+      assert [%{data: %{"model" => "anthropic:claude-sonnet-4-6"}}] =
+               InteractionSchema.for_task(task_id)
+               |> InteractionSchema.of_type(Interaction.UserMessage)
+               |> Repo.all()
     end
   end
 
@@ -522,6 +551,22 @@ defmodule FrontmanServer.TasksTest do
                Repo.config(),
                0,
                BackfillInteractionTurnNumbers,
+               :forward,
+               :up,
+               :up,
+               log: false
+             )
+  end
+
+  defp run_user_message_model_backfill_migration do
+    Code.require_file("priv/repo/migrations/20260618000000_backfill_user_message_models.exs")
+
+    assert :ok =
+             Runner.run(
+               Repo,
+               Repo.config(),
+               0,
+               BackfillUserMessageModels,
                :forward,
                :up,
                :up,

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -186,9 +186,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         )
       )
 
-      %{assigns: assigns} = :sys.get_state(socket.channel_pid)
-
-      assert assigns.last_execution.project_traits == [:react, :typescript]
+      :sys.get_state(socket.channel_pid)
 
       assert_enqueued(
         worker: GenerateTitle,

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -21,6 +21,8 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
     TaskSchema
   }
 
+  @default_test_model "openrouter:openai/gpt-5.5"
+
   @doc """
   Create a task and return its schema.
 
@@ -45,7 +47,7 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
   @doc "Build a production-shaped execution request for task execution tests."
   def execution_request_fixture(overrides \\ []) do
     %{
-      model: nil,
+      model: @default_test_model,
       project_traits: [],
       mcp_tools: []
     }
@@ -74,7 +76,7 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
   """
   def user_message_fixture(scope, task_id, content_blocks) do
     task = task_schema!(scope, task_id)
-    interaction = Interaction.UserMessage.new(content_blocks)
+    interaction = Interaction.UserMessage.new(content_blocks, @default_test_model)
 
     case InteractionSchema.create_changeset(task, interaction, next_turn_number(task_id))
          |> Repo.insert() do

--- a/apps/marketing/src/content/docs/docs/reference/models.md
+++ b/apps/marketing/src/content/docs/docs/reference/models.md
@@ -108,17 +108,11 @@ Grok models are available through OpenRouter with an OpenRouter API key. You can
 **Auth:** API key
 **Get a key:** [console.x.ai](https://console.x.ai/)
 
-## How defaults are chosen
+## Initial selection
 
-When multiple providers are available, Frontman picks the default model from the highest-priority provider:
+When model options load, Frontman selects the first available model in the dropdown. If you connect a new provider, Frontman switches to the first model from that provider.
 
-1. **OpenAI** (priority 10)
-2. **Anthropic** (priority 20)
-3. **OpenRouter** (priority 30)
-4. **Google** (priority 40)
-5. **xAI** (priority 50)
-
-For example, if you have both an Anthropic API key and an OpenRouter key, Frontman defaults to Claude Sonnet 4.5 (Anthropic). You can always switch models from the dropdown in the chat header.
+You can always switch models from the dropdown in the chat header.
 
 ## Tiers
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1339,17 +1339,20 @@ let next = (state: state, action) => {
   // ACP session config option actions
   | ConfigOptionsReceived({configOptions}) =>
     open FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
-    let modelConfigOption = findConfigOptionByCategory(configOptions, Model)
+    let modelConfigOption =
+      findConfigOptionByCategory(configOptions, Model)->Option.getOrThrow(
+        ~message="ConfigOptionsReceived missing model config option",
+      )
 
     let firstModelValue = switch modelConfigOption {
-    | Some(SelectConfigOption({options: Grouped(groups)})) =>
+    | SelectConfigOption({options: Grouped(groups)}) =>
       groups
       ->Array.get(0)
       ->Option.flatMap(g => g.options->Array.get(0))
       ->Option.map(opt => opt.value)
-    | Some(SelectConfigOption({options: Ungrouped(options)})) =>
-      options->Array.get(0)->Option.map(opt => opt.value)
-    | None => None
+      ->Option.getOrThrow(~message="Model config option has no models")
+    | SelectConfigOption({options: Ungrouped(_)}) =>
+      failwith("Model config option must use grouped options")
     }
 
     // When a provider was just connected, auto-select its first model.
@@ -1358,12 +1361,13 @@ let next = (state: state, action) => {
     | Some(providerId) =>
       // Find the first model value from the newly connected provider's group
       let providerModelValue = switch modelConfigOption {
-      | Some(SelectConfigOption({options: Grouped(groups)})) =>
+      | SelectConfigOption({options: Grouped(groups)}) =>
         groups
         ->Array.find(g => g.group == providerId)
         ->Option.flatMap(g => g.options->Array.get(0))
         ->Option.map(opt => opt.value)
-      | _ => None
+      | SelectConfigOption({options: Ungrouped(_)}) =>
+        failwith("Model config option must use grouped options")
       }
       switch providerModelValue {
       | Some(value) => (Some(value), true)
@@ -1372,7 +1376,7 @@ let next = (state: state, action) => {
     | None =>
       switch state.selectedModelValue {
       | Some(value) => (Some(value), false)
-      | None => (firstModelValue, firstModelValue->Option.isSome)
+      | None => (Some(firstModelValue), true)
       }
     }
     // Persist whenever we picked a new model

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1341,14 +1341,19 @@ let next = (state: state, action) => {
     open FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
     let modelConfigOption = findConfigOptionByCategory(configOptions, Model)
 
-    // Extract the server's default currentValue from the model config option
-    let serverDefault = switch modelConfigOption {
-    | Some(SelectConfigOption({currentValue})) => Some(currentValue)
+    let firstModelValue = switch modelConfigOption {
+    | Some(SelectConfigOption({options: Grouped(groups)})) =>
+      groups
+      ->Array.get(0)
+      ->Option.flatMap(g => g.options->Array.get(0))
+      ->Option.map(opt => opt.value)
+    | Some(SelectConfigOption({options: Ungrouped(options)})) =>
+      options->Array.get(0)->Option.map(opt => opt.value)
     | None => None
     }
 
     // When a provider was just connected, auto-select its first model.
-    // Otherwise keep the current selection (or fall back to server default).
+    // Otherwise keep the current selection or choose the first listed model.
     let (selectedModelValue, didAutoSelect) = switch state.pendingProviderAutoSelect {
     | Some(providerId) =>
       // Find the first model value from the newly connected provider's group
@@ -1367,7 +1372,7 @@ let next = (state: state, action) => {
     | None =>
       switch state.selectedModelValue {
       | Some(value) => (Some(value), false)
-      | None => (serverDefault, serverDefault->Option.isSome)
+      | None => (firstModelValue, firstModelValue->Option.isSome)
       }
     }
     // Persist whenever we picked a new model

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -163,7 +163,7 @@ type state = {
   // Persisted to localStorage. Derives from configOptions where category=Model.
   selectedModelValue: option<ACPConfig.sessionConfigValueId>,
   // When a provider is freshly connected, this holds its id (e.g. "anthropic")
-  // so the next config options refresh auto-selects a default model from it.
+  // so the next config options refresh auto-selects its first model.
   pendingProviderAutoSelect: option<string>,
   sessionsLoadState: sessionsLoadState,
   // Update banner: set when a newer integration package version is available

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -67,7 +67,7 @@ module SampleConfig = {
       name: "Model",
       description: None,
       category: Some(ACP.Model),
-      currentValue,
+      currentValue: Some(currentValue),
       options: ACP.Grouped(groups),
       _meta: None,
     })
@@ -288,7 +288,7 @@ describe("ConfigOptionsReceived auto-selects model from newly connected provider
     t->expect(nextState.pendingProviderAutoSelect)->Expect.toEqual(None)
   })
 
-  test("falls back to server default when no selection and no pending provider", t => {
+  test("selects first model when no selection and no pending provider", t => {
     let state = _makeState()
 
     let (nextState, _effects) = Reducer.next(

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -60,14 +60,12 @@ module SampleConfig = {
   // Helper to build a grouped model config option
   let _makeModelConfigOption = (
     ~groups: array<ACP.sessionConfigSelectGroup>,
-    ~currentValue: string,
   ): ACP.sessionConfigOption => {
     ACP.SelectConfigOption({
       id: "model",
       name: "Model",
       description: None,
       category: Some(ACP.Model),
-      currentValue: Some(currentValue),
       options: ACP.Grouped(groups),
       _meta: None,
     })
@@ -137,33 +135,15 @@ module SampleConfig = {
     _meta: None,
   }
 
-  let configWithAnthropic = [
-    _makeModelConfigOption(
-      ~groups=[_anthropicGroup, _openrouterGroup],
-      ~currentValue="anthropic:claude-sonnet-4-5",
-    ),
-  ]
+  let configWithAnthropic = [_makeModelConfigOption(~groups=[_anthropicGroup, _openrouterGroup])]
 
   let configWithOpenAI = [
-    _makeModelConfigOption(
-      ~groups=[_openaiGroup, _anthropicGroup, _openrouterGroup],
-      ~currentValue="openai_codex:gpt-5.1-codex-max",
-    ),
+    _makeModelConfigOption(~groups=[_openaiGroup, _anthropicGroup, _openrouterGroup]),
   ]
 
-  let configWithOpenRouterOnly = [
-    _makeModelConfigOption(
-      ~groups=[_openrouterGroup],
-      ~currentValue="openrouter:google/gemini-3-flash-preview",
-    ),
-  ]
+  let configWithOpenRouterOnly = [_makeModelConfigOption(~groups=[_openrouterGroup])]
 
-  let configWithFireworksOnly = [
-    _makeModelConfigOption(
-      ~groups=[_fireworksGroup],
-      ~currentValue="fireworks:accounts/fireworks/routers/kimi-k2p5-turbo",
-    ),
-  ]
+  let configWithFireworksOnly = [_makeModelConfigOption(~groups=[_fireworksGroup])]
 }
 
 describe("Initiating actions set pendingProviderAutoSelect eagerly", () => {

--- a/libs/frontman-protocol/schemas/acp/sessionConfigOption.json
+++ b/libs/frontman-protocol/schemas/acp/sessionConfigOption.json
@@ -33,9 +33,6 @@
         }
       ]
     },
-    "currentValue": {
-      "type": "string"
-    },
     "options": {
       "anyOf": [
         {
@@ -114,7 +111,6 @@
     "type",
     "id",
     "name",
-    "currentValue",
     "options"
   ]
 }

--- a/libs/frontman-protocol/schemas/acp/sessionLoadResult.json
+++ b/libs/frontman-protocol/schemas/acp/sessionLoadResult.json
@@ -74,9 +74,6 @@
               }
             ]
           },
-          "currentValue": {
-            "type": "string"
-          },
           "options": {
             "anyOf": [
               {
@@ -155,7 +152,6 @@
           "type",
           "id",
           "name",
-          "currentValue",
           "options"
         ]
       },

--- a/libs/frontman-protocol/schemas/acp/sessionNewResult.json
+++ b/libs/frontman-protocol/schemas/acp/sessionNewResult.json
@@ -77,9 +77,6 @@
               }
             ]
           },
-          "currentValue": {
-            "type": "string"
-          },
           "options": {
             "anyOf": [
               {
@@ -158,7 +155,6 @@
           "type",
           "id",
           "name",
-          "currentValue",
           "options"
         ]
       },

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -812,9 +812,6 @@
                           }
                         ]
                       },
-                      "currentValue": {
-                        "type": "string"
-                      },
                       "options": {
                         "anyOf": [
                           {
@@ -893,7 +890,6 @@
                       "type",
                       "id",
                       "name",
-                      "currentValue",
                       "options"
                     ]
                   },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -247,7 +247,6 @@ type sessionConfigOption =
       name: string,
       description: option<string>,
       category: option<sessionConfigOptionCategory>,
-      currentValue: option<sessionConfigValueId>,
       options: sessionConfigSelectOptions,
       _meta: option<JSON.t>,
     })
@@ -260,7 +259,6 @@ let sessionConfigOptionSchema = S.union([
       name: s.field("name", S.string),
       description: s.field("description", S.option(S.string)),
       category: s.field("category", S.option(sessionConfigOptionCategorySchema)),
-      currentValue: s.field("currentValue", S.option(S.string)),
       options: s.field("options", sessionConfigSelectOptionsSchema),
       _meta: s.field("_meta", S.option(S.json)),
     })

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -247,7 +247,7 @@ type sessionConfigOption =
       name: string,
       description: option<string>,
       category: option<sessionConfigOptionCategory>,
-      currentValue: sessionConfigValueId,
+      currentValue: option<sessionConfigValueId>,
       options: sessionConfigSelectOptions,
       _meta: option<JSON.t>,
     })
@@ -260,7 +260,7 @@ let sessionConfigOptionSchema = S.union([
       name: s.field("name", S.string),
       description: s.field("description", S.option(S.string)),
       category: s.field("category", S.option(sessionConfigOptionCategorySchema)),
-      currentValue: s.field("currentValue", S.string),
+      currentValue: s.field("currentValue", S.option(S.string)),
       options: s.field("options", sessionConfigSelectOptionsSchema),
       _meta: s.field("_meta", S.option(S.json)),
     })


### PR DESCRIPTION
## Summary
- remove backend default model/currentValue generation from provider config and ACP model options
- let the client select the first available model option when no model is selected
- require explicit models for backend execution and persist the selected model on user turns for retry/resume

## Tests
- mix test test/agent_client_protocol_test.exs test/frontman_server/providers/prepare_api_key_test.exs
- mix test test/frontman_server/tasks_test.exs test/frontman_server_web/channels/task_channel_test.exs
- mix test test/frontman_server/tasks/execution_test.exs
- yarn vitest run test/Client__ModelsRefresh.test.res.mjs
- mix format --check-formatted
- git diff --check
- pre-push reanalyze hook