### PR TITLE
Tighten user message submit flow

### DIFF
--- a/.changeset/strict-message-submit.md
+++ b/.changeset/strict-message-submit.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Tighten user message submission error handling and title generation enqueue semantics.

--- a/.changeset/strict-message-submit.md
+++ b/.changeset/strict-message-submit.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Tighten user message submission error handling and title generation enqueue semantics.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -503,26 +503,27 @@ defmodule FrontmanServer.Tasks do
       when is_binary(task_id) and is_binary(model) and model != "" and is_list(mcp_tools) and
              is_list(project_traits) do
     user_message_interaction = Interaction.UserMessage.new(content_blocks, model)
-    execution = %{model: model, mcp_tools: mcp_tools, project_traits: project_traits}
 
-    case insert_user_turn_for_locked_task(scope, task_id, user_message_interaction) do
-      {:ok, {task_schema, turn_number}} ->
-        run_execution(scope, task_schema, turn_number, execution)
+    with {:ok, {task_schema, turn_number}} <-
+           insert_user_turn_for_locked_task(scope, task_id, user_message_interaction) do
+      _ =
+        run_execution(scope, task_schema, turn_number, %{
+          model: model,
+          mcp_tools: mcp_tools,
+          project_traits: project_traits
+        })
 
-        if turn_number == 1 do
-          GenerateTitle.new_job(
-            scope,
-            task_id,
-            Enum.join(user_message_interaction.messages, "\n"),
-            model
-          )
-          |> Oban.insert()
-        end
+      if turn_number == 1 do
+        GenerateTitle.new(%{
+          user_id: scope.user.id,
+          task_id: task_id,
+          user_prompt_text: Enum.join(user_message_interaction.messages, "\n"),
+          model: model
+        })
+        |> Oban.insert!()
+      end
 
-        {:ok, user_message_interaction, turn_number}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, user_message_interaction, turn_number}
     end
   end
 
@@ -533,7 +534,7 @@ defmodule FrontmanServer.Tasks do
   defp insert_user_turn_for_locked_task(%Scope{} = scope, task_id, user_message_interaction) do
     Repo.transact(fn ->
       with %TaskSchema{} = task_schema <- get_task_by_id_for_update(scope, task_id),
-           {:ok, turn_number} <- insert_user_turn(task_schema, user_message_interaction) do
+           {:ok, turn_number} <- insert_user_turn_if_idle(task_schema, user_message_interaction) do
         {:ok, {task_schema, turn_number}}
       else
         nil -> {:error, :not_found}
@@ -542,10 +543,9 @@ defmodule FrontmanServer.Tasks do
     end)
   end
 
-  defp insert_user_turn(%TaskSchema{} = task_schema, interaction) do
+  defp insert_user_turn_if_idle(%TaskSchema{} = task_schema, interaction) do
     rows = load_interaction_rows(task_schema.id)
 
-    # NOTE(Itay): OMG this is so complex.
     case active_agent_run_turn_number(rows) do
       {:ok, nil} ->
         turn_number = next_turn_number(rows)
@@ -788,6 +788,8 @@ defmodule FrontmanServer.Tasks do
 
   defp record_execution_start_failure(scope, task_id, turn_number, reason)
        when is_integer(turn_number) and turn_number > 0 do
+    Logger.error("Execution failed to start for task #{task_id}: #{inspect(reason)}")
+
     message = Execution.error_message(scope, reason)
     {:ok, _error} = record_agent_run_result(scope, task_id, turn_number, {:failed, message})
     broadcast_task(task_id, {:execution_start_error, message, turn_number})

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -223,6 +223,6 @@ defmodule FrontmanServer.Tasks.Execution do
   def error_message(%Scope{}, :missing_model),
     do: "Model is required for this request."
 
-  def error_message(%Scope{}, reason),
-    do: inspect(reason)
+  def error_message(%Scope{}, _reason),
+    do: "Agent failed to start. Please try again."
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -400,10 +400,16 @@ defmodule FrontmanServer.Tasks.Interaction do
 
     # Extract text messages from content blocks
     defp extract_messages(content_blocks) do
-      content_blocks
-      |> Enum.filter(&match?(%{"type" => "text"}, &1))
-      |> Enum.map(&Map.get(&1, "text", ""))
-      |> Enum.reject(&(&1 == ""))
+      Enum.flat_map(content_blocks, fn
+        %{"type" => "text", "text" => text} when is_binary(text) and text != "" ->
+          [text]
+
+        %{"type" => "text"} ->
+          raise ArgumentError, "text content block must include non-empty string text"
+
+        _block ->
+          []
+      end)
     end
 
     # Extract annotations from content blocks.

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -23,7 +23,7 @@ defmodule FrontmanServer.Workers.GenerateTitle do
   require Logger
 
   alias FrontmanServer.Accounts
-  alias FrontmanServer.Accounts.{Scope, User}
+  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
   alias ReqLLM.Message.ContentPart
@@ -32,18 +32,6 @@ defmodule FrontmanServer.Workers.GenerateTitle do
   Generate a concise 3-6 word title for this chat based on the user's message.
   Return only the title text, nothing else. No quotes, no punctuation at the end.
   """
-
-  @doc """
-  Builds an Oban job changeset for title generation.
-  """
-  def new_job(%Scope{user: %User{} = user}, task_id, user_prompt_text, model) do
-    new(%{
-      user_id: user.id,
-      task_id: task_id,
-      user_prompt_text: user_prompt_text,
-      model: model
-    })
-  end
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -92,6 +80,8 @@ defmodule FrontmanServer.Workers.GenerateTitle do
       ReqLLM.Context.user(user_prompt_text)
     ]
 
-    {:ok, ReqLLM.generate_text!(model_spec, messages, llm_opts)}
+    with {:ok, response} <- ReqLLM.generate_text(model_spec, messages, llm_opts) do
+      {:ok, ReqLLM.Response.text(response)}
+    end
   end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -18,6 +18,26 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   # ---------------------------------------------------------------------------
 
   describe "UserMessage.new/1" do
+    test "extracts non-empty text messages" do
+      msg = UserMessage.new([text_block("Hello")])
+
+      assert msg.messages == ["Hello"]
+    end
+
+    test "raises for text blocks without non-empty string text" do
+      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
+        UserMessage.new([%{"type" => "text"}])
+      end
+
+      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
+        UserMessage.new([%{"type" => "text", "text" => ""}])
+      end
+
+      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
+        UserMessage.new([%{"type" => "text", "text" => 1}])
+      end
+    end
+
     test "extracts annotation from resource block" do
       msg =
         UserMessage.new([

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -3,7 +3,6 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
 
   import FrontmanServer.Test.Fixtures.Accounts
 
-  alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Workers.GenerateTitle
 
   setup do
@@ -11,17 +10,15 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
     {:ok, user: user}
   end
 
-  describe "new_job/4" do
+  describe "new/1" do
     test "builds a job changeset with model", %{user: user} do
-      scope = Scope.for_user(user)
-
       changeset =
-        GenerateTitle.new_job(
-          scope,
-          "task-123",
-          "Help me build a login page",
-          "anthropic:claude-sonnet-4-20250514"
-        )
+        GenerateTitle.new(%{
+          user_id: user.id,
+          task_id: "task-123",
+          user_prompt_text: "Help me build a login page",
+          model: "anthropic:claude-sonnet-4-20250514"
+        })
 
       args = changeset.changes.args
       assert args.user_id == user.id


### PR DESCRIPTION
## Summary
- simplify user message submit flow and make execution start fire-and-forget explicit
- require valid non-empty text content blocks
- make title enqueue critical and use tuple-style ReqLLM title generation
- use generic user-facing execution start fallback while logging raw reasons

## Tests
- mix test test/frontman_server/tasks/interaction_test.exs test/frontman_server/workers/generate_title_test.exs