### PR TITLE
Add Sentry user and task context

### DIFF
--- a/apps/frontman_server/config/config.exs
+++ b/apps/frontman_server/config/config.exs
@@ -115,7 +115,7 @@ config :tailwind,
 
 config :logger, :default_formatter,
   format: "\n$time [$level] $metadata$message\n",
-  metadata: [:request_id, :module, :function, :reason]
+  metadata: [:request_id, :module, :function, :reason, :task_id, :user_id, :user_name]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/apps/frontman_server/lib/frontman_server.ex
+++ b/apps/frontman_server/lib/frontman_server.ex
@@ -30,6 +30,7 @@ defmodule FrontmanServer do
     Encrypted.Binary,
     {Tools, []},
     Observability.ConsoleHandler,
+    Observability.SentryContext,
     Workers.GenerateTitle,
     Workers.NotifyDiscordNewUser,
     Workers.SendWelcomeEmail,

--- a/apps/frontman_server/lib/frontman_server/accounts.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts.ex
@@ -21,7 +21,7 @@ defmodule FrontmanServer.Accounts do
   @doc """
   Returns the user map from scope.
   """
-  def scope_user(%Scope{user: %User{} = user}), do: user
+  def scope_user(%Scope{} = scope), do: Scope.user(scope)
 
   @doc """
   Returns the user id from scope.

--- a/apps/frontman_server/lib/frontman_server/accounts/scope.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/scope.ex
@@ -46,4 +46,12 @@ defmodule FrontmanServer.Accounts.Scope do
   def for_user(%User{} = user, nil) do
     %__MODULE__{user: user, organization: nil}
   end
+
+  def user(%__MODULE__{user: %User{} = user}), do: user
+
+  def user_id(%__MODULE__{} = scope), do: user(scope).id
+
+  def user_email(%__MODULE__{} = scope), do: user(scope).email
+
+  def user_name(%__MODULE__{} = scope), do: user(scope).name
 end

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -21,6 +21,8 @@ defmodule FrontmanServer.Application do
     :tool_name,
     :tool_call_id,
     :task_id,
+    :user_id,
+    :user_name,
     :reason,
     :raw_arguments,
     :decode_error,
@@ -41,7 +43,7 @@ defmodule FrontmanServer.Application do
         capture_log_messages: true,
         level: :error,
         metadata: @sentry_metadata,
-        tags_from_metadata: [:error_type, :tool_name]
+        tags_from_metadata: [:error_type, :tool_name, :task_id, :user_id]
       }
     })
 

--- a/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
+++ b/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
@@ -10,15 +10,6 @@ defmodule FrontmanServer.Observability.SentryContext do
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Accounts.User
 
-  def init(opts), do: opts
-
-  def call(conn, _opts) do
-    conn.assigns[:current_scope]
-    |> set_scope_context()
-
-    conn
-  end
-
   def set_task_scope_context(%Scope{} = scope, task_id) when is_binary(task_id) do
     set_scope_context(scope)
     set_task_context(task_id)

--- a/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
+++ b/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
@@ -8,7 +8,6 @@ defmodule FrontmanServer.Observability.SentryContext do
   @moduledoc false
 
   alias FrontmanServer.Accounts.Scope
-  alias FrontmanServer.Accounts.User
 
   def set_task_scope_context(%Scope{} = scope, task_id) when is_binary(task_id) do
     set_scope_context(scope)
@@ -19,31 +18,15 @@ defmodule FrontmanServer.Observability.SentryContext do
 
   def set_task_scope_context(_scope, _task_id), do: :ok
 
-  def set_scope_context(%Scope{user: %User{} = user, organization: organization}) do
+  def set_scope_context(%Scope{} = scope) do
     Sentry.Context.set_user_context(%{
-      id: user.id,
-      email: user.email,
-      username: user.name
+      id: Scope.user_id(scope),
+      email: Scope.user_email(scope),
+      username: Scope.user_name(scope)
     })
 
-    extra = %{user_name: user.name}
-
-    extra =
-      case organization do
-        %{id: organization_id, slug: organization_slug} ->
-          Map.merge(extra, %{
-            organization_id: organization_id,
-            organization_slug: organization_slug
-          })
-
-        _ ->
-          extra
-      end
-
-    Sentry.Context.set_extra_context(extra)
-    Sentry.Context.set_tags_context(%{user_id: user.id})
-
-    Logger.metadata(user_id: user.id, user_name: user.name)
+    Sentry.Context.set_tags_context(%{user_id: Scope.user_id(scope)})
+    Logger.metadata(user_id: Scope.user_id(scope), user_name: Scope.user_name(scope))
   end
 
   def set_scope_context(_scope), do: :ok

--- a/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
+++ b/apps/frontman_server/lib/frontman_server/observability/sentry_context.ex
@@ -1,0 +1,67 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Observability.SentryContext do
+  @moduledoc false
+
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Accounts.User
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn.assigns[:current_scope]
+    |> set_scope_context()
+
+    conn
+  end
+
+  def set_task_scope_context(%Scope{} = scope, task_id) when is_binary(task_id) do
+    set_scope_context(scope)
+    set_task_context(task_id)
+  end
+
+  def set_task_scope_context(%Scope{} = scope, _task_id), do: set_scope_context(scope)
+
+  def set_task_scope_context(_scope, _task_id), do: :ok
+
+  def set_scope_context(%Scope{user: %User{} = user, organization: organization}) do
+    Sentry.Context.set_user_context(%{
+      id: user.id,
+      email: user.email,
+      username: user.name
+    })
+
+    extra = %{user_name: user.name}
+
+    extra =
+      case organization do
+        %{id: organization_id, slug: organization_slug} ->
+          Map.merge(extra, %{
+            organization_id: organization_id,
+            organization_slug: organization_slug
+          })
+
+        _ ->
+          extra
+      end
+
+    Sentry.Context.set_extra_context(extra)
+    Sentry.Context.set_tags_context(%{user_id: user.id})
+
+    Logger.metadata(user_id: user.id, user_name: user.name)
+  end
+
+  def set_scope_context(_scope), do: :ok
+
+  def set_task_context(task_id) when is_binary(task_id) do
+    Sentry.Context.set_tags_context(%{task_id: task_id})
+    Sentry.Context.set_extra_context(%{task_id: task_id})
+    Logger.metadata(task_id: task_id)
+  end
+
+  def set_task_context(_task_id), do: :ok
+end

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -40,6 +40,7 @@ defmodule FrontmanServer.Tasks do
 
   alias FrontmanServer.Accounts
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Observability.SentryContext
   alias FrontmanServer.Repo
 
   alias FrontmanServer.Tasks.{
@@ -302,6 +303,8 @@ defmodule FrontmanServer.Tasks do
   """
   def handle_swarm_event(scope, task_id, turn_number, event)
       when is_binary(task_id) and is_integer(turn_number) and turn_number > 0 do
+    SentryContext.set_task_scope_context(scope, task_id)
+
     with :ok <- persist_swarm_event(scope, task_id, turn_number, event) do
       broadcast_swarm_event(task_id, turn_number, event)
     end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -10,6 +10,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   require Logger
 
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Observability.SentryContext
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tools.Backend
   alias ModelContextProtocol, as: MCP
@@ -71,6 +72,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   @doc false
   def run_backend_tool(%Scope{} = scope, module, task_id, turn_number, tool_call)
       when is_integer(turn_number) and turn_number > 0 do
+    SentryContext.set_task_scope_context(scope, task_id)
+
     %{"content" => content} =
       result =
       execute_backend_tool(scope, module, tool_call, task_id, turn_number)
@@ -93,6 +96,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   @doc false
   def start_mcp_tool(%Scope{} = scope, task_id, turn_number, tool_call)
       when is_integer(turn_number) and turn_number > 0 do
+    SentryContext.set_task_scope_context(scope, task_id)
+
     Logger.info("ToolExecutor: Routing to MCP tool #{tool_call.name}")
 
     # Register BEFORE publishing to prevent a race where the client responds
@@ -105,6 +110,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   @doc false
   def handle_timeout(%Scope{} = scope, task_id, turn_number, :error, tool_call, :triggered)
       when is_integer(turn_number) and turn_number > 0 do
+    SentryContext.set_task_scope_context(scope, task_id)
+
     timeout_msg = "Tool #{tool_call.name} timed out"
 
     metadata = [

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -17,6 +17,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   alias AgentClientProtocol, as: ACP
   alias FrontmanServer.Frameworks
+  alias FrontmanServer.Observability.SentryContext
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.RetryCoordinator
@@ -38,6 +39,8 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     case Tasks.get_task(scope, task_id) do
       {:ok, task} ->
+        SentryContext.set_task_scope_context(scope, task_id)
+
         Logger.info("Client joining: #{task_id}, socket_id: #{inspect(self())}")
 
         # Start MCP initialization as a synchronous state machine.

--- a/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
@@ -17,6 +17,7 @@ defmodule FrontmanServerWeb.TasksChannel do
   require Logger
 
   alias AgentClientProtocol, as: ACP
+  alias FrontmanServer.Observability.SentryContext
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
   alias FrontmanServerWeb.ACPHistory
@@ -33,6 +34,8 @@ defmodule FrontmanServerWeb.TasksChannel do
   @impl true
   def join("tasks", _params, socket) do
     if Map.has_key?(socket.assigns, :scope) do
+      SentryContext.set_scope_context(socket.assigns.scope)
+
       Logger.info("Client joining tasks channel (authenticated)")
 
       user_id = socket.assigns.scope.user.id

--- a/apps/frontman_server/lib/frontman_server_web/plugs/sentry_context.ex
+++ b/apps/frontman_server/lib/frontman_server_web/plugs/sentry_context.ex
@@ -1,0 +1,20 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServerWeb.Plugs.SentryContext do
+  @moduledoc false
+
+  alias FrontmanServer.Observability.SentryContext
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn.assigns[:current_scope]
+    |> SentryContext.set_scope_context()
+
+    conn
+  end
+end

--- a/apps/frontman_server/lib/frontman_server_web/router.ex
+++ b/apps/frontman_server/lib/frontman_server_web/router.ex
@@ -17,7 +17,7 @@ defmodule FrontmanServerWeb.Router do
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
     plug(:fetch_current_scope_for_user)
-    plug(FrontmanServer.Observability.SentryContext)
+    plug(FrontmanServerWeb.Plugs.SentryContext)
   end
 
   pipeline :api do
@@ -29,7 +29,7 @@ defmodule FrontmanServerWeb.Router do
     plug(:fetch_session)
     plug(:fetch_current_scope_for_user)
     plug(:require_authenticated_user_api)
-    plug(FrontmanServer.Observability.SentryContext)
+    plug(FrontmanServerWeb.Plugs.SentryContext)
   end
 
   ## Public routes

--- a/apps/frontman_server/lib/frontman_server_web/router.ex
+++ b/apps/frontman_server/lib/frontman_server_web/router.ex
@@ -17,6 +17,7 @@ defmodule FrontmanServerWeb.Router do
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
     plug(:fetch_current_scope_for_user)
+    plug(FrontmanServer.Observability.SentryContext)
   end
 
   pipeline :api do
@@ -28,6 +29,7 @@ defmodule FrontmanServerWeb.Router do
     plug(:fetch_session)
     plug(:fetch_current_scope_for_user)
     plug(:require_authenticated_user_api)
+    plug(FrontmanServer.Observability.SentryContext)
   end
 
   ## Public routes

--- a/apps/frontman_server/test/frontman_server/sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/sentry_test.exs
@@ -3,8 +3,14 @@ defmodule FrontmanServer.SentryTest do
 
   require Logger
 
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Accounts.User
+  alias FrontmanServer.Observability.SentryContext
+
   setup do
     Sentry.Test.setup_sentry(dedup_events: false)
+    Sentry.Context.clear_all()
+    Logger.reset_metadata([])
     :ok
   end
 
@@ -29,6 +35,7 @@ defmodule FrontmanServer.SentryTest do
       [event] = Sentry.Test.pop_sentry_reports()
       assert event.message.formatted == "Logger error with metadata"
       assert event.tags[:error_type] == "logger_metadata_test"
+      assert event.tags[:task_id] == "task-test"
       assert event.extra[:logger_metadata][:task_id] == "task-test"
     end
 
@@ -38,6 +45,23 @@ defmodule FrontmanServer.SentryTest do
 
       [event] = Sentry.Test.pop_sentry_reports()
       assert event.message.formatted == "Unmarked logger error"
+    end
+
+    @tag :capture_log
+    test "captures user and task context for logger errors" do
+      user = %User{id: Ecto.UUID.generate(), email: "sentry@test.local", name: "Sentry User"}
+      task_id = Ecto.UUID.generate()
+
+      Scope.for_user(user)
+      |> SentryContext.set_task_scope_context(task_id)
+
+      Logger.error("Logger error with sentry context")
+
+      [event] = Sentry.Test.pop_sentry_reports()
+      assert event.tags[:user_id] == user.id
+      assert event.tags[:task_id] == task_id
+      assert event.extra[:logger_metadata][:user_id] == user.id
+      assert event.extra[:logger_metadata][:task_id] == task_id
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -18,6 +18,8 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
 
   setup do
     Sentry.Test.setup_sentry(dedup_events: false)
+    Sentry.Context.clear_all()
+    Logger.reset_metadata([])
 
     pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
     on_exit(fn -> Sandbox.stop_owner(pid) end)
@@ -55,6 +57,8 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
 
       [report | _] = error_reports
       assert report.message.formatted == "Agent execution failed"
+      assert report.tags[:task_id] == task_id
+      assert report.tags[:user_id] == scope.user.id
       assert report.extra[:reason] == ":llm_api_failure"
     end
   end
@@ -82,6 +86,8 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
 
       [report | _] = error_reports
       assert report.message.formatted == "Agent execution failed"
+      assert report.tags[:task_id] == task_id
+      assert report.tags[:user_id] == scope.user.id
       assert report.extra[:reason] == "Sentry test: simulated stream error"
     end
   end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -22,6 +22,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
 
   setup do
     Sentry.Test.setup_sentry(dedup_events: false)
+    Sentry.Context.clear_all()
+    Logger.reset_metadata([])
 
     pid = Sandbox.start_owner!(FrontmanServer.Repo, shared: true)
     on_exit(fn -> Sandbox.stop_owner(pid) end)
@@ -77,9 +79,12 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       [report | _] = tool_error_reports
       metadata = report.extra[:logger_metadata]
       assert report.message.formatted == "Tool execution failed"
+      assert report.tags[:user_id] == scope.user.id
+      assert report.tags[:task_id] == task_id
       assert metadata[:tool_name] == "todo_write"
       assert metadata[:tool_call_id] == tool_call.id
       assert metadata[:task_id] == task_id
+      assert metadata[:user_id] == scope.user.id
       assert is_binary(metadata[:reason])
     end
   end
@@ -118,7 +123,11 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       metadata = report.extra[:logger_metadata]
       assert report.message.formatted == "Tool argument parse failure"
       assert report.tags[:tool_name] == "todo_write"
+      assert report.tags[:user_id] == scope.user.id
+      assert report.tags[:task_id] == task_id
       assert metadata[:tool_name] == "todo_write"
+      assert metadata[:user_id] == scope.user.id
+      assert metadata[:task_id] == task_id
       assert metadata[:raw_arguments] == "{invalid json!!!}"
       assert is_binary(metadata[:decode_error])
 
@@ -227,7 +236,9 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
 
       reports = Sentry.Test.pop_sentry_reports()
       timeout_reports = Enum.filter(reports, &(&1.tags[:error_type] == "tool_timeout"))
-      assert length(timeout_reports) == 1
+      assert [report] = timeout_reports
+      assert report.tags[:user_id] == scope.user.id
+      assert report.tags[:task_id] == task_id
     end
 
     test "handle_timeout(:triggered) is a no-op for :pause_agent policy", %{

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
@@ -16,6 +16,8 @@ defmodule FrontmanServerWeb.TaskChannelSentryTest do
 
   setup %{scope: scope} do
     Sentry.Test.setup_sentry(dedup_events: false)
+    Sentry.Context.clear_all()
+    Logger.reset_metadata([])
 
     {socket, task_id} = join_task_channel(scope, framework: "nextjs")
     complete_mcp_handshake(socket)
@@ -138,8 +140,11 @@ defmodule FrontmanServerWeb.TaskChannelSentryTest do
       assert [report] = mcp_error_reports
       metadata = report.extra[:logger_metadata]
       assert report.message.formatted == "MCP tool execution failed"
+      assert report.tags[:user_id] == scope.user.id
+      assert report.tags[:task_id] == task_id
       assert metadata[:tool_name] == "testMcpTool"
       assert metadata[:task_id] == task_id
+      assert metadata[:user_id] == scope.user.id
       assert metadata[:error_message] =~ "permission denied"
     end
 


### PR DESCRIPTION
## Summary
- add shared Sentry context helper for user and task metadata
- wire context into request pipelines, channels, Swarm events, and tool execution callbacks
- tag Sentry logger events with user_id and task_id

## Tests
- mix test
- focused Sentry context tests

Note: unrelated local changes remain unstaged and are not included in this PR.