### PR TITLE
Fix OAuth token refresh handling

### DIFF
--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -64,13 +64,11 @@ config :frontman_server, :web_fetch_req_options,
   retry_delay: fn _ -> 0 end,
   retry_log_level: false
 
-config :frontman_server, :anthropic_oauth_req_options,
-  plug: {Req.Test, :anthropic_oauth},
-  retry: false
+config :frontman_server, FrontmanServer.Providers.AnthropicOAuth,
+  req_options: [plug: {Req.Test, :anthropic_oauth}, retry: false]
 
-config :frontman_server, :openai_oauth_req_options,
-  plug: {Req.Test, :openai_oauth},
-  retry: false
+config :frontman_server, FrontmanServer.Providers.OpenAIOAuth,
+  req_options: [plug: {Req.Test, :openai_oauth}, retry: false]
 
 # Sentry - enable test mode, disable dedup to avoid test interference
 config :sentry,

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -64,6 +64,14 @@ config :frontman_server, :web_fetch_req_options,
   retry_delay: fn _ -> 0 end,
   retry_log_level: false
 
+config :frontman_server, :anthropic_oauth_req_options,
+  plug: {Req.Test, :anthropic_oauth},
+  retry: false
+
+config :frontman_server, :openai_oauth_req_options,
+  plug: {Req.Test, :openai_oauth},
+  retry: false
+
 # Sentry - enable test mode, disable dedup to avoid test interference
 config :sentry,
   test_mode: true,

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -82,11 +82,11 @@ defmodule FrontmanServer.Providers do
   defp oauth_llm_opts(_provider, _token), do: :use_api_key
 
   defp api_key_llm_args(scope, provider, model, opts) do
-    case resolve_api_key(scope, provider) do
-      key when is_binary(key) and key != "" ->
+    case get_api_key(scope, provider) do
+      %ApiKey{key: key} when is_binary(key) and key != "" ->
         {:ok, {model, Keyword.merge(api_key_llm_opts(provider, key), opts)}}
 
-      _auth ->
+      nil ->
         {:error, :no_api_key}
     end
   end
@@ -280,18 +280,6 @@ defmodule FrontmanServer.Providers do
     end
   end
 
-  defp resolve_api_key(%Scope{} = scope, provider) do
-    case get_api_key(scope, provider) do
-      %ApiKey{key: key} when is_binary(key) and key != "" ->
-        key
-
-      _ ->
-        nil
-    end
-  end
-
-  defp resolve_api_key(_scope, _provider), do: nil
-
   ## OAuth Token Management
 
   @doc "Stores or updates an OAuth token for a provider without broadcasting."
@@ -340,17 +328,17 @@ defmodule FrontmanServer.Providers do
         expires_at = OAuthToken.calculate_expires_at(expires_in)
         metadata = if is_map(token.metadata), do: token.metadata, else: %{}
 
-        case upsert_oauth_token(
-               scope,
-               token.provider,
-               new_tokens.access_token,
-               new_tokens.refresh_token || token.refresh_token,
-               expires_at,
-               metadata
-             ) do
-          {:ok, token} -> token
-          {:error, _reason} -> nil
-        end
+        {:ok, token} =
+          upsert_oauth_token(
+            scope,
+            token.provider,
+            new_tokens.access_token,
+            new_tokens.refresh_token || token.refresh_token,
+            expires_at,
+            metadata
+          )
+
+        token
 
       {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}}} ->
         delete_oauth_token(scope, token.provider)
@@ -366,16 +354,16 @@ defmodule FrontmanServer.Providers do
       {:ok, new_tokens} ->
         expires_at = OAuthToken.calculate_expires_at(new_tokens.expires_in)
 
-        case upsert_oauth_token(
-               scope,
-               token.provider,
-               new_tokens.access_token,
-               new_tokens.refresh_token || token.refresh_token,
-               expires_at
-             ) do
-          {:ok, token} -> token
-          {:error, _reason} -> nil
-        end
+        {:ok, token} =
+          upsert_oauth_token(
+            scope,
+            token.provider,
+            new_tokens.access_token,
+            new_tokens.refresh_token || token.refresh_token,
+            expires_at
+          )
+
+        token
 
       {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}}} ->
         delete_oauth_token(scope, token.provider)
@@ -385,8 +373,6 @@ defmodule FrontmanServer.Providers do
         nil
     end
   end
-
-  defp refresh_oauth_token(_scope, %OAuthToken{} = token), do: token
 
   @doc """
   Deletes an OAuth token for a provider.

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -51,19 +51,10 @@ defmodule FrontmanServer.Providers do
   def prepare_llm_args(scope, model, opts) when is_binary(model) and model != "" do
     provider = model_provider_name(model)
 
-    case resolve_oauth_token(scope, provider) do
-      {:ok, token} ->
-        case oauth_llm_opts(provider, token) do
-          {:ok, llm_opts} -> {:ok, {model, Keyword.merge(llm_opts, opts)}}
-          {:error, reason} -> {:error, reason}
-          :use_api_key -> api_key_llm_args(scope, provider, model, opts)
-        end
-
-      :none ->
-        api_key_llm_args(scope, provider, model, opts)
-
-      {:error, {:refresh_failed, _token, _reason}} ->
-        api_key_llm_args(scope, provider, model, opts)
+    case oauth_llm_opts(provider, resolve_oauth_token(scope, provider)) do
+      {:ok, llm_opts} -> {:ok, {model, Keyword.merge(llm_opts, opts)}}
+      {:error, reason} -> {:error, reason}
+      :use_api_key -> api_key_llm_args(scope, provider, model, opts)
     end
   end
 
@@ -158,18 +149,15 @@ defmodule FrontmanServer.Providers do
 
   def oauth_connection_status(scope, provider) do
     case resolve_oauth_token(scope, provider) do
-      :none ->
+      nil ->
         %{connected: false}
 
-      {:ok, token} ->
+      token ->
         %{
           connected: true,
           expires_at: DateTime.to_iso8601(token.expires_at),
-          expired: false
+          expired: OAuthToken.expired?(token)
         }
-
-      {:error, {:refresh_failed, _token, _reason}} ->
-        %{connected: false}
     end
   end
 
@@ -285,14 +273,14 @@ defmodule FrontmanServer.Providers do
   defp resolve_oauth_token(%Scope{} = scope, provider) do
     case get_oauth_token(scope, provider) do
       %OAuthToken{} = token ->
-        if OAuthToken.expired?(token), do: refresh_oauth_token(scope, token), else: {:ok, token}
+        if OAuthToken.expired?(token), do: refresh_oauth_token(scope, token), else: token
 
       nil ->
-        :none
+        nil
     end
   end
 
-  defp resolve_oauth_token(_scope, _provider), do: :none
+  defp resolve_oauth_token(_scope, _provider), do: nil
 
   defp resolve_api_key(%Scope{} = scope, provider) do
     case get_api_key(scope, provider) do
@@ -362,16 +350,16 @@ defmodule FrontmanServer.Providers do
                expires_at,
                metadata
              ) do
-          {:ok, token} -> {:ok, token}
-          {:error, reason} -> {:error, {:refresh_failed, token, reason}}
+          {:ok, token} -> token
+          {:error, _reason} -> nil
         end
 
-      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}} = reason} ->
+      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}}} ->
         delete_oauth_token(scope, token.provider)
-        {:error, {:refresh_failed, token, reason}}
+        nil
 
-      {:error, reason} ->
-        {:error, {:refresh_failed, token, reason}}
+      {:error, _reason} ->
+        nil
     end
   end
 
@@ -387,20 +375,20 @@ defmodule FrontmanServer.Providers do
                new_tokens.refresh_token || token.refresh_token,
                expires_at
              ) do
-          {:ok, token} -> {:ok, token}
-          {:error, reason} -> {:error, {:refresh_failed, token, reason}}
+          {:ok, token} -> token
+          {:error, _reason} -> nil
         end
 
-      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}} = reason} ->
+      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}}} ->
         delete_oauth_token(scope, token.provider)
-        {:error, {:refresh_failed, token, reason}}
+        nil
 
-      {:error, reason} ->
-        {:error, {:refresh_failed, token, reason}}
+      {:error, _reason} ->
+        nil
     end
   end
 
-  defp refresh_oauth_token(_scope, %OAuthToken{} = token), do: {:ok, token}
+  defp refresh_oauth_token(_scope, %OAuthToken{} = token), do: token
 
   @doc """
   Deletes an OAuth token for a provider.
@@ -476,8 +464,8 @@ defmodule FrontmanServer.Providers do
       |> Repo.all()
       |> Enum.flat_map(fn token ->
         case resolve_oauth_token(scope, token.provider) do
-          {:ok, token} -> [token.provider]
-          _unavailable -> []
+          %OAuthToken{} -> [token.provider]
+          nil -> []
         end
       end)
 

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -280,8 +280,6 @@ defmodule FrontmanServer.Providers do
     end
   end
 
-  defp resolve_oauth_token(_scope, _provider), do: nil
-
   defp resolve_api_key(%Scope{} = scope, provider) do
     case get_api_key(scope, provider) do
       %ApiKey{key: key} when is_binary(key) and key != "" ->

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -51,10 +51,19 @@ defmodule FrontmanServer.Providers do
   def prepare_llm_args(scope, model, opts) when is_binary(model) and model != "" do
     provider = model_provider_name(model)
 
-    case oauth_llm_opts(provider, resolve_oauth_token(scope, provider)) do
-      {:ok, llm_opts} -> {:ok, {model, Keyword.merge(llm_opts, opts)}}
-      {:error, reason} -> {:error, reason}
-      :use_api_key -> api_key_llm_args(scope, provider, model, opts)
+    case resolve_oauth_token(scope, provider) do
+      {:ok, token} ->
+        case oauth_llm_opts(provider, token) do
+          {:ok, llm_opts} -> {:ok, {model, Keyword.merge(llm_opts, opts)}}
+          {:error, reason} -> {:error, reason}
+          :use_api_key -> api_key_llm_args(scope, provider, model, opts)
+        end
+
+      :none ->
+        api_key_llm_args(scope, provider, model, opts)
+
+      {:error, {:refresh_failed, _token, _reason}} ->
+        api_key_llm_args(scope, provider, model, opts)
     end
   end
 
@@ -148,16 +157,19 @@ defmodule FrontmanServer.Providers do
   end
 
   def oauth_connection_status(scope, provider) do
-    case get_oauth_token(scope, provider) do
-      nil ->
+    case resolve_oauth_token(scope, provider) do
+      :none ->
         %{connected: false}
 
-      token ->
+      {:ok, token} ->
         %{
           connected: true,
           expires_at: DateTime.to_iso8601(token.expires_at),
-          expired: OAuthToken.expired?(token)
+          expired: false
         }
+
+      {:error, {:refresh_failed, _token, _reason}} ->
+        %{connected: false}
     end
   end
 
@@ -273,14 +285,14 @@ defmodule FrontmanServer.Providers do
   defp resolve_oauth_token(%Scope{} = scope, provider) do
     case get_oauth_token(scope, provider) do
       %OAuthToken{} = token ->
-        if OAuthToken.expired?(token), do: refresh_oauth_token(scope, token), else: token
+        if OAuthToken.expired?(token), do: refresh_oauth_token(scope, token), else: {:ok, token}
 
       nil ->
-        nil
+        :none
     end
   end
 
-  defp resolve_oauth_token(_scope, _provider), do: nil
+  defp resolve_oauth_token(_scope, _provider), do: :none
 
   defp resolve_api_key(%Scope{} = scope, provider) do
     case get_api_key(scope, provider) do
@@ -350,16 +362,20 @@ defmodule FrontmanServer.Providers do
                expires_at,
                metadata
              ) do
-          {:ok, token} -> token
-          {:error, _reason} -> nil
+          {:ok, token} -> {:ok, token}
+          {:error, reason} -> {:error, {:refresh_failed, token, reason}}
         end
 
-      {:error, _reason} ->
-        nil
+      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}} = reason} ->
+        delete_oauth_token(scope, token.provider)
+        {:error, {:refresh_failed, token, reason}}
+
+      {:error, reason} ->
+        {:error, {:refresh_failed, token, reason}}
     end
   end
 
-  defp refresh_oauth_token(%Scope{} = scope, %OAuthToken{} = token) do
+  defp refresh_oauth_token(%Scope{} = scope, %OAuthToken{provider: "anthropic"} = token) do
     case AnthropicOAuth.refresh_token(token.refresh_token) do
       {:ok, new_tokens} ->
         expires_at = OAuthToken.calculate_expires_at(new_tokens.expires_in)
@@ -368,17 +384,23 @@ defmodule FrontmanServer.Providers do
                scope,
                token.provider,
                new_tokens.access_token,
-               new_tokens.refresh_token,
+               new_tokens.refresh_token || token.refresh_token,
                expires_at
              ) do
-          {:ok, token} -> token
-          {:error, _reason} -> nil
+          {:ok, token} -> {:ok, token}
+          {:error, reason} -> {:error, {:refresh_failed, token, reason}}
         end
 
-      {:error, _reason} ->
-        nil
+      {:error, {:token_refresh_failed, 400, %{"error" => "invalid_grant"}} = reason} ->
+        delete_oauth_token(scope, token.provider)
+        {:error, {:refresh_failed, token, reason}}
+
+      {:error, reason} ->
+        {:error, {:refresh_failed, token, reason}}
     end
   end
+
+  defp refresh_oauth_token(_scope, %OAuthToken{} = token), do: {:ok, token}
 
   @doc """
   Deletes an OAuth token for a provider.
@@ -451,8 +473,13 @@ defmodule FrontmanServer.Providers do
     oauth_providers =
       OAuthToken
       |> OAuthToken.for_user(Accounts.scope_user_id(scope))
-      |> select([token], token.provider)
       |> Repo.all()
+      |> Enum.flat_map(fn token ->
+        case resolve_oauth_token(scope, token.provider) do
+          {:ok, token} -> [token.provider]
+          _unavailable -> []
+        end
+      end)
 
     provider_configs =
       Enum.filter(@providers, fn

--- a/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
@@ -17,11 +17,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
 
   require Logger
 
-  @client_id Application.compile_env!(:frontman_server, [__MODULE__, :client_id])
-  @auth_url Application.compile_env!(:frontman_server, [__MODULE__, :auth_url])
-  @token_url Application.compile_env!(:frontman_server, [__MODULE__, :token_url])
-  @redirect_uri Application.compile_env!(:frontman_server, [__MODULE__, :redirect_uri])
-  @scopes Application.compile_env!(:frontman_server, [__MODULE__, :scopes])
+  @config Application.compile_env!(:frontman_server, __MODULE__)
 
   @doc """
   Generates a PKCE verifier and challenge.
@@ -47,16 +43,16 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
     params =
       URI.encode_query(%{
         "code" => "true",
-        "client_id" => @client_id,
+        "client_id" => @config[:client_id],
         "response_type" => "code",
-        "redirect_uri" => @redirect_uri,
-        "scope" => @scopes,
+        "redirect_uri" => @config[:redirect_uri],
+        "scope" => @config[:scopes],
         "code_challenge" => challenge,
         "code_challenge_method" => "S256",
         "state" => verifier
       })
 
-    "#{@auth_url}?#{params}"
+    "#{@config[:auth_url]}?#{params}"
   end
 
   @doc """
@@ -79,8 +75,8 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       %{
         "code" => code,
         "grant_type" => "authorization_code",
-        "client_id" => @client_id,
-        "redirect_uri" => @redirect_uri,
+        "client_id" => @config[:client_id],
+        "redirect_uri" => @config[:redirect_uri],
         "code_verifier" => verifier
       }
       |> add_state(state)
@@ -90,7 +86,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, [json: body, headers: headers] ++ req_options()) do
+    case Req.post(@config[:token_url], [json: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -121,7 +117,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
     body = %{
       "grant_type" => "refresh_token",
       "refresh_token" => refresh_token,
-      "client_id" => @client_id
+      "client_id" => @config[:client_id]
     }
 
     headers = [
@@ -129,7 +125,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, [json: body, headers: headers] ++ req_options()) do
+    case Req.post(@config[:token_url], [json: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -157,8 +153,6 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
   defp add_state(body, state), do: Map.put(body, "state", state)
 
   defp req_options do
-    :frontman_server
-    |> Application.fetch_env!(__MODULE__)
-    |> Keyword.get(:req_options, [])
+    Keyword.get(@config, :req_options, [])
   end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
@@ -157,6 +157,8 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
   defp add_state(body, state), do: Map.put(body, "state", state)
 
   defp req_options do
-    Application.get_env(:frontman_server, :anthropic_oauth_req_options, [])
+    :frontman_server
+    |> Application.fetch_env!(__MODULE__)
+    |> Keyword.get(:req_options, [])
   end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
@@ -90,7 +90,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, json: body, headers: headers) do
+    case Req.post(@token_url, [json: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -129,7 +129,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, json: body, headers: headers) do
+    case Req.post(@token_url, [json: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -155,4 +155,8 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
 
   defp add_state(body, nil), do: body
   defp add_state(body, state), do: Map.put(body, "state", state)
+
+  defp req_options do
+    Application.get_env(:frontman_server, :anthropic_oauth_req_options, [])
+  end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/anthropic_oauth.ex
@@ -17,7 +17,12 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
 
   require Logger
 
-  @config Application.compile_env!(:frontman_server, __MODULE__)
+  @client_id Application.compile_env!(:frontman_server, [__MODULE__, :client_id])
+  @auth_url Application.compile_env!(:frontman_server, [__MODULE__, :auth_url])
+  @token_url Application.compile_env!(:frontman_server, [__MODULE__, :token_url])
+  @redirect_uri Application.compile_env!(:frontman_server, [__MODULE__, :redirect_uri])
+  @scopes Application.compile_env!(:frontman_server, [__MODULE__, :scopes])
+  @req_options Application.compile_env(:frontman_server, [__MODULE__, :req_options], [])
 
   @doc """
   Generates a PKCE verifier and challenge.
@@ -43,16 +48,16 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
     params =
       URI.encode_query(%{
         "code" => "true",
-        "client_id" => @config[:client_id],
+        "client_id" => @client_id,
         "response_type" => "code",
-        "redirect_uri" => @config[:redirect_uri],
-        "scope" => @config[:scopes],
+        "redirect_uri" => @redirect_uri,
+        "scope" => @scopes,
         "code_challenge" => challenge,
         "code_challenge_method" => "S256",
         "state" => verifier
       })
 
-    "#{@config[:auth_url]}?#{params}"
+    "#{@auth_url}?#{params}"
   end
 
   @doc """
@@ -75,8 +80,8 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       %{
         "code" => code,
         "grant_type" => "authorization_code",
-        "client_id" => @config[:client_id],
-        "redirect_uri" => @config[:redirect_uri],
+        "client_id" => @client_id,
+        "redirect_uri" => @redirect_uri,
         "code_verifier" => verifier
       }
       |> add_state(state)
@@ -86,7 +91,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@config[:token_url], [json: body, headers: headers] ++ req_options()) do
+    case Req.post(@token_url, [json: body, headers: headers] ++ @req_options) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -117,7 +122,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
     body = %{
       "grant_type" => "refresh_token",
       "refresh_token" => refresh_token,
-      "client_id" => @config[:client_id]
+      "client_id" => @client_id
     }
 
     headers = [
@@ -125,7 +130,7 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@config[:token_url], [json: body, headers: headers] ++ req_options()) do
+    case Req.post(@token_url, [json: body, headers: headers] ++ @req_options) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -151,8 +156,4 @@ defmodule FrontmanServer.Providers.AnthropicOAuth do
 
   defp add_state(body, nil), do: body
   defp add_state(body, state), do: Map.put(body, "state", state)
-
-  defp req_options do
-    Keyword.get(@config, :req_options, [])
-  end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/oauth_token.ex
@@ -40,6 +40,8 @@ defmodule FrontmanServer.Providers.OAuthToken do
     |> cast(attrs, [:provider, :access_token, :refresh_token, :expires_at, :metadata])
     |> validate_required([:provider, :access_token, :refresh_token, :expires_at])
     |> validate_length(:provider, min: 1, max: 64)
+    |> validate_length(:access_token, min: 1)
+    |> validate_length(:refresh_token, min: 1)
     |> unique_constraint([:user_id, :provider], name: :oauth_tokens_user_id_provider_index)
   end
 

--- a/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
@@ -23,7 +23,10 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
 
   require Logger
 
-  @config Application.compile_env!(:frontman_server, __MODULE__)
+  @client_id Application.compile_env!(:frontman_server, [__MODULE__, :client_id])
+  @issuer Application.compile_env!(:frontman_server, [__MODULE__, :issuer])
+  @token_url "#{@issuer}/oauth/token"
+  @req_options Application.compile_env(:frontman_server, [__MODULE__, :req_options], [])
 
   @doc """
   Step 1: Request a device code from OpenAI.
@@ -34,7 +37,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
   The `interval` is the polling interval in seconds.
   """
   def request_device_code do
-    body = Jason.encode!(%{"client_id" => @config[:client_id]})
+    body = Jason.encode!(%{"client_id" => @client_id})
 
     headers = [
       {"content-type", "application/json"},
@@ -42,8 +45,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
     ]
 
     case Req.post(
-           "#{@config[:issuer]}/api/accounts/deviceauth/usercode",
-           [body: body, headers: headers] ++ req_options()
+           "#{@issuer}/api/accounts/deviceauth/usercode",
+           [body: body, headers: headers] ++ @req_options
          ) do
       {:ok, %Req.Response{status: status, body: response_body}} when status in 200..299 ->
         device_auth_id = response_body["device_auth_id"]
@@ -56,7 +59,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
              device_auth_id: device_auth_id,
              user_code: user_code,
              interval: interval,
-             verification_url: "#{@config[:issuer]}/codex/device"
+             verification_url: "#{@issuer}/codex/device"
            }}
         else
           Logger.error("OpenAI device code response missing fields: #{inspect(response_body)}")
@@ -96,8 +99,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
     ]
 
     case Req.post(
-           "#{@config[:issuer]}/api/accounts/deviceauth/token",
-           [body: body, headers: headers] ++ req_options()
+           "#{@issuer}/api/accounts/deviceauth/token",
+           [body: body, headers: headers] ++ @req_options
          ) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         authorization_code = response_body["authorization_code"]
@@ -144,8 +147,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       URI.encode_query(%{
         "grant_type" => "authorization_code",
         "code" => authorization_code,
-        "redirect_uri" => "#{@config[:issuer]}/deviceauth/callback",
-        "client_id" => @config[:client_id],
+        "redirect_uri" => "#{@issuer}/deviceauth/callback",
+        "client_id" => @client_id,
         "code_verifier" => code_verifier
       })
 
@@ -154,7 +157,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(token_url(), [body: body, headers: headers] ++ req_options()) do
+    case Req.post(@token_url, [body: body, headers: headers] ++ @req_options) do
       {:ok,
        %Req.Response{
          status: 200,
@@ -197,7 +200,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       URI.encode_query(%{
         "grant_type" => "refresh_token",
         "refresh_token" => refresh_token,
-        "client_id" => @config[:client_id]
+        "client_id" => @client_id
       })
 
     headers = [
@@ -205,7 +208,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(token_url(), [body: body, headers: headers] ++ req_options()) do
+    case Req.post(@token_url, [body: body, headers: headers] ++ @req_options) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -285,10 +288,4 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
 
   defp get_first_org_id(%{"organizations" => [%{"id" => id} | _]}) when is_binary(id), do: id
   defp get_first_org_id(_), do: nil
-
-  defp req_options do
-    Keyword.get(@config, :req_options, [])
-  end
-
-  defp token_url, do: "#{@config[:issuer]}/oauth/token"
 end

--- a/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
@@ -289,6 +289,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
   defp get_first_org_id(_), do: nil
 
   defp req_options do
-    Application.get_env(:frontman_server, :openai_oauth_req_options, [])
+    :frontman_server
+    |> Application.fetch_env!(__MODULE__)
+    |> Keyword.get(:req_options, [])
   end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
@@ -43,7 +43,10 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post("#{@issuer}/api/accounts/deviceauth/usercode", body: body, headers: headers) do
+    case Req.post(
+           "#{@issuer}/api/accounts/deviceauth/usercode",
+           [body: body, headers: headers] ++ req_options()
+         ) do
       {:ok, %Req.Response{status: status, body: response_body}} when status in 200..299 ->
         device_auth_id = response_body["device_auth_id"]
         user_code = response_body["user_code"] || response_body["usercode"]
@@ -94,7 +97,10 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post("#{@issuer}/api/accounts/deviceauth/token", body: body, headers: headers) do
+    case Req.post(
+           "#{@issuer}/api/accounts/deviceauth/token",
+           [body: body, headers: headers] ++ req_options()
+         ) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         authorization_code = response_body["authorization_code"]
         code_verifier = response_body["code_verifier"]
@@ -150,7 +156,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, body: body, headers: headers) do
+    case Req.post(@token_url, [body: body, headers: headers] ++ req_options()) do
       {:ok,
        %Req.Response{
          status: 200,
@@ -201,7 +207,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, body: body, headers: headers) do
+    case Req.post(@token_url, [body: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -281,4 +287,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
 
   defp get_first_org_id(%{"organizations" => [%{"id" => id} | _]}) when is_binary(id), do: id
   defp get_first_org_id(_), do: nil
+
+  defp req_options do
+    Application.get_env(:frontman_server, :openai_oauth_req_options, [])
+  end
 end

--- a/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/openai_oauth.ex
@@ -23,9 +23,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
 
   require Logger
 
-  @client_id Application.compile_env!(:frontman_server, [__MODULE__, :client_id])
-  @issuer Application.compile_env!(:frontman_server, [__MODULE__, :issuer])
-  @token_url "#{@issuer}/oauth/token"
+  @config Application.compile_env!(:frontman_server, __MODULE__)
 
   @doc """
   Step 1: Request a device code from OpenAI.
@@ -36,7 +34,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
   The `interval` is the polling interval in seconds.
   """
   def request_device_code do
-    body = Jason.encode!(%{"client_id" => @client_id})
+    body = Jason.encode!(%{"client_id" => @config[:client_id]})
 
     headers = [
       {"content-type", "application/json"},
@@ -44,7 +42,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
     ]
 
     case Req.post(
-           "#{@issuer}/api/accounts/deviceauth/usercode",
+           "#{@config[:issuer]}/api/accounts/deviceauth/usercode",
            [body: body, headers: headers] ++ req_options()
          ) do
       {:ok, %Req.Response{status: status, body: response_body}} when status in 200..299 ->
@@ -58,7 +56,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
              device_auth_id: device_auth_id,
              user_code: user_code,
              interval: interval,
-             verification_url: "#{@issuer}/codex/device"
+             verification_url: "#{@config[:issuer]}/codex/device"
            }}
         else
           Logger.error("OpenAI device code response missing fields: #{inspect(response_body)}")
@@ -98,7 +96,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
     ]
 
     case Req.post(
-           "#{@issuer}/api/accounts/deviceauth/token",
+           "#{@config[:issuer]}/api/accounts/deviceauth/token",
            [body: body, headers: headers] ++ req_options()
          ) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
@@ -146,8 +144,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       URI.encode_query(%{
         "grant_type" => "authorization_code",
         "code" => authorization_code,
-        "redirect_uri" => "#{@issuer}/deviceauth/callback",
-        "client_id" => @client_id,
+        "redirect_uri" => "#{@config[:issuer]}/deviceauth/callback",
+        "client_id" => @config[:client_id],
         "code_verifier" => code_verifier
       })
 
@@ -156,7 +154,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, [body: body, headers: headers] ++ req_options()) do
+    case Req.post(token_url(), [body: body, headers: headers] ++ req_options()) do
       {:ok,
        %Req.Response{
          status: 200,
@@ -199,7 +197,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       URI.encode_query(%{
         "grant_type" => "refresh_token",
         "refresh_token" => refresh_token,
-        "client_id" => @client_id
+        "client_id" => @config[:client_id]
       })
 
     headers = [
@@ -207,7 +205,7 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
       {"accept", "application/json"}
     ]
 
-    case Req.post(@token_url, [body: body, headers: headers] ++ req_options()) do
+    case Req.post(token_url(), [body: body, headers: headers] ++ req_options()) do
       {:ok, %Req.Response{status: 200, body: response_body}} ->
         {:ok,
          %{
@@ -289,8 +287,8 @@ defmodule FrontmanServer.Providers.OpenAIOAuth do
   defp get_first_org_id(_), do: nil
 
   defp req_options do
-    :frontman_server
-    |> Application.fetch_env!(__MODULE__)
-    |> Keyword.get(:req_options, [])
+    Keyword.get(@config, :req_options, [])
   end
+
+  defp token_url, do: "#{@config[:issuer]}/oauth/token"
 end

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -12,6 +12,9 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
 
+  setup {Req.Test, :set_req_test_from_context}
+  setup {Req.Test, :verify_on_exit!}
+
   setup do
     user = user_fixture()
     scope = %Scope{user: user}
@@ -51,6 +54,113 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
                Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
     end
 
+    test "refreshes expired Anthropic OAuth token before resolving LLM args", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_success()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:access_token] == "fresh_access"
+      assert llm_opts[:auth_mode] == :oauth
+    end
+
+    test "falls back to Anthropic API key when expired OAuth refresh fails", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+
+      expect_anthropic_refresh_permanent_failure()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:api_key] == "user_key_456"
+      refute Keyword.has_key?(llm_opts, :access_token)
+    end
+
+    test "permanent Anthropic refresh failure deletes expired OAuth token", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_permanent_failure()
+
+      assert {:error, :no_api_key} =
+               Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
+    end
+
+    test "does not retry Anthropic refresh after permanent refresh failure", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+
+      expect_anthropic_refresh_permanent_failure()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:api_key] == "user_key_456"
+      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:api_key] == "user_key_456"
+    end
+
+    test "transient Anthropic refresh failure keeps expired OAuth token", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+
+      expect_anthropic_refresh_transient_failure()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:api_key] == "user_key_456"
+      refute is_nil(Providers.get_oauth_token(scope, "anthropic"))
+    end
+
+    test "transient Anthropic refresh failure can recover on later request", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      expect_anthropic_refresh_transient_failure()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:api_key] == "user_key_456"
+
+      expect_anthropic_refresh_success()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      assert llm_opts[:access_token] == "fresh_access"
+    end
+
     test "returns :missing_model when no model is provided", %{scope: scope} do
       assert {:error, :missing_model} = Providers.prepare_llm_args(scope, nil)
     end
@@ -67,15 +177,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     test "openai codex oauth resolves direct ReqLLM args", %{scope: scope} do
       expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
 
-      {:ok, _} =
-        Providers.upsert_oauth_token(
-          scope,
-          "openai_codex",
-          "openai_access",
-          "refresh",
-          expires_at,
-          %{"account_id" => "acc-789"}
-        )
+      {:ok, _} = upsert_openai_oauth_token(scope, expires_at)
 
       {:ok, {model, llm_opts}} =
         Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex", max_tokens: 16_384)
@@ -85,6 +187,48 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert llm_opts[:auth_mode] == :oauth
       assert llm_opts[:chatgpt_account_id] == "acc-789"
       assert llm_opts[:max_tokens] == 16_384
+    end
+
+    test "refreshes expired OpenAI OAuth token before resolving LLM args", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_success()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
+
+      assert llm_opts[:access_token] == "fresh_openai_access"
+      assert llm_opts[:auth_mode] == :oauth
+      assert llm_opts[:chatgpt_account_id] == "acc-789"
+    end
+
+    test "permanent OpenAI refresh failure deletes expired OAuth token", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_permanent_failure()
+
+      assert {:error, :no_api_key} =
+               Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
+
+      assert is_nil(Providers.get_oauth_token(scope, "openai_codex"))
+    end
+
+    test "transient OpenAI refresh failure keeps token and can recover", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_transient_failure()
+
+      assert {:error, :no_api_key} =
+               Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
+
+      refute is_nil(Providers.get_oauth_token(scope, "openai_codex"))
+
+      expect_openai_refresh_success()
+
+      {:ok, {_model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
+
+      assert llm_opts[:access_token] == "fresh_openai_access"
     end
 
     test "openai codex oauth without account id is invalid", %{scope: scope} do
@@ -104,6 +248,101 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
   end
 
+  describe "model_config_data/1 OAuth availability" do
+    test "exposes Anthropic models when expired OAuth refresh succeeds", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_success()
+
+      config = Providers.model_config_data(scope)
+
+      assert Enum.any?(config.groups, &(&1.id == "anthropic"))
+    end
+
+    test "does not expose Anthropic models when expired OAuth refresh fails", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_permanent_failure()
+
+      config = Providers.model_config_data(scope)
+
+      refute Enum.any?(config.groups, &(&1.id == "anthropic"))
+      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
+    end
+
+    test "OAuth status refreshes expired Anthropic token", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_success()
+
+      assert %{
+               connected: true,
+               expired: false,
+               expires_at: expires_at
+             } = Providers.oauth_connection_status(scope, "anthropic")
+
+      assert {:ok, refreshed_expires_at, _offset} = DateTime.from_iso8601(expires_at)
+      assert DateTime.compare(refreshed_expires_at, DateTime.utc_now()) == :gt
+    end
+
+    test "OAuth status is disconnected when expired Anthropic refresh fails", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+
+      {:ok, _} =
+        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
+
+      expect_anthropic_refresh_permanent_failure()
+
+      assert %{connected: false} = Providers.oauth_connection_status(scope, "anthropic")
+      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
+    end
+
+    test "exposes OpenAI models when expired OAuth refresh succeeds", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_success()
+
+      config = Providers.model_config_data(scope)
+
+      assert Enum.any?(config.groups, &(&1.id == "openai_codex"))
+    end
+
+    test "does not expose OpenAI models when expired OAuth refresh fails", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_permanent_failure()
+
+      config = Providers.model_config_data(scope)
+
+      refute Enum.any?(config.groups, &(&1.id == "openai_codex"))
+      assert is_nil(Providers.get_oauth_token(scope, "openai_codex"))
+    end
+
+    test "OAuth status refreshes expired OpenAI token", %{scope: scope} do
+      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      expect_openai_refresh_success()
+
+      assert %{
+               connected: true,
+               expired: false,
+               expires_at: expires_at
+             } = Providers.oauth_connection_status(scope, "openai_codex")
+
+      assert {:ok, refreshed_expires_at, _offset} = DateTime.from_iso8601(expires_at)
+      assert DateTime.compare(refreshed_expires_at, DateTime.utc_now()) == :gt
+    end
+  end
+
   describe "model provider names" do
     test "openai_codex is the provider id" do
       assert Providers.model_provider_name("openai_codex:gpt-5.5") == "openai_codex"
@@ -114,5 +353,68 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert Providers.max_image_dimension(Providers.model_provider_name("openai_codex:gpt-5.5")) ==
                nil
     end
+  end
+
+  defp expect_anthropic_refresh_success do
+    Req.Test.expect(:anthropic_oauth, fn conn ->
+      Req.Test.json(conn, %{
+        "access_token" => "fresh_access",
+        "refresh_token" => "fresh_refresh",
+        "expires_in" => 3600
+      })
+    end)
+  end
+
+  defp expect_anthropic_refresh_permanent_failure do
+    Req.Test.expect(:anthropic_oauth, fn conn ->
+      conn
+      |> Plug.Conn.put_status(400)
+      |> Req.Test.json(%{"error" => "invalid_grant"})
+    end)
+  end
+
+  defp expect_anthropic_refresh_transient_failure do
+    Req.Test.expect(:anthropic_oauth, fn conn ->
+      conn
+      |> Plug.Conn.put_status(500)
+      |> Req.Test.json(%{"error" => "server_error"})
+    end)
+  end
+
+  defp upsert_openai_oauth_token(scope, expires_at) do
+    Providers.upsert_oauth_token(
+      scope,
+      "openai_codex",
+      "openai_access",
+      "refresh",
+      expires_at,
+      %{"account_id" => "acc-789"}
+    )
+  end
+
+  defp expect_openai_refresh_success do
+    Req.Test.expect(:openai_oauth, fn conn ->
+      Req.Test.json(conn, %{
+        "access_token" => "fresh_openai_access",
+        "refresh_token" => "fresh_openai_refresh",
+        "expires_in" => 3600
+      })
+    end)
+  end
+
+  defp expect_openai_refresh_permanent_failure do
+    Req.Test.expect(:openai_oauth, fn conn ->
+      conn
+      |> Plug.Conn.put_status(400)
+      |> Req.Test.json(%{"error" => "invalid_grant"})
+    end)
+  end
+
+  defp expect_openai_refresh_transient_failure do
+    Req.Test.expect(:openai_oauth, fn conn ->
+      conn
+      |> Plug.Conn.put_status(500)
+      |> Req.Test.json(%{"error" => "server_error"})
+    end)
   end
 end

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -69,38 +69,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert llm_opts[:auth_mode] == :oauth
     end
 
-    test "falls back to Anthropic API key when expired OAuth refresh fails", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
-
-      expect_anthropic_refresh_permanent_failure()
-
-      {:ok, {_model, llm_opts}} =
-        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
-
-      assert llm_opts[:api_key] == "user_key_456"
-      refute Keyword.has_key?(llm_opts, :access_token)
-    end
-
-    test "permanent Anthropic refresh failure deletes expired OAuth token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      expect_anthropic_refresh_permanent_failure()
-
-      assert {:error, :no_api_key} =
-               Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
-
-      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
-    end
-
-    test "does not retry Anthropic refresh after permanent refresh failure", %{scope: scope} do
+    test "invalid Anthropic refresh falls back to API key and deletes token", %{scope: scope} do
       expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
 
       {:ok, _} =
@@ -115,31 +84,9 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
       assert llm_opts[:api_key] == "user_key_456"
       assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
-
-      {:ok, {_model, llm_opts}} =
-        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
-
-      assert llm_opts[:api_key] == "user_key_456"
     end
 
-    test "transient Anthropic refresh failure keeps expired OAuth token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
-
-      expect_anthropic_refresh_transient_failure()
-
-      {:ok, {_model, llm_opts}} =
-        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
-
-      assert llm_opts[:api_key] == "user_key_456"
-      refute is_nil(Providers.get_oauth_token(scope, "anthropic"))
-    end
-
-    test "transient Anthropic refresh failure can recover on later request", %{scope: scope} do
+    test "transient Anthropic refresh failure keeps token and can recover", %{scope: scope} do
       expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
 
       {:ok, _} =
@@ -152,6 +99,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
 
       assert llm_opts[:api_key] == "user_key_456"
+      refute is_nil(Providers.get_oauth_token(scope, "anthropic"))
 
       expect_anthropic_refresh_success()
 
@@ -213,24 +161,6 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert is_nil(Providers.get_oauth_token(scope, "openai_codex"))
     end
 
-    test "transient OpenAI refresh failure keeps token and can recover", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
-      expect_openai_refresh_transient_failure()
-
-      assert {:error, :no_api_key} =
-               Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
-
-      refute is_nil(Providers.get_oauth_token(scope, "openai_codex"))
-
-      expect_openai_refresh_success()
-
-      {:ok, {_model, llm_opts}} =
-        Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex")
-
-      assert llm_opts[:access_token] == "fresh_openai_access"
-    end
-
     test "openai codex oauth without account id is invalid", %{scope: scope} do
       expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
 
@@ -248,8 +178,8 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
   end
 
-  describe "model_config_data/1 OAuth availability" do
-    test "exposes Anthropic models when expired OAuth refresh succeeds", %{scope: scope} do
+  describe "OAuth availability refresh" do
+    test "model config refreshes expired Anthropic token", %{scope: scope} do
       expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
 
       {:ok, _} =
@@ -262,72 +192,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert Enum.any?(config.groups, &(&1.id == "anthropic"))
     end
 
-    test "does not expose Anthropic models when expired OAuth refresh fails", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      expect_anthropic_refresh_permanent_failure()
-
-      config = Providers.model_config_data(scope)
-
-      refute Enum.any?(config.groups, &(&1.id == "anthropic"))
-      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
-    end
-
-    test "OAuth status refreshes expired Anthropic token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      expect_anthropic_refresh_success()
-
-      assert %{
-               connected: true,
-               expired: false,
-               expires_at: expires_at
-             } = Providers.oauth_connection_status(scope, "anthropic")
-
-      assert {:ok, refreshed_expires_at, _offset} = DateTime.from_iso8601(expires_at)
-      assert DateTime.compare(refreshed_expires_at, DateTime.utc_now()) == :gt
-    end
-
-    test "OAuth status is disconnected when expired Anthropic refresh fails", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      expect_anthropic_refresh_permanent_failure()
-
-      assert %{connected: false} = Providers.oauth_connection_status(scope, "anthropic")
-      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
-    end
-
-    test "exposes OpenAI models when expired OAuth refresh succeeds", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
-      expect_openai_refresh_success()
-
-      config = Providers.model_config_data(scope)
-
-      assert Enum.any?(config.groups, &(&1.id == "openai_codex"))
-    end
-
-    test "does not expose OpenAI models when expired OAuth refresh fails", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
-      expect_openai_refresh_permanent_failure()
-
-      config = Providers.model_config_data(scope)
-
-      refute Enum.any?(config.groups, &(&1.id == "openai_codex"))
-      assert is_nil(Providers.get_oauth_token(scope, "openai_codex"))
-    end
-
-    test "OAuth status refreshes expired OpenAI token", %{scope: scope} do
+    test "connection status refreshes expired OpenAI token", %{scope: scope} do
       expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
       {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
       expect_openai_refresh_success()
@@ -407,14 +272,6 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       conn
       |> Plug.Conn.put_status(400)
       |> Req.Test.json(%{"error" => "invalid_grant"})
-    end)
-  end
-
-  defp expect_openai_refresh_transient_failure do
-    Req.Test.expect(:openai_oauth, fn conn ->
-      conn
-      |> Plug.Conn.put_status(500)
-      |> Req.Test.json(%{"error" => "server_error"})
     end)
   end
 end


### PR DESCRIPTION
## Summary
- Refresh expired Anthropic and OpenAI OAuth tokens before LLM args, connection status, and model config resolution
- Delete OAuth token rows only on permanent `invalid_grant` refresh failures
- Keep expired token rows on transient refresh failures so later requests can recover
- Remove defensive provider-auth fallbacks so malformed DB/auth state fails loudly instead of becoming `:no_api_key`
- Validate OAuth access/refresh tokens at insert boundary
- Keep provider HTTP changes small: existing compile-time config attrs plus provider-local `req_options` for `Req.Test`

## Tests
- `mix test "test/frontman_server/providers/prepare_api_key_test.exs"` (15 passed)
- `mix test "test/frontman_server_web/controllers/user_api_key_controller_test.exs" "test/frontman_server/tasks/execution_test.exs"` (30 passed)
- `git diff --check`
- pre-commit hook: `elixir-format-server`, `elixir-credo-server`

## Diff Size
- Current PR diff: 230 insertions, 56 deletions
- Cleanup commits removed defensive branches and kept provider modules compact