### PR TITLE
Add backend skills foundation

### DIFF
--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -15,6 +15,7 @@ defmodule AgentClientProtocol.History do
 
   @ignored_types [
     :turn_started,
+    :skill_used,
     :agent_completed,
     :agent_retry,
     :discovered_project_rule,

--- a/apps/frontman_server/lib/frontman_server.ex
+++ b/apps/frontman_server/lib/frontman_server.ex
@@ -18,6 +18,7 @@ defmodule FrontmanServer do
     {Agents, []},
     {Organizations, []},
     {Providers, []},
+    {Skills, []},
     {Tasks, []},
     {Frameworks, []},
     BrandTokens,

--- a/apps/frontman_server/lib/frontman_server/skills.ex
+++ b/apps/frontman_server/lib/frontman_server/skills.ex
@@ -11,8 +11,6 @@ defmodule FrontmanServer.Skills do
     deps: [FrontmanServer],
     exports: [Skill]
 
-  import Ecto.Query, warn: false
-
   alias FrontmanServer.Repo
   alias FrontmanServer.Skills.Skill
 
@@ -27,11 +25,15 @@ defmodule FrontmanServer.Skills do
   def get_by_id(_scope, nil), do: {:ok, nil}
 
   def get_by_id(_scope, id) when is_binary(id) do
-    case Repo.get(Skill, id) do
-      %Skill{} = skill -> {:ok, skill}
-      nil -> {:error, :not_found}
+    with {:ok, id} <- Ecto.UUID.cast(id),
+         %Skill{} = skill <- Repo.get(Skill, id) do
+      {:ok, skill}
+    else
+      _missing -> {:error, :not_found}
     end
   end
+
+  def get_by_id(_scope, _id), do: {:error, :not_found}
 
   @doc "Registers a global skill."
   def register(_scope, attrs) do

--- a/apps/frontman_server/lib/frontman_server/skills.ex
+++ b/apps/frontman_server/lib/frontman_server/skills.ex
@@ -1,0 +1,49 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Skills do
+  @moduledoc "Catalogs globally usable Frontman skills."
+
+  use Boundary,
+    deps: [FrontmanServer],
+    exports: [Skill]
+
+  import Ecto.Query, warn: false
+
+  alias FrontmanServer.Repo
+  alias FrontmanServer.Skills.Skill
+
+  @doc "Returns all globally usable skills ordered by name."
+  def catalog(_scope) do
+    Skill
+    |> Skill.ordered_by_name()
+    |> Repo.all()
+  end
+
+  @doc "Gets a skill by database id."
+  def get_by_id(_scope, nil), do: {:ok, nil}
+
+  def get_by_id(_scope, id) when is_binary(id) do
+    case Repo.get(Skill, id) do
+      %Skill{} = skill -> {:ok, skill}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc "Registers a global skill."
+  def register(_scope, attrs) do
+    %Skill{}
+    |> Skill.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc "Updates a global skill."
+  def update(_scope, %Skill{} = skill, attrs) do
+    skill
+    |> Skill.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/skills/skill.ex
+++ b/apps/frontman_server/lib/frontman_server/skills/skill.ex
@@ -1,0 +1,41 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Skills.Skill do
+  @moduledoc "Schema for globally usable Frontman skills."
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @name_format ~r/^[a-z0-9][a-z0-9_-]*$/
+
+  schema "skills" do
+    field :name, :string
+    field :description, :string
+    field :content, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(skill, attrs) do
+    skill
+    |> cast(attrs, [:name, :description, :content])
+    |> update_change(:name, &String.downcase/1)
+    |> validate_required([:name, :description, :content])
+    |> validate_format(:name, @name_format)
+    |> validate_length(:description, min: 1, max: 200)
+    |> validate_length(:content, min: 1)
+    |> unique_constraint(:name)
+    |> check_constraint(:name, name: :skills_name_format)
+  end
+
+  def ordered_by_name(query \\ __MODULE__) do
+    from(s in query, order_by: [asc: s.name])
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -24,6 +24,7 @@ defmodule FrontmanServer.Tasks do
     Interaction.AgentError,
     Interaction.AgentPaused,
     Interaction.AgentRetry,
+    Interaction.SkillUsed,
     Interaction.ToolCall,
     Interaction.ToolResult,
     RetryCoordinator,
@@ -35,6 +36,7 @@ defmodule FrontmanServer.Tasks do
       FrontmanServer,
       FrontmanServer.Accounts,
       FrontmanServer.Providers,
+      FrontmanServer.Skills,
       ModelContextProtocol
     ],
     exports: @exports
@@ -44,6 +46,7 @@ defmodule FrontmanServer.Tasks do
   alias FrontmanServer.Agents
   alias FrontmanServer.Observability.SentryContext
   alias FrontmanServer.Repo
+  alias FrontmanServer.Skills
 
   alias FrontmanServer.Tasks.{
     Execution,
@@ -492,12 +495,16 @@ defmodule FrontmanServer.Tasks do
           message: [_ | _] = content_blocks,
           model: model,
           agent_id: agent_id
-        }
+        } = arguments
       )
       when is_binary(task_id) and is_binary(model) and model != "" and is_binary(agent_id) and
              agent_id != "" do
-    with {:ok, user_message_attrs} <-
+    selected_server_skill_id = Map.get(arguments, :selected_server_skill_id)
+
+    with {:ok, selected_skill} <- selected_skill(scope, selected_server_skill_id),
+         {:ok, user_message_attrs} <-
            Interaction.UserMessage.attrs(content_blocks, model, agent_id),
+         user_message_attrs = put_selected_skill(user_message_attrs, selected_skill),
          {:ok, task_schema} <- get_task_by_id(scope, task_id) do
       record_interaction_row(
         task_schema,
@@ -509,6 +516,24 @@ defmodule FrontmanServer.Tasks do
         }
       )
     end
+  end
+
+  defp selected_skill(_scope, nil), do: {:ok, nil}
+
+  defp selected_skill(%Scope{} = scope, selected_server_skill_id) do
+    case Skills.get_by_id(scope, selected_server_skill_id) do
+      {:ok, selected_skill} -> {:ok, selected_skill}
+      {:error, :not_found} -> {:error, :skill_not_found}
+    end
+  end
+
+  defp put_selected_skill(attrs, nil), do: attrs
+
+  defp put_selected_skill(attrs, selected_skill) do
+    attrs
+    |> Map.put(:selected_server_skill_id, selected_skill.id)
+    |> Map.put(:selected_server_skill_name, selected_skill.name)
+    |> Map.put(:selected_server_skill_content, selected_skill.content)
   end
 
   def submit_user_message(%Scope{}, %{agent_id: agent_id})
@@ -600,7 +625,8 @@ defmodule FrontmanServer.Tasks do
            user_message_ids: user_message_ids
          },
          {:ok, turn_started_row} <-
-           insert_turn_started(task_schema, turn_started_attrs, turn_number) do
+           insert_turn_started(task_schema, turn_started_attrs, turn_number),
+         :ok <- insert_skill_used_rows(task_schema, accepted_messages, turn_number) do
       {:ok,
        {task_schema, turn_started_row, turn_number, turn_model, agent, first_accepted_message}}
     else
@@ -649,6 +675,48 @@ defmodule FrontmanServer.Tasks do
        ) do
     default_agent_id
   end
+
+  defp insert_skill_used_rows(%TaskSchema{} = task_schema, accepted_messages, turn_number) do
+    accepted_messages
+    |> Enum.flat_map(&skill_used_attrs/1)
+    |> Enum.reduce_while(:ok, fn attrs, :ok ->
+      row_attrs = %{
+        id: attrs.id,
+        type: :skill_used,
+        data: attrs,
+        turn_number: turn_number
+      }
+
+      case task_schema
+           |> Ecto.build_assoc(:interaction_rows)
+           |> InteractionSchema.changeset(row_attrs)
+           |> Repo.insert() do
+        {:ok, _row} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp skill_used_attrs(%InteractionSchema{
+         data: %Interaction.UserMessage{
+           selected_server_skill_id: skill_id,
+           selected_server_skill_name: skill_name,
+           selected_server_skill_content: skill_content
+         }
+       })
+       when is_binary(skill_id) and is_binary(skill_name) and is_binary(skill_content) do
+    [
+      %{
+        id: Ecto.UUID.generate(),
+        timestamp: Interaction.now(),
+        skill_id: skill_id,
+        skill_name: skill_name,
+        skill_content: skill_content
+      }
+    ]
+  end
+
+  defp skill_used_attrs(%InteractionSchema{}), do: []
 
   defp insert_turn_started(%TaskSchema{} = task_schema, turn_started_attrs, turn_number) do
     attrs = %{

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -545,15 +545,6 @@ defmodule FrontmanServer.Tasks do
     |> Map.put(:selected_server_skill_content, selected_skill.content)
   end
 
-  def submit_user_message(%Scope{}, %{agent_id: agent_id})
-      when is_binary(agent_id) and agent_id != "" do
-    {:error, :missing_model}
-  end
-
-  def submit_user_message(%Scope{}, %{model: _model}) do
-    {:error, :missing_agent}
-  end
-
   @doc """
   Removes a queued (not yet claimed by a turn) user message.
 
@@ -707,17 +698,20 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp skill_used_attrs(%InteractionSchema{
+         id: user_message_id,
          data: %Interaction.UserMessage{
            selected_server_skill_id: skill_id,
            selected_server_skill_name: skill_name,
            selected_server_skill_content: skill_content
          }
        })
-       when is_binary(skill_id) and is_binary(skill_name) and is_binary(skill_content) do
+       when is_binary(user_message_id) and is_binary(skill_id) and is_binary(skill_name) and
+              is_binary(skill_content) do
     [
       %{
         id: Ecto.UUID.generate(),
         timestamp: Interaction.now(),
+        user_message_id: user_message_id,
         skill_id: skill_id,
         skill_name: skill_name,
         skill_content: skill_content

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -518,6 +518,15 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
+  def submit_user_message(%Scope{}, %{agent_id: agent_id})
+      when is_binary(agent_id) and agent_id != "" do
+    {:error, :missing_model}
+  end
+
+  def submit_user_message(%Scope{}, %{model: _model}) do
+    {:error, :missing_agent}
+  end
+
   defp selected_skill(_scope, nil), do: {:ok, nil}
 
   defp selected_skill(%Scope{} = scope, selected_server_skill_id) do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -173,30 +173,31 @@ defmodule FrontmanServer.Tasks.Execution do
   defp prompt_messages(rows, turn_number)
        when is_list(rows) and is_integer(turn_number) and turn_number > 0 do
     user_messages_by_row_id = user_messages_by_row_id(rows)
-    skill_used_by_turn = skill_used_by_turn(rows)
+    skill_used_by_user_message_id = skill_used_by_user_message_id(rows)
 
     rows
     |> Enum.filter(&(is_nil(&1.turn_number) or &1.turn_number <= turn_number))
     |> Enum.flat_map(fn row ->
       row
-      |> row_to_messages(user_messages_by_row_id, skill_used_by_turn)
+      |> row_to_messages(user_messages_by_row_id, skill_used_by_user_message_id)
       |> decay_historical_images(row.turn_number, turn_number)
     end)
   end
 
   defp row_to_messages(
          %InteractionSchema{
-           turn_number: turn_number,
            type: :turn_started,
            data: %Interaction.TurnStarted{user_message_ids: user_message_ids}
          },
          user_messages_by_row_id,
-         skill_used_by_turn
+         skill_used_by_user_message_id
        ) do
-    user_interactions = Enum.map(user_message_ids, &Map.fetch!(user_messages_by_row_id, &1))
-    skill_interactions = Map.get(skill_used_by_turn, turn_number, [])
+    Enum.flat_map(user_message_ids, fn user_message_id ->
+      skill_interactions = Map.get(skill_used_by_user_message_id, user_message_id, [])
+      user_interaction = Map.fetch!(user_messages_by_row_id, user_message_id)
 
-    Interaction.to_swarm_messages(user_interactions ++ skill_interactions)
+      Interaction.to_swarm_messages(skill_interactions ++ [user_interaction])
+    end)
   end
 
   defp row_to_messages(%InteractionSchema{turn_number: nil}, _user_messages_by_row_id, _skills),
@@ -230,10 +231,10 @@ defmodule FrontmanServer.Tasks.Execution do
     end)
   end
 
-  defp skill_used_by_turn(rows) do
+  defp skill_used_by_user_message_id(rows) do
     rows
     |> Enum.filter(&(&1.type == :skill_used))
-    |> Enum.group_by(& &1.turn_number, & &1.data)
+    |> Enum.group_by(& &1.data.user_message_id, & &1.data)
   end
 
   defp decay_images(%Tool{content: content, tool_call_id: tool_call_id} = msg)

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -173,33 +173,47 @@ defmodule FrontmanServer.Tasks.Execution do
   defp prompt_messages(rows, turn_number)
        when is_list(rows) and is_integer(turn_number) and turn_number > 0 do
     user_messages_by_row_id = user_messages_by_row_id(rows)
+    skill_used_by_turn = skill_used_by_turn(rows)
 
     rows
     |> Enum.filter(&(is_nil(&1.turn_number) or &1.turn_number <= turn_number))
     |> Enum.flat_map(fn row ->
       row
-      |> row_to_messages(user_messages_by_row_id)
+      |> row_to_messages(user_messages_by_row_id, skill_used_by_turn)
       |> decay_historical_images(row.turn_number, turn_number)
     end)
   end
 
   defp row_to_messages(
          %InteractionSchema{
+           turn_number: turn_number,
            type: :turn_started,
            data: %Interaction.TurnStarted{user_message_ids: user_message_ids}
          },
-         user_messages_by_row_id
+         user_messages_by_row_id,
+         skill_used_by_turn
        ) do
-    user_message_ids
-    |> Enum.map(&Map.fetch!(user_messages_by_row_id, &1))
-    |> Interaction.to_swarm_messages()
+    user_interactions = Enum.map(user_message_ids, &Map.fetch!(user_messages_by_row_id, &1))
+    skill_interactions = Map.get(skill_used_by_turn, turn_number, [])
+
+    Interaction.to_swarm_messages(user_interactions ++ skill_interactions)
   end
 
-  defp row_to_messages(%InteractionSchema{turn_number: nil}, _user_messages_by_row_id),
+  defp row_to_messages(%InteractionSchema{turn_number: nil}, _user_messages_by_row_id, _skills),
     do: []
 
-  defp row_to_messages(%InteractionSchema{} = row, _user_messages_by_row_id) do
+  defp row_to_messages(%InteractionSchema{type: :skill_used}, _user_messages_by_row_id, _skills),
+    do: []
+
+  defp row_to_messages(%InteractionSchema{} = row, _user_messages_by_row_id, _skills) do
     row_to_messages(row)
+  end
+
+  defp row_to_messages(row) do
+    row
+    |> Map.fetch!(:data)
+    |> List.wrap()
+    |> Interaction.to_swarm_messages()
   end
 
   defp decay_historical_images(messages, row_turn, turn_number)
@@ -216,11 +230,10 @@ defmodule FrontmanServer.Tasks.Execution do
     end)
   end
 
-  defp row_to_messages(row) do
-    row
-    |> Map.fetch!(:data)
-    |> List.wrap()
-    |> Interaction.to_swarm_messages()
+  defp skill_used_by_turn(rows) do
+    rows
+    |> Enum.filter(&(&1.type == :skill_used))
+    |> Enum.group_by(& &1.turn_number, & &1.data)
   end
 
   defp decay_images(%Tool{content: content, tool_call_id: tool_call_id} = msg)

--- a/apps/frontman_server/lib/frontman_server/tasks/history.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/history.ex
@@ -12,7 +12,7 @@ defmodule FrontmanServer.Tasks.History do
 
   @task_scoped_types InteractionSchema.task_scoped_types()
   @terminal_types [:agent_completed, :agent_error, :agent_paused]
-  @active_turn_types @terminal_types ++ [:agent_response, :tool_call, :tool_result]
+  @active_turn_types @terminal_types ++ [:agent_response, :skill_used, :tool_call, :tool_result]
 
   @enforce_keys ~w(rows ordered_rows users_by_id turns_by_number user_owners response_counts active_turn)a
   defstruct @enforce_keys

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -20,6 +20,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     __MODULE__.AgentError,
     __MODULE__.AgentPaused,
     __MODULE__.AgentRetry,
+    __MODULE__.SkillUsed,
     __MODULE__.ToolCall,
     __MODULE__.ToolResult,
     __MODULE__.DiscoveredProjectRule,
@@ -941,6 +942,43 @@ defmodule FrontmanServer.Tasks.Interaction do
     defp validate_result(:result, _result), do: []
   end
 
+  defmodule SkillUsed do
+    @moduledoc "Records a skill explicitly selected for a task turn."
+
+    alias FrontmanServer.Skills.Skill
+
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      field :id, :string
+      field :timestamp, :utc_datetime_usec
+      field :skill_id, :binary_id
+      field :skill_name, :string
+      field :skill_content, :string
+    end
+
+    def build(%Skill{} = skill) do
+      %__MODULE__{
+        id: Interaction.new_id(),
+        timestamp: Interaction.now(),
+        skill_id: skill.id,
+        skill_name: skill.name,
+        skill_content: skill.content
+      }
+    end
+
+    def changeset(%__MODULE__{} = skill_used, attrs) do
+      Interaction.cast_timestamped(skill_used, attrs, [
+        :id,
+        :timestamp,
+        :skill_id,
+        :skill_name,
+        :skill_content
+      ])
+    end
+  end
+
   defmodule DiscoveredProjectRule do
     @moduledoc """
     Represents a discovered project rule file (e.g., AGENTS.md, CLAUDE.md).
@@ -1099,7 +1137,33 @@ defmodule FrontmanServer.Tasks.Interaction do
   tool results) regardless of database insertion timing.
   """
   def to_swarm_messages(interactions) when is_list(interactions) do
-    Enum.flat_map(interactions, &to_swarm_message/1)
+    Enum.reduce(interactions, [], &add_interaction_to_messages/2)
+  end
+
+  defp add_interaction_to_messages(%SkillUsed{} = skill_used, messages) do
+    case Enum.reverse(messages) do
+      [%SwarmMessage.User{} = user_message | previous_messages] ->
+        user_message = prepend_active_skill(user_message, skill_used)
+        Enum.reverse([user_message | previous_messages])
+
+      _messages ->
+        messages
+    end
+  end
+
+  defp add_interaction_to_messages(interaction, messages) do
+    messages ++ to_swarm_message(interaction)
+  end
+
+  defp prepend_active_skill(
+         %SwarmMessage.User{content: content} = user_message,
+         %SkillUsed{} = skill_used
+       ) do
+    %{user_message | content: [SwarmContentPart.text(active_skill_text(skill_used)) | content]}
+  end
+
+  defp active_skill_text(%SkillUsed{} = skill_used) do
+    "## Active Skill: #{skill_used.skill_name}\n\nUse this expert lens for this turn.\n\n#{skill_used.skill_content}"
   end
 
   defp to_swarm_message(%UserMessage{} = msg) do

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -972,7 +972,7 @@ defmodule FrontmanServer.Tasks.Interaction do
 
     def build(%Skill{} = skill) do
       %__MODULE__{
-        id: Interaction.new_id(),
+        id: Ecto.UUID.generate(),
         timestamp: Interaction.now(),
         skill_id: skill.id,
         skill_name: skill.name,

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -965,15 +965,17 @@ defmodule FrontmanServer.Tasks.Interaction do
     embedded_schema do
       field :id, :string
       field :timestamp, :utc_datetime_usec
+      field :user_message_id, :binary_id
       field :skill_id, :binary_id
       field :skill_name, :string
       field :skill_content, :string
     end
 
-    def build(%Skill{} = skill) do
+    def build(%Skill{} = skill, user_message_id) when is_binary(user_message_id) do
       %__MODULE__{
         id: Ecto.UUID.generate(),
         timestamp: Interaction.now(),
+        user_message_id: user_message_id,
         skill_id: skill.id,
         skill_name: skill.name,
         skill_content: skill.content
@@ -984,6 +986,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       Interaction.cast_timestamped(skill_used, attrs, [
         :id,
         :timestamp,
+        :user_message_id,
         :skill_id,
         :skill_name,
         :skill_content
@@ -1149,33 +1152,11 @@ defmodule FrontmanServer.Tasks.Interaction do
   tool results) regardless of database insertion timing.
   """
   def to_swarm_messages(interactions) when is_list(interactions) do
-    Enum.reduce(interactions, [], &add_interaction_to_messages/2)
+    Enum.flat_map(interactions, &to_swarm_message/1)
   end
 
-  defp add_interaction_to_messages(%SkillUsed{} = skill_used, messages) do
-    case Enum.reverse(messages) do
-      [%SwarmMessage.User{} = user_message | previous_messages] ->
-        user_message = prepend_active_skill(user_message, skill_used)
-        Enum.reverse([user_message | previous_messages])
-
-      _messages ->
-        messages
-    end
-  end
-
-  defp add_interaction_to_messages(interaction, messages) do
-    messages ++ to_swarm_message(interaction)
-  end
-
-  defp prepend_active_skill(
-         %SwarmMessage.User{content: content} = user_message,
-         %SkillUsed{} = skill_used
-       ) do
-    %{user_message | content: [SwarmContentPart.text(active_skill_text(skill_used)) | content]}
-  end
-
-  defp active_skill_text(%SkillUsed{} = skill_used) do
-    "## Active Skill: #{skill_used.skill_name}\n\nUse this expert lens for this turn.\n\n#{skill_used.skill_content}"
+  defp to_swarm_message(%SkillUsed{} = skill_used) do
+    [%SwarmMessage.User{content: [SwarmContentPart.text(active_skill_text(skill_used))]}]
   end
 
   defp to_swarm_message(%UserMessage{} = msg) do
@@ -1231,6 +1212,10 @@ defmodule FrontmanServer.Tasks.Interaction do
   defp to_swarm_message(%AgentRetry{}), do: []
   defp to_swarm_message(%DiscoveredProjectRule{}), do: []
   defp to_swarm_message(%DiscoveredProjectStructure{}), do: []
+
+  defp active_skill_text(%SkillUsed{} = skill_used) do
+    "## Active Skill: #{skill_used.skill_name}\n\nUse this expert lens for this turn.\n\n#{skill_used.skill_content}"
+  end
 
   def user_prompt_text(%UserMessage{} = msg) do
     msg.messages

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -361,6 +361,9 @@ defmodule FrontmanServer.Tasks.Interaction do
     embedded_schema do
       field :agent_id, :string
       field :model, :string
+      field :selected_server_skill_id, :binary_id
+      field :selected_server_skill_name, :string
+      field :selected_server_skill_content, :string
       field :messages, {:array, :string}, default: []
       embeds_many :annotations, Annotation
       embeds_one :selected_figma_node, FigmaNode
@@ -371,7 +374,16 @@ defmodule FrontmanServer.Tasks.Interaction do
 
     def changeset(%__MODULE__{} = user_message, attrs) do
       user_message
-      |> Interaction.cast_timestamped(attrs, [:id, :timestamp, :agent_id, :model, :messages])
+      |> Interaction.cast_timestamped(attrs, [
+        :id,
+        :timestamp,
+        :agent_id,
+        :model,
+        :selected_server_skill_id,
+        :selected_server_skill_name,
+        :selected_server_skill_content,
+        :messages
+      ])
       |> cast_embed(:annotations, with: &Annotation.changeset/2)
       |> cast_embed(:selected_figma_node, with: &FigmaNode.changeset/2)
       |> cast_embed(:images, with: &UserImage.changeset/2)

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -28,6 +28,7 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
     agent_error: Interaction.AgentError,
     agent_paused: Interaction.AgentPaused,
     agent_retry: Interaction.AgentRetry,
+    skill_used: Interaction.SkillUsed,
     tool_call: Interaction.ToolCall,
     tool_result: Interaction.ToolResult,
     discovered_project_rule: Interaction.DiscoveredProjectRule,

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -703,7 +703,8 @@ defmodule FrontmanServerWeb.TaskChannel do
                    message_id: meta["frontman.dev/messageId"],
                    message: content_blocks,
                    model: model,
-                   agent_id: agent_id
+                   agent_id: agent_id,
+                   selected_server_skill_id: meta["selectedServerSkillId"]
                  }
                ) do
           wake_runner(socket, meta)
@@ -720,6 +721,9 @@ defmodule FrontmanServerWeb.TaskChannel do
 
           {:error, :unknown_agent} ->
             reply_invalid_params(socket, id, "Unknown agent")
+
+          {:error, :skill_not_found} ->
+            reply_invalid_params(socket, id, "Selected skill not found")
 
           {:error, {:invalid_content_block, message}} ->
             Logger.error("Failed to add user message: #{message}")

--- a/apps/frontman_server/priv/official_skills/design_polish.md
+++ b/apps/frontman_server/priv/official_skills/design_polish.md
@@ -1,0 +1,10 @@
+---
+name: design_polish
+description: Improve visual quality using selected UI, DOM, CSS, and page context.
+---
+
+You are Frontman's design polish expert.
+
+Use the live page context to improve hierarchy, spacing, typography, contrast, motion, and layout clarity.
+Prefer small, high-leverage changes that preserve the app's existing design language.
+Explain only the changes that matter for the user's goal.

--- a/apps/frontman_server/priv/repo/migrations/20260628000000_create_skills.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260628000000_create_skills.exs
@@ -1,0 +1,20 @@
+defmodule FrontmanServer.Repo.Migrations.CreateSkills do
+  use Ecto.Migration
+
+  def change do
+    create table(:skills, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :description, :text, null: false
+      add :content, :text, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:skills, [:name])
+
+    create constraint(:skills, :skills_name_format,
+             check: "name ~ '^[a-z0-9][a-z0-9_-]*$' AND name = lower(name)"
+           )
+  end
+end

--- a/apps/frontman_server/priv/repo/seeds.exs
+++ b/apps/frontman_server/priv/repo/seeds.exs
@@ -1,5 +1,38 @@
 alias FrontmanServer.Accounts
 alias FrontmanServer.Repo
+alias FrontmanServer.Skills.Skill
+
+official_skills_dir = Application.app_dir(:frontman_server, "priv/official_skills")
+
+official_skills_dir
+|> File.ls!()
+|> Enum.filter(&String.ends_with?(&1, ".md"))
+|> Enum.sort()
+|> Enum.each(fn filename ->
+  path = Path.join(official_skills_dir, filename)
+  content = File.read!(path)
+
+  ["", frontmatter, body] = String.split(content, "---", parts: 3)
+
+  fields =
+    frontmatter
+    |> String.split("\n", trim: true)
+    |> Map.new(fn line ->
+      [key, value] = String.split(line, ":", parts: 2)
+      {String.trim(key), String.trim(value)}
+    end)
+
+  %Skill{}
+  |> Skill.changeset(%{
+    name: Map.fetch!(fields, "name"),
+    description: Map.fetch!(fields, "description"),
+    content: String.trim(body)
+  })
+  |> Repo.insert!(
+    on_conflict: {:replace, [:description, :content, :updated_at]},
+    conflict_target: [:name]
+  )
+end)
 
 dev_email = "dev@frontman.local"
 

--- a/apps/frontman_server/test/frontman_server/skills_test.exs
+++ b/apps/frontman_server/test/frontman_server/skills_test.exs
@@ -94,6 +94,13 @@ defmodule FrontmanServer.SkillsTest do
 
       assert {:error, :not_found} = Skills.get_by_id(scope, Ecto.UUID.generate())
     end
+
+    test "returns not_found for invalid ids" do
+      scope = user_scope_fixture()
+
+      assert {:error, :not_found} = Skills.get_by_id(scope, "not-a-uuid")
+      assert {:error, :not_found} = Skills.get_by_id(scope, 123)
+    end
   end
 
   describe "update/3" do

--- a/apps/frontman_server/test/frontman_server/skills_test.exs
+++ b/apps/frontman_server/test/frontman_server/skills_test.exs
@@ -1,0 +1,120 @@
+defmodule FrontmanServer.SkillsTest do
+  use FrontmanServer.DataCase
+
+  alias FrontmanServer.Skills
+  alias FrontmanServer.Skills.Skill
+
+  import FrontmanServer.Test.Fixtures.Accounts
+
+  describe "register/2" do
+    test "registers a global skill and downcases its name" do
+      scope = user_scope_fixture()
+
+      assert {:ok, %Skill{} = skill} =
+               Skills.register(scope, %{
+                 name: "Design_Polish",
+                 description: "Improve visual quality.",
+                 content: "Use stronger hierarchy."
+               })
+
+      assert skill.name == "design_polish"
+      assert skill.description == "Improve visual quality."
+      assert skill.content == "Use stronger hierarchy."
+    end
+
+    test "validates required fields" do
+      scope = user_scope_fixture()
+
+      assert {:error, changeset} = Skills.register(scope, %{})
+
+      assert "can't be blank" in errors_on(changeset).name
+      assert "can't be blank" in errors_on(changeset).description
+      assert "can't be blank" in errors_on(changeset).content
+    end
+
+    test "validates name format" do
+      scope = user_scope_fixture()
+
+      assert {:error, changeset} =
+               Skills.register(scope, %{
+                 name: "bad name",
+                 description: "Invalid skill.",
+                 content: "Invalid content."
+               })
+
+      assert "has invalid format" in errors_on(changeset).name
+    end
+
+    test "validates description length" do
+      scope = user_scope_fixture()
+
+      assert {:error, changeset} =
+               Skills.register(
+                 scope,
+                 valid_skill_attrs(%{description: String.duplicate("a", 201)})
+               )
+
+      assert "should be at most 200 character(s)" in errors_on(changeset).description
+    end
+
+    test "enforces unique names" do
+      scope = user_scope_fixture()
+      attrs = valid_skill_attrs(%{name: "seo_auditor"})
+
+      assert {:ok, _skill} = Skills.register(scope, attrs)
+      assert {:error, changeset} = Skills.register(scope, attrs)
+
+      assert "has already been taken" in errors_on(changeset).name
+    end
+  end
+
+  describe "catalog/1" do
+    test "returns globally usable skills ordered by name" do
+      scope = user_scope_fixture()
+
+      {:ok, _} = Skills.register(scope, valid_skill_attrs(%{name: "seo_auditor"}))
+      {:ok, _} = Skills.register(scope, valid_skill_attrs(%{name: "design_polish"}))
+
+      assert [%Skill{name: "design_polish"}, %Skill{name: "seo_auditor"}] =
+               Skills.catalog(scope)
+    end
+  end
+
+  describe "get_by_id/2" do
+    test "returns ok tuple for an existing database id" do
+      scope = user_scope_fixture()
+      {:ok, skill} = Skills.register(scope, valid_skill_attrs())
+
+      assert {:ok, %Skill{id: skill_id}} = Skills.get_by_id(scope, skill.id)
+      assert skill_id == skill.id
+    end
+
+    test "returns not_found for a missing database id" do
+      scope = user_scope_fixture()
+
+      assert {:error, :not_found} = Skills.get_by_id(scope, Ecto.UUID.generate())
+    end
+  end
+
+  describe "update/3" do
+    test "updates through the skill changeset" do
+      scope = user_scope_fixture()
+      {:ok, skill} = Skills.register(scope, valid_skill_attrs())
+
+      assert {:ok, updated} = Skills.update(scope, skill, %{description: "Updated skill."})
+
+      assert updated.description == "Updated skill."
+    end
+  end
+
+  defp valid_skill_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        name: "conversion_copy",
+        description: "Rewrite page copy for conversion.",
+        content: "Focus on user intent and clear CTAs."
+      },
+      attrs
+    )
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -525,7 +525,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           selected_server_skill_id: skill.id
         )
 
-      assert_receive {:interaction, %Interaction.AgentCompleted{}, 1}, 5_000
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
       assert_receive {:provider_messages, messages}, 1_000
 
       user_message = Enum.find(messages, &(&1.role == :user))
@@ -543,7 +543,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       {:ok, _, 2} = submit_user_message(scope, task_id, user_content("Now tighten copy"))
 
-      assert_receive {:interaction, %Interaction.AgentCompleted{}, 2}, 5_000
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 2)
       assert_receive {:followup_provider_messages, followup_messages}, 1_000
 
       user_messages = Enum.filter(followup_messages, &(&1.role == :user))

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -485,6 +485,21 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
                submit_user_message(scope, task_id, [%{"type" => "text", "text" => ""}])
     end
 
+    test "returns selected skill errors instead of raising", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      assert {:error, :skill_not_found} =
+               submit_user_message(scope, task_id, user_content("Improve hero"),
+                 selected_server_skill_id: "not-a-uuid"
+               )
+
+      assert {:error, :skill_not_found} =
+               submit_user_message(scope, task_id, user_content("Improve hero"),
+                 selected_server_skill_id: 123
+               )
+    end
+
     test "uses resource context for attachment-only first turn title text", %{
       task_id: task_id,
       scope: scope
@@ -528,12 +543,13 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
       assert_receive {:provider_messages, messages}, 1_000
 
-      user_message = Enum.find(messages, &(&1.role == :user))
-      assert user_message != nil
+      user_messages = Enum.filter(messages, &(&1.role == :user))
+      assert [skill_message, prompt_message] = user_messages
 
-      assert [active_skill_part, user_prompt_part | _rest] = user_message.content
+      assert [active_skill_part] = skill_message.content
       assert active_skill_part.text =~ "## Active Skill: design_polish"
       assert active_skill_part.text =~ "Use hierarchy."
+      assert [user_prompt_part] = prompt_message.content
       assert user_prompt_part.text == "Improve hero"
 
       expect(LLMProviderMock, :stream_text, fn _model, messages, _opts ->
@@ -547,17 +563,68 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert_receive {:followup_provider_messages, followup_messages}, 1_000
 
       user_messages = Enum.filter(followup_messages, &(&1.role == :user))
-      assert [historical_user_message, current_user_message] = user_messages
 
-      assert [historical_skill_part, historical_prompt_part | _rest] =
-               historical_user_message.content
+      assert [historical_skill_message, historical_prompt_message, current_user_message] =
+               user_messages
 
+      assert [historical_skill_part] = historical_skill_message.content
       assert historical_skill_part.text =~ "## Active Skill: design_polish"
       assert historical_skill_part.text =~ "Use hierarchy."
+
+      assert [historical_prompt_part] = historical_prompt_message.content
       assert historical_prompt_part.text == "Improve hero"
 
       assert [current_prompt_part] = current_user_message.content
       assert current_prompt_part.text == "Now tighten copy"
+    end
+
+    test "keeps selected skill attached to its user message in batched turns", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      parent = self()
+      {:ok, skill} = register_skill(scope)
+      execution = execution_request_fixture()
+
+      expect(LLMProviderMock, :stream_text, fn _model, messages, _opts ->
+        send(parent, {:provider_messages, messages})
+        ReqLLMResponses.response("Response")
+      end)
+
+      {:ok, _first} =
+        Tasks.submit_user_message(
+          scope,
+          Map.merge(execution, %{
+            task_id: task_id,
+            message_id: Ecto.UUID.generate(),
+            message: user_content("Improve hero"),
+            selected_server_skill_id: skill.id
+          })
+        )
+
+      {:ok, _second} =
+        Tasks.submit_user_message(
+          scope,
+          Map.merge(execution, %{
+            task_id: task_id,
+            message_id: Ecto.UUID.generate(),
+            message: user_content("Now tighten copy")
+          })
+        )
+
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution)
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
+      assert_receive {:provider_messages, messages}, 1_000
+
+      user_messages = Enum.filter(messages, &(&1.role == :user))
+      assert [skill_message, first_message, second_message] = user_messages
+
+      assert [skill_part] = skill_message.content
+      assert skill_part.text =~ "## Active Skill: design_polish"
+      assert [first_part] = first_message.content
+      assert first_part.text == "Improve hero"
+      assert [second_part] = second_message.content
+      assert second_part.text == "Now tighten copy"
     end
 
     test "startup failure persists terminal error on the same turn" do

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -34,6 +34,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
+  alias FrontmanServer.Skills
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.LLMProviderMock
   alias FrontmanServer.Tasks.{Interaction, InteractionSchema}
@@ -199,6 +200,14 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     previous = Application.fetch_env!(:frontman_server, :backend_tools)
     Application.put_env(:frontman_server, :backend_tools, modules)
     on_exit(fn -> Application.put_env(:frontman_server, :backend_tools, previous) end)
+  end
+
+  defp register_skill(scope) do
+    Skills.register(scope, %{
+      name: "design_polish",
+      description: "Improve visual quality.",
+      content: "Use hierarchy."
+    })
   end
 
   describe "cancel_execution/2 (end-to-end)" do
@@ -497,6 +506,58 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert title_job.args["user_prompt_text"] =~ "https://example.com/app"
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
+    end
+
+    test "sends selected skill content with scoped user turn", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      parent = self()
+      {:ok, skill} = register_skill(scope)
+
+      expect(LLMProviderMock, :stream_text, fn _model, messages, _opts ->
+        send(parent, {:provider_messages, messages})
+        ReqLLMResponses.response("Response")
+      end)
+
+      {:ok, _, 1} =
+        submit_user_message(scope, task_id, user_content("Improve hero"),
+          selected_server_skill_id: skill.id
+        )
+
+      assert_receive {:interaction, %Interaction.AgentCompleted{}, 1}, 5_000
+      assert_receive {:provider_messages, messages}, 1_000
+
+      user_message = Enum.find(messages, &(&1.role == :user))
+      assert user_message != nil
+
+      assert [active_skill_part, user_prompt_part | _rest] = user_message.content
+      assert active_skill_part.text =~ "## Active Skill: design_polish"
+      assert active_skill_part.text =~ "Use hierarchy."
+      assert user_prompt_part.text == "Improve hero"
+
+      expect(LLMProviderMock, :stream_text, fn _model, messages, _opts ->
+        send(parent, {:followup_provider_messages, messages})
+        ReqLLMResponses.response("Follow-up response")
+      end)
+
+      {:ok, _, 2} = submit_user_message(scope, task_id, user_content("Now tighten copy"))
+
+      assert_receive {:interaction, %Interaction.AgentCompleted{}, 2}, 5_000
+      assert_receive {:followup_provider_messages, followup_messages}, 1_000
+
+      user_messages = Enum.filter(followup_messages, &(&1.role == :user))
+      assert [historical_user_message, current_user_message] = user_messages
+
+      assert [historical_skill_part, historical_prompt_part | _rest] =
+               historical_user_message.content
+
+      assert historical_skill_part.text =~ "## Active Skill: design_polish"
+      assert historical_skill_part.text =~ "Use hierarchy."
+      assert historical_prompt_part.text == "Improve hero"
+
+      assert [current_prompt_part] = current_user_message.content
+      assert current_prompt_part.text == "Now tighten copy"
     end
 
     test "startup failure persists terminal error on the same turn" do

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -1,6 +1,8 @@
 defmodule FrontmanServer.Tasks.InteractionTest do
   use FrontmanServer.InteractionCase, async: true
 
+  alias FrontmanServer.CurrentPageContext
+  alias FrontmanServer.Skills.Skill
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tasks.InteractionSchema
 
@@ -11,6 +13,25 @@ defmodule FrontmanServer.Tasks.InteractionTest do
   }
 
   alias ModelContextProtocol, as: MCP
+
+  describe "SkillUsed.build/1" do
+    test "snapshots skill content" do
+      skill = %Skill{
+        id: Ecto.UUID.generate(),
+        name: "design_polish",
+        description: "Improve visual quality.",
+        content: "Use hierarchy."
+      }
+
+      assert %Interaction.SkillUsed{
+               skill_id: skill_id,
+               skill_name: "design_polish",
+               skill_content: "Use hierarchy."
+             } = Interaction.SkillUsed.build(skill)
+
+      assert skill_id == skill.id
+    end
+  end
 
   describe "UserMessage.attrs/1" do
     test "extracts non-empty text messages" do
@@ -309,6 +330,41 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       assert messages == []
     end
 
+    test "adds active skill as separate content part on previous user message" do
+      skill_used = %Interaction.SkillUsed{
+        id: "skill-used-1",
+        timestamp: DateTime.utc_now(),
+        skill_id: Ecto.UUID.generate(),
+        skill_name: "design_polish",
+        skill_content: "Use hierarchy."
+      }
+
+      messages = Interaction.to_swarm_messages([user_msg("Improve hero"), skill_used])
+
+      assert [%SwarmAi.Message.User{content: content}] = messages
+
+      assert [
+               %SwarmAi.Message.ContentPart{
+                 type: :text,
+                 text:
+                   "## Active Skill: design_polish\n\nUse this expert lens for this turn.\n\nUse hierarchy."
+               },
+               %SwarmAi.Message.ContentPart{type: :text, text: "Improve hero"}
+             ] = content
+    end
+
+    test "skips unpaired SkillUsed structs" do
+      skill_used = %Interaction.SkillUsed{
+        id: "skill-used-1",
+        timestamp: DateTime.utc_now(),
+        skill_id: Ecto.UUID.generate(),
+        skill_name: "design_polish",
+        skill_content: "Use hierarchy."
+      }
+
+      assert Interaction.to_swarm_messages([skill_used]) == []
+    end
+
     test "handles mixed conversation in correct order" do
       interactions = [
         user_msg("Calculate 2+2"),
@@ -579,6 +635,45 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
       assert %Interaction.UserMessage{current_page: %Interaction.CurrentPage{}, annotations: [_]} =
                row.data
+    end
+
+    test "deserializes skill used data" do
+      skill_used = %Interaction.SkillUsed{
+        id: "skill-used-1",
+        timestamp: DateTime.utc_now(),
+        skill_id: Ecto.UUID.generate(),
+        skill_name: "design_polish",
+        skill_content: "Use hierarchy."
+      }
+
+      row = %InteractionSchema{
+        type: :skill_used,
+        data: Interaction.to_data_map(skill_used)
+      }
+
+      assert %Interaction.SkillUsed{skill_name: "design_polish", skill_content: "Use hierarchy."} =
+               InteractionSchema.to_struct(row)
+    end
+  end
+
+  describe "InteractionSchema.create_changeset/3" do
+    test "requires a turn number for SkillUsed" do
+      skill_used = %Interaction.SkillUsed{
+        id: "skill-used-1",
+        timestamp: DateTime.utc_now(),
+        skill_id: Ecto.UUID.generate(),
+        skill_name: "design_polish"
+      }
+
+      changeset =
+        InteractionSchema.create_changeset(
+          %FrontmanServer.Tasks.TaskSchema{id: Ecto.UUID.generate()},
+          skill_used,
+          nil
+        )
+
+      refute changeset.valid?
+      assert {"missing for skill_used", []} = changeset.errors[:turn_number]
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -13,7 +13,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
   alias ModelContextProtocol, as: MCP
 
-  describe "SkillUsed.build/1" do
+  describe "SkillUsed.build/2" do
     test "snapshots skill content" do
       skill = %Skill{
         id: Ecto.UUID.generate(),
@@ -22,11 +22,14 @@ defmodule FrontmanServer.Tasks.InteractionTest do
         content: "Use hierarchy."
       }
 
+      user_message_id = Ecto.UUID.generate()
+
       assert %Interaction.SkillUsed{
+               user_message_id: ^user_message_id,
                skill_id: skill_id,
                skill_name: "design_polish",
                skill_content: "Use hierarchy."
-             } = Interaction.SkillUsed.build(skill)
+             } = Interaction.SkillUsed.build(skill, user_message_id)
 
       assert skill_id == skill.id
     end
@@ -329,39 +332,27 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       assert messages == []
     end
 
-    test "adds active skill as separate content part on previous user message" do
+    test "adds active skill as its own user context message" do
       skill_used = %Interaction.SkillUsed{
         id: "skill-used-1",
         timestamp: DateTime.utc_now(),
+        user_message_id: Ecto.UUID.generate(),
         skill_id: Ecto.UUID.generate(),
         skill_name: "design_polish",
         skill_content: "Use hierarchy."
       }
 
-      messages = Interaction.to_swarm_messages([user_msg("Improve hero"), skill_used])
-
-      assert [%SwarmAi.Message.User{content: content}] = messages
+      messages = Interaction.to_swarm_messages([skill_used, user_msg("Improve hero")])
 
       assert [
-               %SwarmAi.Message.ContentPart{
-                 type: :text,
-                 text:
-                   "## Active Skill: design_polish\n\nUse this expert lens for this turn.\n\nUse hierarchy."
-               },
-               %SwarmAi.Message.ContentPart{type: :text, text: "Improve hero"}
-             ] = content
-    end
+               %SwarmAi.Message.User{content: [skill_part]},
+               %SwarmAi.Message.User{content: [prompt_part]}
+             ] = messages
 
-    test "skips unpaired SkillUsed structs" do
-      skill_used = %Interaction.SkillUsed{
-        id: "skill-used-1",
-        timestamp: DateTime.utc_now(),
-        skill_id: Ecto.UUID.generate(),
-        skill_name: "design_polish",
-        skill_content: "Use hierarchy."
-      }
+      assert skill_part.text ==
+               "## Active Skill: design_polish\n\nUse this expert lens for this turn.\n\nUse hierarchy."
 
-      assert Interaction.to_swarm_messages([skill_used]) == []
+      assert prompt_part.text == "Improve hero"
     end
 
     test "handles mixed conversation in correct order" do

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -1,7 +1,6 @@
 defmodule FrontmanServer.Tasks.InteractionTest do
   use FrontmanServer.InteractionCase, async: true
 
-  alias FrontmanServer.CurrentPageContext
   alias FrontmanServer.Skills.Skill
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tasks.InteractionSchema
@@ -648,11 +647,11 @@ defmodule FrontmanServer.Tasks.InteractionTest do
 
       row = %InteractionSchema{
         type: :skill_used,
-        data: Interaction.to_data_map(skill_used)
+        data: skill_used
       }
 
       assert %Interaction.SkillUsed{skill_name: "design_polish", skill_content: "Use hierarchy."} =
-               InteractionSchema.to_struct(row)
+               row.data
     end
   end
 
@@ -666,11 +665,14 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       }
 
       changeset =
-        InteractionSchema.create_changeset(
-          %FrontmanServer.Tasks.TaskSchema{id: Ecto.UUID.generate()},
-          skill_used,
-          nil
-        )
+        %FrontmanServer.Tasks.TaskSchema{id: Ecto.UUID.generate()}
+        |> Ecto.build_assoc(:interaction_rows)
+        |> InteractionSchema.changeset(%{
+          id: Ecto.UUID.generate(),
+          type: :skill_used,
+          data: Map.from_struct(skill_used),
+          turn_number: nil
+        })
 
       refute changeset.valid?
       assert {"missing for skill_used", []} = changeset.errors[:turn_number]

--- a/skills-spec.md
+++ b/skills-spec.md
@@ -493,7 +493,7 @@ Use this expert lens for this turn.
 
 Build backend support first. No client work, no HTTP catalog API, no search endpoint, and no automatic skill router.
 
-### Implementation status as of 2026-06-28
+### Implementation status as of 2026-06-29
 
 Completed:
 
@@ -507,23 +507,20 @@ Completed:
 - Added optional explicit selected skill recording through `Tasks.submit_user_message/2`.
 - Added channel boundary mapping from `_meta.selectedServerSkillId` to internal `:selected_server_skill_id`.
 - Moved selected server skill lookup into `Tasks.submit_user_message/2` via `Skills.get_by_id/2`.
-- Simplified turn insertion by building `[UserMessage]` or `[UserMessage, SkillUsed]` and recording interactions in order.
+- Simplified turn insertion by recording `UserMessage` first and then optionally recording `SkillUsed` in the same transaction.
 - `TaskChannel` no longer queries `Skills`; it only translates ACP casing into domain argument names.
 - `Tasks.submit_user_message/2` maps `Skills.get_by_id/2` `{:error, :not_found}` to `{:error, :skill_not_found}`.
 - `Skills.get_by_id/2` returns `{:ok, nil}` for nil ids so no selected skill stays a normal no-op path.
 - Removed premature `ActiveSkill`/selected-skill wrapper ideas from MVP design.
 - Removed channel-side `rescue Ecto.NoResultsError` and id pre-validation; `Repo.get/2` owns lookup behavior.
 - Removed tiny selected-skill helper functions after they proved noisier than the direct flow.
-- Removed nested optional-skill cases in favor of a single ordered interaction list.
+- Removed nested optional-skill cases and tiny selected-skill wrappers in favor of direct optional interaction recording.
 - Added `:skill_not_found` handling as ACP invalid params with message `Selected skill not found`.
-- Added explicit `SkillUsed` no-op handling in `Interaction.to_swarm_messages/1` because execution currently serializes history immediately after turn insertion. This is now known to be incomplete: `SkillUsed` must instead be folded into its paired `UserMessage` when both are present.
-
-Not completed yet:
-
-- Store `skill_content` snapshot on `SkillUsed`.
-- Fold `[UserMessage, SkillUsed]` into one LLM user message with the active skill section prepended before the original user message.
-- Update execution prompt reconstruction so it serializes ordered turn interactions together instead of one database row at a time.
-- Final `mix precommit`.
+- Added `skill_content` snapshot on `SkillUsed`.
+- Updated `Interaction.to_swarm_messages/1` so `SkillUsed` prepends an active skill text part to the previous user message and emits nothing when unpaired.
+- Updated `Execution.prompt_messages/2` to serialize ordered interactions by turn instead of one database row at a time.
+- Verified selected skill content reaches the current LLM user turn, historical skilled turns replay with their stored skill snapshot, and unskilled later turns do not inherit previous skill instructions.
+- Final backend verification passed with `make precommit` from `apps/frontman_server` (`mix precommit` is not defined in this project).
 
 ### Task 1: Add skills table
 
@@ -688,21 +685,21 @@ Current backend contract:
 
 **Acceptance criteria:**
 
-- [ ] `Interaction.SkillUsed` has `skill_content`.
-- [ ] `Interaction.SkillUsed.build/1` snapshots `skill.content` into `skill_content`.
-- [ ] `Interaction.to_data_map/1` persists `skill_content` in `interactions.data`.
-- [ ] `InteractionSchema.to_struct/1` loads `skill_content` from persisted JSONB.
-- [ ] `Interaction.to_swarm_messages([user_message, skill_used])` emits exactly one user message.
-- [ ] The emitted user message prepends the deterministic `## Active Skill: ...` section before the original user message.
-- [ ] The emitted user message uses `skill_used.skill_content`, not a refetched `skills.content` value.
-- [ ] `Interaction.to_swarm_messages([skill_used])` returns `[]` because an unpaired skill row has no user message to modify.
-- [ ] `SkillUsed` never emits assistant or tool messages.
-- [ ] Existing turns without a selected skill serialize unchanged.
+- [x] `Interaction.SkillUsed` has `skill_content`.
+- [x] `Interaction.SkillUsed.build/1` snapshots `skill.content` into `skill_content`.
+- [x] `Interaction.to_data_map/1` persists `skill_content` in `interactions.data`.
+- [x] `InteractionSchema.to_struct/1` loads `skill_content` from persisted JSONB.
+- [x] `Interaction.to_swarm_messages([user_message, skill_used])` emits exactly one user message.
+- [x] The emitted user message prepends the deterministic `## Active Skill: ...` section before the original user message.
+- [x] The emitted user message uses `skill_used.skill_content`, not a refetched `skills.content` value.
+- [x] `Interaction.to_swarm_messages([skill_used])` returns `[]` because an unpaired skill row has no user message to modify.
+- [x] `SkillUsed` never emits assistant or tool messages.
+- [x] Existing turns without a selected skill serialize unchanged.
 
 **Verification:**
 
-- [ ] `mix test test/frontman_server/tasks/interaction_test.exs`
-- [ ] `mix test test/frontman_server/tasks_test.exs`
+- [x] `mix test test/frontman_server/tasks/interaction_test.exs`
+- [x] `mix test test/frontman_server/tasks_test.exs`
 
 **Dependencies:** Task 4
 
@@ -720,16 +717,16 @@ Current backend contract:
 
 **Acceptance criteria:**
 
-- [ ] `Execution.prompt_messages/2` serializes ordered interactions by turn, not one database row at a time.
-- [ ] A current turn with `[UserMessage, SkillUsed]` sends one user message containing the skill section and original user prompt.
-- [ ] A later turn reconstructs previous skilled turns with their historical skill content snapshot.
-- [ ] Previous turn skills are scoped to their original user messages and do not become global current-turn system instructions.
-- [ ] `Execution.system_prompt/2` and `Prompts.build/1` do not receive selected skill data for MVP.
-- [ ] No duplicate skill instructions are emitted through both user message and system prompt.
+- [x] `Execution.prompt_messages/2` serializes ordered interactions by turn, not one database row at a time.
+- [x] A current turn with `[UserMessage, SkillUsed]` sends one user message containing the skill section and original user prompt.
+- [x] A later turn reconstructs previous skilled turns with their historical skill content snapshot.
+- [x] Previous turn skills are scoped to their original user messages and do not become global current-turn system instructions.
+- [x] `Execution.system_prompt/2` and `Prompts.build/1` do not receive selected skill data for MVP.
+- [x] No duplicate skill instructions are emitted through both user message and system prompt.
 
 **Verification:**
 
-- [ ] `mix test test/frontman_server/tasks/execution_test.exs`
+- [x] `mix test test/frontman_server/tasks/execution_test.exs`
 
 **Dependencies:** Tasks 5 and 6
 
@@ -756,20 +753,20 @@ After Tasks 4-5:
 
 After Tasks 6-7:
 
-- [ ] Current-turn skill affects the paired LLM user message.
-- [ ] Historical skilled turns reconstruct with their stored skill content snapshots.
-- [ ] Conversation message serialization emits no standalone `SkillUsed` assistant/tool/user messages.
-- [ ] ACP replay does not render skill use.
+- [x] Current-turn skill affects the paired LLM user message.
+- [x] Historical skilled turns reconstruct with their stored skill content snapshots.
+- [x] Conversation message serialization emits no standalone `SkillUsed` assistant/tool/user messages.
+- [x] ACP replay does not render skill use.
 
 Final verification:
 
-- [ ] `mix test test/frontman_server/skills_test.exs`
-- [ ] `mix test test/frontman_server/tasks/interaction_test.exs`
-- [ ] `mix test test/frontman_server/tasks_test.exs`
-- [ ] `mix test test/frontman_server/tasks/execution_test.exs`
-- [ ] `mix test test/protocols/acp_history_test.exs`
-- [ ] `mix test test/frontman_server_web/channels/task_channel_test.exs`
-- [ ] `mix precommit`
+- [x] `mix test test/frontman_server/skills_test.exs`
+- [x] `mix test test/frontman_server/tasks/interaction_test.exs`
+- [x] `mix test test/frontman_server/tasks_test.exs`
+- [x] `mix test test/frontman_server/tasks/execution_test.exs`
+- [x] `mix test test/protocols/acp_history_test.exs`
+- [x] `mix test test/frontman_server_web/channels/task_channel_test.exs`
+- [x] `make precommit` from `apps/frontman_server`
 
 ## MVP
 

--- a/skills-spec.md
+++ b/skills-spec.md
@@ -1,0 +1,810 @@
+# Skills Support Product Spec
+
+## Product Thesis
+
+Skills in Frontman should not feel like prompt packs. They should feel like Frontman becoming the right expert at the right moment.
+
+Core delight:
+
+> User asks normal goal. Frontman silently finds right capability, lightly reveals it, and produces better result than generic chat because it understands live app context.
+
+Frontman advantage:
+
+> Skills become more valuable because they run inside real page context: selected UI, DOM, CSS, routes, screenshots, logs, source mapping, and hot reload.
+
+Generic agent skill systems are file/plugin management. Frontman skill system should be outcome routing inside live product surface.
+
+## Primary Job To Be Done
+
+When I am improving my page/app, I want Frontman to know which expert lens to apply, so I can get better design, SEO, copy, and product results without learning prompt engineering, skill names, or coding-agent workflows.
+
+Sub-jobs:
+
+- "Make this page better" -> Frontman routes to design/copy/SEO/conversion skills.
+- "Improve this hero" -> Frontman uses selected element context and suggests relevant skills.
+- "I want more capabilities" -> user opens Skill Library and sees globally available curated official skills.
+- "I know what I want" -> user explicitly says `use SEO skill` or chooses skill chip.
+- "I don't know what exists" -> Frontman exposes skills through contextual suggestions and goal search.
+
+## Experience Principles
+
+1. Skills mostly invisible by default.
+User should not need to know what skill is. Skill should be internal routing layer.
+
+2. Light visibility builds trust.
+Show small chip: `Using Design Polish`, `Using SEO Auditor`, `Using Conversion Copy`. Not modal, not workflow blocker.
+
+3. Discovery happens at moment of intent.
+Best discovery surface is selected page/element plus user goal. "Good skills for this" beats generic marketplace browsing.
+
+4. Library is curated, not chaotic.
+Official skills first. Community later, if ever, behind quality filter.
+
+5. Server-bundled skills are globally usable first.
+No hunting markdown files. No copying prompts. No editing config. Available skills can be used immediately.
+
+## Core UX Model
+
+Three skill entry points:
+
+- Automatic: Frontman detects likely skill from prompt/context.
+Example: "make this section more premium" -> `Design Polish`.
+
+- Explicit: User invokes skill directly.
+Example: "use SEO auditor on this page."
+
+- Library: User browses/searches available skills.
+Example: Search "rank better" -> shows SEO-related official skills.
+
+These should share same mental model: skills are expert lenses for goals.
+
+## Suggested UI Shape
+
+Compact skill chip in chat composer/result area:
+
+`Using Design Polish`
+
+Chip actions:
+
+- click opens short explanation
+- switch skill
+- view related skills
+- disable for this turn
+
+Contextual suggestions near selection:
+
+When user selects page/element, show 1-3 chips:
+
+- `Polish design`
+- `Improve SEO`
+- `Rewrite for conversion`
+
+Not "skills" first. Goals first. Skill name can appear beneath or after selection.
+
+Skill Library:
+
+- always reachable from small icon/menu
+- search by goal, not skill filename
+- curated presentation can be added later without storing category on `skills`
+- all listed server-bundled skills are globally usable in MVP
+- no install/default distinction in MVP
+
+## Skill Library Positioning
+
+Do not call it marketplace early. "Skill Library" or "Expert Library" better.
+
+Marketplace implies abundance and quality variance. Library implies curation and trust.
+
+Recommended framing:
+
+> Official expert skills for improving live pages with Frontman.
+
+Each skill card should answer:
+
+- What user goal does this help with?
+- When will Frontman use it automatically?
+- What kind of results should user expect?
+- What skill name can be referenced explicitly?
+
+## Auto-Routing Behavior
+
+Auto-routing is product direction, not backend MVP scope.
+
+Do not introduce a backend skill router yet. The first backend implementation should only support explicit skill selection and task-history persistence. Routing can be designed later when the client-side surfaces and product interaction model are concrete.
+
+Skill router should optimize for user intent, not exact keywords.
+
+Signals:
+
+- user prompt
+- selected element/page
+- current route/page type
+- page metadata
+- visible DOM/copy
+- available server skills
+- user explicitly named skill
+
+Routing output should be explainable:
+
+> "I'm using Design Polish because you selected a hero section and asked to make it feel more premium."
+
+This creates delight: Frontman feels smart, not magical/opaque.
+
+## Delight Moments
+
+1. "I didn't know skills existed, but Frontman used right one."
+User asks: "make this page better."
+Frontman: `Using Design Polish + Conversion Copy`.
+Result feels sharper.
+
+2. "It knows what this page needs."
+User selects hero.
+Frontman suggests: `Improve headline`, `Polish layout`, `SEO check`.
+
+3. "Using skills is easier than Cursor/Claude Code."
+User opens library, sees available skills, and can use one immediately without install/configuration.
+
+4. "I can find skills without knowing names."
+Search: "get more signups" -> finds Conversion Copy, Landing Page Critic, CTA Optimizer.
+
+## What Not To Build
+
+Avoid:
+
+- filesystem-first skill management
+- giant marketplace grid as primary entry
+- requiring users to know skill names
+- making skill choice mandatory every turn
+- config-heavy install or enablement flows
+- exposing implementation concepts like MCP/OpenClaw unless in advanced view
+- turning skills into reports-only UX
+- hiding skill identity completely, because that kills trust and discoverability
+
+## Product Architecture, Conceptually
+
+Think of feature as four product layers:
+
+- Server skill catalog: trusted official skills bundled with Frontman and available to every user.
+- Skill router: decides best skill from prompt/context.
+- Skill surfaces: chip, contextual suggestions, library/search.
+- Task history: records which skill was used for each turn.
+
+Most user value lives in router + surfaces, not skill format.
+
+Backend MVP deliberately implements only the foundation:
+
+- Server skill catalog stored in the database.
+- Official skill seeds loaded by `priv/repo/seeds.exs`.
+- Task history record for explicit skill use.
+- LLM prompt reconstruction for selected skill use by storing a per-turn skill content snapshot and prepending it to that turn's user message.
+
+Backend MVP does not implement skill library APIs, search APIs, automatic routing, or client-facing skill surfaces. Those should be dictated by the client experience later.
+
+## Phoenix Schema And DB Contract
+
+MVP stores only server-bundled official skills in the database. Future client-bundled skills should stay client-owned and client-resolved; the server database should not become the canonical store for client skill content. Treat namespace as implicit in the boundary field: server skills use server IDs, while future client skills pass the full skill payload for the current turn.
+
+Use domain language instead of generic CRUD naming. The product noun is `Skill`, but the behavior is not "manage skill rows." The behavior is:
+
+> Frontman catalogs skills and records when a task turn used one.
+
+### `skills` table
+
+This is the full MVP table. Do not add extra columns yet.
+
+```elixir
+create table(:skills, primary_key: false) do
+  add :id, :binary_id, primary_key: true
+  add :name, :string, null: false
+  add :description, :text, null: false
+  add :content, :text, null: false
+
+  timestamps(type: :utc_datetime)
+end
+
+create unique_index(:skills, [:name])
+
+create constraint(:skills, :skills_name_format,
+  check: "name ~ '^[a-z0-9][a-z0-9_-]*$' AND name = lower(name)"
+)
+```
+
+### `FrontmanServer.Skills.Skill` schema
+
+```elixir
+defmodule FrontmanServer.Skills.Skill do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @name_format ~r/^[a-z0-9][a-z0-9_-]*$/
+
+  schema "skills" do
+    field :name, :string
+    field :description, :string
+    field :content, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(skill, attrs) do
+    skill
+    |> cast(attrs, [:name, :description, :content])
+    |> update_change(:name, &String.downcase/1)
+    |> validate_required([:name, :description, :content])
+    |> validate_format(:name, @name_format)
+    |> validate_length(:description, min: 1, max: 200)
+    |> validate_length(:content, min: 1)
+    |> unique_constraint(:name)
+    |> check_constraint(:name, name: :skills_name_format)
+  end
+end
+```
+
+### Field meanings
+
+- `id`: database UUID. Used by `Skills.get_by_id(scope, id)` and `SkillUsed.skill_id` for server-bundled skills.
+- `name`: machine-readable skill identifier. Always lowercase. Allowed characters: `a-z`, `0-9`, `_`, `-`. Must match `^[a-z0-9][a-z0-9_-]*$`.
+- `description`: required human summary for catalog/search/UI. Maximum 200 characters.
+- `content`: required skill instructions/body.
+
+### Official skill seeds
+
+Official server-bundled skills live in `priv/official_skills` only as seed input.
+
+For server-bundled skills, the database is the source of truth after seeding. Runtime code for server skills must read from the `skills` table, not from markdown files. Seed loading should be idempotent: re-running seeds updates existing rows by `name` and does not create duplicates.
+
+Invalid official skill seed files should fail loudly during seed load. Do not silently skip malformed files.
+
+MVP seed loading should stay simple: keep markdown parsing and idempotent upsert logic directly in `priv/repo/seeds.exs` unless it becomes reused elsewhere. Do not add a separate loader module for one seed script.
+
+Current seed markdown shape:
+
+```md
+---
+name: design_polish
+description: Improve visual quality using selected UI, DOM, CSS, and page context.
+---
+
+[skill.content]
+```
+
+### Validations
+
+Application validations:
+
+- `name` required.
+- `name` is downcased before validation.
+- `name` must match `^[a-z0-9][a-z0-9_-]*$`.
+- `name` must be unique.
+- `description` required and non-empty.
+- `description` must be at most 200 characters.
+- `content` required and non-empty.
+
+Database validations:
+
+- `name`, `description`, and `content` are `null: false`.
+- `name` has unique index.
+- `skills_name_format` check constraint enforces lowercase machine-name format even outside Ecto.
+
+### Explicit exclusions
+
+Do not add these tables in MVP:
+
+- `skill_versions`
+- `skill_installations`
+- `skill_routing_events`
+- organization-specific skill tables
+- user-specific skill tables
+
+Do not add these fields to `skills` in MVP:
+
+- `slug`
+- `category`
+- `status`
+- `title`
+- `auto_route_enabled`
+- `trigger_terms`
+- `goal_examples`
+- `instructions`
+- `metadata`
+- `provider`
+- `version`
+- `installed_at`
+- `enabled`
+
+`content` replaces the earlier `instructions` field name.
+
+### Phoenix context API
+
+```elixir
+Skills.catalog(scope)
+Skills.get_by_id(scope, id)
+Skills.register(scope, attrs)
+Skills.update(scope, skill, attrs)
+```
+
+Semantics:
+
+- `catalog(scope)`: returns all globally usable server-bundled skills ordered by `name`.
+- `get_by_id(scope, id)`: returns `{:ok, skill}` for a skill by database id or `{:error, :not_found}` if missing. Passing `nil` returns `{:ok, nil}` so callers can treat missing selection as normal no-skill state. Do not add pre-validation around ids here; let `Repo.get/2` own lookup semantics.
+- `register(scope, attrs)`: registers a new server-bundled skill through `Skill.changeset/2`.
+- `update(scope, skill, attrs)`: updates an existing skill through `Skill.changeset/2`.
+
+Each method accepts `scope` first to match existing Phoenix context conventions and preserve future authorization shape. Scope is not used for filtering in MVP because all server-bundled skills are globally usable.
+
+### Selected skill boundary contract
+
+`TaskChannel` should translate ACP metadata casing into domain argument names before calling `Tasks.submit_user_message/2`, but it must not query skills or create task interactions directly.
+
+MVP semantics:
+
+- `_meta.selectedServerSkillId` references a server-bundled skill row.
+- `TaskChannel` maps `_meta.selectedServerSkillId` to internal `:selected_server_skill_id` and does no skill lookup.
+- `Tasks.submit_user_message/2` accepts optional `selected_server_skill_id` in its atom-keyed domain argument map.
+- `Tasks` owns server skill lookup, `Interaction.SkillUsed` creation with a skill content snapshot, and interaction persistence.
+- Missing server skill returns `{:error, :skill_not_found}` from `Tasks.submit_user_message/2`; `TaskChannel` maps it to ACP invalid params.
+
+Current implementation shape:
+
+```elixir
+# TaskChannel boundary mapping only
+selected_server_skill_id: meta["selectedServerSkillId"]
+
+# Tasks context owns lookup
+selected_server_skill_id = Map.get(arguments, :selected_server_skill_id)
+
+with {:ok, user_message} <- Interaction.UserMessage.build(content_blocks, model),
+     {:ok, selected_skill} <- Skills.get_by_id(scope, selected_server_skill_id),
+     {:ok, {task_schema, turn_number}} <-
+       insert_user_turn_for_locked_task(scope, task_id, user_message, selected_skill) do
+  ...
+else
+  {:error, :not_found} -> {:error, :skill_not_found}
+end
+
+# Turn insertion records one ordered list
+interactions =
+  if selected_skill,
+    do: [user_message, Interaction.SkillUsed.build(selected_skill)],
+    else: [user_message]
+```
+
+This shape is intentional: one lookup, no channel query, no selected-skill wrapper, no `%Skills.Skill{}` crossing from channel into `Tasks`, and no validation ceremony after lookup.
+
+Future client-skill semantics:
+
+- Client-bundled skills should use a separate ACP metadata field, not `selectedServerSkillId`.
+- The client should pass the full skill payload for the current turn to avoid a server/client round trip.
+- Future client-bundled skills should use a separate domain argument that carries full client skill data. Do not force client skills through `selected_server_skill_id`, and do not store client skill bodies in the server skill catalog. If client skills are recorded in history later, snapshot their content in the task interaction for the selected turn, same as server skills.
+- Add a dedicated selected-skill contract only when client payload support is implemented.
+
+Lessons from implementation:
+
+- Do not add a generic `ActiveSkill` layer before client-provided skills exist. Server-bundled MVP can use `Skills.Skill` directly inside `Tasks` after lookup.
+- Do not make the channel resolve skills. It creates duplicate ceremony because `Tasks` still owns transaction safety and must decide whether to insert `SkillUsed`.
+- Do not make `Tasks` accept `%Skills.Skill{}` from the channel, then revalidate it. Passing the server skill id is simpler and keeps lookup authority inside the context.
+- Keep optional skill recording as data flow, not nested control flow. Build the interaction list for the turn as `[UserMessage]` or `[UserMessage, SkillUsed]`, then record the list in order. LLM serialization is responsible for folding `SkillUsed` back into the paired user message.
+- Prefer one obvious branch over tiny helper functions for this flow. Helper names did not reduce concepts here; they hid simple optional persistence.
+- Keep `TaskChannel` boring. Its job is protocol translation and error mapping, not domain lookup.
+- Let the context own consistency. `Tasks.submit_user_message/2` must fetch skill before the transaction and return before inserting anything when the selected server skill is unknown.
+- Keep no-skill as nil. `Skills.get_by_id(scope, nil) == {:ok, nil}` lets no-selection flow through the same path without extra branching in the channel.
+
+## Task History Model
+
+Do not create a separate routing events table for MVP.
+
+Record skill usage as a task interaction:
+
+- Add `SkillUsed` to `FrontmanServer.Tasks.Interaction`.
+- Persist it through `interactions.type = :skill_used` and JSONB `data`.
+- Keep it per-turn, not task-scoped, so it requires a `turn_number`.
+
+`SkillUsed` fields:
+
+- `id`
+- `timestamp`
+- `skill_id`
+- `skill_name`
+- `skill_content`
+
+Store `skill_name` denormalized so old task history remains readable if the skill row changes later. Store `skill_content` as a snapshot so future conversation reconstruction uses the exact skill instructions that shaped the original assistant response, even if the catalog row changes later.
+
+`skill_content` lives inside `interactions.data` JSONB. It does not require a database migration for the `interactions` table shape, but existing serialized `skill_used` rows without `skill_content` cannot reconstruct exact historical skill instructions. That is acceptable for current pre-MVP/dev data unless shipped persisted rows need explicit backfill.
+
+### Recording selected skill use
+
+When a turn explicitly uses a skill, insert `SkillUsed` in the same transaction as the `UserMessage` for that turn.
+
+Rules:
+
+- `Tasks.submit_user_message/2` resolves selected server skill before agent execution starts.
+- If selected server skill id is unknown, return an error and insert no turn interactions.
+- `UserMessage` and `SkillUsed` must share the same `turn_number`.
+- Existing turns without a selected skill should continue unchanged.
+- `UserMessage` must be inserted before `SkillUsed` in the same turn, so task history keeps natural turn order for UI/audit.
+- `SkillUsed.skill_content` must snapshot the selected skill's `content` at submission time.
+- The LLM serializer must treat `[UserMessage, SkillUsed]` in the same turn as one user message whose text is `[skill prompt section]\n\n[user message]`.
+
+For MVP, `skill_id` records the server-bundled skill row. Future client skills may have no server id; do not use `skill_id` as the generic selected-skill contract outside `SkillUsed` persistence.
+
+Boundary mapping:
+
+- Client/ACP metadata uses camelCase `_meta.selectedServerSkillId` for server-bundled skills.
+- `TaskChannel` maps that wire field to `:selected_server_skill_id`.
+- `Tasks.submit_user_message/2` accepts atom-keyed domain arguments and should not know about ACP casing.
+- Unknown selected server skill returns `{:error, :skill_not_found}` from `Tasks`.
+- `TaskChannel` maps `:skill_not_found` to `JsonRpc.error_invalid_params()` with message `Selected skill not found`.
+- `TaskChannel` should not call `Skills.get_by_id/2`; doing so duplicates domain responsibility and forces awkward revalidation in `Tasks`.
+
+The `selectedServerSkillId` name is intentionally explicit. Future client-bundled skills should not pass an id that implies server persistence; they can pass the full client skill payload for the current turn through a separate metadata field when that feature is designed.
+
+### LLM conversation serialization
+
+`SkillUsed` is not a standalone user, assistant, or tool message. It is a per-turn prompt modifier for the user message that immediately precedes it in the same turn.
+
+Serialize a skilled turn by folding `SkillUsed` into the paired `UserMessage`:
+
+```elixir
+Interaction.to_swarm_messages([user_message, skill_used])
+# => [%SwarmAi.Message.User{content: [text("[skill section]\n\n[user message]")]}]
+```
+
+`SkillUsed` alone should still serialize to `[]`, because it has no user message to modify. `SkillUsed` must never emit assistant or tool messages.
+
+Selected skill instructions should enter the model by prepending the active skill prompt section to that turn's user message. This must happen for both the immediate current turn and future conversation reconstruction when the user returns to a task and continues the conversation.
+
+This design preserves causality in later turns: if turn 3 used `design_polish`, turn 4's reconstructed message chain still shows the exact skill instructions that shaped turn 3's assistant response.
+
+Do not refetch historical skill content from the `skills` table during replay. Historical replay must use `SkillUsed.skill_content`, not the current catalog row, because official skill content can change after the turn was recorded.
+
+Prompt section format:
+
+```md
+## Active Skill: design_polish
+
+Use this expert lens for this turn.
+
+[skill.content]
+```
+
+Use `skill.name` in the heading unless/until a separate display field exists. There is no `title` field in the MVP schema.
+
+Do not apply a previous turn's skill to a later turn as active current-turn instructions unless the later turn also has its own `SkillUsed` interaction. Previous turns may still include their own scoped skill section as part of historical conversation reconstruction.
+
+When serializing a turn with a selected skill, format the LLM user text as:
+
+```md
+## Active Skill: design_polish
+
+Use this expert lens for this turn.
+
+[skill.content snapshot]
+
+[original user message and attached context]
+```
+
+`Execution.prompt_messages/2` must serialize ordered interactions with enough turn context to fold `[UserMessage, SkillUsed]` together. Serializing one database row at a time is insufficient because the `SkillUsed` row follows the `UserMessage` row and must prepend content to that message.
+
+`SkillUsed` should also replay as an empty ACP history item for now. Client display of skill chips/history can be designed later.
+
+## Backend MVP Implementation Plan
+
+Build backend support first. No client work, no HTTP catalog API, no search endpoint, and no automatic skill router.
+
+### Implementation status as of 2026-06-28
+
+Completed:
+
+- Added `skills` table migration with `id`, `name`, `description`, `content`, timestamps, unique `name`, and lowercase name check constraint.
+- Added `FrontmanServer.Skills.Skill` schema and `FrontmanServer.Skills` context.
+- Added `description` max length of 200 characters.
+- Removed `title` completely from the backend MVP schema and task-history model.
+- Added `priv/official_skills/design_polish.md` and inline seed parsing/upsert in `priv/repo/seeds.exs`.
+- Added `Interaction.SkillUsed` with `id`, `timestamp`, `skill_id`, and `skill_name`.
+- Added `:skill_used` to interaction type handling and ACP history replay as `[]`.
+- Added optional explicit selected skill recording through `Tasks.submit_user_message/2`.
+- Added channel boundary mapping from `_meta.selectedServerSkillId` to internal `:selected_server_skill_id`.
+- Moved selected server skill lookup into `Tasks.submit_user_message/2` via `Skills.get_by_id/2`.
+- Simplified turn insertion by building `[UserMessage]` or `[UserMessage, SkillUsed]` and recording interactions in order.
+- `TaskChannel` no longer queries `Skills`; it only translates ACP casing into domain argument names.
+- `Tasks.submit_user_message/2` maps `Skills.get_by_id/2` `{:error, :not_found}` to `{:error, :skill_not_found}`.
+- `Skills.get_by_id/2` returns `{:ok, nil}` for nil ids so no selected skill stays a normal no-op path.
+- Removed premature `ActiveSkill`/selected-skill wrapper ideas from MVP design.
+- Removed channel-side `rescue Ecto.NoResultsError` and id pre-validation; `Repo.get/2` owns lookup behavior.
+- Removed tiny selected-skill helper functions after they proved noisier than the direct flow.
+- Removed nested optional-skill cases in favor of a single ordered interaction list.
+- Added `:skill_not_found` handling as ACP invalid params with message `Selected skill not found`.
+- Added explicit `SkillUsed` no-op handling in `Interaction.to_swarm_messages/1` because execution currently serializes history immediately after turn insertion. This is now known to be incomplete: `SkillUsed` must instead be folded into its paired `UserMessage` when both are present.
+
+Not completed yet:
+
+- Store `skill_content` snapshot on `SkillUsed`.
+- Fold `[UserMessage, SkillUsed]` into one LLM user message with the active skill section prepended before the original user message.
+- Update execution prompt reconstruction so it serializes ordered turn interactions together instead of one database row at a time.
+- Final `mix precommit`.
+
+### Task 1: Add skills table
+
+**Description:** Add DB persistence for globally usable server-bundled skills using the exact MVP contract in this spec.
+
+**Acceptance criteria:**
+
+- [x] `skills` table exists with `id`, `name`, `description`, `content`, timestamps.
+- [x] `name`, `description`, and `content` are `null: false`.
+- [x] `name` has a unique index.
+- [x] DB check constraint `skills_name_format` enforces lowercase `^[a-z0-9][a-z0-9_-]*$`.
+
+**Verification:**
+
+- [x] `mix test test/frontman_server/skills_test.exs`
+- [x] `mix compile --warnings-as-errors --all-warnings`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `apps/frontman_server/priv/repo/migrations/*_create_skills.exs`
+
+**Estimated scope:** Small
+
+### Task 2: Add Skill schema and Skills context
+
+**Description:** Add `FrontmanServer.Skills.Skill` and public `FrontmanServer.Skills` context API.
+
+**Acceptance criteria:**
+
+- [x] `Skill.changeset/2` downcases `name`.
+- [x] Changeset validates required fields.
+- [x] Changeset validates `name` format.
+- [x] Changeset validates `description` max length of 200 characters.
+- [x] Changeset enforces unique and check constraints.
+- [x] `Skills.catalog(scope)` returns all skills ordered by `name`.
+- [x] `Skills.get_by_id(scope, id)` fetches by DB id, returns `{:error, :not_found}` for missing ids, and returns `{:ok, nil}` when no id is selected.
+- [x] `Skills.register(scope, attrs)` inserts through changeset.
+- [x] `Skills.update(scope, skill, attrs)` updates through changeset.
+- [x] `scope` arg is accepted first but unused for filtering in MVP.
+
+**Verification:**
+
+- [x] `mix test test/frontman_server/skills_test.exs`
+- [x] `mix compile --warnings-as-errors --all-warnings`
+
+**Dependencies:** Task 1
+
+**Files likely touched:**
+
+- `apps/frontman_server/lib/frontman_server/skills.ex`
+- `apps/frontman_server/lib/frontman_server/skills/skill.ex`
+- `apps/frontman_server/test/frontman_server/skills_test.exs`
+
+**Estimated scope:** Medium
+
+### Task 3: Add official skill seed loader
+
+**Description:** Load official skill seed files from `priv/official_skills` into the database idempotently from `priv/repo/seeds.exs`.
+
+**Acceptance criteria:**
+
+- [x] Each official skill file maps deterministically to `name`, `description`, and `content`.
+- [x] Missing or invalid fields fail loudly during seed load.
+- [x] Re-running seeds does not duplicate skills.
+- [x] Existing official skill rows update when seed file changes.
+- [x] Runtime code reads skills from DB, not seed files.
+
+**Verification:**
+
+- [x] `mix run priv/repo/seeds.exs`
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `apps/frontman_server/priv/official_skills/*.md`
+- `apps/frontman_server/priv/repo/seeds.exs`
+
+**Estimated scope:** Medium
+
+### Task 4: Add SkillUsed interaction type
+
+**Description:** Add `Interaction.SkillUsed` to the existing interaction model so selected skill use is persisted per turn.
+
+**Acceptance criteria:**
+
+- [x] `Interaction.SkillUsed` has fields `id`, `timestamp`, `skill_id`, `skill_name`.
+- [x] `:skill_used` is added to `Interaction.type_values/0`.
+- [x] `SkillUsed` is not task-scoped, so `turn_number` is required.
+- [x] `Interaction.to_data_map/1` persists expected JSON data.
+- [x] `InteractionSchema.to_struct/1` loads `SkillUsed`.
+- [x] ACP history protocol has explicit implementation returning `[]`.
+
+**Verification:**
+
+- [x] `mix test test/frontman_server/tasks/interaction_test.exs`
+- [x] `mix test test/protocols/acp_history_test.exs`
+- [x] `mix test test/frontman_server/tasks_test.exs`
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `apps/frontman_server/lib/frontman_server/tasks/interaction.ex`
+- `apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex`
+- `apps/frontman_server/lib/frontman_server_web/protocols/acp_history_impl.ex`
+- `apps/frontman_server/test/protocols/acp_history_test.exs`
+- `apps/frontman_server/test/frontman_server/tasks/interaction_test.exs`
+
+**Estimated scope:** Medium
+
+Task 4 reflects the originally completed interaction type. Task 6 extends that type with `skill_content` after clarifying that LLM history must reconstruct the exact message chain for future turns.
+
+### Task 5: Record selected server skill with user turn
+
+**Description:** Extend task submission internals to accept a selected server skill id, resolve it inside `Tasks`, and insert `UserMessage` plus `SkillUsed` in the same transaction.
+
+Current backend contract:
+
+- ACP boundary: `_meta.selectedServerSkillId`.
+- Channel/domain boundary: `:selected_server_skill_id`.
+- Skills lookup: `Tasks.submit_user_message/2` calls `Skills.get_by_id/2`.
+- No selection: `Skills.get_by_id(scope, nil) -> {:ok, nil}`.
+- Unknown server skill: `Tasks.submit_user_message/2 -> {:error, :skill_not_found}`.
+- Persistence: `insert_user_turn_if_idle/3` records `[UserMessage]` or `[UserMessage, SkillUsed]` in order.
+
+**Acceptance criteria:**
+
+- [x] `TaskChannel` maps `_meta.selectedServerSkillId` to `:selected_server_skill_id` before calling `Tasks.submit_user_message/2`.
+- [x] `Tasks.submit_user_message/2` accepts optional `selected_server_skill_id` in input map.
+- [x] `Tasks.submit_user_message/2` resolves selected server skill from DB before agent execution starts.
+- [x] Missing selected server skill returns tagged error and inserts no user message.
+- [x] `TaskChannel` maps `:skill_not_found` to ACP invalid params.
+- [x] `UserMessage` and `SkillUsed` share same `turn_number`.
+- [x] Existing calls without selected skill continue unchanged.
+- [x] Turn still rejects when agent already running.
+- [x] Turn insertion builds `[UserMessage]` or `[UserMessage, SkillUsed]` and records interactions in order.
+- [x] No `ActiveSkill`, no `%Skills.Skill{}` crossing from channel to tasks, no channel skill lookup.
+
+**Verification:**
+
+- [x] `mix test test/frontman_server/tasks_test.exs`
+- [x] `mix test test/frontman_server_web/channels/task_channel_test.exs`
+- [x] `mix compile --warnings-as-errors --all-warnings`
+
+**Dependencies:** Tasks 2 and 4
+
+**Files likely touched:**
+
+- `apps/frontman_server/lib/frontman_server/tasks.ex`
+- `apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex`
+- `apps/frontman_server/test/frontman_server/tasks_test.exs`
+- `apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs`
+
+**Estimated scope:** Medium
+
+### Task 6: Fold SkillUsed into paired user message
+
+**Description:** Store the selected skill content snapshot on `SkillUsed` and serialize skilled turns by prepending the active skill section to the paired user message. `SkillUsed` must not become a standalone assistant, user, or tool message.
+
+**Acceptance criteria:**
+
+- [ ] `Interaction.SkillUsed` has `skill_content`.
+- [ ] `Interaction.SkillUsed.build/1` snapshots `skill.content` into `skill_content`.
+- [ ] `Interaction.to_data_map/1` persists `skill_content` in `interactions.data`.
+- [ ] `InteractionSchema.to_struct/1` loads `skill_content` from persisted JSONB.
+- [ ] `Interaction.to_swarm_messages([user_message, skill_used])` emits exactly one user message.
+- [ ] The emitted user message prepends the deterministic `## Active Skill: ...` section before the original user message.
+- [ ] The emitted user message uses `skill_used.skill_content`, not a refetched `skills.content` value.
+- [ ] `Interaction.to_swarm_messages([skill_used])` returns `[]` because an unpaired skill row has no user message to modify.
+- [ ] `SkillUsed` never emits assistant or tool messages.
+- [ ] Existing turns without a selected skill serialize unchanged.
+
+**Verification:**
+
+- [ ] `mix test test/frontman_server/tasks/interaction_test.exs`
+- [ ] `mix test test/frontman_server/tasks_test.exs`
+
+**Dependencies:** Task 4
+
+**Files likely touched:**
+
+- `apps/frontman_server/lib/frontman_server/tasks/interaction.ex`
+- `apps/frontman_server/test/frontman_server/tasks/interaction_test.exs`
+- `apps/frontman_server/test/frontman_server/tasks_test.exs`
+
+**Estimated scope:** Small
+
+### Task 7: Reconstruct execution prompts with turn-level skill folding
+
+**Description:** Update execution prompt reconstruction so stored interactions are serialized with enough turn context to fold each `[UserMessage, SkillUsed]` pair into one skilled user message. Do not add separate system prompt injection for selected skills; the selected skill content belongs with the user turn that selected it.
+
+**Acceptance criteria:**
+
+- [ ] `Execution.prompt_messages/2` serializes ordered interactions by turn, not one database row at a time.
+- [ ] A current turn with `[UserMessage, SkillUsed]` sends one user message containing the skill section and original user prompt.
+- [ ] A later turn reconstructs previous skilled turns with their historical skill content snapshot.
+- [ ] Previous turn skills are scoped to their original user messages and do not become global current-turn system instructions.
+- [ ] `Execution.system_prompt/2` and `Prompts.build/1` do not receive selected skill data for MVP.
+- [ ] No duplicate skill instructions are emitted through both user message and system prompt.
+
+**Verification:**
+
+- [ ] `mix test test/frontman_server/tasks/execution_test.exs`
+
+**Dependencies:** Tasks 5 and 6
+
+**Files likely touched:**
+
+- `apps/frontman_server/lib/frontman_server/tasks/execution.ex`
+- `apps/frontman_server/test/frontman_server/tasks/execution_test.exs`
+
+**Estimated scope:** Medium
+
+### Backend checkpoints
+
+After Tasks 1-3:
+
+- [x] Skill catalog can be persisted and seeded.
+- [x] Re-running seeds is safe.
+- [x] No API, router, or client code added.
+
+After Tasks 4-5:
+
+- [x] Skill usage is stored per turn.
+- [x] Failed skill lookup leaves no partial interaction rows.
+- [x] Existing task flows still pass.
+
+After Tasks 6-7:
+
+- [ ] Current-turn skill affects the paired LLM user message.
+- [ ] Historical skilled turns reconstruct with their stored skill content snapshots.
+- [ ] Conversation message serialization emits no standalone `SkillUsed` assistant/tool/user messages.
+- [ ] ACP replay does not render skill use.
+
+Final verification:
+
+- [ ] `mix test test/frontman_server/skills_test.exs`
+- [ ] `mix test test/frontman_server/tasks/interaction_test.exs`
+- [ ] `mix test test/frontman_server/tasks_test.exs`
+- [ ] `mix test test/frontman_server/tasks/execution_test.exs`
+- [ ] `mix test test/protocols/acp_history_test.exs`
+- [ ] `mix test test/frontman_server_web/channels/task_channel_test.exs`
+- [ ] `mix precommit`
+
+## MVP
+
+Build smallest delightful version:
+
+- Bundled official skills seeded from `priv/official_skills` into the database.
+- Server-bundled skills are globally usable; no install flow required.
+- Explicit selected skill can be recorded for current turn.
+- `SkillUsed` interaction records which skill was used during a turn and snapshots `skill_content`.
+- Selected skill content is prepended to the LLM user message for that turn, including later conversation reconstruction.
+
+Client-facing MVP, later:
+
+- Auto-skill chip in chat: "Using X."
+- User can override/switch skill for current turn.
+- Contextual suggestions after element/page selection.
+- Skill Library with goal search.
+
+Skip for MVP:
+
+- skill library API
+- skill search API
+- automatic skill router
+- custom skill authoring
+- per-user or per-organization installations
+- skill versioning
+- community marketplace
+- ratings/reviews
+- complex permissions
+- paid skills
+- deep skill analytics
+- multi-skill orchestration UI
+
+## North Star
+
+Frontman skills should make user think:
+
+> "I didn't have to know which expert to ask. Frontman knew, and result got better."

--- a/what-is-frontman.md
+++ b/what-is-frontman.md
@@ -1,0 +1,259 @@
+# What Frontman Is
+
+Frontman is an open-source browser-based AI coding agent for frontend work.
+
+It runs inside your app at `/frontman`, shows chat plus live preview, lets a user click a UI element, describe a change, then uses runtime context to edit real source files and verify hot reload.
+
+Core idea: the agent sees the running app, not only source code.
+
+It can inspect:
+
+- Live DOM
+- Computed CSS
+- Component/source mappings
+- Screenshots
+- Console/server logs
+- Routes
+- Build errors
+- Project files
+
+## Integrations Included
+
+- `@frontman-ai/nextjs`
+- `@frontman-ai/astro`
+- `@frontman-ai/vite`
+- WordPress plugin: `libs/frontman-wordpress`
+- Browser/client UI: `@frontman-ai/client`
+- Protocol client: `@frontman-ai/frontman-client`
+- Shared schemas: `@frontman-ai/frontman-protocol`
+- Server: Elixir/Phoenix app in `apps/frontman_server`
+- Agent runtime: `apps/swarm_ai`
+- Chrome extension app in monorepo
+- OpenClaw skill support
+- LLM providers: Anthropic, OpenAI, OpenRouter; docs also mention Fireworks and NVIDIA model catalog support
+- Auth/OAuth: Anthropic/OpenAI OAuth, WorkOS for GitHub/Google login
+- Observability: OpenTelemetry for Next.js logs/spans, Sentry on server
+
+WordPress tools include:
+
+- Posts/pages
+- Gutenberg blocks
+- Elementor layouts
+- Menus
+- Templates/template parts
+- Widgets
+- Site options/settings
+- Media
+- Cache tools
+- WooCommerce when active
+
+## Framework Integration Model
+
+All JS framework integrations follow same pattern: dev-server adapter wraps shared Frontman core.
+
+They:
+
+- Serve Frontman UI at `/frontman`
+- Expose tool endpoints like `/frontman/tools` and `/frontman/tools/call`
+- Allow file read/edit/search through local dev server
+- Resolve selected DOM/source locations back to files
+- Relay tool calls from server through browser to dev server
+- Run development-only; production builds strip it out
+
+## Next.js
+
+Package: `@frontman-ai/nextjs`
+
+Hooks through:
+
+- `middleware.ts` for Next 15
+- `proxy.ts` for Next 16+
+- Optional `instrumentation.ts` for OpenTelemetry
+
+Captures:
+
+- Console logs
+- Build output
+- Uncaught exceptions
+- Unhandled rejections
+- HTTP requests
+- API routes
+- Render spans
+
+Uses circular buffer on `globalThis` so logs survive Turbopack/Next isolated execution contexts.
+
+## Astro
+
+Package: `@frontman-ai/astro`
+
+Hooks through Astro integration API:
+
+- `astro:config:setup`
+- `astro:server:setup`
+
+Does:
+
+- Registers dev toolbar app
+- Injects source annotation capture script
+- Uses Vite middleware
+- Reads Astro source annotations like `data-astro-source-file`
+- Supports static, SSR, hybrid Astro modes
+
+## Vite
+
+Package: `@frontman-ai/vite`
+
+Hooks through Vite plugin:
+
+- `configureServer`
+- Connect middleware
+
+Supports:
+
+- React
+- Vue
+- Svelte/SvelteKit
+- SolidJS
+- Vanilla JS/TS
+- Other Vite-compatible frameworks
+
+Adapts Node `IncomingMessage`/`ServerResponse` to Web API `Request`/`Response`, including SSE stream piping.
+
+## WordPress
+
+Plugin runs inside WordPress.
+
+It:
+
+- Serves `/frontman`
+- Uses WordPress cookie auth
+- Loads hosted Frontman UI assets
+- Handles tool calls server-side in PHP
+- Exposes WordPress-native tools
+- Can technically run in production, unlike JS framework integrations, but is marked experimental
+
+## Protocols
+
+Frontman uses several protocol layers.
+
+## JSON-RPC 2.0
+
+Base wire format for client/server messages.
+
+Used over Phoenix WebSockets for:
+
+- `acp:message`
+- `mcp:message`
+
+Malformed messages intentionally crash channels rather than silently fail.
+
+## ACP: Agent Client Protocol
+
+Conversation/session protocol.
+
+Handles:
+
+- Session creation/loading/deletion
+- User prompts
+- Assistant streaming
+- Tool call display updates
+- Plan updates
+- Turn completion
+- Model/config updates
+
+Events include:
+
+- `UserMessageChunk`
+- `AssistantMessageStart`
+- `ToolCallStart`
+- `ToolInputChunk`
+- `ToolCallEnd`
+- `TurnComplete`
+- `PlanEntry`
+
+## MCP: Model Context Protocol
+
+Tool protocol.
+
+Frontman uses MCP concepts for:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+- Tool discovery
+- Tool execution
+- Browser-side tools
+- Relay tools to dev server
+
+Flow:
+
+```text
+Agent -> Frontman Server -> Browser MCP client -> Dev Server tool endpoint
+Agent <- Frontman Server <- Browser MCP client <- Dev Server result
+```
+
+## Relay Protocol
+
+Frontman-specific framework relay.
+
+Used when browser forwards MCP tool call to local dev server.
+
+Includes:
+
+- `remoteTool`
+- `toolsResponse`
+
+Transport:
+
+- HTTP request to dev-server endpoint
+- SSE stream for tool results
+
+## WebSocket
+
+Browser client connects to Frontman server at `/socket`.
+
+Used for:
+
+- Streaming agent responses
+- Tool call routing
+- Tool results
+- Session state
+- Reconnection/history replay
+
+## HTTP/SSE
+
+Used between browser and local dev server framework integration.
+
+Used for:
+
+- Tool calls
+- Streaming tool results
+- Source resolution
+- UI asset serving
+
+## OpenTelemetry
+
+Used mainly in Next.js integration.
+
+Captures:
+
+- Logs
+- Spans
+- HTTP/request/render timing
+
+Frontman writes OTEL processors into its log buffer so agent can query server/runtime context.
+
+## OAuth/Auth Protocols
+
+Uses:
+
+- OAuth for Anthropic/OpenAI account connection
+- WorkOS OAuth for GitHub/Google login
+- Signed JWT/socket token for cross-origin WebSocket auth
+- Session cookie for same-origin auth
+
+## Not WebMCP
+
+Repo docs say Frontman is not WebMCP. Similar philosophy, different layer.
+
+WebMCP exposes website actions as browser tools. Frontman exposes dev/runtime/frontend-editing tools so an agent can map live UI back to source and edit code.


### PR DESCRIPTION
## Summary
- add persisted official skills catalog and seed loading
- record explicit selected server skill usage per turn with content snapshots
- fold selected skill instructions into LLM prompt reconstruction without adding client skill UI or routing

## Verification
- `make precommit` from `apps/frontman_server`