### PR TITLE
Fix retry error identity handling

### DIFF
--- a/.changeset/fast-ravens-spark.md
+++ b/.changeset/fast-ravens-spark.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix production agent failures where provider rate-limit retry delays surfaced as stream stalls, and tolerate client-generated retry IDs when retrying failed turns.

--- a/.changeset/strict-retry-error-ids.md
+++ b/.changeset/strict-retry-error-ids.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-protocol": patch
+---
+
+Carry stable agent error IDs through retry error updates.

--- a/apps/frontman_server/lib/agent_client_protocol.ex
+++ b/apps/frontman_server/lib/agent_client_protocol.ex
@@ -294,14 +294,15 @@ defmodule AgentClientProtocol do
   Pass `retry_opts` when the server is scheduling an automatic retry. The client
   uses `retryAt` to show a countdown and infers retry state from its presence.
 
-    retry_opts: [retry_at: %DateTime{}, attempt: 1, max_attempts: 5]
+    retry_opts: [category: "rate_limit", agent_error_id: "err_...", retry_at: %DateTime{}, attempt: 1, max_attempts: 5]
   """
   def build_error_notification(session_id, message, timestamp, retry_opts \\ []) do
     update = %{
       "sessionUpdate" => "error",
       "message" => message,
       "timestamp" => DateTime.to_iso8601(timestamp),
-      "category" => Keyword.get(retry_opts, :category, "unknown")
+      "category" => Keyword.fetch!(retry_opts, :category),
+      "_meta" => %{"frontman.dev/agentErrorId" => Keyword.fetch!(retry_opts, :agent_error_id)}
     }
 
     update =

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -695,7 +695,7 @@ defmodule FrontmanServer.Tasks do
     with {:ok, schema} <- get_task_by_id(scope, task_id),
          rows = load_interaction_rows(task_id),
          {:ok, turn_number} <- retry_turn_number(task_id, retried_error_id),
-         :ok <- ensure_latest_retry_turn(turn_number, rows),
+         :ok <- ensure_latest_retry_turn(retried_error_id, turn_number, rows),
          {:ok, execution} <- ensure_execution_model(task_id, turn_number, execution),
          retry_interaction = Interaction.AgentRetry.build(retried_error_id),
          {:ok, _retry} <- record_interaction(schema, retry_interaction, turn_number) do
@@ -719,8 +719,19 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp ensure_latest_retry_turn(turn_number, rows) do
-    if turn_number == latest_turn_number(rows), do: :ok, else: {:error, :stale_turn}
+  defp ensure_latest_retry_turn(retried_error_id, turn_number, rows) do
+    latest_turn_interaction =
+      rows
+      |> Enum.reverse()
+      |> Enum.find(&(&1.turn_number == turn_number))
+
+    case {turn_number == latest_turn_number(rows), latest_turn_interaction} do
+      {true, %InteractionSchema{type: :agent_error, data: %{"id" => ^retried_error_id}}} ->
+        :ok
+
+      _ ->
+        {:error, :stale_turn}
+    end
   end
 
   @doc "Resumes execution for the active agent run."

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -644,21 +644,15 @@ defmodule FrontmanServer.Tasks do
         turn_number
 
       :error ->
-        persisted_tool_call_turn_number(task_id, tool_call_id)
-    end
-  end
-
-  defp persisted_tool_call_turn_number(task_id, tool_call_id) do
-    row =
-      InteractionSchema.for_task(task_id)
-      |> InteractionSchema.of_type(Interaction.ToolCall)
-      |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
-      |> Repo.one()
-
-    case row do
-      %InteractionSchema{turn_number: turn_number}
-      when is_integer(turn_number) and turn_number > 0 ->
-        turn_number
+        InteractionSchema.for_task(task_id)
+        |> InteractionSchema.of_type(Interaction.ToolCall)
+        |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
+        |> Repo.one()
+        |> case do
+          %InteractionSchema{turn_number: turn_number}
+          when is_integer(turn_number) and turn_number > 0 ->
+            turn_number
+        end
     end
   end
 
@@ -710,13 +704,19 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp retry_turn_number(task_id, retried_error_id) do
-    %InteractionSchema{turn_number: turn_number} =
+    row =
       InteractionSchema.for_task(task_id)
       |> InteractionSchema.of_type(Interaction.AgentError)
       |> InteractionSchema.data_equals("id", retried_error_id)
       |> Repo.one()
 
-    {:ok, turn_number}
+    case row do
+      %InteractionSchema{turn_number: turn_number} ->
+        {:ok, turn_number}
+
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   defp ensure_latest_retry_turn(turn_number, rows) do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
@@ -26,6 +26,8 @@ defmodule FrontmanServer.Tasks.Execution.ErrorClassifier do
     classify_reqllm_request(status, reason)
   end
 
+  def classify_error({:llm_error, reason}), do: classify_error(reason)
+
   def classify_error(:no_api_key), do: {"No API key available for this request.", "auth", false}
   def classify_error(:missing_model), do: {"Model is required for this request.", "auth", false}
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
@@ -74,6 +74,7 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
     llm_opts =
       client.llm_opts
       |> Keyword.put_new(:tools, reqllm_tools)
+      |> Keyword.put_new(:max_retries, 0)
       |> Keyword.reject(fn
         {:parallel_tool_calls, _value} -> true
         {_key, value} -> value == []

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -289,7 +289,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   defp handle_interaction(%Tasks.Interaction.AgentError{} = error, turn_number, socket) do
-    finalize_turn(socket, {:error, error.error, error.category}, turn_number)
+    finalize_turn(socket, {:error, error.id, error.error, error.category}, turn_number)
   end
 
   defp handle_interaction(_interaction, _turn_number, socket) do
@@ -811,7 +811,11 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     case RetryCoordinator.handle_error(socket.assigns[:retry_state], error_info) do
       {:exhausted, error_info} ->
-        finalize_turn(socket, {:error, error_info.message, error_info.category}, turn_number)
+        finalize_turn(
+          socket,
+          {:error, error_info.retried_error_id, error_info.message, error_info.category},
+          turn_number
+        )
 
       {:retry_scheduled, state, notification} ->
         notification =
@@ -819,7 +823,8 @@ defmodule FrontmanServerWeb.TaskChannel do
             retry_at: notification.retry_at,
             attempt: notification.attempt,
             max_attempts: notification.max_attempts,
-            category: notification.category
+            category: notification.category,
+            agent_error_id: state.retried_error_id
           )
 
         push(socket, @acp_message, notification)
@@ -841,11 +846,14 @@ defmodule FrontmanServerWeb.TaskChannel do
         push(socket, @acp_message, notification)
         {:noreply, socket}
 
-      {:error, message, category} ->
+      {:error, agent_error_id, message, category} ->
         socket = resolve_pending_prompt(socket, {:error, message}, turn_number)
 
         notification =
-          ACP.build_error_notification(task_id, message, DateTime.utc_now(), category: category)
+          ACP.build_error_notification(task_id, message, DateTime.utc_now(),
+            category: category,
+            agent_error_id: agent_error_id
+          )
 
         push(socket, @acp_message, notification)
         {:noreply, socket}

--- a/apps/frontman_server/lib/frontman_server_web/protocols/acp_history_impl.ex
+++ b/apps/frontman_server/lib/frontman_server_web/protocols/acp_history_impl.ex
@@ -185,12 +185,17 @@ end
 
 defimpl ACPHistory, for: Interaction.AgentError do
   def to_history_items(
-        %Interaction.AgentError{error: error, category: category, timestamp: timestamp},
+        %Interaction.AgentError{id: id, error: error, category: category, timestamp: timestamp},
         session_id
       ) do
     # Replay errors as sessionUpdate: "error" notifications so the client
     # renders them the same as live agent errors.
-    [ACP.build_error_notification(session_id, error, timestamp, category: category)]
+    [
+      ACP.build_error_notification(session_id, error, timestamp,
+        category: category,
+        agent_error_id: id
+      )
+    ]
   end
 end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
@@ -18,6 +18,12 @@ defmodule FrontmanServer.Tasks.ExecutionClassifyErrorTest do
       assert String.contains?(msg, "Rate limited")
     end
 
+    test "wrapped llm_error request error delegates to underlying classifier" do
+      err = {:llm_error, Request.exception(status: 429, reason: "Too many requests")}
+      {msg, "rate_limit", true} = ErrorClassifier.classify_error(err)
+      assert String.contains?(msg, "Rate limited")
+    end
+
     test "ReqLLM stream error with request cause 413 is classified as payload too large" do
       request_error =
         Request.exception(

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -9,6 +9,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   use FrontmanServer.ExecutionCase
   use Oban.Testing, repo: FrontmanServer.Repo
 
+  import Mox
   import Phoenix.ChannelTest
 
   import FrontmanServer.InteractionCase.Helpers,
@@ -30,9 +31,12 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
   alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Execution.LLMProviderMock
   alias FrontmanServer.Tasks.{Interaction, InteractionSchema}
+  alias FrontmanServer.Test.Fixtures.ReqLLMResponses
   alias FrontmanServer.Tools.MCP
   alias FrontmanServer.Workers.GenerateTitle
+  alias ReqLLM.Error.API.Request
 
   @endpoint FrontmanServerWeb.Endpoint
   @acp_message AgentClientProtocol.event_acp_message()
@@ -860,6 +864,58 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert agent_error.kind == "failed"
       assert agent_error.retryable == false
       assert agent_error.category == "unknown"
+    end
+
+    @tag :capture_log
+    test "retryable provider failures retry only after channel timer fires", %{
+      task_id: task_id,
+      scope: scope,
+      socket: socket
+    } do
+      Phoenix.PubSub.subscribe(FrontmanServer.PubSub, task_topic(task_id))
+
+      attempts = :counters.new(1, [])
+
+      expect(LLMProviderMock, :stream_text, 2, fn
+        _model, _messages, opts ->
+          provider_attempts = if Keyword.get(opts, :max_retries, 2) == 0, do: 1, else: 2
+          :counters.add(attempts, 1, provider_attempts)
+
+          case :counters.get(attempts, 1) do
+            1 ->
+              {:error, Request.exception(status: 429, reason: "rate limited")}
+
+            count when count > 1 ->
+              ReqLLMResponses.response("Recovered")
+          end
+      end)
+
+      {:ok, _, 1} = submit_user_message(scope, task_id, user_content("Hello"))
+
+      assert_receive {:interaction,
+                      %Interaction.AgentError{retryable: true, category: "rate_limit"}, 1},
+                     5_000
+
+      :sys.get_state(socket.channel_pid)
+
+      assert :counters.get(attempts, 1) == 1
+
+      assert_push(@acp_message, %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "error",
+            "category" => "rate_limit",
+            "attempt" => 1,
+            "retryAt" => _
+          }
+        }
+      })
+
+      %{assigns: %{retry_state: retry_state}} = :sys.get_state(socket.channel_pid)
+      send(socket.channel_pid, {:fire_retry, retry_state.timer_token})
+
+      assert_receive {:interaction, %Interaction.AgentCompleted{}, 1}, 5_000
+      assert :counters.get(attempts, 1) == 2
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -229,9 +229,8 @@ defmodule FrontmanServer.TasksTest do
       task_id = task_fixture(scope).id
       {:ok, user_message} = user_message_fixture(scope, task_id, user_content("not an error"))
 
-      assert_raise MatchError, fn ->
-        Tasks.retry_execution(scope, task_id, user_message.id, execution_request_fixture())
-      end
+      assert {:error, :not_found} =
+               Tasks.retry_execution(scope, task_id, user_message.id, execution_request_fixture())
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -232,6 +232,21 @@ defmodule FrontmanServer.TasksTest do
       assert {:error, :not_found} =
                Tasks.retry_execution(scope, task_id, user_message.id, execution_request_fixture())
     end
+
+    test "rejects an older error after later interactions in the same turn", %{scope: scope} do
+      task_id = task_fixture(scope).id
+      insert_interaction_row(task_id, Interaction.UserMessage, 1)
+      insert_interaction_row(task_id, Interaction.AgentError, 1, %{"id" => "error-1"})
+
+      insert_interaction_row(task_id, Interaction.AgentRetry, 1, %{
+        "retried_error_id" => "error-1"
+      })
+
+      insert_interaction_row(task_id, Interaction.AgentCompleted, 1)
+
+      assert {:error, :stale_turn} =
+               Tasks.retry_execution(scope, task_id, "error-1", execution_request_fixture())
+    end
   end
 
   describe "resume_execution/3" do

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1385,6 +1385,38 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert_agent_turn_complete(task_id)
     end
 
+    test "session/retry_turn rejects client-generated error ids", %{
+      scope: scope,
+      socket: socket,
+      task_id: task_id
+    } do
+      user_message_fixture(scope, task_id, [%{"type" => "text", "text" => "retry me"}])
+      turn_number = latest_turn_number(task_id)
+
+      {:ok, _error_interaction} =
+        Tasks.record_agent_run_result(scope, task_id, turn_number, {:failed, "Rate limited"})
+
+      retried_error_id = "error-#{task_id}-2026-06-26T17:13:06.931002Z"
+
+      push(
+        socket,
+        "acp:message",
+        build_acp_request("session/retry_turn", nil, %{
+          "sessionId" => task_id,
+          "retriedErrorId" => retried_error_id
+        })
+      )
+
+      :sys.get_state(socket.channel_pid)
+
+      {:ok, task} = Tasks.get_task(scope, task_id)
+
+      refute Enum.any?(
+               task.interactions,
+               &match?(%Interaction.AgentRetry{}, &1)
+             )
+    end
+
     test "cancel during retry countdown clears pending retry without recording retry", %{
       scope: scope,
       socket: socket,

--- a/apps/frontman_server/test/protocols/acp_contract_test.exs
+++ b/apps/frontman_server/test/protocols/acp_contract_test.exs
@@ -112,17 +112,25 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.build_error_notification/3" do
+  describe "AgentClientProtocol.build_error_notification/4" do
     test "validates against jsonrpc/notification and acp/sessionUpdateNotification schemas" do
       payload =
         AgentClientProtocol.build_error_notification(
           "session-123",
           "Rate limit exceeded",
-          DateTime.utc_now()
+          DateTime.utc_now(),
+          category: "rate_limit",
+          agent_error_id: "agent-error-123"
         )
 
       ProtocolSchema.validate!(payload, "jsonrpc/notification")
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
+
+      assert %{
+               "params" => %{
+                 "update" => %{"_meta" => %{"frontman.dev/agentErrorId" => "agent-error-123"}}
+               }
+             } = payload
     end
   end
 

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -106,7 +106,6 @@ let make = (~onConfigureProvider: unit => unit) => {
   let sessionInitialized = Client__State.useSelector(Client__State.Selectors.sessionInitialized)
   let planEntries = Client__State.useSelector(Client__State.Selectors.currentPlanEntries)
   let turnError = Client__State.useSelector(Client__State.Selectors.turnError)
-  let lastErrorId = Client__State.useSelector(Client__State.Selectors.lastErrorId)
   let currentTaskId = Client__State.useSelector(Client__State.Selectors.currentTaskId)
   let retryStatus = Client__State.useSelector(Client__State.Selectors.retryStatus)
   let configOptions = Client__State.useSelector(Client__State.Selectors.configOptions)
@@ -396,16 +395,12 @@ let make = (~onConfigureProvider: unit => unit) => {
         // Error banner (shows when there's a turn error, or retry banner during countdown)
         {switch (retryStatus, turnError, currentTaskId) {
         | (Some(rs), _, _) => <Client__RetryBanner retryStatus=rs />
-        | (None, Some({message, category}), Some(taskId)) =>
+        | (None, Some({id, message, category}), Some(taskId)) =>
           <ErrorBanner
             error=message
             category
             onConfigureProvider
-            onRetry={() =>
-              Client__State.Actions.retryTurn(
-                ~taskId,
-                ~retriedErrorId=lastErrorId->Option.getOr(""),
-              )}
+            onRetry={() => Client__State.Actions.retryTurn(~taskId, ~retriedErrorId=id)}
           />
         | _ => React.null
         }}

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -567,7 +567,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
     ACP.cancelPrompt(session)
 
   | RetryTurnEffect({session, retriedErrorId}) =>
-    // ACP spec: session/retry_turn is a notification (fire-and-forget).
+    // Frontman extension: session/retry_turn is a notification (fire-and-forget).
     // Signals the server to retry the failed agent turn.
     ACP.retryTurn(session, ~retriedErrorId)
 

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -26,6 +26,20 @@ let getContentBlockText = (block: Types.contentBlock): option<string> =>
   | ImageContent(_) | AudioContent(_) | ResourceLink(_) | EmbeddedResource(_) => None
   }
 
+@schema
+type frontmanErrorMeta = {
+  @as("frontman.dev/agentErrorId")
+  agentErrorId: string,
+}
+
+let agentErrorId = meta => {
+  let json = switch meta {
+  | Some(json) => json
+  | None => failwith("Frontman error update missing _meta.frontman.dev/agentErrorId")
+  }
+  S.parseOrThrow(json, ~to=frontmanErrorMetaSchema).agentErrorId
+}
+
 // Parse accumulated user_message_chunk content blocks into (content, annotations).
 // Inverse of messageAnnotationsToContentBlocks + buildAttachmentContentBlocks on the send path.
 let _parseUserMessageBlocks = (blocks: array<Types.contentBlock>): (
@@ -381,7 +395,7 @@ module Provider = {
       | ConfigOptionUpdate({configOptions}) =>
         Client__State.Actions.configOptionsReceived(~configOptions)
       | CurrentModeUpdate(_) => () // TODO: dispatch mode change when modes are supported in UI
-      | Error({message, timestamp, retryAt, attempt, maxAttempts, category}) =>
+      | Error({_meta, message, timestamp, retryAt, attempt, maxAttempts, category}) =>
         Client__TextDeltaBuffer.flush()
         switch retryAt {
         | Some(retryAtStr) =>
@@ -396,6 +410,7 @@ module Provider = {
         | None =>
           Client__State.Actions.agentErrorReceived(
             ~taskId,
+            ~id=agentErrorId(_meta),
             ~error=message,
             ~timestamp,
             ~category=category->Option.getOr("unknown"),

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -143,6 +143,7 @@ module Actions = {
   // Error action creators (ForTask)
   let agentErrorReceived = (
     ~taskId: string,
+    ~id: string,
     ~error: string,
     ~timestamp: string,
     ~category: string,
@@ -150,7 +151,7 @@ module Actions = {
     Client__State__Store.dispatch(
       TaskAction({
         target: ForTask(taskId),
-        action: AgentError({error, timestamp, category}),
+        action: AgentError({id, error, timestamp, category}),
       }),
     )
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -333,10 +333,6 @@ module Selectors = {
     TaskReducer.Selectors.turnError(currentTask(state))
   }
 
-  let lastErrorId = (state: state): option<string> => {
-    TaskReducer.Selectors.lastErrorId(currentTask(state))
-  }
-
   let retryStatus = (state: state): option<Task.retryStatus> => {
     TaskReducer.Selectors.retryStatus(currentTask(state))
   }

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -238,24 +238,6 @@ module Selectors = {
     }
   }
 
-  // Get the ID of the last Error message in the messages list
-  let lastErrorId = (task: Task.t): option<string> => {
-    switch task {
-    | Task.Loaded({turnError: Some({id})}) => Some(id)
-    | _ =>
-      messages(task)->Option.flatMap(msgs =>
-        msgs
-        ->Array.toReversed
-        ->Array.findMap(msg =>
-          switch msg {
-          | Message.Error(err) => Some(Message.ErrorMessage.id(err))
-          | _ => None
-          }
-        )
-      )
-    }
-  }
-
   // Get message created at timestamp
   let getMessageCreatedAt = (msg: Message.t): float => {
     switch msg {
@@ -348,7 +330,7 @@ type action =
   | TurnCompleted
   | CancelTurn
   // Error actions
-  | AgentError({error: string, timestamp: string, category: string})
+  | AgentError({id: string, error: string, timestamp: string, category: string})
   | RetryingUpdate({retryStatus: Types.Task.retryStatus})
   | RetryTurn({retriedErrorId: string})
   | ClearTurnError
@@ -1017,14 +999,12 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
       }
     }
 
-  | (Task.Loading(_), AgentError({error, timestamp, category})) =>
-    let id = `error-${getTaskIdForError(task)}-${timestamp}`
+  | (Task.Loading(_), AgentError({id, error, timestamp, category})) =>
     let errorMsg = Message.Error(Message.ErrorMessage.make(~id, ~error, ~timestamp, ~category))
     (task->Lens.completeStreamingMessage->Lens.insertMessage(errorMsg), [])
 
-  | (Task.Loaded(data), AgentError({error, category, timestamp})) =>
+  | (Task.Loaded(data), AgentError({id, error, category, timestamp: _timestamp})) =>
     // Set turn error and stop agent running - user can still send messages
-    let id = `error-${getTaskIdForError(task)}-${timestamp}`
     let completed = task->Lens.completeStreamingMessage
     switch completed {
     | Task.Loaded(completedData) => (

--- a/libs/client/test/Client__HistoryReplay.test.res
+++ b/libs/client/test/Client__HistoryReplay.test.res
@@ -438,6 +438,7 @@ describe("History Replay - Integration (Buffer + Reducer)", () => {
     let (updated, _) = TaskReducer.next(
       task.contents,
       AgentError({
+        id: "agent-error-1",
         error: "Rate limit exceeded",
         timestamp: "2025-01-10T10:00:10Z",
         category: "unknown",

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -395,6 +395,7 @@ describe("Task - Error Handling", () => {
     let (task2, _) = TaskReducer.next(
       task,
       AgentError({
+        id: "agent-error-1",
         error: "Rate limit exceeded",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -404,7 +405,7 @@ describe("Task - Error Handling", () => {
     ->expect(TaskReducer.Selectors.turnError(task2))
     ->Expect.toEqual(
       Some({
-        id: "error-test-task-1-2025-01-15T10:30:00Z",
+        id: "agent-error-1",
         message: "Rate limit exceeded",
         category: "unknown",
       }),
@@ -428,6 +429,7 @@ describe("Task - Error Handling", () => {
     let (task3, _) = TaskReducer.next(
       task2,
       AgentError({
+        id: "agent-error-1",
         error: "Some error",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -463,6 +465,7 @@ describe("Task - Error Handling", () => {
     let (task3, _) = TaskReducer.next(
       task2,
       AgentError({
+        id: "agent-error-1",
         error: "Error occurred",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -484,6 +487,7 @@ describe("Task - Error Handling", () => {
     let (_, effects) = TaskReducer.next(
       task,
       AgentError({
+        id: "agent-error-1",
         error: "Error",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -498,6 +502,7 @@ describe("Task - Error Handling", () => {
     let (task2, _) = TaskReducer.next(
       task,
       AgentError({
+        id: "agent-error-1",
         error: "Some error",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -507,7 +512,7 @@ describe("Task - Error Handling", () => {
     ->expect(TaskReducer.Selectors.turnError(task2))
     ->Expect.toEqual(
       Some({
-        id: "error-test-task-1-2025-01-15T10:30:00Z",
+        id: "agent-error-1",
         message: "Some error",
         category: "unknown",
       }),
@@ -531,6 +536,7 @@ describe("Task - Error Handling", () => {
     let (task2, _) = TaskReducer.next(
       task,
       AgentError({
+        id: "agent-error-1",
         error: "Previous error",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",
@@ -540,7 +546,7 @@ describe("Task - Error Handling", () => {
     ->expect(TaskReducer.Selectors.turnError(task2))
     ->Expect.toEqual(
       Some({
-        id: "error-test-task-1-2025-01-15T10:30:00Z",
+        id: "agent-error-1",
         message: "Previous error",
         category: "unknown",
       }),
@@ -683,6 +689,7 @@ describe("Task - CancelTurn", () => {
     let (task1, _) = TaskReducer.next(
       task,
       AgentError({
+        id: "agent-error-1",
         error: "Some error",
         timestamp: "2025-01-15T10:30:00Z",
         category: "unknown",

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -425,7 +425,7 @@ let cancelPrompt = (session: session): unit => {
 }
 
 // Retry a failed turn
-// ACP spec: session/retry_turn is a notification (fire-and-forget).
+// Frontman extension: session/retry_turn is a notification (fire-and-forget).
 let retryTurn = (session: session, ~retriedErrorId: string): unit => {
   Protocol.sendRetryTurn(
     ~channel=session.channel,

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -132,7 +132,7 @@ let sendCancel = (
   channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore
 }
 
-// ACP spec: session/retry_turn is a NOTIFICATION (no id, no response expected).
+// Frontman extension: session/retry_turn is a notification (no response expected).
 // Signals the server to retry the failed turn identified by retriedErrorId.
 let sendRetryTurn = (
   ~channel: Channel.t,

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -878,6 +878,7 @@
           "type": "string",
           "const": "error"
         },
+        "_meta": {},
         "message": {
           "type": "string"
         },

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -893,6 +893,7 @@
                   "type": "string",
                   "const": "error"
                 },
+                "_meta": {},
                 "message": {
                   "type": "string"
                 },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -581,6 +581,7 @@ type sessionUpdate =
   | CurrentModeUpdate({currentModeId: sessionModeId})
   | AgentTurnComplete({stopReason: stopReason})
   | Error({
+      _meta: option<JSON.t>,
       message: string,
       timestamp: string,
       retryAt: option<string>,
@@ -653,6 +654,7 @@ let sessionUpdateSchema = S.union([
   S.object(s => {
     s.tag("sessionUpdate", "error")
     Error({
+      _meta: s.field("_meta", S.option(S.json)),
       message: s.field("message", S.string),
       timestamp: s.field("timestamp", S.string),
       retryAt: s.field("retryAt", S.option(S.string)),


### PR DESCRIPTION
## Summary
- Carry stable Frontman agent error IDs in ACP-compliant namespaced _meta
- Store retry IDs as required state, remove client-generated fallback IDs
- Reject stale/client-generated retry IDs instead of retrying latest error
- Mark session/retry_turn as a Frontman extension and update retry tests/contracts

## Verification
- make build (libs/client)
- make test (libs/client)
- make export-schemas (libs/frontman-protocol)
- mix test test/protocols/acp_contract_test.exs test/frontman_server/tasks_test.exs test/frontman_server_web/channels/task_channel_test.exs
- pre-commit hook: rescript format, elixir format, credo
- pre-push hook: reanalyze