### PR TITLE
Reduce Sentry noise for provider rate limits

### DIFF
--- a/.changeset/fix-rate-limit-sentry-noise.md
+++ b/.changeset/fix-rate-limit-sentry-noise.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stop reporting retryable LLM provider rate limits as Sentry errors.

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -30,6 +30,8 @@ defmodule FrontmanServer.Application do
     :error_message
   ]
 
+  @reqllm_finch_client_file "lib/req_llm/streaming/finch_client.ex"
+
   @impl true
   def start(_type, _args) do
     # Setup console telemetry logging in dev
@@ -71,19 +73,26 @@ defmodule FrontmanServer.Application do
 
   def sentry_logger_filter(%{msg: msg, meta: meta}, _opts) do
     message = logger_message_to_string(msg)
+    file = logger_file_to_string(Map.get(meta, :file))
 
-    case {Map.get(meta, :file), message} do
-      {"lib/req_llm/streaming/finch_client.ex", "Finch streaming failed: " <> rest} ->
-        if String.contains?(rest, "status: 429") do
-          :stop
-        else
-          :ignore
+    case {reqllm_finch_client_file?(file), message} do
+      {true, "Finch streaming failed: " <> rest} ->
+        case String.contains?(rest, "status: 429") do
+          true -> :stop
+          false -> :ignore
         end
 
       _other ->
         :ignore
     end
   end
+
+  defp logger_file_to_string(file) when is_binary(file), do: file
+  defp logger_file_to_string(file) when is_list(file), do: IO.chardata_to_string(file)
+  defp logger_file_to_string(_file), do: nil
+
+  defp reqllm_finch_client_file?(nil), do: false
+  defp reqllm_finch_client_file?(file), do: String.ends_with?(file, @reqllm_finch_client_file)
 
   defp logger_message_to_string({:string, chardata}), do: IO.chardata_to_string(chardata)
 

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -39,6 +39,7 @@ defmodule FrontmanServer.Application do
 
     # Capture crashes plus all Logger.error/2 messages as Sentry events.
     :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
+      filters: [reqllm_rate_limit_filter: {&__MODULE__.sentry_logger_filter/2, []}],
       config: %{
         capture_log_messages: true,
         level: :error,
@@ -67,6 +68,32 @@ defmodule FrontmanServer.Application do
     opts = [strategy: :one_for_one, name: FrontmanServer.Supervisor]
     Supervisor.start_link(children, opts)
   end
+
+  def sentry_logger_filter(%{msg: msg, meta: meta}, _opts) do
+    message = logger_message_to_string(msg)
+
+    case {Map.get(meta, :file), message} do
+      {"lib/req_llm/streaming/finch_client.ex", "Finch streaming failed: " <> rest} ->
+        if String.contains?(rest, "status: 429") do
+          :stop
+        else
+          :ignore
+        end
+
+      _other ->
+        :ignore
+    end
+  end
+
+  defp logger_message_to_string({:string, chardata}), do: IO.chardata_to_string(chardata)
+
+  defp logger_message_to_string({format, args}) when is_list(args) do
+    format
+    |> :io_lib.format(args)
+    |> IO.chardata_to_string()
+  end
+
+  defp logger_message_to_string(message), do: inspect(message)
 
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -433,6 +433,10 @@ defmodule FrontmanServer.Tasks do
     Logger.warning("Execution failed for task #{task_id}, reason: #{reason_str}")
   end
 
+  defp report_agent_execution_failure(task_id, reason_str, "rate_limit", true) do
+    Logger.warning("Execution failed for task #{task_id}, reason: #{reason_str}")
+  end
+
   defp report_agent_execution_failure(task_id, reason_str, _category, _retryable) do
     Logger.error("Execution failed for task #{task_id}, reason: #{reason_str}")
 

--- a/apps/frontman_server/test/frontman_server/sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/sentry_test.exs
@@ -78,6 +78,18 @@ defmodule FrontmanServer.SentryTest do
       assert FrontmanServer.Application.sentry_logger_filter(event, []) == :stop
     end
 
+    test "drops ReqLLM streaming rate-limit errors with Logger file metadata" do
+      event = %{
+        level: :error,
+        msg:
+          {:string,
+           "Finch streaming failed: %ReqLLM.Error.API.Request{reason: \"rate limited\", status: 429}"},
+        meta: %{file: ~c"/app/lib/req_llm/streaming/finch_client.ex"}
+      }
+
+      assert FrontmanServer.Application.sentry_logger_filter(event, []) == :stop
+    end
+
     test "keeps non-rate-limit ReqLLM streaming errors" do
       event = %{
         level: :error,

--- a/apps/frontman_server/test/frontman_server/sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/sentry_test.exs
@@ -64,4 +64,30 @@ defmodule FrontmanServer.SentryTest do
       assert event.extra[:logger_metadata][:task_id] == task_id
     end
   end
+
+  describe "Sentry logger filtering" do
+    test "drops ReqLLM streaming rate-limit errors" do
+      event = %{
+        level: :error,
+        msg:
+          {:string,
+           "Finch streaming failed: %ReqLLM.Error.API.Request{reason: \"rate limited\", status: 429}"},
+        meta: %{file: "lib/req_llm/streaming/finch_client.ex"}
+      }
+
+      assert FrontmanServer.Application.sentry_logger_filter(event, []) == :stop
+    end
+
+    test "keeps non-rate-limit ReqLLM streaming errors" do
+      event = %{
+        level: :error,
+        msg:
+          {:string,
+           "Finch streaming failed: %ReqLLM.Error.API.Request{reason: \"server error\", status: 500}"},
+        meta: %{file: "lib/req_llm/streaming/finch_client.ex"}
+      }
+
+      assert FrontmanServer.Application.sentry_logger_filter(event, []) == :ignore
+    end
+  end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -113,6 +113,28 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
 
       assert Enum.filter(reports, &agent_execution_error_for_task?(&1, task_id)) == []
     end
+
+    @tag :capture_log
+    test "persists retryable rate limits without Sentry error", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      reason = %ReqLLM.Error.API.Request{status: 429, reason: "rate limited"}
+
+      Tasks.handle_swarm_event(scope, task_id, latest_turn_number(task_id), {:failed, reason})
+
+      assert_receive {:interaction,
+                      %Interaction.AgentError{
+                        kind: "failed",
+                        retryable: true,
+                        category: "rate_limit"
+                      }, _turn_number},
+                     5_000
+
+      reports = Sentry.Test.pop_sentry_reports()
+
+      assert Enum.filter(reports, &agent_execution_error_for_task?(&1, task_id)) == []
+    end
   end
 
   defp agent_execution_error_for_task?(event, task_id) do


### PR DESCRIPTION
## Summary
- Downgrade retryable LLM provider rate-limit failures to warnings instead of Sentry errors
- Filter ReqLLM Finch streaming 429 logs from the Sentry logger handler while keeping non-429 stream errors
- Add regression coverage and a changeset

## Verification
- make precommit