### PR TITLE
Add WordPress marketing hub

### DIFF
--- a/.changeset/add-wordpress-marketing-hub.md
+++ b/.changeset/add-wordpress-marketing-hub.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Add a dedicated Frontman for WordPress marketing hub and wire it into homepage, integrations, install, docs, and WordPress blog discovery.

--- a/apps/marketing/src/components/blocks/features/FeatureHighlights.astro
+++ b/apps/marketing/src/components/blocks/features/FeatureHighlights.astro
@@ -74,8 +74,8 @@ const compactFeatures: CompactFeature[] = [
 	},
 	{
 		icon: '⚡',
-		title: 'Multi-framework support',
-		description: 'Works with Next.js, Astro, and Vite out of the box. React, Vue, Svelte — your framework, your rules.',
+		title: 'Framework and WordPress support',
+		description: 'Works with Next.js, Astro, Vite, and WordPress. Modern apps or CMS sites — your stack, your rules.',
 		color: '#eab308'
 	}
 ]

--- a/apps/marketing/src/components/blocks/frameworks/FrameworkSupport.astro
+++ b/apps/marketing/src/components/blocks/frameworks/FrameworkSupport.astro
@@ -31,6 +31,12 @@ const frameworks = [
 		logo: viteLogo,
 		features: ['React', 'Vue', 'Svelte'],
 		href: '/docs/integrations/vite/'
+	},
+	{
+		name: 'WordPress',
+		logo: { src: '/logo.svg' },
+		features: ['Plugin Directory', 'Elementor', 'Gutenberg'],
+		href: '/wordpress/'
 	}
 ]
 ---
@@ -40,11 +46,12 @@ const frameworks = [
 		<Row>
 			<Col span="12" align="center" classes="mb-12 lg:mb-16">
 				<h2 class="frameworks-title">Works with your stack</h2>
+				<p class="frameworks-subtitle">Framework middleware for modern apps. Plugin-native editing for WordPress sites.</p>
 			</Col>
 		</Row>
 		<Row classes="gap-6 lg:gap-8">
 			{frameworks.map((fw) => (
-				<Col spanMobile="12" span="4">
+				<Col spanMobile="12" span="3">
 					<a href={fw.href} class="framework-card-link">
 						<div class="framework-card">
 							<div class="framework-logo">
@@ -83,6 +90,10 @@ const frameworks = [
 
 	.frameworks-title {
 		@apply font-headings text-4xl lg:text-5xl font-bold text-black;
+	}
+
+	.frameworks-subtitle {
+		@apply mx-auto mt-4 max-w-2xl text-base lg:text-lg leading-relaxed text-neutral-600;
 	}
 
 	.framework-card {

--- a/apps/marketing/src/components/blocks/hero/HomeCTA.astro
+++ b/apps/marketing/src/components/blocks/hero/HomeCTA.astro
@@ -67,6 +67,10 @@ if ('modelContext' in navigator && typeof navigator.modelContext?.provideContext
 			<div class="hero-section__cta">
 				<Button size="lg" style="white" link="#install" classes="hero-section__primary-cta" data-ga-event="click_start_building" data-ga-category="conversion" data-ga-label="hero">Try It Free <span class="hero-section__cta-arrow" aria-hidden="true">→</span></Button>
 				<div class="hero-section__secondary-links">
+					<a href="/wordpress/" class="hero-section__text-link" data-ga-event="click_wordpress" data-ga-category="conversion" data-ga-label="hero">
+						Using WordPress? Try Frontman for WordPress
+					</a>
+					<span class="hero-section__link-divider" aria-hidden="true">·</span>
 					<a href="https://discord.gg/xk8uXJSvhC" target="_blank" rel="noopener noreferrer" class="hero-section__text-link" data-ga-event="click_join_discord" data-ga-category="engagement" data-ga-label="hero">
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true">
 							<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
@@ -129,7 +133,7 @@ if ('modelContext' in navigator && typeof navigator.modelContext?.provideContext
 			</span>
 		</div>
 		<!-- SEO-targeted detail text, visually de-emphasized -->
-		<p class="hero-section__geo-lead">Frontman is an AI agent that lives inside your framework's dev server as middleware. It sees the live DOM, component tree, CSS styles, routes, and server logs — the full runtime context that file-level agents miss. Supports Next.js, Astro, and Vite (React, Vue, Svelte). Open-source core (Apache 2.0 / AGPL-3.0) with BYOK model support for local development.</p>
+		<p class="hero-section__geo-lead">Frontman is an AI agent that lives inside your framework's dev server as middleware or inside WordPress as a plugin. It sees the live DOM, component tree or CMS context, CSS styles, routes, and logs — the runtime context that file-level agents miss. Supports Next.js, Astro, Vite (React, Vue, Svelte), and WordPress. Open-source core with BYOK model support.</p>
 	</div>
 </section>
 

--- a/apps/marketing/src/components/blocks/install/InstallSteps.astro
+++ b/apps/marketing/src/components/blocks/install/InstallSteps.astro
@@ -14,9 +14,62 @@ import astroLogo from '../../../assets/frameworks/astro.svg'
 import viteLogo from '../../../assets/frameworks/vite.svg'
 
 const frameworks = [
-	{ id: 'nextjs', name: 'Next.js', logo: nextjsLogo, command: 'npx @frontman-ai/nextjs install', port: '3000' },
-	{ id: 'astro', name: 'Astro', logo: astroLogo, command: 'astro add @frontman-ai/astro', port: '4321' },
-	{ id: 'vite', name: 'Vite', logo: viteLogo, command: 'npx @frontman-ai/vite install', port: '5173' }
+	{
+		id: 'nextjs',
+		name: 'Next.js',
+		logo: nextjsLogo,
+		command: 'npx @frontman-ai/nextjs install',
+		url: 'http://localhost:3000/frontman',
+		step1Title: 'Add to your project',
+		step1Description: 'Run one command in your project folder',
+		step2Title: 'Open Frontman',
+		step2Description: 'Visit localhost/frontman in your browser',
+		step3Title: 'Connect your AI',
+		step3Description: 'Connect to your preferred AI model subscription',
+		showPluginLink: 'false'
+	},
+	{
+		id: 'astro',
+		name: 'Astro',
+		logo: astroLogo,
+		command: 'astro add @frontman-ai/astro',
+		url: 'http://localhost:4321/frontman',
+		step1Title: 'Add to your project',
+		step1Description: 'Run one command in your project folder',
+		step2Title: 'Open Frontman',
+		step2Description: 'Visit localhost/frontman in your browser',
+		step3Title: 'Connect your AI',
+		step3Description: 'Connect to your preferred AI model subscription',
+		showPluginLink: 'false'
+	},
+	{
+		id: 'vite',
+		name: 'Vite',
+		logo: viteLogo,
+		command: 'npx @frontman-ai/vite install',
+		url: 'http://localhost:5173/frontman',
+		step1Title: 'Add to your project',
+		step1Description: 'Run one command in your project folder',
+		step2Title: 'Open Frontman',
+		step2Description: 'Visit localhost/frontman in your browser',
+		step3Title: 'Connect your AI',
+		step3Description: 'Connect to your preferred AI model subscription',
+		showPluginLink: 'false'
+	},
+	{
+		id: 'wordpress',
+		name: 'WordPress',
+		logo: { src: '/logo.svg' },
+		command: 'Plugins -> Add New Plugin',
+		url: 'https://yoursite.com/frontman',
+		step1Title: 'Install the plugin',
+		step1Description: 'Search for Frontman Agentic AI Editor in wp-admin',
+		step2Title: 'Activate and open Frontman',
+		step2Description: 'Visit /frontman on your WordPress site',
+		step3Title: 'Describe a site change',
+		step3Description: 'Connect your AI provider, describe the edit, and review it beside live preview',
+		showPluginLink: 'true'
+	}
 ]
 ---
 
@@ -43,7 +96,14 @@ const frameworks = [
 					class={`framework-tab ${i === 0 ? 'active' : ''}`}
 					data-framework={fw.id}
 					data-command={fw.command}
-					data-port={fw.port}
+					data-url={fw.url}
+					data-step1-title={fw.step1Title}
+					data-step1-description={fw.step1Description}
+					data-step2-title={fw.step2Title}
+					data-step2-description={fw.step2Description}
+					data-step3-title={fw.step3Title}
+					data-step3-description={fw.step3Description}
+					data-show-plugin-link={fw.showPluginLink}
 				>
 						<img src={fw.logo.src} alt="" width="24" height="24" loading="lazy" aria-hidden="true" />
 						{fw.name}
@@ -60,8 +120,8 @@ const frameworks = [
 					<div class="step-line"></div>
 				</div>
 				<div class="step-card step-card--yellow">
-					<h3 class="step-title">Add to your project</h3>
-					<p class="step-description">Run one command in your project folder</p>
+					<h3 class="step-title" data-step1-title>Add to your project</h3>
+					<p class="step-description" data-step1-description>Run one command in your project folder</p>
 					<div class="terminal">
 						<div class="terminal-bar">
 							<span class="terminal-dot"></span>
@@ -79,6 +139,7 @@ const frameworks = [
 							</button>
 						</div>
 					</div>
+					<a class="plugin-directory-link" data-plugin-directory-link href="https://wordpress.org/plugins/frontman-agentic-ai-editor/" target="_blank" rel="noopener noreferrer" hidden>Open WordPress Plugin Directory &rarr;</a>
 				</div>
 			</div>
 
@@ -89,8 +150,8 @@ const frameworks = [
 					<div class="step-line"></div>
 				</div>
 				<div class="step-card step-card--pink">
-					<h3 class="step-title">Open Frontman</h3>
-					<p class="step-description">Visit localhost/frontman in your browser</p>
+					<h3 class="step-title" data-step2-title>Open Frontman</h3>
+					<p class="step-description" data-step2-description>Visit localhost/frontman in your browser</p>
 					<div class="terminal">
 						<div class="terminal-bar">
 							<span class="terminal-dot"></span>
@@ -121,8 +182,8 @@ const frameworks = [
 					<div class="step-number step-number--peach">3</div>
 				</div>
 				<div class="step-card step-card--peach">
-					<h3 class="step-title">Connect your AI</h3>
-					<p class="step-description">Connect to your preferred AI model subscription</p>
+					<h3 class="step-title" data-step3-title>Connect your AI</h3>
+					<p class="step-description" data-step3-description>Connect to your preferred AI model subscription</p>
 					<div class="ai-badges">
 						<span class="ai-badge">Claude</span>
 						<span class="ai-badge">ChatGPT</span>
@@ -319,6 +380,10 @@ const frameworks = [
 		color: #C084FF;
 	}
 
+	.plugin-directory-link {
+		@apply mt-4 inline-flex text-sm font-semibold text-primary-600 underline underline-offset-4 hover:text-primary-700;
+	}
+
 	/* AI badges */
 	.ai-badges {
 		@apply mt-5 flex flex-wrap gap-2;
@@ -337,6 +402,13 @@ const frameworks = [
 		const tabs = document.querySelectorAll('.framework-tab')
 		const installCommand = document.querySelector('[data-install-command]')
 		const portUrl = document.querySelector('[data-port-url]')
+		const step1Title = document.querySelector('[data-step1-title]')
+		const step1Description = document.querySelector('[data-step1-description]')
+		const step2Title = document.querySelector('[data-step2-title]')
+		const step2Description = document.querySelector('[data-step2-description]')
+		const step3Title = document.querySelector('[data-step3-title]')
+		const step3Description = document.querySelector('[data-step3-description]')
+		const pluginDirectoryLink = document.querySelector('[data-plugin-directory-link]')
 
 		// Framework tab switching
 		tabs.forEach((tab) => {
@@ -349,9 +421,30 @@ const frameworks = [
 					installCommand.textContent = command
 				}
 
-				const port = tab.getAttribute('data-port')
-				if (portUrl && port) {
-					portUrl.textContent = `http://localhost:${port}/frontman`
+				const url = tab.getAttribute('data-url')
+				if (portUrl && url) {
+					portUrl.textContent = url
+				}
+
+
+				const updates = [
+					{ element: step1Title, text: tab.getAttribute('data-step1-title') },
+					{ element: step1Description, text: tab.getAttribute('data-step1-description') },
+					{ element: step2Title, text: tab.getAttribute('data-step2-title') },
+					{ element: step2Description, text: tab.getAttribute('data-step2-description') },
+					{ element: step3Title, text: tab.getAttribute('data-step3-title') },
+					{ element: step3Description, text: tab.getAttribute('data-step3-description') }
+				]
+
+				updates.forEach(({ element, text }) => {
+					if (element && text) {
+						element.textContent = text
+					}
+				})
+
+				if (pluginDirectoryLink) {
+					const showPluginLink = tab.getAttribute('data-show-plugin-link') === 'true'
+					pluginDirectoryLink.toggleAttribute('hidden', !showPluginLink)
 				}
 			})
 		})

--- a/apps/marketing/src/components/blocks/install/InstallSteps.astro
+++ b/apps/marketing/src/components/blocks/install/InstallSteps.astro
@@ -400,14 +400,15 @@ const frameworks = [
 <script>
 	document.addEventListener('DOMContentLoaded', () => {
 		const tabs = document.querySelectorAll('.framework-tab')
+		const stepsTimeline = document.querySelector('.steps-timeline')
 		const installCommand = document.querySelector('[data-install-command]')
 		const portUrl = document.querySelector('[data-port-url]')
-		const step1Title = document.querySelector('[data-step1-title]')
-		const step1Description = document.querySelector('[data-step1-description]')
-		const step2Title = document.querySelector('[data-step2-title]')
-		const step2Description = document.querySelector('[data-step2-description]')
-		const step3Title = document.querySelector('[data-step3-title]')
-		const step3Description = document.querySelector('[data-step3-description]')
+		const step1Title = stepsTimeline?.querySelector('[data-step1-title]')
+		const step1Description = stepsTimeline?.querySelector('[data-step1-description]')
+		const step2Title = stepsTimeline?.querySelector('[data-step2-title]')
+		const step2Description = stepsTimeline?.querySelector('[data-step2-description]')
+		const step3Title = stepsTimeline?.querySelector('[data-step3-title]')
+		const step3Description = stepsTimeline?.querySelector('[data-step3-description]')
 		const pluginDirectoryLink = document.querySelector('[data-plugin-directory-link]')
 
 		// Framework tab switching

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -58,6 +58,10 @@ export const footerNavigationData: FooterData = {
 			category: 'Product',
 			subCategories: [
 				{
+					subCategory: 'WordPress',
+					subCategoryLink: '/wordpress/'
+				},
+				{
 					subCategory: 'About',
 					subCategoryLink: '/about/'
 				},
@@ -105,6 +109,10 @@ export const footerNavigationData: FooterData = {
 				{
 					subCategory: 'Vite (React, Vue, Svelte)',
 					subCategoryLink: '/docs/integrations/vite/'
+				},
+				{
+					subCategory: 'WordPress',
+					subCategoryLink: '/wordpress/'
 				}
 			]
 		},

--- a/apps/marketing/src/config/navigationBar.ts
+++ b/apps/marketing/src/config/navigationBar.ts
@@ -38,6 +38,7 @@ export const navigationBarData: NavData = {
 		text: 'Frontman'
 	},
 	navItems: [
+		{ name: 'WordPress', link: '/wordpress/' },
 		{ name: 'Docs', link: '/docs/' },
 		{
 			name: 'Compare',
@@ -55,6 +56,7 @@ export const navigationBarData: NavData = {
 			link: '/integrations/',
 			submenu: [
 				{ name: 'All integrations', link: '/integrations/' },
+				{ name: 'WordPress', link: '/wordpress/' },
 				{ name: 'Next.js', link: '/docs/integrations/nextjs/' },
 				{ name: 'Astro', link: '/docs/integrations/astro/' },
 				{ name: 'Vite', link: '/docs/integrations/vite/' }

--- a/apps/marketing/src/content/blog/ai-agent-wordpress-plugin-comparison.md
+++ b/apps/marketing/src/content/blog/ai-agent-wordpress-plugin-comparison.md
@@ -63,7 +63,7 @@ The winner depends on the job. Annoying, but true.
 
 If you want a chatbot, use the chatbot plugin. If you want embeddings and knowledge search, use the framework. If you want Claude Desktop or ChatGPT to talk to WordPress tools, evaluate MCP plugins. If you want to edit the site you are looking at, use the tool built around the page.
 
-That last sentence is where Frontman lives.
+That last sentence is where [Frontman for WordPress](/wordpress/) lives.
 
 ### Why Frontman's WordPress plugin is different
 
@@ -173,4 +173,4 @@ There are content AI plugins. There are MCP servers. There are site builders. An
 
 Frontman belongs in the last category. It is not the broadest AI plugin. It is not the canonical MCP adapter. It is not a site generator. It is the WordPress agent workflow for people who need to change the page, see the result, and stay inside the same loop.
 
-Install [Frontman - Agentic AI Editor from the WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/), open `/frontman`, and start on staging. The better workflow is not more AI buttons in wp-admin. It is an agent that changes WordPress while the page stays visible.
+Install [Frontman - Agentic AI Editor from the WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/), open `/frontman`, and start on staging. For the product overview, see [Frontman for WordPress](/wordpress/). The better workflow is not more AI buttons in wp-admin. It is an agent that changes WordPress while the page stays visible.

--- a/apps/marketing/src/content/blog/best-ai-tools-ui-ux-designers-2026.md
+++ b/apps/marketing/src/content/blog/best-ai-tools-ui-ux-designers-2026.md
@@ -7,7 +7,7 @@ author: 'Danni Friedland'
 authorRole: 'Co-founder, Frontman'
 image: '/blog/best-ai-tools-ui-ux-designers-2026-cover.png'
 tags: ['ai', 'comparison', 'collaboration']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-06-22T00:00:00Z
 faq:
   - question: 'What are the best AI tools for UI/UX designers in 2026?'
     answer: 'The best AI tools for designers depend on what you need. For AI-powered prototyping: Figma AI, Google Stitch, and UX Pilot. For wireframing: Relume and Uizard. For editing live code in your browser without an IDE: Frontman. For image generation: Midjourney and Adobe Firefly. For generating new UI from a prompt: v0 by Vercel. Each category covers a different part of the design-to-production pipeline.'
@@ -44,6 +44,18 @@ If you want a narrower comparison of tools that generate or edit frontend source
 | [Midjourney](#midjourney) | Images | $10–$60/mo | N/A (assets only) |
 | [Adobe Firefly](#adobe-firefly) | Images + vectors | Creative Cloud subscription | N/A (assets only) |
 | [v0 by Vercel](#v0) | React/Next.js code | Free–$30/mo | Minimal (code output) |
+
+## Figma Make vs UX Pilot vs Uizard: Output Quality
+
+Figma Make, UX Pilot, and Uizard all help designers move faster, but their output quality differs because they optimize for different users.
+
+| Tool | Output quality | Best use | Where it falls short |
+|------|----------------|----------|----------------------|
+| Figma Make | Highest fidelity if your team already uses Figma patterns | Interactive prototypes and app concepts inside the Figma ecosystem | Still needs design review and engineering implementation |
+| UX Pilot | Strongest UX-oriented screen generation and analysis | UI screen ideas, heatmaps, and automated UX reviews | Credit limits and handoff work remain |
+| Uizard | Fastest rough wireframes for non-designers | PM/founder mockups and early layout communication | Generic visual quality; trained designers will need heavy polish |
+
+Choose Figma Make when visual fidelity and Figma workflow fit matter most. Choose UX Pilot when you want AI-generated UI plus UX critique. Choose Uizard when speed and low barrier to entry matter more than polish.
 
 ## AI Prototyping and Wireframing
 

--- a/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
+++ b/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
@@ -1,12 +1,12 @@
 ---
-title: 'Best Open-Source AI Coding Tools in 2026'
-seoTitle: '12 Best Open-Source AI Coding Tools (2026)'
+title: 'Best Open-Source AI Coding Tools in 2026: Cline, Roo Code, OpenHands, Kilo Code Compared'
+seoTitle: 'Best Open-Source AI Coding Tools 2026: Cline, Roo Code, OpenHands, Kilo Code Compared'
 pubDate: 2026-03-03T10:00:00Z
-description: 'Compare 12 open-source AI coding tools in 2026: Cline, Aider, Kilo Code, Goose, Continue, OpenHands, Tabby, Stagewise, Frontman, and more.'
+description: 'Compare the best open-source AI coding tools in 2026, including Cline, Roo Code, OpenHands, Kilo Code, Aider, Goose, Continue, Tabby, Stagewise, and Frontman.'
 author: 'Danni Friedland'
 image: '/blog/best-open-source-ai-coding-tools-2026-cover.png'
 tags: ['comparison', 'ai', 'developer-tools', 'open-source']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-06-22T00:00:00Z
 faq:
   - question: 'What are the best open-source AI coding tools in 2026?'
     answer: 'The most popular open-source AI coding tools by GitHub stars are OpenHands (68k stars, MIT), Cline (58k, Apache 2.0), Aider (41k, Apache 2.0), Tabby (33k, Apache 2.0), Goose (32k, Apache 2.0), Continue (31k, Apache 2.0), archived Roo Code (22k, Apache 2.0), and bolt.diy (19k, MIT). Each targets a different workflow: Aider and Goose are CLI-based, Cline and Roo-style forks are VS Code agents, Tabby is self-hosted autocomplete, and OpenHands is a full agent platform.'
@@ -52,6 +52,19 @@ Last updated: June 2026. Star counts are approximate. Update: Roo Code was shut 
 | [Frontman](https://github.com/frontman-ai/frontman) | ~131 | Apache-2.0 / AGPL-3.0 | Browser-based | Yes | Active |
 
 Apache-2.0 is the dominant license. AGPL-3.0 appears on Stagewise and Frontman's server component. MIT on OpenHands and bolt.diy.
+
+## Cline vs Roo Code vs Kilo Code vs OpenHands
+
+If you're choosing between the highest-intent 2026 AI coding agents, the short version is this:
+
+| Tool | Best fit | Main tradeoff |
+|------|----------|---------------|
+| Cline | VS Code users who want the largest open-source agent community | Approval-heavy workflow can feel slow |
+| Roo Code | Teams that liked Cline-style agents with structured modes | Original project was archived in May 2026 |
+| Kilo Code | Developers who want a Cline-family agent with JetBrains support | Newer project with overlapping features |
+| OpenHands | Teams evaluating full autonomous agent platforms | Broader scope, more complex self-hosting |
+
+Cline is the safest default for an open-source VS Code AI coding agent in 2026. Roo Code is still useful as a reference point because many teams compare Roo Code vs Cline, but the archived status changes the adoption calculus. Kilo Code is the Cline-family option to watch if JetBrains support matters. OpenHands is not a drop-in editor assistant; it is closer to an open-source Devin-style agent platform.
 
 ## CLI-Based Open-Source AI Coding Tools
 

--- a/apps/marketing/src/content/blog/frontman-wordpress-plugin-released.md
+++ b/apps/marketing/src/content/blog/frontman-wordpress-plugin-released.md
@@ -13,7 +13,7 @@ Open wp-admin. Search for the plugin. Click install. Activate it. Start editing 
 
 That is now the Frontman workflow.
 
-The [Frontman WordPress plugin](https://wordpress.org/plugins/frontman-agentic-ai-editor/) is live in the WordPress Plugin Directory as **Frontman - Agentic AI Editor**. It puts an AI agent inside your WordPress site, next to a live preview, with tools for posts, pages, blocks, Elementor pages, menus, templates, widgets, and settings.
+[Frontman for WordPress](/wordpress/) is live in the WordPress Plugin Directory as **Frontman - Agentic AI Editor**. It puts an AI agent inside your WordPress site, next to a live preview, with tools for posts, pages, blocks, Elementor pages, menus, templates, widgets, and settings. You can install it from the [Frontman WordPress plugin page](https://wordpress.org/plugins/frontman-agentic-ai-editor/).
 
 ### Install Frontman from the WordPress Plugin Directory
 

--- a/apps/marketing/src/content/blog/wordpress-7-breaking-changes.md
+++ b/apps/marketing/src/content/blog/wordpress-7-breaking-changes.md
@@ -400,4 +400,4 @@ WordPress market share dropped from 65.2% in 2022 to [60.2% in 2026](https://blo
 
 If you maintain dozens of client sites with varied plugin stacks, the calculus is different. The maintenance burden compounds with every major release, and WordPress 7 is a heavier release than most.
 
-You just read a 2,500-word breaking changes audit. WordPress 8 will need one too. [Frontman](https://frontman.sh) is how developer teams stop doing this — visual AI editing on Next.js and Astro, with none of the upgrade overhead. Your content team edits visually while your codebase stays modern.
+You just read a 2,500-word breaking changes audit. WordPress 8 will need one too. [Frontman for WordPress](/wordpress/) helps teams edit existing WordPress sites with an AI agent beside live preview, while still treating staging, backups, and review as part of the workflow.

--- a/apps/marketing/src/content/blog/wordpress-integration.md
+++ b/apps/marketing/src/content/blog/wordpress-integration.md
@@ -13,7 +13,7 @@ We started Frontman with a clear idea: put an AI agent inside the app, not the e
 
 WordPress powers over 40% of the web. Millions of sites, run by people who range from full-time developers to business owners who just want their site to look right. So we built a WordPress integration.
 
-**Quick answer:** Frontman is an AI WordPress editor plugin that lets you describe changes in plain English, edit WordPress content and Elementor pages, and verify the result in a live site preview.
+**Quick answer:** [Frontman for WordPress](/wordpress/) is an AI WordPress editor plugin that lets you describe changes in plain English, edit WordPress content and Elementor pages, and verify the result in a live site preview.
 
 ## How It Works
 

--- a/apps/marketing/src/content/docs/docs/index.md
+++ b/apps/marketing/src/content/docs/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: Introduction
-description: Frontman is an open-source AI coding agent that lives in your browser. Chat with it, point at elements, and watch it edit your source code in real time. 
+title: Frontman Docs
+description: Frontman documentation for installation, framework integrations, API keys, usage guides, troubleshooting, and self-hosting.
 ---
 
 Frontman is an open-source AI coding agent that runs inside your development browser. You chat with it in natural language or point at elements on your page, and it edits your actual source files — with instant hot reload so you see changes immediately.
@@ -11,7 +11,7 @@ You describe a change → the agent takes a screenshot of your running app → r
 
 ## Who uses Frontman?
 
-**Developers** set up Frontman in their project (a one-line integration for Astro, Next.js, or Vite) and use it alongside their existing editor. The agent sees both the rendered page and the source code, so it makes precise, file-level edits that compile and render correctly.
+**Developers** set up Frontman in their project (a one-line integration for Astro, Next.js, or Vite) or install the WordPress plugin. The agent sees the rendered experience plus the underlying source or CMS context, so it makes precise edits you can review.
 
 **Designers, PMs, and non-technical teammates** use the chat UI to make changes directly. Select an element, describe what you want ("make this button larger," "change the heading text," "swap the layout to two columns"), and the agent handles the code. No IDE required.
 
@@ -26,7 +26,7 @@ Start here if Frontman isn't running in your project yet.
 | **Astro** | `astro add @frontman-ai/astro` | [Astro integration →](/docs/integrations/astro/) |
 | **Next.js** | `npx @frontman-ai/nextjs install` | [Next.js integration →](/docs/integrations/nextjs/) |
 | **Vite** | `npx @frontman-ai/vite install` | [Vite integration →](/docs/integrations/vite/) |
-| **WordPress** | WordPress Plugin Directory (beta) | [WordPress setup →](/docs/integrations/wordpress/) |
+| **WordPress** | [WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/) (beta) | [WordPress setup →](/docs/integrations/wordpress/) |
 
 Then continue with:
 

--- a/apps/marketing/src/content/docs/docs/installation.md
+++ b/apps/marketing/src/content/docs/docs/installation.md
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install Frontman in Astro, Next.js, or Vite projects with the right package command, then open the browser agent in your local dev server.
+description: Install Frontman in Astro, Next.js, Vite, or WordPress, then open the browser agent in your app or site.
 ---
 
-Frontman ships as a framework-specific integration — pick the guide that matches your project.
+Frontman ships as framework-specific integrations for JavaScript apps and as a WordPress plugin — pick the guide that matches your project.
 
 ## Astro
 
@@ -31,7 +31,7 @@ Then follow the [Vite integration guide →](/docs/integrations/vite/)
 
 ## WordPress (Beta)
 
-Install **Frontman - Agentic AI Editor** from the WordPress Plugin Directory in wp-admin. No npm package required.
+Install **Frontman - Agentic AI Editor** from the [WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/) in wp-admin. No npm package required.
 
 See the [WordPress setup guide →](/docs/integrations/wordpress/)
 

--- a/apps/marketing/src/content/docs/docs/integrations/wordpress.md
+++ b/apps/marketing/src/content/docs/docs/integrations/wordpress.md
@@ -5,6 +5,8 @@ description: Install the Frontman WordPress plugin to edit posts, blocks, Elemen
 
 The Frontman WordPress plugin adds an AI agent directly to your WordPress site. Navigate to `/frontman`, describe what you want to change, and the agent handles the supported workflow inside the site preview — no code editor or terminal required for those supported changes.
 
+For the product overview, see [Frontman for WordPress](/wordpress/).
+
 > **Beta:** This is experimental software. Start on a staging site, keep backups, and review changes before deploying to production.
 
 ## Requirements
@@ -15,22 +17,13 @@ The Frontman WordPress plugin adds an AI agent directly to your WordPress site. 
 
 ## Installation
 
-### Recommended: Install from the WordPress Plugin Directory
+### Install from the WordPress Plugin Directory
 
-Install Frontman from the WordPress store in wp-admin. This is the preferred installation method because WordPress handles the normal plugin install and update flow.
+Install Frontman from the [WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/) in wp-admin. WordPress handles the normal plugin install and update flow.
 
 1. In your WordPress admin, go to **Plugins → Add New Plugin**.
 2. Search for **Frontman Agentic AI Editor**, or open the [Frontman plugin page](https://wordpress.org/plugins/frontman-agentic-ai-editor/).
 3. Click **Install Now**.
-4. Click **Activate Plugin**.
-
-### Alternative: Upload a GitHub Release ZIP
-
-Use this if you need to pin a specific version, audit the release artifact, or install through a controlled deployment process.
-
-1. Download the latest plugin ZIP from the [GitHub releases page](https://github.com/frontman-ai/frontman/releases).
-2. In your WordPress admin, go to **Plugins → Add New Plugin → Upload Plugin**.
-3. Choose the ZIP file and click **Install Now**.
 4. Click **Activate Plugin**.
 
 ## Using Frontman

--- a/apps/marketing/src/data/json-files/faqData.json
+++ b/apps/marketing/src/data/json-files/faqData.json
@@ -48,6 +48,12 @@
 		"open": true
 	},
 	{
+		"question": "Does Frontman support WordPress?",
+		"reply": "Yes. Frontman for WordPress installs from the WordPress Plugin Directory and opens at /frontman on your site. It lets administrators edit posts, pages, Gutenberg blocks, Elementor pages, menus, templates, widgets, settings, cache, and WooCommerce data beside live preview. See /wordpress/ for the product overview and /docs/integrations/wordpress/ for setup.",
+		"category": "technical",
+		"open": false
+	},
+	{
 		"question": "How does it get context about my app?",
 		"reply": "Frontman gets context from the runtime it is installed into. For JavaScript frameworks, it hooks into your local dev server and browser tools. For WordPress, the plugin exposes WordPress-native content, template, menu, widget, option, Elementor, and WooCommerce tools directly from the running site. In both cases, the agent queries live runtime context instead of relying only on static files.",
 		"category": "technical",

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -16,9 +16,9 @@ import faqData from '../data/json-files/faqData.json'
 // Content
 // - SEO
 const SEO = {
-	title: 'Frontman: Visual AI Frontend Editing',
+	title: 'Frontman: AI Frontend Agent',
 	description:
-		'Click any element, describe changes in plain English, get real code edits. Frontman sees your live DOM and running app. Open-source core with BYOK model support.'
+		'Frontman is an AI frontend agent that sees your live DOM, component tree, CSS, routes, and logs so it can turn visual requests into real code edits.'
 }
 
 // FAQPage JSON-LD

--- a/apps/marketing/src/pages/integrations/index.astro
+++ b/apps/marketing/src/pages/integrations/index.astro
@@ -5,9 +5,9 @@
 import Layout from '../../layouts/Layout.astro'
 
 const SEO = {
-	title: 'Next.js, Astro & Vite Integrations | Frontman',
+	title: 'Next.js, Astro, Vite & WordPress Integrations | Frontman',
 	description:
-		'Install in one command. Frontman supports Next.js, Astro, and Vite (React, Vue, Svelte) with deep framework context and visual editing.'
+		'Install Frontman in JavaScript frameworks or as a WordPress plugin with live preview and AI editing.'
 }
 
 const integrations = [
@@ -31,6 +31,13 @@ const integrations = [
 		description: 'One integration for React, Vue, and Svelte. Frontman hooks into Vite\'s dev server and HMR pipeline for instant feedback on every edit.',
 		command: 'npx @frontman-ai/vite install',
 		tags: ['React', 'Vue', 'Svelte', 'HMR']
+	},
+	{
+		title: 'WordPress',
+		href: '/wordpress/',
+		description: 'Install from the WordPress Plugin Directory. Frontman adds an AI agent to /frontman with tools for posts, pages, Gutenberg blocks, Elementor content, menus, templates, widgets, settings, cache, and WooCommerce when active.',
+		command: 'Plugins -> Add New Plugin',
+		tags: ['Plugin Directory', 'Gutenberg', 'Elementor', 'WooCommerce', 'Live Preview']
 	}
 ]
 ---
@@ -41,7 +48,7 @@ const integrations = [
 			<p class="hero-label">Integrations</p>
 			<h1 class="hero-title">Frontman Integrations</h1>
 			<p class="hero-subtitle">
-				Frontman installs as framework middleware inside your dev server. Each integration gives the AI direct access to the component tree, computed styles, and server-side context for your specific framework.
+				Frontman installs as framework middleware for JavaScript apps and as a native WordPress plugin for CMS workflows. Each integration gives the AI runtime context for the thing you are editing.
 			</p>
 		</div>
 	</section>
@@ -70,17 +77,16 @@ const integrations = [
 
 	<section class="content-section">
 		<div class="content-container">
-			<h2 class="section-title">Why Framework Middleware?</h2>
+			<h2 class="section-title">Two Integration Models</h2>
 			<div class="prose-content">
-				<p>Most AI coding tools are "code-first." They read your source files but never see the running application. Browser-based tools like CLI overlays inject a toolbar on top of your app and only see the DOM surface.</p>
-				<p>Frontman takes a different approach. It installs as <strong>framework middleware</strong> and runs inside your dev server, which gives the AI access to information that's invisible from the outside:</p>
+				<p>For Next.js, Astro, and Vite, Frontman installs as <strong>framework middleware</strong> inside your dev server. That gives the AI access to source files, component context, computed styles, routes, logs, and hot reload.</p>
+				<p>For WordPress, Frontman installs as a <strong>WordPress plugin</strong>. It serves the /frontman workspace, respects WordPress permissions, and exposes platform-native tools for the content and settings that power the live site.</p>
 				<ul>
-					<li>The <strong>component tree</strong>: React fiber nodes, Vue reactivity graph, Svelte component hierarchy. The actual components that rendered each element, not just the DOM output.</li>
-					<li>The <strong>props and state</strong> each component received, how state flows through the tree, and what data drives the current render.</li>
-					<li><strong>Server-side context</strong> including routes, server logs, query timing, and middleware chains. The AI sees both the client and the server.</li>
-					<li><strong>Computed styles</strong> with the full cascade resolved, including specificity and inherited values.</li>
+					<li><strong>Framework apps:</strong> edit source files in local development with browser runtime context and HMR.</li>
+					<li><strong>WordPress sites:</strong> edit posts, pages, Gutenberg blocks, Elementor content, menus, templates, widgets, settings, cache, and WooCommerce data beside live preview.</li>
+					<li><strong>Same principle:</strong> the agent should see the thing you see before changing it.</li>
 				</ul>
-				<p>When you click an element and describe a change, the AI has the full picture. It targets the right component file, adjusts the right props, and understands how the edit affects the rest of the UI.</p>
+				<p>When correctness depends on the rendered result, source files or admin screens alone are not enough. Frontman keeps context, tools, and visual review in one loop.</p>
 			</div>
 		</div>
 	</section>

--- a/apps/marketing/src/pages/vs/onlook.astro
+++ b/apps/marketing/src/pages/vs/onlook.astro
@@ -12,9 +12,9 @@ import type {
 } from '../../layouts/ComparisonLayout.astro'
 
 const seo: SEOInfo = {
-	title: 'Frontman vs Onlook: Visual AI Code Editors Compared',
+	title: 'Onlook vs Frontman: Visual React Editor Comparison',
 	description:
-		'Compare Frontman and Onlook. Onlook is a Figma-like sandbox editor for React code; Frontman edits an existing running app through browser-aware framework middleware.',
+		'Compare Onlook and Frontman. Onlook is an open-source visual React editor with GitHub integration; Frontman edits an existing running app through framework middleware.',
 }
 
 const competitor: CompetitorInfo = {
@@ -98,7 +98,7 @@ const faqs: FAQ[] = [
 >
   <Fragment slot="hero-summary">
     <p>
-      <a href="https://frontman.sh" class="text-link">Frontman</a> and <a href="https://onlook.dev" class="text-link" rel="nofollow">Onlook</a> both use AI to help edit frontend code visually, but they're built for different people. Onlook is a Figma-like editor that outputs React code in a sandbox. Frontman is a developer tool that hooks into your running app in the browser.
+      <a href="https://onlook.dev" class="text-link" rel="nofollow">Onlook</a> is an open-source visual React editor from <code>onlook-dev/onlook</code> on GitHub. <a href="https://frontman.sh" class="text-link">Frontman</a> and Onlook both use AI to help edit frontend code visually, but they're built for different people. Onlook is a Figma-like editor that outputs React code in a sandbox. Frontman is a developer tool that hooks into your running app in the browser.
     </p>
     <p>
       <strong>Frontman</strong> is an open-source AI coding agent that installs as middleware in your dev server (Next.js, Astro, Vite). It sees the live DOM, component tree, computed CSS, and server-side context of your real running application. You click elements in your browser, describe changes in plain English, and Frontman edits the actual source files with hot reload. Free and unlimited — bring your own API keys.

--- a/apps/marketing/src/pages/wordpress.astro
+++ b/apps/marketing/src/pages/wordpress.astro
@@ -1,0 +1,314 @@
+---
+import { Image } from 'astro:assets'
+import Layout from '../layouts/Layout.astro'
+import Button from '../components/ui/Button.astro'
+import gridNetBackground from '../assets/grid-net-background.svg'
+import videoPlaceholder from '../assets/video-placeholder.png'
+
+const pluginUrl = 'https://wordpress.org/plugins/frontman-agentic-ai-editor/'
+const youtubeVideoId = '-4GD1GYwH8Y'
+
+const SEO = {
+	title: 'AI WordPress Editor Plugin | Frontman for WordPress',
+	description:
+		'Describe changes to posts, pages, Gutenberg blocks, Elementor pages, menus, templates, widgets, settings, and WooCommerce data. Frontman edits WordPress beside live preview.'
+}
+
+const capabilities = [
+	'Create, edit, and delete posts and pages',
+	'Insert, update, move, and delete Gutenberg blocks',
+	'Edit Elementor pages with Elementor-aware tools',
+	'Add and update navigation menu items',
+	'Read and change safe site options like title, tagline, and permalinks',
+	'Browse and update block templates and template parts',
+	'Manage widgets and flush WordPress cache',
+	'Work with WooCommerce data when WooCommerce is active'
+]
+
+const faqs = [
+	{
+		question: 'What is Frontman for WordPress?',
+		answer:
+			'Frontman for WordPress is an AI editor plugin for existing WordPress sites. It adds a /frontman workspace with chat, WordPress-native tools, and live site preview so administrators can describe changes and review the result in context.'
+	},
+	{
+		question: 'How do I install it?',
+		answer:
+			'Install Frontman Agentic AI Editor from the WordPress Plugin Directory in wp-admin: Plugins > Add New Plugin, search for Frontman Agentic AI Editor, install, activate, then visit /frontman on your site.'
+	},
+	{
+		question: 'Does it work with Elementor?',
+		answer:
+			'Yes. Frontman includes Elementor-aware tools for inspecting and editing Elementor-backed pages, while keeping the page preview visible during the workflow.'
+	},
+	{
+		question: 'Can I use it on production?',
+		answer:
+			'Technically yes, but Frontman for WordPress is beta software. Start on staging, keep backups, and review changes before relying on it in production.'
+	},
+	{
+		question: 'Who can access Frontman in WordPress?',
+		answer:
+			'Only WordPress users with the manage_options capability can access Frontman. Tool requests are protected with WordPress nonces, and site option writes are restricted to a safe allowlist.'
+	}
+]
+
+const pageJsonLd = {
+	'@context': 'https://schema.org',
+	'@graph': [
+		{
+			'@type': 'SoftwareApplication',
+			name: 'Frontman for WordPress',
+			applicationCategory: 'WordPress Plugin',
+			operatingSystem: 'WordPress',
+			description: SEO.description,
+			url: 'https://frontman.sh/wordpress/',
+			sameAs: [pluginUrl, 'https://github.com/frontman-ai/frontman']
+		},
+		{
+			'@type': 'FAQPage',
+			mainEntity: faqs.map((faq) => ({
+				'@type': 'Question',
+				name: faq.question,
+				acceptedAnswer: {
+					'@type': 'Answer',
+					text: faq.answer
+				}
+			}))
+		}
+	]
+}
+---
+
+<Layout title={SEO.title} description={SEO.description}>
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(pageJsonLd)} />
+
+	<section class="wp-hero">
+		<div class="wp-hero__bg">
+			<img src={gridNetBackground.src} alt="" aria-hidden="true" class="wp-hero__bg-image" width="1440" height="900" fetchpriority="high" />
+		</div>
+		<div class="wp-container wp-container--wide wp-hero__grid">
+			<div class="wp-hero__content">
+				<p class="wp-label">Frontman for WordPress</p>
+				<h1>AI WordPress editor plugin that works beside your live site.</h1>
+				<p class="wp-lead">
+					Make WordPress changes by describing the outcome you want. Frontman handles the right post, block, menu, template, setting, or WooCommerce update while you watch the live page change in context.
+				</p>
+				<div class="wp-actions wp-hero__cta">
+					<Button size="lg" style="white" link={pluginUrl} classes="wp-primary-cta">Install from WordPress.org <span class="wp-cta-arrow" aria-hidden="true">→</span></Button>
+					<a href="/docs/integrations/wordpress/" class="wp-secondary-link">Read setup guide</a>
+				</div>
+				<p class="wp-note">WordPress 6.0+, PHP 7.4+, administrator access required. Beta: start on staging and keep backups.</p>
+			</div>
+			<div class="wp-video-wrapper">
+				<button
+					class="wp-video-trigger"
+					data-video-id={youtubeVideoId}
+					aria-label="Play Frontman demo video"
+					type="button"
+				>
+					<Image
+						src={videoPlaceholder}
+						alt="Frontman demo video — click any element, describe changes, get real code edits"
+						class="wp-video-thumbnail"
+						loading="eager"
+						fetchpriority="high"
+						format="webp"
+						quality={80}
+						widths={[400, 960]}
+						sizes="(max-width: 1023px) 100vw, 960px"
+					/>
+					<div class="wp-play-button" aria-hidden="true">
+						<svg viewBox="0 0 68 48" width="68" height="48">
+							<path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55C3.97 2.33 2.27 4.81 1.48 7.74.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="#FF0000"/>
+							<path d="M45 24L27 14v20" fill="#fff"/>
+						</svg>
+					</div>
+				</button>
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--dark">
+		<div class="wp-container wp-narrow">
+			<h2>WordPress work is scattered. Frontman puts it in one loop.</h2>
+			<p>
+				A real WordPress change rarely lives in one obvious place. Copy may be in Gutenberg, layout in Elementor, navigation in menus, structure in templates, and behavior in settings or plugins. Frontman gives the agent WordPress-native tools and keeps the page visible while it works.
+			</p>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--light">
+		<div class="wp-container">
+			<div class="wp-section-header">
+				<p class="wp-label wp-label--dark">Workflow</p>
+				<h2>Install the plugin. Open /frontman. Describe the change.</h2>
+			</div>
+			<div class="wp-steps">
+				<div class="wp-step"><span>1</span><h3>Install from wp-admin</h3><p>Go to Plugins > Add New Plugin, search for Frontman Agentic AI Editor, install, and activate.</p></div>
+				<div class="wp-step"><span>2</span><h3>Open the live workspace</h3><p>Visit https://yoursite.com/frontman, or append /frontman to a specific page URL.</p></div>
+				<div class="wp-step"><span>3</span><h3>Review what changed</h3><p>Ask for the update, watch the preview, and decide whether the result is ready.</p></div>
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--dark">
+		<div class="wp-container">
+			<div class="wp-section-header">
+				<p class="wp-label">Capabilities</p>
+				<h2>Built for existing WordPress sites.</h2>
+				<p>Not a blank writing box. Not a site generator. Frontman works against the WordPress structures already powering your site.</p>
+			</div>
+			<div class="wp-capabilities">
+				{capabilities.map((capability) => <div class="wp-capability">{capability}</div>)}
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--light">
+		<div class="wp-container wp-split">
+			<div>
+				<p class="wp-label wp-label--dark">Why different</p>
+				<h2>The page is the workspace.</h2>
+			</div>
+			<div class="wp-copy">
+				<p>Most WordPress AI plugins generate text or expose tools somewhere inside wp-admin. Frontman centers the editing loop around the page you are changing.</p>
+				<p>The agent can use WordPress APIs for content, blocks, Elementor data, menus, templates, widgets, settings, cache, and WooCommerce. You keep visual review in the same workflow instead of switching tabs and hoping the right field changed.</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--dark">
+		<div class="wp-container wp-split">
+			<div>
+				<p class="wp-label">Safety</p>
+				<h2>Powerful enough to use carefully.</h2>
+			</div>
+			<div class="wp-copy">
+				<p>Frontman for WordPress is beta software. It can make real changes to content, menus, templates, Elementor pages, settings, widgets, and cache state.</p>
+				<p>Only administrators can access it. Tool requests use WordPress nonces. Site option writes are restricted to a safe allowlist. Start on staging, keep backups, and review changes before production use.</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-section wp-section--light">
+		<div class="wp-container wp-narrow">
+			<p class="wp-label wp-label--dark">FAQ</p>
+			<h2>Common questions</h2>
+			<div class="wp-faqs">
+				{faqs.map((faq) => (
+					<details class="wp-faq">
+						<summary>{faq.question}</summary>
+						<p>{faq.answer}</p>
+					</details>
+				))}
+			</div>
+		</div>
+	</section>
+
+	<section class="wp-final">
+		<div class="wp-container wp-narrow">
+			<h2>Install Frontman for WordPress.</h2>
+			<p>Search for Frontman Agentic AI Editor in wp-admin, or open the Plugin Directory page.</p>
+			<div class="wp-actions wp-actions--center">
+				<Button size="lg" style="white" link={pluginUrl}>Install from WordPress.org</Button>
+				<a href="/docs/integrations/wordpress/" class="wp-secondary-link">Setup guide</a>
+			</div>
+		</div>
+	</section>
+</Layout>
+
+<style>
+	@reference "../styles/global.css";
+
+	.wp-container { @apply mx-auto max-w-6xl px-6; }
+	.wp-container--wide { max-width: 1100px; }
+	.wp-narrow { max-width: 760px; }
+	.wp-label { @apply mb-3 font-mono text-sm uppercase tracking-[0.14em]; color: #c4b5fd; }
+	.wp-label--dark { color: #7c3aed; }
+	.wp-hero { position: relative; overflow: hidden; background: #7c3aed; color: #fafafa; }
+	.wp-hero__bg { position: absolute; inset: 0; z-index: 0; opacity: 0.3; }
+	.wp-hero__bg-image { width: 100%; height: 100%; object-fit: cover; object-position: center; }
+	.wp-hero__grid { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: center; padding-top: 104px; padding-bottom: 80px; }
+	.wp-hero__content { max-width: 780px; text-align: center; display: flex; flex-direction: column; align-items: center; }
+	h1 { font-family: 'SF Pro Display', system-ui, helvetica, sans-serif; font-size: 48px; line-height: 54px; font-weight: 700; letter-spacing: -0.035em; color: white; text-wrap: balance; }
+	.wp-lead { @apply mt-6 text-lg text-white/85; line-height: 1.55; max-width: 620px; text-wrap: pretty; }
+	.wp-actions { @apply mt-8 flex flex-wrap items-center gap-4; }
+	.wp-hero__cta { gap: 20px; }
+	.wp-hero__cta .button { justify-content: center; }
+	.wp-primary-cta { min-width: 268px; }
+	.wp-cta-arrow { margin-left: 8px; }
+	.wp-actions--center { justify-content: center; }
+	.wp-secondary-link { @apply font-semibold text-white underline underline-offset-4 hover:text-primary-100; }
+	.wp-note { @apply mt-6 text-sm leading-6 text-white/70; }
+	.wp-video-wrapper { width: 100%; max-width: 960px; aspect-ratio: 16 / 9; position: relative; margin: 40px auto 0; border-radius: 12px; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.35); }
+	.wp-video-trigger { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; padding: 0; margin: 0; cursor: pointer; background: none; transition: opacity 0.2s ease; }
+	.wp-video-trigger:hover { opacity: 0.92; }
+	.wp-video-trigger:focus-visible { outline: 3px solid white; outline-offset: 3px; }
+	.wp-video-trigger[data-playing] { display: none; }
+	.wp-video-thumbnail { width: 100%; height: 100%; object-fit: cover; display: block; }
+	.wp-play-button { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); transition: transform 0.2s ease; filter: drop-shadow(0 2px 8px rgba(0,0,0,0.4)); }
+	.wp-video-trigger:hover .wp-play-button { transform: translate(-50%, -50%) scale(1.1); }
+	.wp-video-wrapper :global(iframe) { position: absolute; inset: 0; width: 100%; height: 100%; border: none; }
+	.wp-section { padding: 80px 0; }
+	.wp-section--dark { background: #09090b; color: #fafafa; }
+	.wp-section--light { background: #fafafa; color: #09090b; }
+	.wp-section h2 { @apply mb-5 text-3xl font-bold tracking-[-0.03em] md:text-5xl; line-height: 1.08; color: inherit; opacity: 1; }
+	.wp-section p { @apply text-lg leading-8; color: inherit; opacity: 0.78; }
+	.wp-section-header { max-width: 760px; margin-bottom: 36px; }
+	.wp-steps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+	.wp-step { border: 2px solid #111827; border-radius: 20px; padding: 24px; background: white; box-shadow: 6px 6px 0 #111827; }
+	.wp-step span { display: inline-flex; width: 34px; height: 34px; align-items: center; justify-content: center; border-radius: 999px; background: #7c3aed; color: white; font-weight: 800; margin-bottom: 18px; }
+	.wp-step h3 { @apply mb-2 text-xl font-bold text-slate-950; }
+	.wp-step p { @apply text-base leading-7 text-slate-600; opacity: 1; }
+	.wp-capabilities { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+	.wp-capability { border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 18px; background: rgba(255,255,255,0.04); color: #e4e4e7; }
+	.wp-split { display: grid; grid-template-columns: 0.8fr 1.2fr; gap: 56px; align-items: start; }
+	.wp-copy p + p { margin-top: 18px; }
+	.wp-faqs { margin-top: 28px; border-top: 1px solid #d4d4d8; }
+	.wp-faq { border-bottom: 1px solid #d4d4d8; padding: 18px 0; }
+	.wp-faq summary { cursor: pointer; font-weight: 700; color: #09090b; }
+	.wp-faq p { @apply mt-3 text-base leading-7 text-slate-600; opacity: 1; }
+	.wp-final { background: #7c3aed; color: white; text-align: center; padding: 72px 0; }
+	.wp-final h2 { @apply mb-4 text-4xl font-bold tracking-[-0.03em] md:text-5xl; }
+	.wp-final p { @apply text-lg text-violet-100; }
+
+	@media (min-width: 1024px) {
+		h1 { font-size: 64px; line-height: 70px; }
+	}
+
+	@media (max-width: 900px) {
+		.wp-split, .wp-steps, .wp-capabilities { grid-template-columns: 1fr; }
+		.wp-hero__grid { padding-top: 64px; padding-bottom: 56px; }
+		.wp-video-wrapper { margin-top: 28px; }
+	}
+
+	@media (max-width: 639px) {
+		h1 { font-size: 38px; line-height: 44px; }
+		.wp-hero__cta .button { width: 100%; }
+	}
+</style>
+
+<script>
+	const trigger = document.querySelector('.wp-video-trigger') as HTMLButtonElement | null;
+	if (!trigger) throw new Error('Video trigger button not found in WordPress hero');
+
+	trigger.addEventListener('click', () => {
+		if (trigger.hasAttribute('data-playing')) return;
+		const videoId = trigger.dataset.videoId;
+		if (!videoId) return;
+
+		const iframe = document.createElement('iframe');
+		iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1&iv_load_policy=3`;
+		iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+		iframe.allowFullscreen = true;
+		iframe.title = 'Frontman demo video';
+
+		const wrapper = trigger.parentElement;
+		if (wrapper) {
+			trigger.setAttribute('data-playing', '');
+			wrapper.appendChild(iframe);
+			iframe.focus();
+		}
+	});
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/internal-helpers@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@astrojs/internal-helpers@npm:0.10.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.4"
+    "@types/mdast": "npm:^4.0.4"
+    js-yaml: "npm:^4.1.1"
+    picomatch: "npm:^4.0.4"
+    retext-smartypants: "npm:^6.2.0"
+    shiki: "npm:^4.0.2"
+    smol-toml: "npm:^1.6.0"
+    unified: "npm:^11.0.5"
+  checksum: 10c0/e6729142b607b9aebaf36afeb045c5e137a4dd2a89051a5221c16c8d55379e6986e663c683ec524459dd3f35965027b94cbd02c9034bddc5a6acd0da21dfe5d4
+  languageName: node
+  linkType: hard
+
 "@astrojs/internal-helpers@npm:0.9.1":
   version: 0.9.1
   resolution: "@astrojs/internal-helpers@npm:0.9.1"
@@ -180,6 +196,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/markdown-remark@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@astrojs/markdown-remark@npm:7.2.0"
+  dependencies:
+    "@astrojs/internal-helpers": "npm:0.10.0"
+    "@astrojs/prism": "npm:4.0.2"
+    github-slugger: "npm:^2.0.0"
+    hast-util-from-html: "npm:^2.0.3"
+    hast-util-to-text: "npm:^4.0.2"
+    mdast-util-definitions: "npm:^6.0.0"
+    rehype-raw: "npm:^7.0.0"
+    rehype-stringify: "npm:^10.0.1"
+    remark-gfm: "npm:^4.0.1"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.1.2"
+    remark-smartypants: "npm:^3.0.2"
+    unified: "npm:^11.0.5"
+    unist-util-remove-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.1.0"
+    unist-util-visit-parents: "npm:^6.0.2"
+    vfile: "npm:^6.0.3"
+  checksum: 10c0/4332f03768733beff038ebdd68ae1d0207d0b66f1089bf98a42ed5f25614bfe5bfc6b8459acd7d639ebb03a914375b942d8253f80ee6141dcf2b305449a77938
+  languageName: node
+  linkType: hard
+
 "@astrojs/mdx@npm:^5.0.4":
   version: 5.0.6
   resolution: "@astrojs/mdx@npm:5.0.6"
@@ -204,18 +245,18 @@ __metadata:
   linkType: hard
 
 "@astrojs/preact@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "@astrojs/preact@npm:5.1.3"
+  version: 5.1.5
+  resolution: "@astrojs/preact@npm:5.1.5"
   dependencies:
-    "@astrojs/internal-helpers": "npm:0.9.1"
+    "@astrojs/internal-helpers": "npm:0.10.0"
     "@preact/preset-vite": "npm:^2.10.5"
     "@preact/signals": "npm:^2.8.2"
-    devalue: "npm:^5.6.4"
+    devalue: "npm:^5.8.1"
     preact-render-to-string: "npm:^6.6.6"
     vite: "npm:^7.3.2"
   peerDependencies:
     preact: ^10.6.5
-  checksum: 10c0/2ac5cef6ff01cc64d2a7df82863ae5c8d58377b1f8f4195cedebb5093d70bd69ac14881d0e48a053e2bc936b9bb7955de754f9a117e722921b54d3c4d4b3a14e
+  checksum: 10c0/1f085b1c7ec210908a9536f5f9dd1d1f7394edfab298a3a9c0a2f5ca37199f3294237a32ae8d807727839cb0116355fc6c57c9c9074c166180cd5874eb1ebb5f
   languageName: node
   linkType: hard
 
@@ -8346,12 +8387,12 @@ __metadata:
   linkType: hard
 
 "astro@npm:^6.3.7":
-  version: 6.3.7
-  resolution: "astro@npm:6.3.7"
+  version: 6.4.8
+  resolution: "astro@npm:6.4.8"
   dependencies:
     "@astrojs/compiler": "npm:^4.0.0"
-    "@astrojs/internal-helpers": "npm:0.9.1"
-    "@astrojs/markdown-remark": "npm:7.1.2"
+    "@astrojs/internal-helpers": "npm:0.10.0"
+    "@astrojs/markdown-remark": "npm:7.2.0"
     "@astrojs/telemetry": "npm:3.3.2"
     "@capsizecss/unpack": "npm:^4.0.0"
     "@clack/prompts": "npm:^1.1.0"
@@ -8363,7 +8404,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     common-ancestor-path: "npm:^2.0.0"
     cookie: "npm:^1.1.1"
-    devalue: "npm:^5.6.3"
+    devalue: "npm:^5.8.1"
     diff: "npm:^8.0.3"
     dset: "npm:^3.1.4"
     es-module-lexer: "npm:^2.0.0"
@@ -8410,7 +8451,7 @@ __metadata:
       optional: true
   bin:
     astro: ./bin/astro.mjs
-  checksum: 10c0/5ba358816a4c8c50ebb055e9f0d37540abbeeee8b33334d9bfecd20e1255d0de163c870a08767a2b614ec889242c5b9f22a9f819eb043cc876aa029c81522b2a
+  checksum: 10c0/52cb75f1bf4acd9a6fba0e4f949411763bab6294b9a2d4c819334c0632e2194a13cb1a3f8a437b84862191c923f303ff421ec1fb7d0a5ac69feb51903bed1040
   languageName: node
   linkType: hard
 
@@ -12749,11 +12790,11 @@ __metadata:
   linkType: hard
 
 "marked@npm:^18.0.4":
-  version: 18.0.4
-  resolution: "marked@npm:18.0.4"
+  version: 18.0.5
+  resolution: "marked@npm:18.0.5"
   bin:
     marked: bin/marked.js
-  checksum: 10c0/f54dcbb39d3acdcd0356f7629b42811eec56db5f6daef7404e582cdf800f5b598b681f9f8a187e7f51262e37c607f5e0cd9880e56b5c8160a49c3f7828e9e459
+  checksum: 10c0/22763935a0a243c41851b010a086ea85a09951e379948b6aa629b6cecdcd66e3a5e8c4acac2f6b29c183c20609d3e5102495270207dfd5f4c46ddd773a4ddb9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add dedicated Frontman for WordPress marketing page
- Add WordPress links across nav, integrations, docs, and related blog posts
- Update install tabs and FAQ content for WordPress plugin flow

## Test
- make build (apps/marketing)