### PR TITLE
Cache Anthropic conversation messages

### DIFF
--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -66,7 +66,8 @@ defmodule FrontmanServer.Providers do
        auth_mode: :oauth,
        access_token: access_token,
        with_claude_subscription: true,
-       anthropic_prompt_cache: true
+       anthropic_prompt_cache: true,
+       anthropic_cache_messages: -1
      ]}
   end
 
@@ -91,7 +92,9 @@ defmodule FrontmanServer.Providers do
     end
   end
 
-  defp api_key_llm_opts("anthropic", key), do: [api_key: key, anthropic_prompt_cache: true]
+  defp api_key_llm_opts("anthropic", key),
+    do: [api_key: key, anthropic_prompt_cache: true, anthropic_cache_messages: -1]
+
   defp api_key_llm_opts(_provider, key), do: [api_key: key]
 
   def model_from_client_params(nil), do: :error

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -38,6 +38,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert llm_opts[:auth_mode] == :oauth
       assert llm_opts[:with_claude_subscription] == true
       assert llm_opts[:anthropic_prompt_cache] == true
+      assert llm_opts[:anthropic_cache_messages] == -1
     end
 
     test "falls back to user key when no OAuth token", %{scope: scope} do
@@ -47,6 +48,8 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
 
       assert llm_opts[:api_key] == "user_key_456"
+      assert llm_opts[:anthropic_prompt_cache] == true
+      assert llm_opts[:anthropic_cache_messages] == -1
     end
 
     test "returns :no_api_key when no key source is available", %{scope: scope} do

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -11,6 +11,8 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
+  alias ReqLLM.Context
+  alias ReqLLM.Providers.Anthropic
 
   setup {Req.Test, :set_req_test_from_context}
   setup {Req.Test, :verify_on_exit!}
@@ -50,6 +52,32 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert llm_opts[:api_key] == "user_key_456"
       assert llm_opts[:anthropic_prompt_cache] == true
       assert llm_opts[:anthropic_cache_messages] == -1
+    end
+
+    test "resolved Anthropic opts mark the last message for prompt caching", %{scope: scope} do
+      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+
+      {:ok, {model, llm_opts}} =
+        Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-5")
+
+      context =
+        Context.new([
+          Context.system("system prompt"),
+          Context.user("first user message"),
+          Context.assistant("assistant reply"),
+          Context.user("latest user message")
+        ])
+
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, llm_opts)
+      encoded_request = Anthropic.encode_body(request)
+      body = encoded_request.options[:json]
+
+      last_message = List.last(body[:messages])
+      [last_block] = last_message[:content]
+
+      assert last_message[:role] == "user"
+      assert last_block[:text] == "latest user message"
+      assert last_block[:cache_control] == %{type: "ephemeral"}
     end
 
     test "returns :no_api_key when no key source is available", %{scope: scope} do


### PR DESCRIPTION
## Summary
- enable Anthropic message-level prompt caching for OAuth and API-key paths
- assert cache options in provider resolution tests
- verify the encoded Anthropic request body marks the last message with cache_control

## Verification
- cd apps/frontman_server && mix test test/frontman_server/providers/prepare_api_key_test.exs
