### PR TITLE
Handle retry errors gracefully

### DIFF
--- a/.changeset/fix-stream-stall-retry.md
+++ b/.changeset/fix-stream-stall-retry.md
@@ -1,0 +1,4 @@
+---
+---
+
+Classify wrapped stream stall failures as retryable overloads and stop reporting expected stalls as Sentry errors.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -326,8 +326,7 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, :completed) do
-    {:ok, _interaction} = record_agent_run_result(scope, task_id, turn_number, :completed)
-    :ok
+    persist_agent_run_result(scope, task_id, turn_number, :completed)
   end
 
   defp persist_swarm_event(
@@ -338,23 +337,15 @@ defmodule FrontmanServer.Tasks do
        ) do
     {reason_str, category, retryable} = ErrorClassifier.classify_error(reason)
 
-    Logger.error("Execution failed for task #{task_id}, reason: #{reason_str}")
-
-    Sentry.capture_message("Agent execution failed",
-      level: :error,
-      tags: %{error_type: "agent_execution_error"},
-      extra: %{task_id: task_id, reason: reason_str}
-    )
-
-    {:ok, _interaction} =
-      record_agent_run_result(
-        scope,
-        task_id,
-        turn_number,
-        {:failed, reason_str, retryable, category}
-      )
-
-    :ok
+    with :ok <-
+           persist_agent_run_result(
+             scope,
+             task_id,
+             turn_number,
+             {:failed, reason_str, retryable, category}
+           ) do
+      report_agent_execution_failure(task_id, reason_str, category, retryable)
+    end
   end
 
   defp persist_swarm_event(
@@ -369,15 +360,11 @@ defmodule FrontmanServer.Tasks do
       extra: %{task_id: task_id, reason: inspect(message)}
     )
 
-    {:ok, _interaction} =
-      record_agent_run_result(scope, task_id, turn_number, {:crashed, message})
-
-    :ok
+    persist_agent_run_result(scope, task_id, turn_number, {:crashed, message})
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:cancelled, _}) do
-    {:ok, _interaction} = record_agent_run_result(scope, task_id, turn_number, :cancelled)
-    :ok
+    persist_agent_run_result(scope, task_id, turn_number, :cancelled)
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:terminated, _}) do
@@ -401,8 +388,7 @@ defmodule FrontmanServer.Tasks do
 
     case interactive_tool_calls do
       [] ->
-        {:ok, _interaction} = record_agent_run_result(scope, task_id, turn_number, :terminated)
-        :ok
+        persist_agent_run_result(scope, task_id, turn_number, :terminated)
 
       [_ | _] ->
         :ok
@@ -426,19 +412,36 @@ defmodule FrontmanServer.Tasks do
       turn_number: turn_number
     )
 
-    {:ok, _interaction} =
-      record_agent_run_result(
-        scope,
-        task_id,
-        turn_number,
-        {:paused_for_tool_timeout, tool_name, timeout_ms}
-      )
-
-    :ok
+    persist_agent_run_result(
+      scope,
+      task_id,
+      turn_number,
+      {:paused_for_tool_timeout, tool_name, timeout_ms}
+    )
   end
 
   defp persist_swarm_event(%Scope{}, _task_id, _turn_number, {:chunk, _}), do: :ok
   defp persist_swarm_event(%Scope{}, _task_id, _turn_number, {:tool_call, _}), do: :ok
+
+  defp persist_agent_run_result(scope, task_id, turn_number, outcome) do
+    with {:ok, _interaction} <- record_agent_run_result(scope, task_id, turn_number, outcome) do
+      :ok
+    end
+  end
+
+  defp report_agent_execution_failure(task_id, reason_str, "overload", true) do
+    Logger.warning("Execution failed for task #{task_id}, reason: #{reason_str}")
+  end
+
+  defp report_agent_execution_failure(task_id, reason_str, _category, _retryable) do
+    Logger.error("Execution failed for task #{task_id}, reason: #{reason_str}")
+
+    Sentry.capture_message("Agent execution failed",
+      level: :error,
+      tags: %{error_type: "agent_execution_error"},
+      extra: %{task_id: task_id, reason: reason_str}
+    )
+  end
 
   defp broadcast_swarm_event(task_id, turn_number, {:chunk, chunk}) do
     broadcast_task(task_id, {:execution_chunk, turn_number, chunk})

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -791,7 +791,7 @@ defmodule FrontmanServer.Tasks do
        when is_integer(turn_number) and turn_number > 0 do
     case Execution.run(scope, task, turn_number, execution) do
       {:error, :already_running} ->
-        :already_running
+        {:error, :already_running}
 
       {:ok, _pid} ->
         :ok

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/error_classifier.ex
@@ -26,6 +26,8 @@ defmodule FrontmanServer.Tasks.Execution.ErrorClassifier do
     classify_reqllm_request(status, reason)
   end
 
+  def classify_error({:exception, reason}), do: classify_error(reason)
+
   def classify_error({:llm_error, reason}), do: classify_error(reason)
 
   def classify_error(:no_api_key), do: {"No API key available for this request.", "auth", false}

--- a/apps/frontman_server/lib/frontman_server/tasks/stream_stall_timeout.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/stream_stall_timeout.ex
@@ -107,7 +107,7 @@ defmodule FrontmanServer.Tasks.StreamStallTimeout do
         :erlang.raise(kind, reason, stacktrace)
     after
       stall_timeout_ms ->
-        Logger.error(
+        Logger.warning(
           "StreamStallTimeout: no chunk received for #{stall_timeout_ms}ms, aborting stream"
         )
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -91,14 +91,12 @@ defmodule FrontmanServerWeb.TaskChannel do
         handle_session_load(id, params, socket)
 
       {:ok, {:request, id, method, _params}} ->
-        response =
-          JsonRpc.error_response(
-            id,
-            JsonRpc.error_method_not_found(),
-            "Method not found: #{method}"
-          )
-
-        {:reply, {:ok, %{@acp_message => response}}, socket}
+        reply_acp_error(
+          socket,
+          id,
+          JsonRpc.error_method_not_found(),
+          "Method not found: #{method}"
+        )
 
       {:ok, {:notification, "session/retry_turn", %{"retriedErrorId" => retried_error_id}}} ->
         handle_retry_turn(retried_error_id, socket)
@@ -163,18 +161,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   def handle_info({:fire_retry, token}, socket) do
     case socket.assigns[:retry_state] do
       %{timer_token: ^token, retried_error_id: retried_error_id} ->
-        task_id = socket.assigns.task_id
-
-        Tasks.retry_execution(
-          socket.assigns.scope,
-          task_id,
-          retried_error_id,
-          %{
-            model: nil,
-            mcp_tools: socket.assigns.mcp_tools,
-            project_traits: Frameworks.project_traits_from_meta(nil, socket.assigns.framework)
-          }
-        )
+        retry_turn(socket, retried_error_id)
 
       _stale_or_nil ->
         :ok
@@ -650,13 +637,7 @@ defmodule FrontmanServerWeb.TaskChannel do
         {:noreply, socket}
 
       {:error, :not_found} ->
-        push(
-          socket,
-          @acp_message,
-          JsonRpc.error_response(id, JsonRpc.error_invalid_params(), "Session not found")
-        )
-
-        {:noreply, socket}
+        push_acp_error(socket, id, JsonRpc.error_invalid_params(), "Session not found")
     end
   end
 
@@ -690,8 +671,7 @@ defmodule FrontmanServerWeb.TaskChannel do
              ) do
           {:error, :already_running} ->
             Logger.info("Rejected prompt — agent already running for task #{task_id}")
-            error_response = JsonRpc.error_response(id, -32_000, "Agent already running")
-            {:reply, {:ok, %{@acp_message => error_response}}, socket}
+            reply_acp_error(socket, id, -32_000, "Agent already running")
 
           {:ok, _interaction, turn_number} ->
             socket =
@@ -707,24 +687,25 @@ defmodule FrontmanServerWeb.TaskChannel do
 
           {:error, {:invalid_content_block, message}} ->
             Logger.error("Failed to add user message: #{message}")
-
-            error_response =
-              JsonRpc.error_response(id, JsonRpc.error_invalid_params(), message)
-
-            {:reply, {:ok, %{@acp_message => error_response}}, socket}
+            reply_acp_error(socket, id, JsonRpc.error_invalid_params(), message)
 
           {:error, reason} ->
             Logger.error("Failed to add user message: #{inspect(reason)}")
-            error_response = JsonRpc.error_response(id, -32_000, inspect(reason))
-            {:reply, {:ok, %{@acp_message => error_response}}, socket}
+            reply_acp_error(socket, id, -32_000, inspect(reason))
         end
 
       :error ->
-        error_response =
-          JsonRpc.error_response(id, JsonRpc.error_invalid_params(), "Model is required")
-
-        {:reply, {:ok, %{@acp_message => error_response}}, socket}
+        reply_acp_error(socket, id, JsonRpc.error_invalid_params(), "Model is required")
     end
+  end
+
+  defp reply_acp_error(socket, id, code, message) do
+    {:reply, {:ok, %{@acp_message => JsonRpc.error_response(id, code, message)}}, socket}
+  end
+
+  defp push_acp_error(socket, id, code, message) do
+    push(socket, @acp_message, JsonRpc.error_response(id, code, message))
+    {:noreply, socket}
   end
 
   defp handle_execution_chunk(socket, %{type: :content, text: text})
@@ -774,15 +755,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     case payload do
       %{"id" => id} ->
-        error_response =
-          JsonRpc.error_response(
-            id,
-            JsonRpc.error_invalid_request(),
-            "Invalid JSON-RPC message"
-          )
-
-        push(socket, @acp_message, error_response)
-        {:noreply, socket}
+        push_acp_error(socket, id, JsonRpc.error_invalid_request(), "Invalid JSON-RPC message")
 
       _ ->
         {:noreply, socket}
@@ -790,25 +763,39 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   defp handle_retry_turn(retried_error_id, socket) do
-    task_id = socket.assigns.task_id
-
-    Tasks.retry_execution(
-      socket.assigns.scope,
-      task_id,
-      retried_error_id,
-      %{
-        model: nil,
-        mcp_tools: socket.assigns.mcp_tools,
-        project_traits: Frameworks.project_traits_from_meta(nil, socket.assigns.framework)
-      }
-    )
-
+    retry_turn(socket, retried_error_id)
     {:noreply, socket}
   end
 
-  defp handle_transient_error(socket, error_info, turn_number) do
-    task_id = socket.assigns.task_id
+  defp retry_turn(socket, retried_error_id) do
+    case Tasks.retry_execution(
+           socket.assigns.scope,
+           socket.assigns.task_id,
+           retried_error_id,
+           %{
+             model: nil,
+             mcp_tools: socket.assigns.mcp_tools,
+             project_traits: Frameworks.project_traits_from_meta(nil, socket.assigns.framework)
+           }
+         ) do
+      :ok ->
+        :ok
 
+      {:error, reason} ->
+        unless reason in [:not_found, :stale_turn] do
+          Logger.warning("Retry turn failed: #{inspect(reason)}")
+        end
+
+        push_agent_error(
+          socket,
+          retried_error_id,
+          "That response can no longer be retried. Please send a new message instead.",
+          "retry_unavailable"
+        )
+    end
+  end
+
+  defp handle_transient_error(socket, error_info, turn_number) do
     case RetryCoordinator.handle_error(socket.assigns[:retry_state], error_info) do
       {:exhausted, error_info} ->
         finalize_turn(
@@ -818,16 +805,16 @@ defmodule FrontmanServerWeb.TaskChannel do
         )
 
       {:retry_scheduled, state, notification} ->
-        notification =
-          ACP.build_error_notification(task_id, notification.message, DateTime.utc_now(),
-            retry_at: notification.retry_at,
-            attempt: notification.attempt,
-            max_attempts: notification.max_attempts,
-            category: notification.category,
-            agent_error_id: state.retried_error_id
-          )
+        push_agent_error(
+          socket,
+          state.retried_error_id,
+          notification.message,
+          notification.category,
+          retry_at: notification.retry_at,
+          attempt: notification.attempt,
+          max_attempts: notification.max_attempts
+        )
 
-        push(socket, @acp_message, notification)
         {:noreply, assign(socket, :retry_state, state)}
     end
   end
@@ -848,16 +835,21 @@ defmodule FrontmanServerWeb.TaskChannel do
 
       {:error, agent_error_id, message, category} ->
         socket = resolve_pending_prompt(socket, {:error, message}, turn_number)
-
-        notification =
-          ACP.build_error_notification(task_id, message, DateTime.utc_now(),
-            category: category,
-            agent_error_id: agent_error_id
-          )
-
-        push(socket, @acp_message, notification)
+        push_agent_error(socket, agent_error_id, message, category)
         {:noreply, socket}
     end
+  end
+
+  defp push_agent_error(socket, agent_error_id, message, category, opts \\ []) do
+    notification =
+      ACP.build_error_notification(
+        socket.assigns.task_id,
+        message,
+        DateTime.utc_now(),
+        Keyword.merge(opts, category: category, agent_error_id: agent_error_id)
+      )
+
+    push(socket, @acp_message, notification)
   end
 
   defp resolve_pending_prompt(socket, result, turn_number) do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -15,6 +15,7 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Interaction
+  alias FrontmanServer.Tasks.StreamStallTimeout
 
   setup do
     Sentry.Test.setup_sentry(dedup_events: false)
@@ -89,6 +90,28 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
       assert report.tags[:task_id] == task_id
       assert report.tags[:user_id] == scope.user.id
       assert report.extra[:reason] == "Sentry test: simulated stream error"
+    end
+
+    @tag :capture_log
+    test "persists wrapped stream stall timeout as retryable overload without Sentry error", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      reason = {:exception, %StreamStallTimeout.Error{timeout_ms: 60_000}}
+
+      Tasks.handle_swarm_event(scope, task_id, latest_turn_number(task_id), {:failed, reason})
+
+      assert_receive {:interaction,
+                      %Interaction.AgentError{
+                        kind: "failed",
+                        retryable: true,
+                        category: "overload"
+                      }, _turn_number},
+                     5_000
+
+      reports = Sentry.Test.pop_sentry_reports()
+
+      assert Enum.filter(reports, &agent_execution_error_for_task?(&1, task_id)) == []
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_classify_error_test.exs
@@ -43,6 +43,12 @@ defmodule FrontmanServer.Tasks.ExecutionClassifyErrorTest do
       assert String.length(msg) > 0
     end
 
+    test "wrapped StreamStallTimeout.Error returns overload, retryable" do
+      err = {:exception, %StreamStallTimeout.Error{timeout_ms: 60_000}}
+      {msg, "overload", true} = ErrorClassifier.classify_error(err)
+      assert String.contains?(msg, "stopped responding")
+    end
+
     test ":genserver_call_timeout returns overload, retryable" do
       {msg, "overload", true} = ErrorClassifier.classify_error(:genserver_call_timeout)
       assert String.length(msg) > 0

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -249,6 +249,15 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
+  describe "handle_swarm_event/4" do
+    test "returns persistence errors instead of crashing", %{scope: scope} do
+      missing_task_id = Ecto.UUID.generate()
+
+      assert {:error, :not_found} =
+               Tasks.handle_swarm_event(scope, missing_task_id, 1, :completed)
+    end
+  end
+
   describe "resume_execution/3" do
     test "returns not_running when no active agent run exists", %{scope: scope} do
       task_id = task_fixture(scope).id

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1415,6 +1415,17 @@ defmodule FrontmanServerWeb.TaskChannelTest do
                task.interactions,
                &match?(%Interaction.AgentRetry{}, &1)
              )
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "update" => %{
+            "sessionUpdate" => "error",
+            "category" => "retry_unavailable",
+            "message" =>
+              "That response can no longer be retried. Please send a new message instead."
+          }
+        }
+      })
     end
 
     test "cancel during retry countdown clears pending retry without recording retry", %{


### PR DESCRIPTION
## Summary\n- send a friendly ACP error when a retry target is missing or stale instead of crashing/no-oping\n- share retry execution/error notification paths in the task channel\n- classify wrapped stream stall timeouts as retryable overloads and avoid reporting expected stalls as Sentry errors\n\n## Testing\n- mix test test/frontman_server/tasks_test.exs test/frontman_server_web/channels/task_channel_test.exs test/frontman_server/tasks/execution_classify_error_test.exs test/frontman_server/tasks/execution/execution_sentry_test.exs\n- mix format --check-formatted