### PR TITLE
Fix killed SwarmAi termination events

### DIFF
--- a/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
@@ -97,6 +97,11 @@ defmodule SwarmAi.ExecutionWorker do
         event = {:terminated, nil}
         loop.dispatch_event.(event)
 
+      {:DOWN, ^monitor_ref, :process, ^worker_pid, :killed} ->
+        Logger.info("Execution terminated by supervisor for #{loop.task_id}, reason: :killed")
+        event = {:terminated, :killed}
+        loop.dispatch_event.(event)
+
       {:DOWN, ^monitor_ref, :process, ^worker_pid, {:shutdown, reason}} ->
         Logger.info(fn ->
           "Execution terminated by supervisor for #{loop.task_id}, reason: #{inspect(reason)}"

--- a/apps/swarm_ai/test/swarm_ai/supervisor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/supervisor_test.exs
@@ -51,6 +51,18 @@ defmodule SwarmAi.SupervisorTest do
       refute_receive {:test_event, "task-ts", {:crashed, _}}, 100
     end
 
+    test "dispatches terminated events for killed execution workers" do
+      runtime = start_runtime!()
+
+      {:ok, pid} = run_agent(runtime, "task-kill", %MockLLM{response: "slow", delay_ms: 5000})
+
+      Process.exit(pid, :kill)
+      await_exit(pid)
+
+      assert_receive {:test_event, "task-kill", {:terminated, :killed}}, 2000
+      refute_receive {:test_event, "task-kill", {:crashed, _}}, 100
+    end
+
     test "accepts new work after task supervisor crash" do
       runtime = start_runtime!()
 


### PR DESCRIPTION
## Summary
- classify killed SwarmAi execution workers as supervisor termination instead of crashes
- add regression coverage for direct `:kill` exits

Fixes #1110

## Tests
- `mix test test/swarm_ai/supervisor_test.exs`
- `mix test test/swarm_ai_test.exs test/swarm_ai/supervisor_test.exs`
- `mix format --check-formatted`