### PR TITLE
Improve MCP schema error diagnostics

### DIFF
--- a/.changeset/mcp-schema-diagnostics.md
+++ b/.changeset/mcp-schema-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Improve MCP tool schema validation error diagnostics in Sentry.

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -147,10 +147,9 @@ let executeLocalTool = async (
         "taskId": taskId,
         "toolCallId": toolCallId,
         "schemaError": msg,
+        "argumentKeys": argumentKeys(arguments),
       },
-      `Tool input schema validation failed: tool=${T.name} taskId=${taskId} toolCallId=${toolCallId} argumentKeys=${argumentKeys(
-          arguments,
-        )} error=${msg}`,
+      "Tool input schema validation failed",
     )
     Completed(
       Types.CallToolResult.makeError(`Invalid input: ${msg}`)->Types.CallToolResult.withMeta(meta),

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -114,6 +114,12 @@ let getToolByName = (server: t, name: string): option<module(Tool.Tool)> => {
   })
 }
 
+let argumentKeys = (arguments: option<Dict.t<JSON.t>>): string =>
+  switch arguments {
+  | None => "none"
+  | Some(args) => args->Dict.keysToArray->Array.join(",")
+  }
+
 // Execute a local tool module
 let executeLocalTool = async (
   server: t,
@@ -135,7 +141,17 @@ let executeLocalTool = async (
 
   switch inputResult {
   | Error(msg) =>
-    Log.error(~ctx={"tool": T.name}, "Schema error")
+    Log.error(
+      ~ctx={
+        "tool": T.name,
+        "taskId": taskId,
+        "toolCallId": toolCallId,
+        "schemaError": msg,
+      },
+      `Tool input schema validation failed: tool=${T.name} taskId=${taskId} toolCallId=${toolCallId} argumentKeys=${argumentKeys(
+          arguments,
+        )} error=${msg}`,
+    )
     Completed(
       Types.CallToolResult.makeError(`Invalid input: ${msg}`)->Types.CallToolResult.withMeta(meta),
     )

--- a/libs/frontman-client/src/FrontmanClient__Sentry__LogHandler.res
+++ b/libs/frontman-client/src/FrontmanClient__Sentry__LogHandler.res
@@ -10,13 +10,14 @@
 module Bindings = FrontmanBindings.Sentry__Browser
 module Sentry = FrontmanClient__Sentry
 
-let run = (~component, ~stacktrace as _, ~level, message, _ctx, error) => {
+let run = (~component, ~stacktrace as _, ~level, message, ctx, error) => {
   switch level {
   | FrontmanLogs.Logs_level.Error =>
     if Sentry.isEnabled() {
       Bindings.withScope(scope => {
         scope->Bindings.scopeSetTag("frontman.library", "frontman-client")
         scope->Bindings.scopeSetTag("frontman.component", component)
+        scope->Bindings.scopeSetContext("frontman.log_context", Obj.magic(ctx))
         switch error {
         | Some(jsExn) =>
           // captureException preserves stack traces for Sentry grouping.


### PR DESCRIPTION
## Summary
- include tool, task, call id, argument keys, and schema error in MCP schema validation log messages
- keep Sentry alerting behavior unchanged while collecting enough detail for future diagnosis
- add changeset for frontman-client patch release

## Verification
- make rescript-build
- pre-push reanalyze hook passed