### PR TITLE
Fix Anthropic thinking detail replay

### DIFF
--- a/.changeset/anthropic-thinking-replay.md
+++ b/.changeset/anthropic-thinking-replay.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Anthropic thinking detail replay after tool calls.

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
@@ -213,21 +213,32 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
     Enum.map(details, &normalize_reasoning_detail/1)
   end
 
-  defp normalize_reasoning_detail(%{format: "anthropic-thinking-v1"} = detail) do
-    detail
-    |> put_fixed_atom_key(:index)
-    |> put_fixed_atom_key(:text)
+  defp normalize_reasoning_detail(%ReqLLM.Message.ReasoningDetails{} = detail), do: detail
+
+  defp normalize_reasoning_detail(detail) when is_map(detail) do
+    case detail_field(detail, :format) do
+      "anthropic-thinking-v1" ->
+        %ReqLLM.Message.ReasoningDetails{
+          text: detail_field(detail, :text),
+          signature: detail_field(detail, :signature),
+          encrypted?: detail_field(detail, :encrypted?) || false,
+          provider: :anthropic,
+          format: "anthropic-thinking-v1",
+          index: detail_field(detail, :index) || 0,
+          provider_data: detail_field(detail, :provider_data) || %{}
+        }
+
+      _other ->
+        detail
+    end
   end
 
   defp normalize_reasoning_detail(detail), do: detail
 
-  defp put_fixed_atom_key(map, key) when is_map(map) and is_atom(key) do
+  defp detail_field(map, key) when is_map(map) and is_atom(key) do
     string_key = Atom.to_string(key)
 
-    case Map.fetch(map, string_key) do
-      {:ok, value} -> map |> Map.put(key, value) |> Map.delete(string_key)
-      :error -> map
-    end
+    Map.get(map, key) || Map.get(map, string_key)
   end
 
   defp to_reqllm_content_part(%ContentPart{type: :text, text: text}) do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/llm_client.ex
@@ -192,7 +192,7 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
       content: Enum.map(msg.content, &to_reqllm_content_part/1),
       tool_calls: to_reqllm_tool_calls(msg.tool_calls),
       metadata: msg.metadata,
-      reasoning_details: msg.reasoning_details
+      reasoning_details: normalize_reasoning_details(msg.reasoning_details)
     }
   end
 
@@ -204,6 +204,30 @@ defimpl SwarmAi.LLM, for: FrontmanServer.Tasks.Execution.LLMClient do
       name: msg.name,
       metadata: msg.metadata
     }
+  end
+
+  defp normalize_reasoning_details(nil), do: nil
+  defp normalize_reasoning_details([]), do: nil
+
+  defp normalize_reasoning_details(details) when is_list(details) do
+    Enum.map(details, &normalize_reasoning_detail/1)
+  end
+
+  defp normalize_reasoning_detail(%{format: "anthropic-thinking-v1"} = detail) do
+    detail
+    |> put_fixed_atom_key(:index)
+    |> put_fixed_atom_key(:text)
+  end
+
+  defp normalize_reasoning_detail(detail), do: detail
+
+  defp put_fixed_atom_key(map, key) when is_map(map) and is_atom(key) do
+    string_key = Atom.to_string(key)
+
+    case Map.fetch(map, string_key) do
+      {:ok, value} -> map |> Map.put(key, value) |> Map.delete(string_key)
+      :error -> map
+    end
   end
 
   defp to_reqllm_content_part(%ContentPart{type: :text, text: text}) do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
@@ -168,6 +168,44 @@ defmodule FrontmanServer.Tasks.Execution.LLMClientTest do
 
       assert {:ok, _stream} = SwarmAi.LLM.stream(client, messages, [])
     end
+
+    test "normalizes Anthropic thinking details before provider requests" do
+      reasoning = [
+        %{
+          :format => "anthropic-thinking-v1",
+          :provider => :anthropic,
+          :provider_data => %{"type" => "thinking"},
+          :encrypted? => false,
+          "index" => 0,
+          "text" => "Let me explore the project structure."
+        }
+      ]
+
+      expect(LLMProviderMock, :stream_text, fn _model, [message], _opts ->
+        assert [thinking] = message.reasoning_details
+        assert thinking.index == 0
+        assert thinking.text == "Let me explore the project structure."
+        refute Map.has_key?(thinking, "index")
+        refute Map.has_key?(thinking, "text")
+
+        {:ok, stream_response([])}
+      end)
+
+      client =
+        LLMClient.new(
+          model: "anthropic:claude-sonnet-4-5",
+          llm_opts: [api_key: "test-key"]
+        )
+
+      messages = [
+        %SwarmAi.Message.Assistant{
+          content: [ContentPart.text("thinking done")],
+          reasoning_details: reasoning
+        }
+      ]
+
+      assert {:ok, _stream} = SwarmAi.LLM.stream(client, messages, [])
+    end
   end
 
   describe "ping keepalive filtering (issue #731)" do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
@@ -183,10 +183,19 @@ defmodule FrontmanServer.Tasks.Execution.LLMClientTest do
 
       expect(LLMProviderMock, :stream_text, fn _model, [message], _opts ->
         assert [thinking] = message.reasoning_details
+        assert %ReqLLM.Message.ReasoningDetails{provider: :anthropic} = thinking
         assert thinking.index == 0
         assert thinking.text == "Let me explore the project structure."
-        refute Map.has_key?(thinking, "index")
-        refute Map.has_key?(thinking, "text")
+
+        request =
+          [message]
+          |> ReqLLM.Context.new()
+          |> ReqLLM.Providers.Anthropic.Context.encode_request(%{model: "claude-sonnet-4-5"})
+
+        assert [%{role: "assistant", content: [%{type: "thinking"} = thinking_block | _]}] =
+                 request.messages
+
+        assert thinking_block.thinking == "Let me explore the project structure."
 
         {:ok, stream_response([])}
       end)


### PR DESCRIPTION
## Summary
- convert replayed Anthropic thinking-v1 reasoning details into ReqLLM.Message.ReasoningDetails structs before provider requests
- preserve non-Anthropic/encrypted reasoning detail shapes unchanged
- add regression coverage that runs the real ReqLLM Anthropic request encoder and asserts the replayed thinking block is present in the encoded request

## Why tests missed it
- prior tests stopped at LLMProviderMock, so they verified adapter output but not the real Anthropic encoder path
- atomizing map keys avoided KeyError but still let ReqLLM silently drop plain-map reasoning details
- new test crosses that boundary by calling ReqLLM.Providers.Anthropic.Context.encode_request/2

## Testing
- mix test test/frontman_server/tasks/execution/llm_client_test.exs
- make precommit