### PR TITLE
Deploy marketing Pages Functions

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: yarn
           workingDirectory: apps/marketing
           command: pages deploy dist --project-name=frontman-marketing --branch=main
 

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/marketing/dist --project-name=frontman-marketing --branch=main
+          workingDirectory: apps/marketing
+          command: pages deploy dist --project-name=frontman-marketing --branch=main
 
       - name: Submit to IndexNow
         if: success()


### PR DESCRIPTION
## Summary

- Run Wrangler from `apps/marketing` during marketing deploys.
- Deploy `dist` from that cwd so `apps/marketing/functions/index.ts` is included by Cloudflare Pages.
- Fix production `/?mode=agent` returning homepage HTML after #1185.

## Verification

- Locally verified with `npx wrangler pages dev dist --port 8788 --ip 127.0.0.1` from `apps/marketing`.
- `/?mode=agent` returned JSON.
- `/blog/gpt-5.4-support` still returned the `_redirects` 301.
- `/.well-known/mcp` returned MCP JSON.
