### PR TITLE
Add WordPress listing changeset

### DIFF
--- a/.changeset/retro-wordpress-listing.md
+++ b/.changeset/retro-wordpress-listing.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Update the WordPress.org listing copy to position Frontman as an AI website editor for non-developer WordPress teams.

--- a/libs/frontman-wordpress/package.json
+++ b/libs/frontman-wordpress/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@frontman-ai/frontman-wordpress",
+	"version": "1.1.0",
+	"description": "WordPress plugin for Frontman",
+	"license": "GPL-2.0-or-later",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/frontman-ai/frontman.git",
+		"directory": "libs/frontman-wordpress"
+	},
+	"homepage": "https://frontman.sh/wordpress/",
+	"bugs": {
+		"url": "https://github.com/frontman-ai/frontman/issues"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"libs/frontman-astro",
 		"libs/frontman-astro-browser",
 		"libs/frontman-nextjs",
+		"libs/frontman-wordpress",
 		"libs/frontman-vite",
 		"test/sites/blog-starter",
 		"test/e2e",

--- a/scripts/package-wordpress-plugin.sh
+++ b/scripts/package-wordpress-plugin.sh
@@ -27,8 +27,8 @@ rm -rf "$BUILD_DIR" "$ZIP_PATH" "$WPORG_TARBALL_PATH" "$WPORG_EXPORT_PATH"
 mkdir -p "$DIST_DIR"
 mkdir -p "$PLUGIN_DIR" "$WPORG_DIR/trunk" "$WPORG_DIR/tags/$VERSION"
 
-rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' "$PLUGIN_SRC/" "$PLUGIN_DIR/"
-rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' "$PLUGIN_SRC/" "$WPORG_DIR/trunk/"
+rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' "$PLUGIN_SRC/" "$PLUGIN_DIR/"
+rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' "$PLUGIN_SRC/" "$WPORG_DIR/trunk/"
 rsync -a --delete "$WPORG_DIR/trunk/" "$WPORG_DIR/tags/$VERSION/"
 
 if [ -d "$PLUGIN_SRC/.wordpress-org/assets" ]; then

--- a/scripts/sync-wordpress-plugin-release.sh
+++ b/scripts/sync-wordpress-plugin-release.sh
@@ -11,6 +11,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 VERSION="${1:-${VERSION:-}}"
 FRONTMAN_PHP="$ROOT_DIR/libs/frontman-wordpress/frontman.php"
 README_TXT="$ROOT_DIR/libs/frontman-wordpress/readme.txt"
+PACKAGE_JSON="$ROOT_DIR/libs/frontman-wordpress/package.json"
 
 if [ -z "$VERSION" ]; then
   printf 'Provide VERSION as an argument or environment variable\n' >&2
@@ -55,6 +56,15 @@ awk -v version="$VERSION" '
 }
 
 mv "$tmp_frontman" "$FRONTMAN_PHP"
+
+node -e '
+  const fs = require("node:fs");
+  const path = process.argv[1];
+  const version = process.argv[2];
+  const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+  pkg.version = version;
+  fs.writeFileSync(path, `${JSON.stringify(pkg, null, "\t")}\n`);
+' "$PACKAGE_JSON" "$VERSION"
 
 tmp_readme=$(mktemp)
 

--- a/scripts/validate-wordpress-plugin-release.sh
+++ b/scripts/validate-wordpress-plugin-release.sh
@@ -5,26 +5,29 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 FRONTMAN_PHP="$ROOT_DIR/libs/frontman-wordpress/frontman.php"
 README_TXT="$ROOT_DIR/libs/frontman-wordpress/readme.txt"
+PACKAGE_JSON="$ROOT_DIR/libs/frontman-wordpress/package.json"
 
 header_version=$(sed -nE 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$/\1/p' "$FRONTMAN_PHP" | head -n 1)
 constant_version=$(sed -nE "s/^define\([[:space:]]*'FRONTMAN_VERSION',[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'[[:space:]]*\);$/\1/p" "$FRONTMAN_PHP" | head -n 1)
 stable_tag=$(sed -nE 's/^Stable tag:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$/\1/p' "$README_TXT" | head -n 1)
 changelog_entry=$(sed -nE 's/^= ([0-9]+\.[0-9]+\.[0-9]+) =$/\1/p' "$README_TXT" | head -n 1)
+package_version=$(node -e "console.log(require(process.argv[1]).version)" "$PACKAGE_JSON")
 
 missing=()
 [ -n "$header_version" ] || missing+=("Plugin header")
 [ -n "$constant_version" ] || missing+=("FRONTMAN_VERSION")
 [ -n "$stable_tag" ] || missing+=("Stable tag")
 [ -n "$changelog_entry" ] || missing+=("Top changelog entry")
+[ -n "$package_version" ] || missing+=("package.json")
 
 if [ "${#missing[@]}" -gt 0 ]; then
   printf 'Missing WordPress release metadata: %s\n' "$(IFS=', '; echo "${missing[*]}")" >&2
   exit 1
 fi
 
-if [ "$header_version" != "$constant_version" ] || [ "$header_version" != "$stable_tag" ] || [ "$header_version" != "$changelog_entry" ]; then
-  printf 'WordPress release metadata is out of sync: Plugin header=%s, FRONTMAN_VERSION=%s, Stable tag=%s, Top changelog entry=%s\n' \
-    "$header_version" "$constant_version" "$stable_tag" "$changelog_entry" >&2
+if [ "$header_version" != "$constant_version" ] || [ "$header_version" != "$stable_tag" ] || [ "$header_version" != "$changelog_entry" ] || [ "$header_version" != "$package_version" ]; then
+  printf 'WordPress release metadata is out of sync: Plugin header=%s, FRONTMAN_VERSION=%s, Stable tag=%s, Top changelog entry=%s, package.json=%s\n' \
+    "$header_version" "$constant_version" "$stable_tag" "$changelog_entry" "$package_version" >&2
   exit 1
 fi
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@frontman-ai/frontman-wordpress@workspace:libs/frontman-wordpress":
+  version: 0.0.0-use.local
+  resolution: "@frontman-ai/frontman-wordpress@workspace:libs/frontman-wordpress"
+  languageName: unknown
+  linkType: soft
+
 "@frontman-ai/nextjs@workspace:*, @frontman-ai/nextjs@workspace:libs/frontman-nextjs":
   version: 0.0.0-use.local
   resolution: "@frontman-ai/nextjs@workspace:libs/frontman-nextjs"


### PR DESCRIPTION
## Summary
- add a retroactive empty changeset for the WordPress.org listing copy update from #1179
- enables the release workflow to create a new release after the listing update is merged

## Validation
- yarn changeset status