### PR TITLE
Fix empty prompt blocks

### DIFF
--- a/.changeset/fix-empty-prompt-blocks.md
+++ b/.changeset/fix-empty-prompt-blocks.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Avoid sending empty text content blocks for attachment-only prompts.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -175,8 +175,7 @@ defmodule FrontmanServer.Tasks do
       if rule_loaded?(interactions, path) do
         {:ok, :already_loaded}
       else
-        interaction = Interaction.DiscoveredProjectRule.new(path, content)
-        record_interaction(schema, interaction)
+        record_interaction(schema, Interaction.DiscoveredProjectRule.build(path, content))
       end
     end
   end
@@ -192,8 +191,7 @@ defmodule FrontmanServer.Tasks do
       if Enum.any?(interactions, &match?(%Interaction.DiscoveredProjectStructure{}, &1)) do
         {:ok, :already_loaded}
       else
-        interaction = Interaction.DiscoveredProjectStructure.new(summary)
-        record_interaction(task, interaction)
+        record_interaction(task, Interaction.DiscoveredProjectStructure.build(summary))
       end
     end
   end
@@ -505,9 +503,8 @@ defmodule FrontmanServer.Tasks do
       )
       when is_binary(task_id) and is_binary(model) and model != "" and is_list(mcp_tools) and
              is_list(project_traits) do
-    user_message_interaction = Interaction.UserMessage.new(content_blocks, model)
-
-    with {:ok, {task_schema, turn_number}} <-
+    with {:ok, user_message_interaction} <- Interaction.UserMessage.build(content_blocks, model),
+         {:ok, {task_schema, turn_number}} <-
            insert_user_turn_for_locked_task(scope, task_id, user_message_interaction) do
       _ =
         run_execution(scope, task_schema, turn_number, %{
@@ -520,7 +517,7 @@ defmodule FrontmanServer.Tasks do
         GenerateTitle.new(%{
           user_id: scope.user.id,
           task_id: task_id,
-          user_prompt_text: Enum.join(user_message_interaction.messages, "\n"),
+          user_prompt_text: Interaction.user_prompt_text(user_message_interaction),
           model: model
         })
         |> Oban.insert!()
@@ -570,7 +567,7 @@ defmodule FrontmanServer.Tasks do
     with {:ok, task_schema} <- get_task_by_id(scope, task_id) do
       record_interaction(
         task_schema,
-        Interaction.AgentResponse.new(content, metadata),
+        Interaction.AgentResponse.build(content, metadata),
         turn_number
       )
     end
@@ -579,24 +576,25 @@ defmodule FrontmanServer.Tasks do
   @doc "Records how the given agent run ended."
   def record_agent_run_result(scope, task_id, turn_number, outcome)
       when is_integer(turn_number) and turn_number > 0 do
-    interaction =
-      case outcome do
-        :completed -> Interaction.AgentCompleted.new()
-        :cancelled -> turn_error("Cancelled", "cancelled")
-        :terminated -> turn_error("Terminated by supervisor", "terminated")
-        {:failed, error} -> turn_error(error)
-        {:failed, error, retry, category} -> turn_error(error, "failed", retry, category)
-        {:crashed, error} -> turn_error(error, "crashed")
-        {:paused_for_tool_timeout, tool, timeout} -> Interaction.AgentPaused.new(tool, timeout)
-      end
-
     with {:ok, task_schema} <- get_task_by_id(scope, task_id) do
-      record_interaction(task_schema, interaction, turn_number)
+      record_interaction(task_schema, build_agent_run_result(outcome), turn_number)
+    end
+  end
+
+  defp build_agent_run_result(outcome) do
+    case outcome do
+      :completed -> Interaction.AgentCompleted.build()
+      :cancelled -> turn_error("Cancelled", "cancelled")
+      :terminated -> turn_error("Terminated by supervisor", "terminated")
+      {:failed, error} -> turn_error(error)
+      {:failed, error, retry, category} -> turn_error(error, "failed", retry, category)
+      {:crashed, error} -> turn_error(error, "crashed")
+      {:paused_for_tool_timeout, tool, timeout} -> Interaction.AgentPaused.build(tool, timeout)
     end
   end
 
   defp turn_error(error, kind \\ "failed", retryable \\ false, category \\ "unknown"),
-    do: Interaction.AgentError.new(error, kind, retryable, category)
+    do: Interaction.AgentError.build(error, kind, retryable, category)
 
   # --- Tool Requests ---
 
@@ -604,7 +602,7 @@ defmodule FrontmanServer.Tasks do
   def request_client_tool(scope, task_id, turn_number, %SwarmAi.ToolCall{} = tool_call_data)
       when is_integer(turn_number) and turn_number > 0 do
     with {:ok, schema} <- get_task_by_id(scope, task_id),
-         {:ok, interaction} <- Interaction.ToolCall.new(tool_call_data) do
+         {:ok, interaction} <- Interaction.ToolCall.build(tool_call_data) do
       record_interaction(schema, interaction, turn_number)
     end
   end
@@ -632,7 +630,7 @@ defmodule FrontmanServer.Tasks do
 
     with {:ok, schema} <- get_task_by_id(scope, task_id),
          turn_number = tool_result_turn_number(task_id, tool_call_id, opts),
-         interaction = Interaction.ToolResult.new(tool_call_data, result, is_error),
+         interaction = Interaction.ToolResult.build(tool_call_data, result, is_error),
          {:ok, interaction} <- record_interaction(schema, interaction, turn_number) do
       executor_status = Execution.notify_tool_result(interaction)
 
@@ -705,8 +703,8 @@ defmodule FrontmanServer.Tasks do
          {:ok, turn_number} <- retry_turn_number(task_id, retried_error_id),
          :ok <- ensure_latest_retry_turn(turn_number, rows),
          {:ok, execution} <- ensure_execution_model(task_id, turn_number, execution),
-         {:ok, _retry} <-
-           record_interaction(schema, Interaction.AgentRetry.new(retried_error_id), turn_number) do
+         retry_interaction = Interaction.AgentRetry.build(retried_error_id),
+         {:ok, _retry} <- record_interaction(schema, retry_interaction, turn_number) do
       run_execution(scope, schema, turn_number, execution)
     end
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -385,31 +385,42 @@ defmodule FrontmanServer.Tasks.Interaction do
       embeds_one :current_page, CurrentPage
     end
 
-    def new(content_blocks, model \\ nil) do
-      %__MODULE__{
-        id: Interaction.new_id(),
-        timestamp: Interaction.now(),
-        model: model,
-        messages: extract_messages(content_blocks),
-        annotations: extract_annotations(content_blocks),
-        selected_figma_node: extract_selected_figma_node(content_blocks),
-        images: extract_user_images(content_blocks),
-        current_page: extract_current_page(content_blocks)
-      }
+    def build(content_blocks, model \\ nil) do
+      with {:ok, messages} <- extract_messages(content_blocks) do
+        {:ok,
+         %__MODULE__{
+           id: Interaction.new_id(),
+           timestamp: Interaction.now(),
+           model: model,
+           messages: messages,
+           annotations: extract_annotations(content_blocks),
+           selected_figma_node: extract_selected_figma_node(content_blocks),
+           images: extract_user_images(content_blocks),
+           current_page: extract_current_page(content_blocks)
+         }}
+      end
     end
 
     # Extract text messages from content blocks
     defp extract_messages(content_blocks) do
-      Enum.flat_map(content_blocks, fn
-        %{"type" => "text", "text" => text} when is_binary(text) and text != "" ->
-          [text]
+      content_blocks
+      |> Enum.reduce_while({:ok, []}, fn
+        %{"type" => "text", "text" => text}, {:ok, messages}
+        when is_binary(text) and text != "" ->
+          {:cont, {:ok, [text | messages]}}
 
-        %{"type" => "text"} ->
-          raise ArgumentError, "text content block must include non-empty string text"
+        %{"type" => "text"}, {:ok, _messages} ->
+          {:halt,
+           {:error,
+            {:invalid_content_block, "text content block must include non-empty string text"}}}
 
-        _block ->
-          []
+        _block, {:ok, messages} ->
+          {:cont, {:ok, messages}}
       end)
+      |> case do
+        {:ok, messages} -> {:ok, Enum.reverse(messages)}
+        {:error, reason} -> {:error, reason}
+      end
     end
 
     # Extract annotations from content blocks.
@@ -563,7 +574,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :metadata, :map
     end
 
-    def new(content, metadata \\ %{}) do
+    def build(content, metadata \\ %{}) do
       %__MODULE__{
         id: Interaction.new_id(),
         content: content,
@@ -587,7 +598,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :result, :map
     end
 
-    def new(result \\ nil) do
+    def build(result \\ nil) do
       %__MODULE__{
         id: Interaction.new_id(),
         timestamp: Interaction.now(),
@@ -623,7 +634,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     `retryable` indicates whether the client should offer a retry action.
     `category` is a machine-readable error category (e.g. "rate_limit", "context_limit").
     """
-    def new(error, kind \\ "failed", retryable \\ false, category \\ "unknown") do
+    def build(error, kind \\ "failed", retryable \\ false, category \\ "unknown") do
       %__MODULE__{
         id: Interaction.new_id(),
         timestamp: Interaction.now(),
@@ -650,7 +661,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :retried_error_id, :string
     end
 
-    def new(retried_error_id) do
+    def build(retried_error_id) do
       %__MODULE__{
         id: Interaction.new_id(),
         timestamp: Interaction.now(),
@@ -677,7 +688,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :timeout_ms, :integer
     end
 
-    def new(tool_name, timeout_ms) do
+    def build(tool_name, timeout_ms) do
       %__MODULE__{
         id: Interaction.new_id(),
         timestamp: Interaction.now(),
@@ -704,7 +715,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :timestamp, :utc_datetime_usec
     end
 
-    def new(%SwarmAi.ToolCall{} = tc) do
+    def build(%SwarmAi.ToolCall{} = tc) do
       case SwarmAi.ToolCall.parse_arguments(tc) do
         {:ok, arguments} ->
           {:ok,
@@ -739,7 +750,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :timestamp, :utc_datetime_usec
     end
 
-    def new(tool_call_data, result, is_error \\ false) do
+    def build(tool_call_data, result, is_error \\ false) do
       %__MODULE__{
         id: Interaction.new_id(),
         tool_call_id: tool_call_data.id,
@@ -768,7 +779,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :timestamp, :utc_datetime_usec
     end
 
-    def new(path, content) do
+    def build(path, content) do
       %__MODULE__{
         path: path,
         content: content,
@@ -793,7 +804,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :timestamp, :utc_datetime_usec
     end
 
-    def new(summary) do
+    def build(summary) do
       %__MODULE__{
         summary: summary,
         timestamp: Interaction.now()
@@ -904,7 +915,7 @@ defmodule FrontmanServer.Tasks.Interaction do
   end
 
   defp to_swarm_message(%UserMessage{} = msg) do
-    prompt_text = build_user_prompt_text(msg)
+    prompt_text = user_prompt_text(msg)
     content_parts = build_user_content_parts(prompt_text, msg)
 
     [build_swarm_user_message(content_parts)]
@@ -941,7 +952,7 @@ defmodule FrontmanServer.Tasks.Interaction do
   defp to_swarm_message(%DiscoveredProjectRule{}), do: []
   defp to_swarm_message(%DiscoveredProjectStructure{}), do: []
 
-  defp build_user_prompt_text(%UserMessage{} = msg) do
+  def user_prompt_text(%UserMessage{} = msg) do
     msg.messages
     |> Enum.join("\n\n")
     |> CurrentPageContext.append_prompt_section(msg.current_page)

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -705,9 +705,17 @@ defmodule FrontmanServerWeb.TaskChannel do
 
             {:noreply, socket}
 
+          {:error, {:invalid_content_block, message}} ->
+            Logger.error("Failed to add user message: #{message}")
+
+            error_response =
+              JsonRpc.error_response(id, JsonRpc.error_invalid_params(), message)
+
+            {:reply, {:ok, %{@acp_message => error_response}}, socket}
+
           {:error, reason} ->
             Logger.error("Failed to add user message: #{inspect(reason)}")
-            error_response = JsonRpc.error_response(id, -32_000, to_string(reason))
+            error_response = JsonRpc.error_response(id, -32_000, inspect(reason))
             {:reply, {:ok, %{@acp_message => error_response}}, socket}
         end
 

--- a/apps/frontman_server/lib/frontman_server_web/protocols/acp_history_impl.ex
+++ b/apps/frontman_server/lib/frontman_server_web/protocols/acp_history_impl.ex
@@ -14,7 +14,7 @@ defimpl ACPHistory, for: Interaction.UserMessage do
   Reconstructs the original ACP content blocks from stored UserMessage fields
   and replays them as `user_message_chunk` notifications.
 
-  This is the inverse of `Interaction.UserMessage.new/1` which extracts fields
+  This is the inverse of `Interaction.UserMessage.build/1` which extracts fields
   from incoming content blocks.
   """
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -196,6 +196,38 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
                2
     end
 
+    test "returns invalid content block errors instead of raising", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      assert {:error,
+              {:invalid_content_block, "text content block must include non-empty string text"}} =
+               submit_user_message(scope, task_id, [%{"type" => "text", "text" => ""}])
+    end
+
+    test "uses resource context for attachment-only first turn title text", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      expect_llm_responses(["Response"])
+
+      {:ok, _, 1} =
+        submit_user_message(scope, task_id, [
+          current_page_block("https://example.com/app", %{
+            "viewport_width" => 390,
+            "viewport_height" => 844
+          })
+        ])
+
+      title_job =
+        all_enqueued(worker: GenerateTitle)
+        |> Enum.find(&(&1.args["task_id"] == task_id))
+
+      assert title_job.args["user_prompt_text"] =~ "https://example.com/app"
+
+      assert_receive {:interaction, %Interaction.AgentCompleted{}, 1}, 5_000
+    end
+
     test "startup failure persists terminal error on the same turn" do
       scope = user_scope_fixture()
       task_id = task_with_pubsub_fixture(scope).id
@@ -512,7 +544,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       Phoenix.PubSub.broadcast(
         FrontmanServer.PubSub,
         task_topic(task_id),
-        {:interaction, Interaction.AgentPaused.new("question", 120_000), 1}
+        {:interaction, Interaction.AgentPaused.build("question", 120_000), 1}
       )
 
       :sys.get_state(socket.channel_pid)

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_agent_retry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_agent_retry_test.exs
@@ -3,22 +3,24 @@ defmodule FrontmanServer.Tasks.InteractionAgentRetryTest do
 
   alias FrontmanServer.Tasks.Interaction
 
-  describe "AgentError new fields" do
-    test "new/4 sets retryable and category" do
-      err = Interaction.AgentError.new("Rate limited", "failed", true, "rate_limit")
+  describe "AgentError build fields" do
+    test "build/4 sets retryable and category" do
+      err = Interaction.AgentError.build("Rate limited", "failed", true, "rate_limit")
+
       assert err.retryable == true
       assert err.category == "rate_limit"
       assert err.error == "Rate limited"
     end
 
-    test "new/2 defaults retryable=false, category=unknown" do
-      err = Interaction.AgentError.new("Something went wrong", "failed")
+    test "build/2 defaults retryable=false, category=unknown" do
+      err = Interaction.AgentError.build("Something went wrong", "failed")
       assert err.retryable == false
       assert err.category == "unknown"
     end
 
     test "Jason.Encoder includes retryable and category" do
-      err = Interaction.AgentError.new("Rate limited", "failed", true, "rate_limit")
+      err = Interaction.AgentError.build("Rate limited", "failed", true, "rate_limit")
+
       encoded = Jason.encode!(err)
       decoded = Jason.decode!(encoded)
       assert decoded["retryable"] == true
@@ -28,15 +30,15 @@ defmodule FrontmanServer.Tasks.InteractionAgentRetryTest do
   end
 
   describe "AgentRetry" do
-    test "new/1 creates with retried_error_id" do
-      retry = Interaction.AgentRetry.new("error-123")
+    test "build/1 creates with retried_error_id" do
+      retry = Interaction.AgentRetry.build("error-123")
       assert retry.retried_error_id == "error-123"
       assert is_binary(retry.id)
       assert %DateTime{} = retry.timestamp
     end
 
     test "Jason.Encoder includes type and retried_error_id" do
-      retry = Interaction.AgentRetry.new("error-123")
+      retry = Interaction.AgentRetry.build("error-123")
       decoded = Jason.decode!(Jason.encode!(retry))
       assert decoded["type"] == "agent_retry"
       assert decoded["retried_error_id"] == "error-123"

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -14,33 +14,46 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   alias ModelContextProtocol, as: MCP
 
   # ---------------------------------------------------------------------------
-  # UserMessage.new/1
+  # UserMessage.build/1
   # ---------------------------------------------------------------------------
 
-  describe "UserMessage.new/1" do
+  describe "UserMessage.build/1" do
     test "extracts non-empty text messages" do
-      msg = UserMessage.new([text_block("Hello")])
+      msg = build_user_message([text_block("Hello")])
 
       assert msg.messages == ["Hello"]
     end
 
-    test "raises for text blocks without non-empty string text" do
-      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
-        UserMessage.new([%{"type" => "text"}])
-      end
+    test "accepts resource-only prompts without a text block" do
+      msg =
+        build_user_message([
+          current_page_block("https://example.com/app", %{
+            "viewport_width" => 390,
+            "viewport_height" => 844
+          })
+        ])
 
-      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
-        UserMessage.new([%{"type" => "text", "text" => ""}])
-      end
+      assert msg.messages == []
+      assert msg.current_page.url == "https://example.com/app"
+    end
 
-      assert_raise ArgumentError, "text content block must include non-empty string text", fn ->
-        UserMessage.new([%{"type" => "text", "text" => 1}])
-      end
+    test "returns error for text blocks without non-empty string text" do
+      assert {:error,
+              {:invalid_content_block, "text content block must include non-empty string text"}} =
+               UserMessage.build([%{"type" => "text"}])
+
+      assert {:error,
+              {:invalid_content_block, "text content block must include non-empty string text"}} =
+               UserMessage.build([%{"type" => "text", "text" => ""}])
+
+      assert {:error,
+              {:invalid_content_block, "text content block must include non-empty string text"}} =
+               UserMessage.build([%{"type" => "text", "text" => 1}])
     end
 
     test "extracts annotation from resource block" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Hello"),
           annotation_block("ann-1", "div", "/path/to/component.tsx", 42, 10)
         ])
@@ -56,13 +69,13 @@ defmodule FrontmanServer.Tasks.InteractionTest do
     end
 
     test "returns empty annotations when no annotation blocks" do
-      msg = UserMessage.new([text_block("Hello")])
+      msg = build_user_message([text_block("Hello")])
       assert msg.annotations == []
     end
 
     test "pairs screenshot with annotation by annotation_id" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Fix this button"),
           annotation_block("ann-1", "button", "/src/Button.tsx", 15, 3),
           screenshot_block("ann-1", "base64screenshotdata")
@@ -79,7 +92,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
     test "extracts multiple annotations with enrichment data" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Fix these"),
           annotation_block("ann-1", "div", "/src/A.tsx", 10, 1,
             component_name: "Header",
@@ -105,7 +118,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       bb = %{"x" => 10.5, "y" => 20.0, "width" => 200.0, "height" => 50.0}
 
       msg =
-        UserMessage.new([
+        build_user_message([
           annotation_block("ann-bb", "div", "/src/Component.tsx", 5, 1, bounding_box: bb)
         ])
 
@@ -126,7 +139,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       }
 
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Fix this"),
           annotation_block("ann-el", "span", "/src/Component.tsx", 5, 1,
             metadata: %{"custom_context" => context}
@@ -139,7 +152,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
     test "extracts current page context from resource block" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Hello"),
           current_page_block("https://example.com/app", %{
             "viewport_width" => 390,
@@ -164,7 +177,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
     test "coerces integer device pixel ratio before persistence" do
       msg =
-        UserMessage.new([
+        build_user_message([
           current_page_block("https://example.com/app", %{"device_pixel_ratio" => 1})
         ])
 
@@ -175,7 +188,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
     test "ignores resource url meta without current page marker" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Hello"),
           %{
             "type" => "resource",
@@ -558,7 +571,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   describe "InteractionSchema.to_struct/1" do
     test "deserializes normalized user message data" do
       message =
-        UserMessage.new([
+        build_user_message([
           text_block("hello"),
           current_page_block("http://localhost:4321/"),
           annotation_block("ann-1", "H1", "/src/Hero.tsx", 12, 4,
@@ -583,7 +596,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   describe "JSON encoding" do
     test "encodes UserMessage with annotation including all enrichment fields" do
       msg =
-        UserMessage.new([
+        build_user_message([
           text_block("Fix this"),
           annotation_block("ann-full", "H1", "/src/Hero.tsx", 30, 5,
             component_name: "Hero",
@@ -648,8 +661,8 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   end
 
   describe "AgentPaused" do
-    test "new/2 builds struct with correct fields" do
-      interaction = Interaction.AgentPaused.new("question", 120_000)
+    test "build/2 builds struct with correct fields" do
+      interaction = Interaction.AgentPaused.build("question", 120_000)
 
       assert interaction.tool_name == "question"
       assert interaction.timeout_ms == 120_000
@@ -663,5 +676,10 @@ defmodule FrontmanServer.Tasks.InteractionTest do
     test "AgentPaused is in interaction_modules list" do
       assert Interaction.AgentPaused in Interaction.interaction_modules()
     end
+  end
+
+  defp build_user_message(content_blocks) do
+    assert {:ok, message} = UserMessage.build(content_blocks)
+    message
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -23,11 +23,13 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       {:execution_chunk, 1,
        %{type: :tool_call, name: name, arguments: %{}, metadata: %{id: id, index: 0}}}
 
-  defp agent_completed,
-    do: {:interaction, Interaction.AgentCompleted.new(), 1}
+  defp agent_completed do
+    {:interaction, Interaction.AgentCompleted.build(), 1}
+  end
 
-  defp agent_failed(message, category \\ "unknown"),
-    do: {:interaction, Interaction.AgentError.new(message, "failed", false, category), 1}
+  defp agent_failed(message, category \\ "unknown") do
+    {:interaction, Interaction.AgentError.build(message, "failed", false, category), 1}
+  end
 
   defp broadcast_retryable_error(scope, task_id) do
     user_message_fixture(scope, task_id, [%{"type" => "text", "text" => "retry me"}])
@@ -44,8 +46,9 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     error_interaction
   end
 
-  defp agent_cancelled,
-    do: {:interaction, Interaction.AgentError.new("Cancelled", "cancelled"), 1}
+  defp agent_cancelled do
+    {:interaction, Interaction.AgentError.build("Cancelled", "cancelled"), 1}
+  end
 
   # Collects all pending push messages from the test process mailbox.
   # Phoenix.ChannelTest sends pushes as {:socket_push, event, payload} messages.
@@ -198,6 +201,28 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       )
 
       assert_agent_turn_complete(task_id)
+    end
+
+    test "returns invalid params for malformed text content block", %{socket: socket} do
+      complete_mcp_handshake(socket)
+
+      ref =
+        push(
+          socket,
+          "acp:message",
+          build_acp_request("session/prompt", 44, %{
+            "prompt" => [%{"type" => "text", "text" => ""}],
+            "_meta" => %{
+              "model" => %{"provider" => "openrouter", "value" => "google/gemini-3-flash-preview"}
+            }
+          })
+        )
+
+      assert_reply(ref, :ok, %{"acp:message" => response})
+      assert response["error"]["code"] == JsonRpc.error_invalid_params()
+
+      assert response["error"]["message"] ==
+               "text content block must include non-empty string text"
     end
   end
 

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -76,7 +76,7 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
   """
   def user_message_fixture(scope, task_id, content_blocks) do
     task = task_schema!(scope, task_id)
-    interaction = Interaction.UserMessage.new(content_blocks, @default_test_model)
+    {:ok, interaction} = Interaction.UserMessage.build(content_blocks, @default_test_model)
 
     case InteractionSchema.create_changeset(task, interaction, next_turn_number(task_id))
          |> Repo.insert() do

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -392,11 +392,14 @@ let sendPrompt = async (
   ~additionalBlocks: array<Types.contentBlock>=[],
   ~_meta: option<JSON.t>=None,
 ): result<Types.promptResult, string> => {
-  // Build prompt array starting with the text block
-  let textBlock: Types.contentBlock = TextContent({text, _meta: None, annotations: None})
+  let baseBlocks: array<Types.contentBlock> = switch text->String.trim != "" {
+  | true => [TextContent({text, _meta: None, annotations: None})]
+  | false => []
+  }
+
   // Serialize through S.unknown to avoid strict JSON checks on option fields inside union arms.
   let allBlocks =
-    Array.concat([textBlock], additionalBlocks)->Array.map(block =>
+    Array.concat(baseBlocks, additionalBlocks)->Array.map(block =>
       block->S.decodeOrThrow(~from=Types.contentBlockSchema, ~to=S.json->S.noValidation(true))
     )
 


### PR DESCRIPTION
## Summary
- avoid emitting empty ACP text content blocks from the frontman client
- replace raising user-message construction with result-returning validation
- keep infallible interaction builders simple while validating malformed text blocks

## Verification
- mix test test/frontman_server/tasks/interaction_test.exs test/frontman_server/tasks/interaction_agent_retry_test.exs test/frontman_server/tasks/execution_test.exs test/frontman_server_web/channels/task_channel_test.exs
- cd libs/frontman-client && make test
- cd apps/marketing && make build
- git diff --check HEAD
- mix format --check-formatted lib/frontman_server/tasks.ex lib/frontman_server/tasks/interaction.ex test/frontman_server/tasks/execution_test.exs test/frontman_server/tasks/interaction_agent_retry_test.exs test/frontman_server/tasks/interaction_test.exs test/frontman_server_web/channels/task_channel_test.exs test/support/fixtures/tasks.ex

Note: pre-commit and pre-push hooks also passed.