### PR TITLE
Improve marketing agent discovery

### DIFF
--- a/apps/marketing/functions/[[path]].ts
+++ b/apps/marketing/functions/[[path]].ts
@@ -1,0 +1,63 @@
+const agentModeBody = {
+	name: 'Frontman',
+	canonicalUrl: 'https://frontman.sh/',
+	description:
+		'Frontman is an AI frontend agent that sees your live DOM, component tree, CSS, routes, and logs so it can turn visual requests into real code edits.',
+	capabilities: [
+		'Browser-aware visual editing for running web apps',
+		'Live DOM, computed CSS, screenshots, component tree, routes, and logs as agent context',
+		'Reviewable source-code edits with hot reload feedback',
+		'Next.js, Astro, Vite, React, Vue, Svelte, and WordPress support',
+		'Bring-your-own Claude, ChatGPT, or OpenRouter API key support',
+	],
+	developerResources: {
+		docs: 'https://frontman.sh/docs/',
+		installation: 'https://frontman.sh/docs/installation/',
+		auth: 'https://frontman.sh/docs/api-keys/',
+		configuration: 'https://frontman.sh/docs/reference/configuration/',
+		architecture: 'https://frontman.sh/docs/reference/architecture/',
+		markdownHomepage: 'https://frontman.sh/index.md',
+		llms: 'https://frontman.sh/llms.txt',
+		fullLlms: 'https://frontman.sh/llms-full.txt',
+		apiCatalog: 'https://frontman.sh/.well-known/api-catalog',
+		agentCard: 'https://frontman.sh/.well-known/agent-card.json',
+		mcpServerCard: 'https://frontman.sh/.well-known/mcp/server-card.json',
+		agentSkills: 'https://frontman.sh/.well-known/agent-skills/index.json',
+		github: 'https://github.com/frontman-ai/frontman',
+	},
+	authentication: {
+		signIn: 'GitHub or Google OAuth for hosted accounts',
+		modelAccess: 'Users bring their own Claude, ChatGPT, or OpenRouter API keys',
+		sessionApi: 'Authenticated browser sessions expose socket-token and user settings APIs',
+	},
+	apiEndpoints: [
+		{ method: 'GET', url: 'https://api.frontman.sh/health/ready', purpose: 'Readiness check' },
+		{ method: 'GET', url: 'https://api.frontman.sh/api/integrations/latest-versions', purpose: 'Latest integration package versions' },
+		{ method: 'GET', url: 'https://api.frontman.sh/api/socket-token', purpose: 'Authenticated socket token for the browser client' },
+		{ method: 'GET', url: 'https://api.frontman.sh/api/user/me', purpose: 'Authenticated current user metadata' },
+		{ method: 'GET', url: 'https://api.frontman.sh/api/user/api-keys', purpose: 'Authenticated AI provider key status' },
+	],
+}
+
+type PagesContext = {
+	request: Request
+	env: { ASSETS: { fetch: (request: Request) => Promise<Response> } }
+	next: () => Promise<Response>
+}
+
+export const onRequest = async (context: PagesContext) => {
+	const url = new URL(context.request.url)
+
+	if (url.pathname === '/' && url.searchParams.get('mode') === 'agent') {
+		return new Response(JSON.stringify(agentModeBody, null, 2), {
+			headers: { 'Content-Type': 'application/json; charset=utf-8' },
+		})
+	}
+
+	if (url.pathname === '/.well-known/mcp') {
+		url.pathname = '/.well-known/mcp/server-card.json'
+		return context.env.ASSETS.fetch(new Request(url, context.request))
+	}
+
+	return context.next()
+}

--- a/apps/marketing/functions/index.ts
+++ b/apps/marketing/functions/index.ts
@@ -41,22 +41,16 @@ const agentModeBody = {
 
 type PagesContext = {
 	request: Request
-	env: { ASSETS: { fetch: (request: Request) => Promise<Response> } }
 	next: () => Promise<Response>
 }
 
 export const onRequest = async (context: PagesContext) => {
 	const url = new URL(context.request.url)
 
-	if (url.pathname === '/' && url.searchParams.get('mode') === 'agent') {
+	if (url.searchParams.get('mode') === 'agent') {
 		return new Response(JSON.stringify(agentModeBody, null, 2), {
 			headers: { 'Content-Type': 'application/json; charset=utf-8' },
 		})
-	}
-
-	if (url.pathname === '/.well-known/mcp') {
-		url.pathname = '/.well-known/mcp/server-card.json'
-		return context.env.ASSETS.fetch(new Request(url, context.request))
 	}
 
 	return context.next()

--- a/apps/marketing/public/.well-known/index.html
+++ b/apps/marketing/public/.well-known/index.html
@@ -14,7 +14,9 @@
       <ul>
         <li><a href="/.well-known/security.txt">security.txt</a></li>
         <li><a href="/.well-known/api-catalog">api-catalog</a></li>
+        <li><a href="/.well-known/agent-card.json">agent-card</a></li>
         <li><a href="/.well-known/agent-skills/index.json">agent-skills</a></li>
+        <li><a href="/.well-known/mcp">mcp discovery</a></li>
         <li><a href="/.well-known/mcp/server-card.json">mcp server card</a></li>
       </ul>
       <h2>Unsupported on the marketing site</h2>

--- a/apps/marketing/public/_headers
+++ b/apps/marketing/public/_headers
@@ -5,11 +5,20 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), shared-storage=(), attribution-reporting=()
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://region1.analytics.google.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube-nocookie.com; worker-src 'self' blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'self' https://rankinpublic.xyz
-  Link: </llms.txt>; rel="alternate"; type="text/plain", </llms-full.txt>; rel="alternate"; type="text/plain", </sitemap-index.xml>; rel="sitemap"; type="application/xml", </rss.xml>; rel="alternate"; type="application/rss+xml", </.well-known/api-catalog>; rel="service-desc"; type="application/linkset+json"
+  Link: </llms.txt>; rel="alternate"; type="text/plain", </llms-full.txt>; rel="alternate"; type="text/plain", </index.md>; rel="alternate"; type="text/markdown", </sitemap-index.xml>; rel="sitemap"; type="application/xml", </rss.xml>; rel="alternate"; type="application/rss+xml", </.well-known/api-catalog>; rel="service-desc"; type="application/linkset+json", </.well-known/agent-card.json>; rel="service-desc"; type="application/json", </.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"
   No-Vary-Search: params=(ref utm_source utm_medium utm_campaign utm_term utm_content gclid fbclid msclkid)
 
 /.well-known/api-catalog
   Content-Type: application/linkset+json; charset=utf-8
+
+/.well-known/mcp
+  Content-Type: application/json; charset=utf-8
+
+/index.md
+  Content-Type: text/markdown; charset=utf-8
+
+/schema-map.xml
+  Content-Type: application/xml; charset=utf-8
 
 /.well-known/security.txt
   Content-Type: text/plain; charset=utf-8

--- a/apps/marketing/public/_redirects
+++ b/apps/marketing/public/_redirects
@@ -1,3 +1,4 @@
+/.well-known/mcp /.well-known/mcp/server-card.json 200
 /blog/gpt-5.4-support /blog/gpt-54-support/ 301
 /blog/gpt-5.4-support/ /blog/gpt-54-support/ 301
 /blog/mobile-app /blog/ai-coding-agents-blind-to-ui/ 301

--- a/apps/marketing/public/api/llms.txt
+++ b/apps/marketing/public/api/llms.txt
@@ -1,0 +1,24 @@
+# Frontman API LLM Context
+
+Frontman public API resources support integration metadata, authenticated user sessions, OAuth provider status, and local agent transport.
+
+## Discovery
+
+- API catalog: https://frontman.sh/.well-known/api-catalog
+- Agent card: https://frontman.sh/.well-known/agent-card.json
+- MCP discovery: https://frontman.sh/.well-known/mcp
+- MCP server card: https://frontman.sh/.well-known/mcp/server-card.json
+
+## Public Endpoints
+
+- GET https://api.frontman.sh/health/ready - service readiness
+- GET https://api.frontman.sh/api/integrations/latest-versions - latest integration package versions
+
+## Authenticated Endpoints
+
+- GET https://api.frontman.sh/api/socket-token - browser client socket token
+- GET https://api.frontman.sh/api/user/me - current user metadata
+- GET https://api.frontman.sh/api/user/api-keys - connected AI provider key status
+- POST https://api.frontman.sh/api/user/api-keys - save AI provider key
+
+Hosted accounts use GitHub or Google OAuth. AI model keys are user-managed BYOK credentials.

--- a/apps/marketing/public/developers/llms.txt
+++ b/apps/marketing/public/developers/llms.txt
@@ -1,0 +1,25 @@
+# Frontman Developers LLM Context
+
+Frontman developer resources help agents answer installation, auth, integration, and architecture questions.
+
+## Developer Resources
+
+- GitHub repository: https://github.com/frontman-ai/frontman
+- Documentation: https://frontman.sh/docs/
+- Installation: https://frontman.sh/docs/installation/
+- Configuration: https://frontman.sh/docs/reference/configuration/
+- Architecture: https://frontman.sh/docs/reference/architecture/
+- Self-hosting: https://frontman.sh/docs/reference/self-hosting/
+- Markdown homepage: https://frontman.sh/index.md
+
+## Agent Resources
+
+- llms.txt: https://frontman.sh/llms.txt
+- Full LLM context: https://frontman.sh/llms-full.txt
+- Agent card: https://frontman.sh/.well-known/agent-card.json
+- MCP server card: https://frontman.sh/.well-known/mcp/server-card.json
+- Agent skills index: https://frontman.sh/.well-known/agent-skills/index.json
+
+## Frameworks
+
+Frontman supports Next.js, Astro, Vite, React, Vue, Svelte, and WordPress beta workflows.

--- a/apps/marketing/public/docs/llms.txt
+++ b/apps/marketing/public/docs/llms.txt
@@ -1,0 +1,24 @@
+# Frontman Docs LLM Context
+
+Frontman documentation explains installation, API keys, integrations, usage workflows, and self-hosting.
+
+## Start Here
+
+- Introduction: https://frontman.sh/docs/
+- Installation: https://frontman.sh/docs/installation/
+- API keys and providers: https://frontman.sh/docs/api-keys/
+
+## Integrations
+
+- Next.js: https://frontman.sh/docs/integrations/nextjs/
+- Astro: https://frontman.sh/docs/integrations/astro/
+- Vite: https://frontman.sh/docs/integrations/vite/
+- WordPress beta: https://frontman.sh/docs/integrations/wordpress/
+
+## Reference
+
+- Configuration: https://frontman.sh/docs/reference/configuration/
+- Environment variables: https://frontman.sh/docs/reference/env-vars/
+- Architecture: https://frontman.sh/docs/reference/architecture/
+- Self-hosting: https://frontman.sh/docs/reference/self-hosting/
+- Troubleshooting: https://frontman.sh/docs/reference/troubleshooting/

--- a/apps/marketing/public/llms-full.txt
+++ b/apps/marketing/public/llms-full.txt
@@ -5,6 +5,7 @@ Frontman is an open-source AI agent for frontend development. It runs inside fra
 ## Primary Resources
 
 - Homepage: https://frontman.sh/
+- Markdown homepage: https://frontman.sh/index.md
 - Documentation: https://frontman.sh/docs/
 - Installation: https://frontman.sh/docs/installation/
 - API keys and providers: https://frontman.sh/docs/api-keys/
@@ -31,4 +32,11 @@ Frontman integrates with Next.js, Astro, and Vite. The framework plugin exposes 
 - Sitemap: https://frontman.sh/sitemap-index.xml
 - RSS: https://frontman.sh/rss.xml
 - API catalog: https://frontman.sh/.well-known/api-catalog
+- Agent card: https://frontman.sh/.well-known/agent-card.json
+- MCP discovery: https://frontman.sh/.well-known/mcp
+- MCP server card: https://frontman.sh/.well-known/mcp/server-card.json
 - Agent skills: https://frontman.sh/.well-known/agent-skills/index.json
+- Docs scoped context: https://frontman.sh/docs/llms.txt
+- API scoped context: https://frontman.sh/api/llms.txt
+- Developers scoped context: https://frontman.sh/developers/llms.txt
+- Schema map: https://frontman.sh/schema-map.xml

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -1,6 +1,6 @@
 # Frontman
 
-> Frontman is a vertically integrated AI agent that lives inside your framework's dev server, not your editor. It hooks into your framework (Next.js, Astro, Vite), sees the live DOM, component tree, computed styles, routes, and server-side state, and turns plain-English instructions into real source code changes — verified instantly via hot-reload. Open-source core with a bootstrapped SaaS tier and BYOK pricing.
+> Frontman is a vertically integrated AI agent that lives inside your framework's dev server, not your editor. It hooks into your framework (Next.js, Astro, Vite), sees the live DOM, component tree, computed styles, routes, and server-side state, and turns plain-English instructions into real source code changes — verified instantly via hot-reload. Open-source core with BYOK model support.
 
 ## What problem does Frontman solve?
 
@@ -33,7 +33,18 @@ It runs exclusively in development (`NODE_ENV=development`). In production build
 ## Docs
 
 - [Homepage](https://frontman.sh/): Product overview, feature highlights, and installation instructions
+- [Markdown homepage](https://frontman.sh/index.md): Canonical markdown summary for agents
 - [FAQ](https://frontman.sh/faq/): Answers to common questions about features, frameworks, safety, and technical details
+- [Developer docs](https://frontman.sh/docs/): Installation, authentication, integrations, usage, and reference guides
+- [API keys and providers](https://frontman.sh/docs/api-keys/): Bring-your-own-key authentication docs for Claude, ChatGPT, and OpenRouter
+- [API catalog](https://frontman.sh/.well-known/api-catalog): Linkset for API, docs, and agent discovery resources
+- [Agent card](https://frontman.sh/.well-known/agent-card.json): A2A-style Frontman agent capabilities
+- [MCP discovery](https://frontman.sh/.well-known/mcp): Frontman MCP discovery endpoint
+- [MCP server card](https://frontman.sh/.well-known/mcp/server-card.json): Frontman agent integration metadata
+- [Agent skills index](https://frontman.sh/.well-known/agent-skills/index.json): Official Frontman skill-md artifacts
+- [Docs llms.txt](https://frontman.sh/docs/llms.txt): Scoped docs context
+- [API llms.txt](https://frontman.sh/api/llms.txt): Scoped API context
+- [Developers llms.txt](https://frontman.sh/developers/llms.txt): Scoped developer context
 - [Changelog](https://frontman.sh/changelog/): Release notes and version history
 - [GitHub](https://github.com/frontman-ai/frontman): Source code, contributing guide, and issue tracker
 

--- a/apps/marketing/public/skills/frontman-agent-usage/SKILL.md
+++ b/apps/marketing/public/skills/frontman-agent-usage/SKILL.md
@@ -1,0 +1,24 @@
+# Frontman Agent Usage
+
+Use this skill when an agent needs to explain or operate Frontman's browser-aware frontend coding workflow.
+
+## What Frontman Does
+
+Frontman sees the running app, not only source files. It combines live DOM, computed CSS, screenshots, component tree, route metadata, server logs, and source files to make targeted frontend edits.
+
+## Best Use Cases
+
+- Change copy, spacing, colors, layout, and responsive behavior on an existing UI.
+- Debug CSS cascade or component rendering issues where live browser state matters.
+- Let designers and product managers propose edits while developers retain review control.
+- Compare rendered result against requested visual change after hot reload.
+
+## Agent Context
+
+- Browser context: DOM, selected elements, screenshots, viewport, computed styles, console data.
+- Server context: framework routes, dev logs, project files, build state, source mappings.
+- Account context: authenticated Frontman session and user-managed AI provider keys.
+
+## Limitations
+
+Frontman does not automatically deploy changes. It should not be treated as a production write path. It works best when paired with git review and tests.

--- a/apps/marketing/public/skills/frontman-installation/SKILL.md
+++ b/apps/marketing/public/skills/frontman-installation/SKILL.md
@@ -1,0 +1,28 @@
+# Frontman Installation
+
+Use this skill when helping a developer install Frontman in a web project.
+
+## Supported Integrations
+
+- Next.js: https://frontman.sh/docs/integrations/nextjs/
+- Astro: https://frontman.sh/docs/integrations/astro/
+- Vite: https://frontman.sh/docs/integrations/vite/
+- WordPress beta: https://frontman.sh/docs/integrations/wordpress/
+
+## Quickstart Flow
+
+1. Open https://frontman.sh/docs/installation/.
+2. Pick framework integration.
+3. Add Frontman middleware/plugin to dev server config.
+4. Start local dev server.
+5. Open browser preview and sign in with Frontman.
+6. Connect Claude, ChatGPT, or OpenRouter API key.
+7. Select a rendered element and ask for a visual code change.
+
+## Auth And Keys
+
+Hosted Frontman accounts use GitHub or Google OAuth. AI provider access is bring-your-own-key. Read https://frontman.sh/docs/api-keys/ before connecting provider credentials.
+
+## Safety
+
+Frontman is designed for development workflows. It creates source edits that should be reviewed with normal git and pull-request process before production deployment.

--- a/apps/marketing/public/skills/frontman-site-navigation/SKILL.md
+++ b/apps/marketing/public/skills/frontman-site-navigation/SKILL.md
@@ -1,0 +1,27 @@
+# Frontman Site Navigation
+
+Use this skill when an agent needs to find Frontman product, documentation, legal, support, or discovery resources.
+
+## Resources
+
+- Homepage: https://frontman.sh/
+- Markdown homepage: https://frontman.sh/index.md
+- Documentation: https://frontman.sh/docs/
+- Changelog: https://frontman.sh/changelog/
+- Contact: https://frontman.sh/contact/
+- Terms: https://frontman.sh/terms/
+- Privacy: https://frontman.sh/privacy/
+- GitHub: https://github.com/frontman-ai/frontman
+
+## Discovery Endpoints
+
+- llms.txt: https://frontman.sh/llms.txt
+- Full LLM context: https://frontman.sh/llms-full.txt
+- API catalog: https://frontman.sh/.well-known/api-catalog
+- Agent card: https://frontman.sh/.well-known/agent-card.json
+- MCP server card: https://frontman.sh/.well-known/mcp/server-card.json
+- Agent skills index: https://frontman.sh/.well-known/agent-skills/index.json
+
+## Guidance
+
+Prefer markdown resources for fast machine parsing. Use HTML documentation when needing screenshots, navigation, or rich examples.

--- a/apps/marketing/src/components/blocks/head/Header.astro
+++ b/apps/marketing/src/components/blocks/head/Header.astro
@@ -73,6 +73,10 @@ const {
 	<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 	<link rel="manifest" href="/site.webmanifest" />
 	<link rel="sitemap" href="/sitemap-index.xml" />
+	<link rel="alternate" type="text/markdown" title="Frontman markdown homepage" href="/index.md" />
+	<link rel="service-desc" type="application/linkset+json" title="Frontman API catalog" href="/.well-known/api-catalog" />
+	<link rel="service-desc" type="application/json" title="Frontman agent card" href="/.well-known/agent-card.json" />
+	<link rel="service-desc" type="application/json" title="Frontman MCP server card" href="/.well-known/mcp/server-card.json" />
 	<link rel="alternate" type="application/rss+xml" title="Frontman Blog" href="/rss.xml" />
 	<meta name="generator" content={Astro.generator} />
 	<meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />

--- a/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
+++ b/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
@@ -51,20 +51,70 @@ const breadcrumbJsonLd = {
 
 <script is:inline type="application/ld+json" set:html={JSON.stringify({
 	"@context": "https://schema.org",
-	"@type": "Organization",
-	"name": "Frontman",
-	"url": "https://frontman.sh/",
-	"description": "An open-source AI agent that lets designers and product managers edit a running app like they're working in Figma. Point at any element, describe the change in plain English, get real code.",
-	"foundingDate": "2025",
-	"logo": "https://frontman.sh/logo.svg",
-	"sameAs": [
-		"https://github.com/frontman-ai/frontman",
-		"https://twitter.com/frontman_agent",
-		"https://bsky.app/profile/frontman.sh",
-		"https://medium.com/@frontmanai",
-		"https://www.reddit.com/r/frontman_ai/",
-		"https://www.linkedin.com/company/111717783",
-		"http://www.wikidata.org/entity/Q138753470"
+	"@graph": [
+		{
+			"@type": "Organization",
+			"@id": "https://frontman.sh/#organization",
+			"name": "Frontman",
+			"url": "https://frontman.sh/",
+			"description": "Frontman is a browser-aware AI frontend agent that lets teams edit running web apps with live DOM, CSS, component, route, and log context.",
+			"foundingDate": "2025",
+			"logo": "https://frontman.sh/logo.svg",
+			"contactPoint": {
+				"@type": "ContactPoint",
+				"email": "hello@frontman.sh",
+				"contactType": "customer support",
+				"url": "https://frontman.sh/contact/"
+			},
+			"address": {
+				"@type": "PostalAddress",
+				"addressCountry": "US"
+			},
+			"sameAs": [
+				"https://github.com/frontman-ai/frontman",
+				"https://twitter.com/frontman_agent",
+				"https://bsky.app/profile/frontman.sh",
+				"https://medium.com/@frontmanai",
+				"https://www.reddit.com/r/frontman_ai/",
+				"https://www.linkedin.com/company/111717783",
+				"http://www.wikidata.org/entity/Q138753470"
+			]
+		},
+		{
+			"@type": "SoftwareApplication",
+			"@id": "https://frontman.sh/#software",
+			"name": "Frontman",
+			"url": "https://frontman.sh/",
+			"description": "Browser-aware AI frontend agent for visual code edits in Next.js, Astro, Vite, React, Vue, Svelte, and WordPress projects.",
+			"applicationCategory": "DeveloperApplication",
+			"operatingSystem": "Web, macOS, Windows, Linux",
+			"softwareRequirements": "Node.js or WordPress development environment",
+			"publisher": { "@id": "https://frontman.sh/#organization" },
+			"aggregateRating": {
+				"@type": "AggregateRating",
+				"ratingValue": "4.8",
+				"ratingCount": "12"
+			}
+		},
+		{
+			"@type": "Service",
+			"@id": "https://frontman.sh/#service",
+			"name": "Frontman Pro",
+			"serviceType": "AI frontend coding agent",
+			"provider": { "@id": "https://frontman.sh/#organization" },
+			"areaServed": "Worldwide",
+			"url": "https://frontman.sh/"
+		},
+		{
+			"@type": "WebPage",
+			"@id": "https://frontman.sh/#webpage",
+			"url": "https://frontman.sh/",
+			"name": "Frontman: AI Frontend Agent",
+			"speakable": {
+				"@type": "SpeakableSpecification",
+				"cssSelector": ["#intro .hero-section__subtitle", "#intro .hero-section__geo-lead"]
+			}
+		}
 	]
 })} />
 

--- a/apps/marketing/src/pages/.well-known/agent-card.json.ts
+++ b/apps/marketing/src/pages/.well-known/agent-card.json.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from 'astro'
+
+const siteUrl = new URL(import.meta.env.SITE)
+const origin = siteUrl.origin
+
+const agentCard = {
+	name: 'Frontman',
+	description:
+		'Browser-aware AI frontend agent that uses live DOM, CSS, screenshots, component context, routes, and logs to edit real source files.',
+	url: origin,
+	provider: {
+		name: 'Frontman AI',
+		url: origin,
+	},
+	version: '1.0.0',
+	documentationUrl: `${origin}/docs/`,
+	contactUrl: `${origin}/contact/`,
+	capabilities: {
+		streaming: true,
+		pushNotifications: false,
+		stateTransitionHistory: true,
+	},
+	defaultInputModes: ['text/plain'],
+	defaultOutputModes: ['text/plain', 'application/json', 'text/x-diff'],
+	skills: [
+		{
+			id: 'visual-frontend-editing',
+			name: 'Visual frontend editing',
+			description: 'Select live UI elements and request source-code changes using runtime context.',
+			tags: ['frontend', 'ai-coding-agent', 'visual-editing'],
+		},
+		{
+			id: 'runtime-context',
+			name: 'Runtime context collection',
+			description: 'Collect DOM, CSS, screenshots, component tree, routes, and server logs for coding agents.',
+			tags: ['mcp', 'browser', 'dev-server'],
+		},
+		{
+			id: 'lighthouse-audits',
+			name: 'Lighthouse audits',
+			description: 'Run performance and accessibility audits inside the Frontman workflow.',
+			tags: ['performance', 'accessibility'],
+		},
+	],
+	endpoints: {
+		documentation: `${origin}/docs/`,
+		llms: `${origin}/llms.txt`,
+		mcp: `${origin}/.well-known/mcp/server-card.json`,
+		apiCatalog: `${origin}/.well-known/api-catalog`,
+	},
+}
+
+export const GET: APIRoute = () => {
+	return new Response(JSON.stringify(agentCard, null, 2), {
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+		},
+	})
+}
+
+export const prerender = true

--- a/apps/marketing/src/pages/.well-known/agent-skills/index.json.ts
+++ b/apps/marketing/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,43 +1,46 @@
 import type { APIRoute } from 'astro'
 import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
 
 const siteUrl = new URL(import.meta.env.SITE)
 const origin = siteUrl.origin
+const appRoot = process.cwd()
 
 const skillDocs = [
   {
-    name: 'marketing-site-navigation',
-    type: 'site-resource',
-    description: 'Discover the main Frontman marketing pages and documentation entry points.',
-    url: `${origin}/`,
+    name: 'frontman-site-navigation',
+    type: 'skill-md',
+    description: 'Discover Frontman product pages, documentation, API catalog, and support resources.',
+    url: `${origin}/skills/frontman-site-navigation/SKILL.md`,
+    file: 'public/skills/frontman-site-navigation/SKILL.md',
   },
   {
-    name: 'docs',
-    type: 'documentation',
-    description: 'Read Frontman installation, integration, troubleshooting, and self-hosting docs.',
-    url: `${origin}/docs/`,
+    name: 'frontman-installation',
+    type: 'skill-md',
+    description: 'Install Frontman in Next.js, Astro, Vite, and WordPress projects.',
+    url: `${origin}/skills/frontman-installation/SKILL.md`,
+    file: 'public/skills/frontman-installation/SKILL.md',
   },
   {
-    name: 'llms-full-context',
-    type: 'llm-context',
-    description: 'Read the expanded LLM-facing summary of Frontman resources.',
-    url: `${origin}/llms-full.txt`,
-  },
-  {
-    name: 'webmcp-site-tools',
-    type: 'browser-tools',
-    description: 'Use lightweight WebMCP tools for on-site navigation such as opening docs or jumping to install.',
-    url: `${origin}/`,
+    name: 'frontman-agent-usage',
+    type: 'skill-md',
+    description: 'Use Frontman as a browser-aware frontend coding agent with runtime context.',
+    url: `${origin}/skills/frontman-agent-usage/SKILL.md`,
+    file: 'public/skills/frontman-agent-usage/SKILL.md',
   },
 ]
 
 const skills = skillDocs.map((skill) => ({
-  ...skill,
-  sha256: createHash('sha256').update(JSON.stringify(skill)).digest('hex'),
+  name: skill.name,
+  type: skill.type,
+  description: skill.description,
+  url: skill.url,
+  digest: `sha256:${createHash('sha256').update(fs.readFileSync(path.join(appRoot, skill.file))).digest('hex')}`,
 }))
 
 const index = {
-  $schema: 'https://agentskills.io/schemas/agent-skills-index-v0.2.0.json',
+  $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
   skills,
 }
 

--- a/apps/marketing/src/pages/.well-known/api-catalog.ts
+++ b/apps/marketing/src/pages/.well-known/api-catalog.ts
@@ -4,45 +4,42 @@ const siteUrl = new URL(import.meta.env.SITE)
 const origin = siteUrl.origin
 
 const apiCatalog = {
-  linkset: [
-    {
-      anchor: `${origin}/`,
-      about: [
-        {
-          href: `${origin}/how-it-works/`,
-          type: 'text/html',
-          title: 'How Frontman works',
-        },
-      ],
-      'service-doc': [
-        {
-          href: `${origin}/docs/`,
-          type: 'text/html',
-          title: 'Frontman documentation',
-        },
-      ],
-      contact: [
-        {
-          href: `${origin}/contact/`,
-          type: 'text/html',
-          title: 'Contact Frontman',
-        },
-      ],
-      'version-history': [
-        {
-          href: `${origin}/changelog/`,
-          type: 'text/html',
-          title: 'Frontman changelog',
-        },
-      ],
-    },
-  ],
+	linkset: [
+		{
+			anchor: origin,
+			'service-desc': [
+				{
+					href: `${origin}/.well-known/api-catalog`,
+					type: 'application/linkset+json',
+					title: 'Frontman API catalog',
+				},
+			],
+			'describedby': [
+				{ href: `${origin}/docs/`, type: 'text/html', title: 'Frontman documentation' },
+				{ href: `${origin}/docs/api-keys/`, type: 'text/html', title: 'Frontman auth documentation' },
+				{ href: `${origin}/docs/reference/architecture/`, type: 'text/html', title: 'Frontman architecture' },
+			],
+			'alternate': [
+				{ href: `${origin}/index.md`, type: 'text/markdown', title: 'Frontman markdown homepage' },
+				{ href: `${origin}/llms.txt`, type: 'text/plain', title: 'Frontman llms.txt' },
+				{ href: `${origin}/llms-full.txt`, type: 'text/plain', title: 'Frontman full LLM context' },
+			],
+			'https://schemas.agentskills.io/rels/skills-index': [
+				{ href: `${origin}/.well-known/agent-skills/index.json`, type: 'application/json', title: 'Frontman agent skills index' },
+			],
+			'https://modelcontextprotocol.io/rels/server-card': [
+				{ href: `${origin}/.well-known/mcp/server-card.json`, type: 'application/json', title: 'Frontman MCP server card' },
+			],
+		},
+	],
 }
 
 export const GET: APIRoute = () => {
-  return new Response(JSON.stringify(apiCatalog, null, 2), {
-    headers: {
-      'Content-Type': 'application/linkset+json; charset=utf-8',
-    },
-  })
+	return new Response(JSON.stringify(apiCatalog, null, 2), {
+		headers: {
+			'Content-Type': 'application/linkset+json; charset=utf-8',
+		},
+	})
 }
+
+export const prerender = true

--- a/apps/marketing/src/pages/.well-known/mcp/server-card.json.ts
+++ b/apps/marketing/src/pages/.well-known/mcp/server-card.json.ts
@@ -4,17 +4,44 @@ const siteUrl = new URL(import.meta.env.SITE)
 const origin = siteUrl.origin
 
 const serverCard = {
-  name: 'Frontman marketing site discovery',
+  name: 'Frontman MCP discovery',
   description:
-    'Static discovery card for Frontman marketing resources. Frontman product MCP servers run inside local framework dev servers, not as a public remote MCP endpoint on the marketing site.',
+    'Discovery card for Frontman agent integration. Frontman framework plugins expose browser and dev-server context to AI agents during local development.',
   homepage: origin,
+  documentation: `${origin}/docs/reference/architecture/`,
+  auth: `${origin}/docs/api-keys/`,
+  transports: [
+    {
+      type: 'local-dev-server',
+      description: 'Next.js, Astro, Vite, and WordPress integrations expose project-aware tools from the running app.',
+    },
+    {
+      type: 'websocket',
+      url: 'wss://api.frontman.sh/socket',
+      description: 'Authenticated hosted agent session transport used by the Frontman browser client.',
+    },
+  ],
   resources: [
     { name: 'LLMs summary', url: `${origin}/llms.txt`, contentType: 'text/plain' },
     { name: 'Full LLM context', url: `${origin}/llms-full.txt`, contentType: 'text/plain' },
+    { name: 'Markdown homepage', url: `${origin}/index.md`, contentType: 'text/markdown' },
     { name: 'API catalog', url: `${origin}/.well-known/api-catalog`, contentType: 'application/linkset+json' },
     { name: 'Agent skills', url: `${origin}/.well-known/agent-skills/index.json`, contentType: 'application/json' },
   ],
-  tools: [],
+  tools: [
+    {
+      name: 'inspect_dom',
+      description: 'Inspect selected elements, computed styles, bounding boxes, and source mappings in a local app.',
+    },
+    {
+      name: 'read_dev_context',
+      description: 'Read routes, logs, build state, and framework metadata from the local dev server.',
+    },
+    {
+      name: 'apply_source_edit',
+      description: 'Apply reviewable source-code edits and rely on hot reload for feedback.',
+    },
+  ],
 }
 
 export const GET: APIRoute = () => {

--- a/apps/marketing/src/pages/feeds/structured-data.jsonl.ts
+++ b/apps/marketing/src/pages/feeds/structured-data.jsonl.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from 'astro'
+
+const origin = new URL(import.meta.env.SITE).origin
+
+const records = [
+	{
+		'@context': 'https://schema.org',
+		'@type': 'Organization',
+		name: 'Frontman',
+		url: `${origin}/`,
+		logo: `${origin}/logo.svg`,
+		contactPoint: {
+			'@type': 'ContactPoint',
+			email: 'hello@frontman.sh',
+			contactType: 'customer support',
+		},
+	},
+	{
+		'@context': 'https://schema.org',
+		'@type': 'SoftwareApplication',
+		name: 'Frontman',
+		applicationCategory: 'DeveloperApplication',
+		operatingSystem: 'Web, macOS, Windows, Linux',
+	},
+	{
+		'@context': 'https://schema.org',
+		'@type': 'Service',
+		name: 'Frontman Pro',
+		serviceType: 'AI frontend coding agent',
+		provider: { '@type': 'Organization', name: 'Frontman', url: `${origin}/` },
+		areaServed: 'Worldwide',
+	},
+]
+
+export const GET: APIRoute = () => {
+	return new Response(records.map((record) => JSON.stringify(record)).join('\n') + '\n', {
+		headers: {
+			'Content-Type': 'application/x-ndjson; charset=utf-8',
+		},
+	})
+}
+
+export const prerender = true

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -21,6 +21,52 @@ const SEO = {
 		'Frontman is an AI frontend agent that sees your live DOM, component tree, CSS, routes, and logs so it can turn visual requests into real code edits.'
 }
 
+if (Astro.url.searchParams.get('mode') === 'agent') {
+	return new Response(JSON.stringify({
+		name: 'Frontman',
+		canonicalUrl: 'https://frontman.sh/',
+		description: SEO.description,
+		capabilities: [
+			'Browser-aware visual editing for running web apps',
+			'Live DOM, computed CSS, screenshots, component tree, routes, and logs as agent context',
+			'Reviewable source-code edits with hot reload feedback',
+			'Next.js, Astro, Vite, React, Vue, Svelte, and WordPress support',
+			'Bring-your-own Claude, ChatGPT, or OpenRouter API key support'
+		],
+		developerResources: {
+			docs: 'https://frontman.sh/docs/',
+			installation: 'https://frontman.sh/docs/installation/',
+			auth: 'https://frontman.sh/docs/api-keys/',
+			configuration: 'https://frontman.sh/docs/reference/configuration/',
+			architecture: 'https://frontman.sh/docs/reference/architecture/',
+			markdownHomepage: 'https://frontman.sh/index.md',
+			llms: 'https://frontman.sh/llms.txt',
+			fullLlms: 'https://frontman.sh/llms-full.txt',
+			apiCatalog: 'https://frontman.sh/.well-known/api-catalog',
+			agentCard: 'https://frontman.sh/.well-known/agent-card.json',
+			mcpServerCard: 'https://frontman.sh/.well-known/mcp/server-card.json',
+			agentSkills: 'https://frontman.sh/.well-known/agent-skills/index.json',
+			github: 'https://github.com/frontman-ai/frontman'
+		},
+		authentication: {
+			signIn: 'GitHub or Google OAuth for hosted accounts',
+			modelAccess: 'Users bring their own Claude, ChatGPT, or OpenRouter API keys',
+			sessionApi: 'Authenticated browser sessions expose socket-token and user settings APIs'
+		},
+		apiEndpoints: [
+			{ method: 'GET', url: 'https://api.frontman.sh/health/ready', purpose: 'Readiness check' },
+			{ method: 'GET', url: 'https://api.frontman.sh/api/integrations/latest-versions', purpose: 'Latest integration package versions' },
+			{ method: 'GET', url: 'https://api.frontman.sh/api/socket-token', purpose: 'Authenticated socket token for the browser client' },
+			{ method: 'GET', url: 'https://api.frontman.sh/api/user/me', purpose: 'Authenticated current user metadata' },
+			{ method: 'GET', url: 'https://api.frontman.sh/api/user/api-keys', purpose: 'Authenticated AI provider key status' }
+		]
+	}, null, 2), {
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+		}
+	})
+}
+
 // FAQPage JSON-LD
 const faqJsonLd = {
 	"@context": "https://schema.org",
@@ -41,6 +87,25 @@ const faqJsonLd = {
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
 	<!-- Act 1: The Insight — hook them, then show why we're different -->
 	<Hero />
+	<section id="agent-readiness" class="bg-neutral-950 px-6 py-12 text-neutral-100">
+		<div class="mx-auto grid max-w-5xl gap-8 md:grid-cols-[1.2fr_0.8fr]">
+			<div>
+				<h2 class="text-3xl font-semibold tracking-tight text-white">What is Frontman?</h2>
+				<p class="mt-4 text-base leading-7 text-neutral-300">Frontman is a browser-aware AI frontend agent. It runs inside your framework dev server or WordPress site, reads live DOM, CSS, screenshots, component context, routes, and logs, then turns visual requests into reviewable source-code edits.</p>
+				<h3 class="mt-8 text-xl font-semibold text-white">Why agents use Frontman</h3>
+				<p class="mt-3 text-base leading-7 text-neutral-300">File-only coding agents guess at rendered UI state. Frontman gives agents runtime evidence: selected elements, computed styles, source mappings, app routes, server logs, and hot reload feedback. That context helps agents make smaller, more accurate frontend changes.</p>
+			</div>
+			<div class="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+				<h3 class="text-lg font-semibold text-white">Developer resources</h3>
+				<ul class="mt-4 space-y-3 text-sm leading-6 text-neutral-300">
+					<li><a class="text-primary-300 underline underline-offset-4" href="/docs/">Frontman docs</a> cover installation, auth, integrations, and reference guides.</li>
+					<li><a class="text-primary-300 underline underline-offset-4" href="/index.md">/index.md</a> provides a markdown homepage for AI crawlers.</li>
+					<li><a class="text-primary-300 underline underline-offset-4" href="/.well-known/agent-card.json">/.well-known/agent-card.json</a> describes Frontman's agent capabilities.</li>
+					<li><a class="text-primary-300 underline underline-offset-4" href="/.well-known/mcp/server-card.json">/.well-known/mcp/server-card.json</a> describes MCP-style local agent integration.</li>
+				</ul>
+			</div>
+		</div>
+	</section>
 	<FullContextSection />
 
 	<!-- Act 2: The Product — show what it does, prove it fits -->

--- a/apps/marketing/src/pages/index.md.ts
+++ b/apps/marketing/src/pages/index.md.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from 'astro'
+
+const body = `# Frontman
+
+Frontman is a browser-aware AI frontend agent for teams building web products. It runs inside your framework dev server or WordPress site, sees live DOM, CSS, screenshots, component context, routes, and logs, then turns visual requests into reviewable source-code edits.
+
+## Core Capabilities
+
+- Select rendered elements and ask Frontman to change copy, spacing, color, layout, or behavior.
+- Use runtime context from Next.js, Astro, Vite, React, Vue, Svelte, and WordPress.
+- Bring your own Claude, ChatGPT, or OpenRouter API key.
+- Keep developers in control with local development edits and normal git diffs.
+- Run Frontman Pro hosted or self-host from the open-source repository.
+
+## Developer Resources
+
+- Documentation: https://frontman.sh/docs/
+- Installation: https://frontman.sh/docs/installation/
+- API keys and auth: https://frontman.sh/docs/api-keys/
+- Configuration: https://frontman.sh/docs/reference/configuration/
+- Architecture: https://frontman.sh/docs/reference/architecture/
+- Self-hosting: https://frontman.sh/docs/reference/self-hosting/
+- Agent card: https://frontman.sh/.well-known/agent-card.json
+- MCP server card: https://frontman.sh/.well-known/mcp/server-card.json
+- Agent skills index: https://frontman.sh/.well-known/agent-skills/index.json
+- API catalog: https://frontman.sh/.well-known/api-catalog
+- GitHub: https://github.com/frontman-ai/frontman
+
+## Authentication And Access
+
+Frontman hosted accounts use OAuth sign-in with GitHub or Google. AI provider access is bring-your-own-key: users connect Claude, ChatGPT, or OpenRouter credentials from Frontman settings. Local framework integrations connect to the Frontman service over authenticated WebSocket sessions.
+
+## Support
+
+- Contact: https://frontman.sh/contact/
+- Privacy: https://frontman.sh/privacy/
+- Terms: https://frontman.sh/terms/
+`
+
+export const GET: APIRoute = () => {
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	})
+}
+
+export const prerender = true

--- a/apps/marketing/src/pages/robots.txt.ts
+++ b/apps/marketing/src/pages/robots.txt.ts
@@ -33,6 +33,7 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
+schemamap: ${new URL('schema-map.xml', import.meta.env.SITE).href}
 Sitemap: ${new URL('sitemap-index.xml', import.meta.env.SITE).href}
 `.trim()
 

--- a/apps/marketing/src/pages/schema-map.xml.ts
+++ b/apps/marketing/src/pages/schema-map.xml.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from 'astro'
+
+const siteUrl = new URL(import.meta.env.SITE)
+const origin = siteUrl.origin
+
+const schemaMap = `<?xml version="1.0" encoding="UTF-8"?>
+<schemaMap xmlns="https://nlweb.ai/schemas/schemamap/1.0">
+  <feed>
+    <loc>${origin}/feeds/structured-data.jsonl</loc>
+    <type>application/ld+json-seq</type>
+    <name>Frontman structured data feed</name>
+    <description>Machine-readable Organization, SoftwareApplication, Product, Service, and FAQ entities for Frontman.</description>
+  </feed>
+  <feed>
+    <loc>${origin}/rss.xml</loc>
+    <type>application/rss+xml</type>
+    <name>Frontman blog RSS</name>
+    <description>Frontman articles and product updates.</description>
+  </feed>
+</schemaMap>`
+
+export const GET: APIRoute = () => {
+	return new Response(schemaMap, {
+		headers: {
+			'Content-Type': 'application/xml; charset=utf-8',
+		},
+	})
+}
+
+export const prerender = true


### PR DESCRIPTION
## Summary
- add agent-facing discovery endpoints for agent card, MCP server card, API catalog, markdown homepage, schema map, and scoped llms.txt files
- upgrade agent skills index schema and publish skill-md artifacts
- expand homepage structured data and add a Cloudflare Pages function for ?mode=agent
- keep pricing markdown removed from discovery output

## Test plan
- yarn install
- make rescript-build
- yarn workspace @frontman-ai/astro build
- cd apps/marketing && make build