### PR TITLE
fix(openrouter): add ~ prefix to Claude latest aliases

### DIFF
--- a/apps/frontman_server/config/providers.exs
+++ b/apps/frontman_server/config/providers.exs
@@ -53,8 +53,10 @@ providers = [
        {"Claude Opus 4.8 Fast", "anthropic/claude-opus-4.8-fast", :packaged},
        {"Claude Opus 4.7", "anthropic/claude-opus-4.7", :packaged},
        {"Claude Opus 4.7 Fast", "anthropic/claude-opus-4.7-fast", :packaged},
-       {"Claude Sonnet Latest", "anthropic/claude-sonnet-latest", :packaged},
-       {"Claude Haiku Latest", "anthropic/claude-haiku-latest", :packaged},
+       {"Claude Sonnet Latest", "~anthropic/claude-sonnet-latest", :packaged},
+       {"Claude Haiku Latest", "~anthropic/claude-haiku-latest", :packaged},
+       {"Claude Sonnet 4.6", "anthropic/claude-sonnet-4.6", :packaged},
+       {"Claude Haiku 4.5", "anthropic/claude-haiku-4.5", :packaged},
        # --------------
        {"Gemini 3.1 Pro Preview", "google/gemini-3.1-pro-preview", :packaged},
        {"Gemini Flash Latest", "~google/gemini-flash-latest", :packaged},


### PR DESCRIPTION
# Fix: add `~` prefix to OpenRouter Claude latest aliases

## What

The OpenRouter `Claude Sonnet Latest` and `Claude Haiku Latest` entries were
sending `anthropic/claude-sonnet-latest` / `anthropic/claude-haiku-latest`,
which are not valid OpenRouter slugs. OpenRouter's latest-resolution aliases
require the `~` prefix (as already used by the Gemini/Kimi latest entries in
the same list).

This caused: `... is not a valid model ID` when using OpenRouter (including
OpenRouter BYOK → AWS Bedrock).

## Change

`apps/frontman_server/config/providers.exs` — add `~` to both aliases, and add
explicitly pinned Sonnet 4.6 / Haiku 4.5 entries for BYOK reliability.

## Diff

```diff
        {"Claude Opus 4.7 Fast", "anthropic/claude-opus-4.7-fast", :packaged},
-       {"Claude Sonnet Latest", "anthropic/claude-sonnet-latest", :packaged},
-       {"Claude Haiku Latest", "anthropic/claude-haiku-latest", :packaged},
+       {"Claude Sonnet Latest", "~anthropic/claude-sonnet-latest", :packaged},
+       {"Claude Haiku Latest", "~anthropic/claude-haiku-latest", :packaged},
+       {"Claude Sonnet 4.6", "anthropic/claude-sonnet-4.6", :packaged},
+       {"Claude Haiku 4.5", "anthropic/claude-haiku-4.5", :packaged},
        # --------------
```

## Testing

- Selecting "Claude Sonnet Latest" / "Claude Haiku Latest" via the OpenRouter
  provider now resolves instead of returning "not a valid model ID".
- Verified the slugs exist in OpenRouter's catalog:
  - https://openrouter.ai/~anthropic/claude-haiku-latest
  - https://openrouter.ai/anthropic/claude-sonnet-4.6

## Notes

For OpenRouter BYOK → AWS Bedrock users, the pinned `4.6` / `4.5` entries are
recommended because a bare "latest" alias can resolve to a model tier the
account is not entitled to on Bedrock.
