### PR TITLE
Fix no API key provider UX

### DIFF
--- a/.changeset/fix-no-api-key-provider-actions.md
+++ b/.changeset/fix-no-api-key-provider-actions.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Fix no-API-key errors to show provider configuration and keep annotation chips within message bounds.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -790,9 +790,15 @@ defmodule FrontmanServer.Tasks do
        when is_integer(turn_number) and turn_number > 0 do
     Logger.error("Execution failed to start for task #{task_id}: #{inspect(reason)}")
 
-    message = Execution.error_message(scope, reason)
-    {:ok, _error} = record_agent_run_result(scope, task_id, turn_number, {:failed, message})
-    broadcast_task(task_id, {:execution_start_error, message, turn_number})
+    {message, category, retryable} = ErrorClassifier.classify_error(reason)
+
+    {:ok, _error} =
+      record_agent_run_result(
+        scope,
+        task_id,
+        turn_number,
+        {:failed, message, retryable, category}
+      )
 
     :ok
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -212,17 +212,4 @@ defmodule FrontmanServer.Tasks.Execution do
 
   defp to_swarm_content_part(%{"type" => "image", "data" => data, "mimeType" => mime_type}),
     do: ContentPart.image(Base.decode64!(data), mime_type)
-
-  @doc false
-  def error_message(%Scope{}, :no_api_key),
-    do: "No API key available for this request."
-
-  def error_message(%Scope{}, :registration_timeout),
-    do: "Agent failed to start. Please try again."
-
-  def error_message(%Scope{}, :missing_model),
-    do: "Model is required for this request."
-
-  def error_message(%Scope{}, _reason),
-    do: "Agent failed to start. Please try again."
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
@@ -26,6 +26,12 @@ defmodule FrontmanServer.Tasks.Execution.ErrorClassifier do
     classify_reqllm_request(status, reason)
   end
 
+  def classify_error(:no_api_key), do: {"No API key available for this request.", "auth", false}
+  def classify_error(:missing_model), do: {"Model is required for this request.", "auth", false}
+
+  def classify_error(:registration_timeout),
+    do: {"Agent failed to start. Please try again.", "unknown", false}
+
   def classify_error(%StreamStallTimeout.Error{}) do
     {"The AI provider stopped responding mid-reply. " <>
        "This usually happens when the provider is temporarily overloaded. " <>

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -157,10 +157,6 @@ defmodule FrontmanServerWeb.TaskChannel do
     handle_interaction(interaction, turn_number, socket)
   end
 
-  def handle_info({:execution_start_error, msg, turn_number}, socket) do
-    finalize_turn(socket, {:error, msg, "unknown"}, turn_number)
-  end
-
   def handle_info({:fire_retry, token}, socket) do
     case socket.assigns[:retry_state] do
       %{timer_token: ^token, retried_error_id: retried_error_id} ->

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -203,9 +203,9 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       {:ok, _, 1} =
         submit_user_message(scope, task_id, user_content("Hello"), model: "missing:test")
 
-      assert_receive {:execution_start_error, "No API key available for this request.", 1}
+      assert_receive {:interaction, %Interaction.AgentError{category: "auth"}, 1}
 
-      assert %InteractionSchema{turn_number: 1} =
+      assert %InteractionSchema{turn_number: 1, data: %{"category" => "auth"}} =
                Repo.get_by!(InteractionSchema,
                  task_id: task_id,
                  type: Interaction.type_for(Interaction.AgentError)
@@ -259,7 +259,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert [%Interaction.Annotation{screenshot: %Interaction.Screenshot{}}] =
                broadcast_message.annotations
 
-      assert_receive {:execution_start_error, "No API key available for this request.", 1}
+      assert_receive {:interaction, %Interaction.AgentError{category: "auth"}, 1}
 
       {:ok, task} = Tasks.get_task(scope, task_id)
       assert [%Interaction.UserMessage{} = persisted_message | _] = task.interactions

--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -135,7 +135,7 @@ let make = (~apiBaseUrl: string) => {
         style={{width: `${Int.toString(chatboxWidth)}px`}}
         className="h-full border-r flex flex-col overflow-hidden relative shrink-0"
       >
-        <Client__Chatbox />
+        <Client__Chatbox onConfigureProvider=openSettingsProviders />
         // Resize handle on right edge
         <div
           className={[

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -96,7 +96,7 @@ let groupMessages = (messages: array<Message.t>): array<displayItem> => {
 }
 
 @react.component
-let make = () => {
+let make = (~onConfigureProvider: unit => unit) => {
   let {session, createSession} = Client__FrontmanProvider.useFrontman()
 
   let messages = Client__State.useSelector(Client__State.Selectors.messages)
@@ -361,6 +361,7 @@ let make = () => {
         <ErrorBanner
           error={Message.ErrorMessage.error(err)}
           category={Message.ErrorMessage.category(err)}
+          onConfigureProvider
           onRetry={switch currentTaskId {
           | Some(taskId) =>
             () =>
@@ -399,6 +400,7 @@ let make = () => {
           <ErrorBanner
             error=message
             category
+            onConfigureProvider
             onRetry={() =>
               Client__State.Actions.retryTurn(
                 ~taskId,
@@ -429,6 +431,7 @@ let make = () => {
           isModelsConfigLoading
           selectedModelValue
           onModelChange={value => Client__State.Actions.setSelectedModelValue(~value)}
+          onConfigureProvider
           isAgentRunning
           hasActiveACPSession
           onSelectElement={Client__State.Actions.toggleWebPreviewSelection}

--- a/libs/client/src/components/frontman/Client__ErrorBanner.res
+++ b/libs/client/src/components/frontman/Client__ErrorBanner.res
@@ -2,7 +2,12 @@
 // Always shows a retry button. Permanent errors show category-specific guidance.
 
 @react.component
-let make = (~error: string, ~category: string, ~onRetry: unit => unit) => {
+let make = (
+  ~error: string,
+  ~category: string,
+  ~onRetry: unit => unit,
+  ~onConfigureProvider: option<unit => unit>=?,
+) => {
   let guidance = switch category {
   | "auth" | "billing" => Some("Check Settings")
   | "rate_limit" => Some("Wait a moment before retrying")
@@ -24,6 +29,16 @@ let make = (~error: string, ~category: string, ~onRetry: unit => unit) => {
       >
         {React.string("Retry")}
       </button>
+      {switch (category, onConfigureProvider) {
+      | ("auth", Some(onConfigureProvider)) | ("billing", Some(onConfigureProvider)) =>
+        <button
+          onClick={_ => onConfigureProvider()}
+          className="text-xs text-red-100 border border-red-500/70 bg-red-500/10 hover:bg-red-500/20 hover:border-red-400 px-3 py-1 rounded transition-colors"
+        >
+          {React.string("Configure provider")}
+        </button>
+      | _ => React.null
+      }}
       <a
         href="https://frontman.sh/docs"
         target="_blank"

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -12,6 +12,7 @@
  * - Submit button with status
  */
 module Icons = Client__ToolIcons
+module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 // ============================================================================
 // Types
@@ -239,7 +240,6 @@ let focusAtEnd: Dom.element => unit = %raw(`
 // Uses Radix UI Select for consistent dark theme styling across all platforms (including Linux)
 module ModelSelector = {
   module Select = FrontmanBindings.Bindings__RadixUI__Select
-  module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
   // Get the display name for the currently selected value from config option
   let _getSelectedDisplay = (configOption: ACP.sessionConfigOption, selectedValue: string): option<
@@ -351,6 +351,14 @@ module ModelSelector = {
         </Select.Content>
       </Select.Portal>
     </Select.Root>
+  }
+}
+
+let modelConfigOptionHasModels = (configOption: ACP.sessionConfigOption) => {
+  switch configOption {
+  | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
+    groups->Array.some(group => group.options->Array.length > 0)
+  | ACP.SelectConfigOption({options: ACP.Ungrouped(options)}) => options->Array.length > 0
   }
 }
 
@@ -469,12 +477,11 @@ module SubmitButton = {
 let make = (
   ~onSubmit: (~text: string, ~inputItems: array<inputItem>) => unit,
   ~onCancel: unit => unit,
-  ~modelConfigOption: option<FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionConfigOption>,
+  ~modelConfigOption: option<ACP.sessionConfigOption>,
   ~isModelsConfigLoading: bool,
-  ~selectedModelValue: option<
-    FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionConfigValueId,
-  >,
+  ~selectedModelValue: option<ACP.sessionConfigValueId>,
   ~onModelChange: string => unit,
+  ~onConfigureProvider: unit => unit,
   ~isAgentRunning: bool,
   ~hasActiveACPSession: bool,
   ~placeholder: string="What would you like to change?",
@@ -497,6 +504,12 @@ let make = (
   let formRef = React.useRef(Nullable.null)
   // Ref to hold the latest inputItems so callbacks always see current value
   let itemsRef: React.ref<array<inputItem>> = React.useRef([])
+  let noModelsConfigured =
+    !isModelsConfigLoading &&
+    switch modelConfigOption {
+    | Some(configOption) => !modelConfigOptionHasModels(configOption)
+    | None => false
+    }
 
   // Keep itemsRef in sync
   React.useEffect1(() => {
@@ -798,7 +811,7 @@ let make = (
     })
   }
 
-  let isInputDisabled = !hasActiveACPSession || isAgentRunning || disabled
+  let isInputDisabled = !hasActiveACPSession || isAgentRunning || disabled || noModelsConfigured
   let isSubmitDisabled = isInputDisabled || !hasContent && !hasAnnotations || isEnrichingAnnotations
 
   // Handle keydown in contentEditable.
@@ -818,7 +831,9 @@ let make = (
   }
 
   // Determine placeholder text based on state
-  let currentPlaceholder = if disabled {
+  let currentPlaceholder = if noModelsConfigured {
+    "Connect an AI provider to start chatting."
+  } else if disabled {
     disabledPlaceholder->Option.getOr("Input disabled")
   } else if isAgentRunning {
     "Waiting for response..."
@@ -958,6 +973,16 @@ let make = (
           >
             <span className="truncate"> {React.string("Loading...")} </span>
           </div>
+        | (false, Some(configOption)) if !modelConfigOptionHasModels(configOption) =>
+          <button
+            type_="button"
+            onClick={_ => onConfigureProvider()}
+            className="inline-flex items-center gap-1 h-8 px-2 text-xs rounded-md
+                       text-violet-300 bg-violet-600/15 hover:bg-violet-600/25
+                       transition-colors cursor-pointer shrink-0"
+          >
+            {React.string("Configure provider")}
+          </button>
         | (false, Some(configOption)) =>
           <div className="shrink min-w-0 max-w-[160px]">
             <ModelSelector

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -70,10 +70,12 @@ let make = (
 
   // Sticky container with dark background for proper stacking
   <div className={`sticky top-0 z-10 bg-[#130d20] py-2 px-3 ${animationClass}`}>
-    <div className="inline-block max-w-[85%] bg-violet-600/80 rounded-2xl px-4 py-3">
+    <div
+      className="inline-block max-w-[85%] min-w-0 overflow-hidden bg-violet-600/80 rounded-2xl px-4 py-3"
+    >
       // Annotation chips (above images/text)
       {hasAnnotations
-        ? <div className="flex flex-wrap gap-1.5 mb-2">
+        ? <div className="flex flex-wrap gap-1.5 mb-2 min-w-0">
             {annotations
             ->Array.mapWithIndex((annotation, i) => {
               let badge = _getBadge(i)
@@ -85,13 +87,16 @@ let make = (
                   : `<${annotation.tagName}>`
               | None => `<${annotation.tagName}>`
               }
-              <div key={`${messageId}-ann-${Int.toString(i)}`} className="flex flex-col gap-0.5">
+              <div
+                key={`${messageId}-ann-${Int.toString(i)}`}
+                className="flex flex-col gap-0.5 min-w-0"
+              >
                 <div
-                  className="flex items-center gap-1 px-2 py-0.5 rounded-md
+                  className="flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0
                              bg-violet-500/60 text-violet-100 text-xs font-mono"
                 >
-                  <span className="text-violet-200"> {React.string(badge)} </span>
-                  <span className="truncate max-w-[160px]"> {React.string(label)} </span>
+                  <span className="text-violet-200 shrink-0"> {React.string(badge)} </span>
+                  <span className="truncate min-w-0 max-w-[160px]"> {React.string(label)} </span>
                 </div>
                 {switch annotation.comment {
                 | Some(comment) =>

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -12,6 +12,7 @@ let name = "Client::StateReducer"
 module UserContentPart = Client__State__Types.UserContentPart
 module Message = Client__State__Types.Message
 module Task = Client__State__Types.Task
+module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 type state = Client__State__Types.state
 
 // ============================================================================
@@ -1338,20 +1339,18 @@ let next = (state: state, action) => {
 
   // ACP session config option actions
   | ConfigOptionsReceived({configOptions}) =>
-    open FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
     let modelConfigOption =
-      findConfigOptionByCategory(configOptions, Model)->Option.getOrThrow(
+      ACP.findConfigOptionByCategory(configOptions, ACP.Model)->Option.getOrThrow(
         ~message="ConfigOptionsReceived missing model config option",
       )
 
     let firstModelValue = switch modelConfigOption {
-    | SelectConfigOption({options: Grouped(groups)}) =>
+    | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
       groups
       ->Array.get(0)
       ->Option.flatMap(g => g.options->Array.get(0))
       ->Option.map(opt => opt.value)
-      ->Option.getOrThrow(~message="Model config option has no models")
-    | SelectConfigOption({options: Ungrouped(_)}) =>
+    | ACP.SelectConfigOption({options: ACP.Ungrouped(_)}) =>
       failwith("Model config option must use grouped options")
     }
 
@@ -1361,12 +1360,12 @@ let next = (state: state, action) => {
     | Some(providerId) =>
       // Find the first model value from the newly connected provider's group
       let providerModelValue = switch modelConfigOption {
-      | SelectConfigOption({options: Grouped(groups)}) =>
+      | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
         groups
         ->Array.find(g => g.group == providerId)
         ->Option.flatMap(g => g.options->Array.get(0))
         ->Option.map(opt => opt.value)
-      | SelectConfigOption({options: Ungrouped(_)}) =>
+      | ACP.SelectConfigOption({options: ACP.Ungrouped(_)}) =>
         failwith("Model config option must use grouped options")
       }
       switch providerModelValue {
@@ -1376,7 +1375,7 @@ let next = (state: state, action) => {
     | None =>
       switch state.selectedModelValue {
       | Some(value) => (Some(value), false)
-      | None => (Some(firstModelValue), true)
+      | None => (firstModelValue, firstModelValue->Option.isSome)
       }
     }
     // Persist whenever we picked a new model

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -144,6 +144,8 @@ module SampleConfig = {
   let configWithOpenRouterOnly = [_makeModelConfigOption(~groups=[_openrouterGroup])]
 
   let configWithFireworksOnly = [_makeModelConfigOption(~groups=[_fireworksGroup])]
+
+  let configWithNoModels = [_makeModelConfigOption(~groups=[])]
 }
 
 describe("Initiating actions set pendingProviderAutoSelect eagerly", () => {
@@ -294,6 +296,18 @@ describe("ConfigOptionsReceived auto-selects model from newly connected provider
     )
 
     t->expect(nextState.selectedModelValue)->Expect.toEqual(Some(existingModel))
+    t->expect(nextState.pendingProviderAutoSelect)->Expect.toEqual(None)
+  })
+
+  test("accepts empty model config when no providers are configured", t => {
+    let state = _makeState()
+
+    let (nextState, _effects) = Reducer.next(
+      state,
+      ConfigOptionsReceived({configOptions: SampleConfig.configWithNoModels}),
+    )
+
+    t->expect(nextState.selectedModelValue)->Expect.toEqual(None)
     t->expect(nextState.pendingProviderAutoSelect)->Expect.toEqual(None)
   })
 })


### PR DESCRIPTION
## Summary
- classify startup auth failures through the existing error classifier and AgentError category path
- disable the composer when no provider models are available and show a Configure provider CTA
- keep annotation chips bounded inside user message bubbles

## Tests
- yarn vitest run test/Client__ModelsRefresh.test.res.mjs
- mix test test/frontman_server/tasks/execution_test.exs test/frontman_server_web/channels/task_channel_test.exs test/frontman_server/tasks/execution_classify_test.exs
- pre-push reanalyze