### PR TITLE
feat(astro): expose content collections

### DIFF
--- a/.changeset/astro-content-collections.md
+++ b/.changeset/astro-content-collections.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/astro": patch
+---
+
+Add `get_content_collections` tool for Astro projects.

--- a/libs/bindings/src/Astro.res
+++ b/libs/bindings/src/Astro.res
@@ -39,6 +39,9 @@ external use: (connectMiddlewareStack, NodeHttp.connectMiddleware) => unit = "us
 // Vite dev server (minimal bindings for astro:server:setup)
 type viteDevServer = {middlewares: connectMiddlewareStack}
 
+@send
+external ssrLoadModule: (viteDevServer, string) => promise<'a> = "ssrLoadModule"
+
 // Config for constructing a Vite plugin with typed fields we use.
 // Keeps vitePlugin opaque while avoiding Obj.magic at call sites.
 type vitePluginConfig = {

--- a/libs/frontman-astro/src/FrontmanAstro__Integration.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Integration.res
@@ -110,20 +110,27 @@ let make = (configInput: Config.jsConfigInput): Bindings.astroIntegration => {
               )
             }
 
-            // Create our Web API middleware and adapt it to Vite's Connect middleware.
-            // Registered as a Vite plugin via configureServer so it runs BEFORE Astro's
-            // own page routing. If registered via astro:server:setup instead, Astro's
-            // catch-all dynamic routes (e.g. blog/[...id]) would match suffix URLs
-            // like /blog/frontman and return 404 before our middleware gets the request.
-            let webMiddleware = Middleware.createMiddleware(config, ~routeDiscovery)
-            let connectMiddleware = ViteAdapter.adaptToConnect(
-              webMiddleware,
-              ~basePath=config.basePath,
-            )
             let middlewarePlugin = Bindings.makeVitePlugin({
               name: "frontman-middleware",
               configureServer: ?Some(
                 server => {
+                  // Create our Web API middleware and adapt it to Vite's Connect middleware.
+                  // Registered as a Vite plugin via configureServer so it runs BEFORE Astro's
+                  // own page routing. If registered via astro:server:setup instead, Astro's
+                  // catch-all dynamic routes (e.g. blog/[...id]) would match suffix URLs
+                  // like /blog/frontman and return 404 before our middleware gets the request.
+                  let loadContentApi = async () =>
+                    await server->Bindings.ssrLoadModule("astro:content")
+                  let webMiddleware = Middleware.createMiddleware(
+                    config,
+                    ~routeDiscovery,
+                    ~loadContentApi,
+                  )
+                  let connectMiddleware = ViteAdapter.adaptToConnect(
+                    webMiddleware,
+                    ~basePath=config.basePath,
+                  )
+
                   server.middlewares->Bindings.use(connectMiddleware)
                 },
               ),

--- a/libs/frontman-astro/src/FrontmanAstro__Middleware.res
+++ b/libs/frontman-astro/src/FrontmanAstro__Middleware.res
@@ -19,6 +19,8 @@ type routeDiscovery =
   | Filesystem
   | ResolvedRoutes({getRoutes: unit => array<FrontmanBindings.Astro.integrationResolvedRoute>})
 
+type loadContentApi = unit => promise<FrontmanAstro__Tool__GetContentCollections.contentApi>
+
 // Convert Astro config to core middleware config
 let toMiddlewareConfig = (config: Config.t): CoreMiddlewareConfig.t => {
   projectRoot: config.projectRoot,
@@ -37,10 +39,15 @@ let toMiddlewareConfig = (config: Config.t): CoreMiddlewareConfig.t => {
 // Returns a function: Request => promise<option<Response>>
 //   Some(response) => this route was handled
 //   None => not a frontman route, pass through
-let createMiddleware = (config: Config.t, ~routeDiscovery: routeDiscovery) => {
+let createMiddleware = (
+  config: Config.t,
+  ~routeDiscovery: routeDiscovery,
+  ~loadContentApi: loadContentApi,
+) => {
   let registry = switch routeDiscovery {
-  | Filesystem => ToolRegistry.make()
-  | ResolvedRoutes({getRoutes}) => ToolRegistry.makeWithResolvedRoutes(~getRoutes)
+  | Filesystem => ToolRegistry.makeWithAstroRuntime(~loadContentApi)
+  | ResolvedRoutes({getRoutes}) =>
+    ToolRegistry.makeWithResolvedRoutesAndAstroRuntime(~getRoutes, ~loadContentApi)
   }
   let middlewareConfig = toMiddlewareConfig(config)
   CoreMiddleware.createMiddleware(~config=middlewareConfig, ~registry)

--- a/libs/frontman-astro/src/FrontmanAstro__ToolRegistry.res
+++ b/libs/frontman-astro/src/FrontmanAstro__ToolRegistry.res
@@ -11,7 +11,10 @@ type t = CoreRegistry.t
 let astroTools: array<tool> = [
   module(FrontmanAstro__Tool__GetPages),
   module(FrontmanAstro__Tool__GetLogs),
+  module(FrontmanAstro__Tool__GetContentCollections),
 ]
+
+type loadContentApi = unit => promise<FrontmanAstro__Tool__GetContentCollections.contentApi>
 
 // Default: v4 filesystem-based page discovery
 let make = (): t => {
@@ -28,7 +31,39 @@ let makeWithResolvedRoutes = (
 ): t => {
   let resolvedRoutesTool = FrontmanAstro__Tool__GetResolvedRoutes.make(~getRoutes)
   CoreRegistry.coreTools()
-  ->CoreRegistry.addTools([resolvedRoutesTool, module(FrontmanAstro__Tool__GetLogs)])
+  ->CoreRegistry.addTools([
+    resolvedRoutesTool,
+    module(FrontmanAstro__Tool__GetLogs),
+    module(FrontmanAstro__Tool__GetContentCollections),
+  ])
+  ->CoreRegistry.replaceByName(module(FrontmanAstro__Tool__EditFile))
+}
+
+let makeWithAstroRuntime = (~loadContentApi: loadContentApi): t => {
+  let contentCollectionsTool = FrontmanAstro__Tool__GetContentCollections.make(~loadContentApi)
+
+  CoreRegistry.coreTools()
+  ->CoreRegistry.addTools([
+    module(FrontmanAstro__Tool__GetPages),
+    module(FrontmanAstro__Tool__GetLogs),
+    contentCollectionsTool,
+  ])
+  ->CoreRegistry.replaceByName(module(FrontmanAstro__Tool__EditFile))
+}
+
+let makeWithResolvedRoutesAndAstroRuntime = (
+  ~getRoutes: unit => array<FrontmanBindings.Astro.integrationResolvedRoute>,
+  ~loadContentApi: loadContentApi,
+): t => {
+  let resolvedRoutesTool = FrontmanAstro__Tool__GetResolvedRoutes.make(~getRoutes)
+  let contentCollectionsTool = FrontmanAstro__Tool__GetContentCollections.make(~loadContentApi)
+
+  CoreRegistry.coreTools()
+  ->CoreRegistry.addTools([
+    resolvedRoutesTool,
+    module(FrontmanAstro__Tool__GetLogs),
+    contentCollectionsTool,
+  ])
   ->CoreRegistry.replaceByName(module(FrontmanAstro__Tool__EditFile))
 }
 

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
@@ -1,0 +1,156 @@
+// Exposes Astro content collection entries through Astro's runtime API.
+
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+
+let name = "get_content_collections"
+let visibleToAgent = true
+
+let description = `Queries Astro content collections through astro:content.
+
+Parameters:
+- collection (required): Collection name to query.
+- entryId (optional): Entry id inside collection. When provided, uses getEntry().
+- offset (optional): Entry pagination offset, default 0.
+- limit (optional): Maximum entries to return, default 50.
+
+Returns entries as Astro's runtime API sees them: id, collection, data, body, and filePath.`
+
+@schema
+type input = {
+  collection: string,
+  @live
+  entryId?: string,
+  @s.default(0) @live
+  offset?: int,
+  @s.default(50) @live
+  limit?: int,
+}
+
+@schema
+type contentEntry = {
+  @live
+  id: string,
+  @live
+  collection: string,
+  @live
+  data: JSON.t,
+  @live
+  body?: string,
+  @live
+  filePath?: string,
+}
+
+@schema
+type output = {
+  @live
+  collection: string,
+  @live
+  totalEntries: int,
+  @live
+  offset: int,
+  @live
+  limit: int,
+  @live
+  hasMore: bool,
+  @live
+  entries: array<contentEntry>,
+}
+
+type runtimeEntry = {
+  id: string,
+  collection: string,
+  data: JSON.t,
+  body?: string,
+  filePath?: string,
+}
+
+type contentApi = {
+  getCollection: string => promise<array<runtimeEntry>>,
+  getEntry: (string, string) => promise<option<runtimeEntry>>,
+}
+
+let unavailableContentApi = async (): contentApi =>
+  failwith("Astro runtime content API unavailable. This tool only works inside astro dev.")
+
+let jsonClone = (value: JSON.t): JSON.t => {
+  switch JSON.stringifyAny(value) {
+  | Some(text) => text->JSON.parseOrThrow
+  | None => JSON.Encode.null
+  }
+}
+
+let toContentEntry = (entry: runtimeEntry): contentEntry => {
+  id: entry.id,
+  collection: entry.collection,
+  data: entry.data->jsonClone,
+  body: ?entry.body,
+  filePath: ?entry.filePath,
+}
+
+let executeWith = async (
+  ~loadContentApi: unit => promise<contentApi>,
+  _ctx: Tool.serverExecutionContext,
+  input: input,
+): Tool.MCP.CallToolResult.t => {
+  try {
+    let offset = max(0, input.offset->Option.getOr(0))
+    let limit = max(1, min(200, input.limit->Option.getOr(50)))
+    let api = await loadContentApi()
+
+    let allEntries = switch input.entryId {
+    | Some(entryId) =>
+      switch await api.getEntry(input.collection, entryId) {
+      | Some(entry) => [entry]
+      | None => []
+      }
+    | None => await api.getCollection(input.collection)
+    }
+
+    let selectedEntries = switch input.entryId {
+    | Some(_) => allEntries
+    | None => allEntries->Array.slice(~start=offset, ~end=offset + limit)
+    }
+
+    Tool.jsonResult(
+      {
+        collection: input.collection,
+        totalEntries: allEntries->Array.length,
+        offset: switch input.entryId {
+        | Some(_) => 0
+        | None => offset
+        },
+        limit,
+        hasMore: switch input.entryId {
+        | Some(_) => false
+        | None => offset + limit < allEntries->Array.length
+        },
+        entries: selectedEntries->Array.map(toContentEntry),
+      },
+      outputSchema,
+    )
+  } catch {
+  | exn =>
+    let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Unknown error")
+    Tool.MCP.CallToolResult.makeError(`Failed to query Astro content collections: ${msg}`)
+  }
+}
+
+let execute = (ctx: Tool.serverExecutionContext, input: input): promise<
+  Tool.MCP.CallToolResult.t,
+> => executeWith(~loadContentApi=unavailableContentApi, ctx, input)
+
+let make = (~loadContentApi: unit => promise<contentApi>): module(Tool.ServerTool) => {
+  module(
+    {
+      let name = name
+      let visibleToAgent = visibleToAgent
+      let description = description
+      type input = input
+      type output = output
+      let inputSchema = inputSchema
+      let outputSchema = outputSchema
+
+      let execute = (ctx, input) => executeWith(~loadContentApi, ctx, input)
+    }
+  )
+}

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
@@ -1,6 +1,8 @@
 // Exposes Astro content collection entries through Astro's runtime API.
 
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
+module Path = FrontmanBindings.Path
+module PathContext = FrontmanAiFrontmanCore.FrontmanCore__PathContext
 
 let name = "get_content_collections"
 let visibleToAgent = true
@@ -79,17 +81,26 @@ let jsonClone = (value: JSON.t): JSON.t => {
   }
 }
 
-let toContentEntry = (entry: runtimeEntry): contentEntry => {
+let normalizeFilePath = (~ctx: Tool.serverExecutionContext, filePath: string): string => {
+  let absolutePath = switch Path.isAbsolute(filePath) {
+  | true => filePath
+  | false => Path.join([ctx.projectRoot, filePath])
+  }
+
+  PathContext.toRelativePath(~sourceRoot=ctx.sourceRoot, ~absolutePath)
+}
+
+let toContentEntry = (~ctx: Tool.serverExecutionContext, entry: runtimeEntry): contentEntry => {
   id: entry.id,
   collection: entry.collection,
   data: entry.data->jsonClone,
   body: ?entry.body,
-  filePath: ?entry.filePath,
+  filePath: ?(entry.filePath->Option.map(filePath => normalizeFilePath(~ctx, filePath))),
 }
 
 let executeWith = async (
   ~loadContentApi: unit => promise<contentApi>,
-  _ctx: Tool.serverExecutionContext,
+  ctx: Tool.serverExecutionContext,
   input: input,
 ): Tool.MCP.CallToolResult.t => {
   try {
@@ -124,7 +135,7 @@ let executeWith = async (
         | Some(_) => false
         | None => offset + limit < allEntries->Array.length
         },
-        entries: selectedEntries->Array.map(toContentEntry),
+        entries: selectedEntries->Array.map(entry => toContentEntry(~ctx, entry)),
       },
       outputSchema,
     )

--- a/libs/frontman-astro/test/FrontmanAstro__Tool__GetContentCollections.test.res
+++ b/libs/frontman-astro/test/FrontmanAstro__Tool__GetContentCollections.test.res
@@ -1,0 +1,120 @@
+open Vitest
+
+module Tool = FrontmanAstro__Tool__GetContentCollections
+module MCP = FrontmanAiFrontmanProtocol.FrontmanProtocol__MCP
+
+let projectRoot = "/tmp/frontman-astro-content-collections-test"
+let ctx = {FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.projectRoot, sourceRoot: projectRoot}
+
+let decodeToolResult = (result: MCP.CallToolResult.t): result<Tool.output, string> => {
+  let json =
+    result->S.decodeOrThrow(~from=MCP.callToolResultSchema, ~to=S.json->S.noValidation(true))
+  let obj = json->JSON.Decode.object->Option.getOrThrow
+  let isError = obj->Dict.get("isError")->Option.flatMap(JSON.Decode.bool)->Option.getOr(false)
+  let content = obj->Dict.get("content")->Option.flatMap(JSON.Decode.array)->Option.getOrThrow
+  let text = switch content->Array.get(0)->Option.flatMap(JSON.Decode.object) {
+  | Some(block) => block->Dict.get("text")->Option.flatMap(JSON.Decode.string)->Option.getOr("")
+  | None => ""
+  }
+
+  switch isError {
+  | true => Error(text)
+  | false =>
+    try {
+      Ok(text->JSON.parseOrThrow->S.parseOrThrow(~to=Tool.outputSchema))
+    } catch {
+    | _ => Error("Failed to decode tool result")
+    }
+  }
+}
+
+let blogEntry: Tool.runtimeEntry = {
+  id: "hello-world",
+  collection: "blog",
+  data: `{"title":"Hello world","draft":false}`->JSON.parseOrThrow,
+  body: ?Some("# Hello\n\nBody text."),
+  filePath: ?Some("src/content/blog/hello-world.md"),
+}
+
+let secondEntry: Tool.runtimeEntry = {
+  id: "second",
+  collection: "blog",
+  data: `{"title":"Second"}`->JSON.parseOrThrow,
+  body: ?None,
+  filePath: ?Some("src/content/blog/second.md"),
+}
+
+let loadContentApi = async (): Tool.contentApi => {
+  getCollection: collection =>
+    switch collection {
+    | "blog" => Promise.resolve([blogEntry, secondEntry])
+    | _ => Promise.resolve([])
+    },
+  getEntry: (collection, id) =>
+    switch (collection, id) {
+    | ("blog", "hello-world") => Promise.resolve(Some(blogEntry))
+    | _ => Promise.resolve(None)
+    },
+}
+
+let executeTool = async input => {
+  let result = await Tool.executeWith(~loadContentApi, ctx, input)
+  result->decodeToolResult
+}
+
+describe("get_content_collections", _t => {
+  testAsync("queries collection entries through runtime API", async t => {
+    let result = await executeTool({collection: "blog"})
+
+    switch result {
+    | Error(msg) => t->expect(msg)->Expect.toBe("")
+    | Ok(output) =>
+      t->expect(output.collection)->Expect.toBe("blog")
+      t->expect(output.totalEntries)->Expect.toBe(2)
+      t->expect(output.hasMore)->Expect.toBe(false)
+
+      let entry = output.entries->Array.get(0)->Option.getOrThrow
+      t->expect(entry.id)->Expect.toBe("hello-world")
+      t->expect(entry.collection)->Expect.toBe("blog")
+      t->expect(entry.body->Option.getOr("")->String.includes("Body text."))->Expect.toBe(true)
+
+      let data = entry.data->JSON.Decode.object->Option.getOrThrow
+      t
+      ->expect(data->Dict.get("title")->Option.flatMap(JSON.Decode.string))
+      ->Expect.toBe(Some("Hello world"))
+    }
+  })
+
+  testAsync("queries individual entry through runtime API", async t => {
+    let result = await executeTool({collection: "blog", entryId: ?Some("hello-world")})
+
+    switch result {
+    | Error(msg) => t->expect(msg)->Expect.toBe("")
+    | Ok(output) =>
+      t->expect(output.totalEntries)->Expect.toBe(1)
+      let entry = output.entries->Array.get(0)->Option.getOrThrow
+      t->expect(entry.id)->Expect.toBe("hello-world")
+      t->expect(entry.filePath)->Expect.toBe(Some("src/content/blog/hello-world.md"))
+    }
+  })
+
+  testAsync("paginates runtime collection results", async t => {
+    let result = await executeTool({collection: "blog", offset: ?Some(1), limit: ?Some(1)})
+
+    switch result {
+    | Error(msg) => t->expect(msg)->Expect.toBe("")
+    | Ok(output) =>
+      t->expect(output.totalEntries)->Expect.toBe(2)
+      t->expect(output.entries->Array.length)->Expect.toBe(1)
+      let entry = output.entries->Array.get(0)->Option.getOrThrow
+      t->expect(entry.id)->Expect.toBe("second")
+    }
+  })
+
+  testAsync("tool is registered", async t => {
+    let registry = FrontmanAstro__ToolRegistry.make()
+    t
+    ->expect(FrontmanAstro__ToolRegistry.getToolByName(registry, "get_content_collections") != None)
+    ->Expect.toBe(true)
+  })
+})

--- a/libs/frontman-astro/test/FrontmanAstro__Tool__GetContentCollections.test.res
+++ b/libs/frontman-astro/test/FrontmanAstro__Tool__GetContentCollections.test.res
@@ -3,8 +3,9 @@ open Vitest
 module Tool = FrontmanAstro__Tool__GetContentCollections
 module MCP = FrontmanAiFrontmanProtocol.FrontmanProtocol__MCP
 
-let projectRoot = "/tmp/frontman-astro-content-collections-test"
-let ctx = {FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.projectRoot, sourceRoot: projectRoot}
+let sourceRoot = "/tmp/frontman-astro-content-collections-test"
+let projectRoot = sourceRoot ++ "/apps/site"
+let ctx = {FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.projectRoot, sourceRoot}
 
 let decodeToolResult = (result: MCP.CallToolResult.t): result<Tool.output, string> => {
   let json =
@@ -94,7 +95,7 @@ describe("get_content_collections", _t => {
       t->expect(output.totalEntries)->Expect.toBe(1)
       let entry = output.entries->Array.get(0)->Option.getOrThrow
       t->expect(entry.id)->Expect.toBe("hello-world")
-      t->expect(entry.filePath)->Expect.toBe(Some("src/content/blog/hello-world.md"))
+      t->expect(entry.filePath)->Expect.toBe(Some("apps/site/src/content/blog/hello-world.md"))
     }
   })
 


### PR DESCRIPTION
## Summary
- add get_content_collections tool backed by Astro's astro:content runtime API
- wire Vite ssrLoadModule through Astro middleware/registry so the tool calls getCollection/getEntry
- add runtime API tests and changeset

Closes #649

## Test plan
- make test in libs/frontman-astro
- pre-push reanalyze hook