### PR TITLE
feat(tools): add access metadata

### DIFF
--- a/.changeset/tool-access-metadata.md
+++ b/.changeset/tool-access-metadata.md
@@ -1,0 +1,12 @@
+---
+"@frontman-ai/frontman-protocol": patch
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-core": patch
+"@frontman-ai/client": patch
+"@frontman-ai/nextjs": patch
+"@frontman-ai/vite": patch
+"@frontman-ai/astro": patch
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Add read/write access metadata to browser, backend, framework, and WordPress tool definitions.

--- a/apps/frontman_server/lib/frontman_server/tools/backend.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/backend.ex
@@ -22,9 +22,11 @@ defmodule FrontmanServer.Tools.Backend do
   end
 
   @type result :: map()
+  @type access :: :read | :write | :read_write
 
   @callback name() :: String.t()
   @callback description() :: String.t()
+  @callback access() :: access()
   @callback parameter_schema() :: map()
   @callback timeout_ms() :: pos_integer()
   @callback on_timeout() :: :error | :pause_agent
@@ -34,6 +36,7 @@ defmodule FrontmanServer.Tools.Backend do
     SwarmAi.Tool.new(
       name: module.name(),
       description: module.description(),
+      access: module.access(),
       parameter_schema: module.parameter_schema(),
       timeout_ms: module.timeout_ms(),
       on_timeout: module.on_timeout()

--- a/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
@@ -29,6 +29,9 @@ defmodule FrontmanServer.Tools.GetToolResult do
   end
 
   @impl true
+  def access, do: :read
+
+  @impl true
   def parameter_schema do
     %{
       "type" => "object",

--- a/apps/frontman_server/lib/frontman_server/tools/mcp.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/mcp.ex
@@ -13,6 +13,7 @@ defmodule FrontmanServer.Tools.MCP do
   defstruct name: nil,
             description: nil,
             input_schema: nil,
+            access: :read_write,
             visible_to_agent: true,
             timeout_ms: nil,
             on_timeout: nil
@@ -30,6 +31,7 @@ defmodule FrontmanServer.Tools.MCP do
       name: tool["name"],
       description: tool["description"] || "",
       input_schema: tool["inputSchema"] || %{"type" => "object", "properties" => %{}},
+      access: parse_access(tool["access"]),
       visible_to_agent: Map.get(tool, "visibleToAgent", true),
       timeout_ms: timeout_ms,
       on_timeout: on_timeout
@@ -41,6 +43,11 @@ defmodule FrontmanServer.Tools.MCP do
   # user never responds. All other tools use the default long timeout.
   defp timeout_policy("interactive"), do: {120_000, :pause_agent}
   defp timeout_policy(_), do: {@default_timeout_ms, @default_on_timeout}
+
+  defp parse_access("read"), do: :read
+  defp parse_access("write"), do: :write
+  defp parse_access("read-write"), do: :read_write
+  defp parse_access(_), do: :read_write
 
   def from_maps(tools) when is_list(tools) do
     Enum.map(tools, &from_map/1)
@@ -56,6 +63,7 @@ defmodule FrontmanServer.Tools.MCP do
     SwarmAi.Tool.new(
       name: tool.name,
       description: tool.description,
+      access: tool.access,
       parameter_schema: tool.input_schema,
       timeout_ms: tool.timeout_ms,
       on_timeout: tool.on_timeout

--- a/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
@@ -56,6 +56,9 @@ defmodule FrontmanServer.Tools.TodoWrite do
   end
 
   @impl true
+  def access, do: :write
+
+  @impl true
   def parameter_schema do
     %{
       "type" => "object",

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -58,6 +58,9 @@ defmodule FrontmanServer.Tools.WebFetch do
   end
 
   @impl true
+  def access, do: :read
+
+  @impl true
   def parameter_schema do
     %{
       "type" => "object",

--- a/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
@@ -33,6 +33,7 @@ defmodule FrontmanServer.Tasks.Execution.LLMClientTest do
       tool = %SwarmAi.Tool{
         name: "read_file",
         description: "Reads a file",
+        access: :read,
         parameter_schema: %{
           "type" => "object",
           "properties" => %{

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -26,6 +26,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
 
     def name, do: "pause_on_timeout_tool"
     def description, do: "Declares on_timeout: :pause_agent"
+    def access, do: :read
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 30_000
     def on_timeout, do: :pause_agent

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -753,6 +753,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     @behaviour FrontmanServer.Tools.Backend
     def name, do: "crash_tool"
     def description, do: "always crashes"
+    def access, do: :write
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 5_000
     def on_timeout, do: :error
@@ -764,6 +765,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     @behaviour FrontmanServer.Tools.Backend
     def name, do: "hang_tool"
     def description, do: "hangs forever"
+    def access, do: :write
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 100
     def on_timeout, do: :error

--- a/apps/frontman_server/test/frontman_server/tools/backend_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/backend_test.exs
@@ -13,6 +13,7 @@ defmodule FrontmanServer.Tools.BackendTest do
 
     def name, do: "fake_tool"
     def description, do: "A fake tool for testing"
+    def access, do: :read
     def parameter_schema, do: %{}
     def timeout_ms, do: 45_000
     def on_timeout, do: :error
@@ -25,6 +26,7 @@ defmodule FrontmanServer.Tools.BackendTest do
 
       assert tool.name == "fake_tool"
       assert tool.description == "A fake tool for testing"
+      assert tool.access == :read
       assert tool.parameter_schema == %{}
       assert tool.timeout_ms == 45_000
       assert tool.on_timeout == :error

--- a/apps/frontman_server/test/frontman_server/tools/mcp_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/mcp_test.exs
@@ -14,6 +14,26 @@ defmodule FrontmanServer.Tools.MCPTest do
 
       assert tool.name == "navigate"
       assert tool.description == "Navigate to a URL"
+      assert tool.access == :read_write
+    end
+
+    test "parses access from wire format" do
+      for {wire, expected} <- [
+            {"read", :read},
+            {"write", :write},
+            {"read-write", :read_write},
+            {"bogus", :read_write}
+          ] do
+        tool =
+          MCP.from_map(%{
+            "name" => "test_tool",
+            "description" => "Test tool",
+            "inputSchema" => %{},
+            "access" => wire
+          })
+
+        assert tool.access == expected
+      end
     end
 
     test "applies server-side timeout defaults" do
@@ -92,6 +112,20 @@ defmodule FrontmanServer.Tools.MCPTest do
 
       assert swarm_tool.timeout_ms == 600_000
       assert swarm_tool.on_timeout == :error
+    end
+
+    test "passes access through to swarm tool" do
+      mcp_tool =
+        MCP.from_map(%{
+          "name" => "read_file",
+          "description" => "Read file",
+          "inputSchema" => %{},
+          "access" => "read"
+        })
+
+      [swarm_tool] = MCP.to_swarm_tools([mcp_tool])
+
+      assert swarm_tool.access == :read
     end
 
     test "passes pause_agent policy through to swarm tool for interactive tools" do

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -28,8 +28,17 @@ defmodule FrontmanServer.ToolsTest do
         assert %SwarmAi.Tool{} = tool
         assert is_binary(tool.name)
         assert is_binary(tool.description)
+        assert tool.access in [:read, :write, :read_write]
         assert is_map(tool.parameter_schema)
       end)
+    end
+
+    test "tools expose expected access levels" do
+      by_name = Map.new(Tools.backend_tools(), &{&1.name, &1.access})
+
+      assert by_name["get_tool_result"] == :read
+      assert by_name["web_fetch"] == :read
+      assert by_name["todo_write"] == :write
     end
   end
 

--- a/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
+++ b/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
@@ -366,31 +366,32 @@ The agent uses this for tasks with 3+ distinct steps. The todo list appears in t
 
 This table shows which tools are available for each framework integration.
 
-| Tool | Astro | Next.js | Vite | Where |
-|------|:-----:|:-------:|:----:|-------|
-| `take_screenshot` | ✓ | ✓ | ✓ | Browser |
-| `execute_js` | ✓ | ✓ | ✓ | Browser |
-| `get_dom` | ✓ | ✓ | ✓ | Browser |
-| `get_interactive_elements` | ✓ | ✓ | ✓ | Browser |
-| `interact_with_element` | ✓ | ✓ | ✓ | Browser |
-| `search_text` | ✓ | ✓ | ✓ | Browser |
-| `set_device_mode` | ✓ | ✓ | ✓ | Browser |
-| `question` | ✓ | ✓ | ✓ | Browser |
-| `get_astro_audit` | ✓ | — | — | Browser |
-| `read_file` | ✓ | ✓ | ✓ | Dev server |
-| `write_file` | ✓ | ✓ | ✓ | Dev server |
-| `edit_file` | ✓ | ✓ | ✓ | Dev server |
-| `list_files` | ✓ | ✓ | ✓ | Dev server |
-| `list_tree` | ✓ | ✓ | ✓ | Dev server |
-| `file_exists` | ✓ | ✓ | ✓ | Dev server |
-| `grep` | ✓ | ✓ | ✓ | Dev server |
-| `search_files` | ✓ | ✓ | ✓ | Dev server |
-| `lighthouse` | ✓ | ✓ | ✓ | Dev server |
-| `get_client_pages` | ✓ | — | — | Dev server |
-| `get_routes` | — | ✓ | — | Dev server |
-| `get_logs` | ✓ | ✓ | ✓ | Dev server |
-| `web_fetch` | ✓ | ✓ | ✓ | Backend |
-| `todo_write` | ✓ | ✓ | ✓ | Backend |
+| Tool | Astro | Next.js | Vite | Where | Access |
+|------|:-----:|:-------:|:----:|-------|--------|
+| `take_screenshot` | ✓ | ✓ | ✓ | Browser | read |
+| `execute_js` | ✓ | ✓ | ✓ | Browser | read-write |
+| `get_dom` | ✓ | ✓ | ✓ | Browser | read |
+| `get_interactive_elements` | ✓ | ✓ | ✓ | Browser | read |
+| `interact_with_element` | ✓ | ✓ | ✓ | Browser | read-write |
+| `search_text` | ✓ | ✓ | ✓ | Browser | read |
+| `set_device_mode` | ✓ | ✓ | ✓ | Browser | write |
+| `question` | ✓ | ✓ | ✓ | Browser | write |
+| `get_astro_audit` | ✓ | — | — | Browser | read |
+| `read_file` | ✓ | ✓ | ✓ | Dev server | read |
+| `write_file` | ✓ | ✓ | ✓ | Dev server | write |
+| `edit_file` | ✓ | ✓ | ✓ | Dev server | read-write |
+| `list_files` | ✓ | ✓ | ✓ | Dev server | read |
+| `list_tree` | ✓ | ✓ | ✓ | Dev server | read |
+| `file_exists` | ✓ | ✓ | ✓ | Dev server | read |
+| `grep` | ✓ | ✓ | ✓ | Dev server | read |
+| `search_files` | ✓ | ✓ | ✓ | Dev server | read |
+| `lighthouse` | ✓ | ✓ | ✓ | Dev server | read |
+| `get_client_pages` | ✓ | — | — | Dev server | read |
+| `get_routes` | — | ✓ | — | Dev server | read |
+| `get_logs` | ✓ | ✓ | ✓ | Dev server | read |
+| `web_fetch` | ✓ | ✓ | ✓ | Backend | read |
+| `get_tool_result` | ✓ | ✓ | ✓ | Backend | read |
+| `todo_write` | ✓ | ✓ | ✓ | Backend | write |
 
 ---
 

--- a/apps/swarm_ai/lib/swarm_ai/tool.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool.ex
@@ -19,6 +19,7 @@ defmodule SwarmAi.Tool do
   typedstruct enforce: true do
     field(:name, String.t())
     field(:description, String.t())
+    field(:access, :read | :write | :read_write)
     field(:parameter_schema, map())
     field(:timeout_ms, pos_integer())
     field(:on_timeout, :error | :pause_agent)
@@ -35,6 +36,7 @@ defmodule SwarmAi.Tool do
       Tool.new(
         name: "question",
         description: "Ask the user a question",
+        access: :write,
         parameter_schema: %{},
         timeout_ms: 120_000,
         on_timeout: :pause_agent

--- a/apps/swarm_ai/test/swarm_ai/tool_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/tool_test.exs
@@ -9,6 +9,7 @@ defmodule SwarmAi.ToolTest do
         Tool.new(
           name: "my_tool",
           description: "Does something",
+          access: :read,
           parameter_schema: %{},
           timeout_ms: 30_000,
           on_timeout: :error
@@ -16,6 +17,7 @@ defmodule SwarmAi.ToolTest do
 
       assert tool.name == "my_tool"
       assert tool.description == "Does something"
+      assert tool.access == :read
       assert tool.parameter_schema == %{}
       assert tool.timeout_ms == 30_000
       assert tool.on_timeout == :error
@@ -26,6 +28,7 @@ defmodule SwarmAi.ToolTest do
         Tool.new(
           name: "t",
           description: "d",
+          access: :read,
           parameter_schema: %{},
           on_timeout: :error
         )
@@ -37,6 +40,7 @@ defmodule SwarmAi.ToolTest do
         Tool.new(
           name: "t",
           description: "d",
+          access: :read,
           parameter_schema: %{},
           timeout_ms: 5_000
         )
@@ -48,6 +52,7 @@ defmodule SwarmAi.ToolTest do
         Tool.new(
           name: "t",
           description: "d",
+          access: :read,
           parameter_schema: %{},
           timeout_ms: 5_000,
           on_timeout: :error,

--- a/libs/client/src/tools/Client__Tool__ExecuteJs.res
+++ b/libs/client/src/tools/Client__Tool__ExecuteJs.res
@@ -4,6 +4,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.executeJs
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Execute a JavaScript expression or statement(s) inside the web preview iframe and return the result.

--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -6,6 +6,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.getDom
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Inspect a specific section of the DOM in the web preview.

--- a/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
+++ b/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
@@ -5,6 +5,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.getInteractiveElements
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Discover interactive elements on the current web preview page. Returns a list of clickable/interactive elements with their ARIA roles, accessible names, CSS selectors, and visible text.

--- a/libs/client/src/tools/Client__Tool__InteractWithElement.res
+++ b/libs/client/src/tools/Client__Tool__InteractWithElement.res
@@ -5,6 +5,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.interactWithElement
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Interact with an element in the web preview. Supports click, hover, and focus actions.

--- a/libs/client/src/tools/Client__Tool__Question.res
+++ b/libs/client/src/tools/Client__Tool__Question.res
@@ -5,6 +5,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.question
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Write
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Interactive
 

--- a/libs/client/src/tools/Client__Tool__SearchText.res
+++ b/libs/client/src/tools/Client__Tool__SearchText.res
@@ -5,6 +5,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.searchText
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Search for visible text on the current web preview page. Works like Ctrl+F — finds elements whose visible text contains the query string (case-insensitive).

--- a/libs/client/src/tools/Client__Tool__SetDeviceMode.res
+++ b/libs/client/src/tools/Client__Tool__SetDeviceMode.res
@@ -4,6 +4,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.setDeviceMode
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Write
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = `Set the device emulation mode in the web preview for responsive design testing.

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -4,6 +4,7 @@
 module Tool = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool
 
 let name = Tool.ToolNames.takeScreenshot
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 let description = "Take a screenshot of the current web preview page. By default captures only the visible viewport. Set fullPage to true to capture the entire scrollable page. Returns a base64-encoded JPEG image data URL."

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -20,6 +20,31 @@ let toolNames = (framework): array<string> => {
   )
 }
 
+let toolAccessByName = (framework): Dict.t<string> => {
+  let registry = ToolRegistry.forFramework(framework)
+  let relay = Relay.make(~baseUrl="http://localhost:3000")
+  let server = ToolRegistry.registerAll(registry, MCPServer.make(~relay))
+  let accessByName = Dict.make()
+
+  server
+  ->MCPServer.getToolsJson
+  ->Array.forEach(json => {
+    switch json->JSON.Decode.object {
+    | Some(obj) =>
+      switch (
+        obj->Dict.get("name")->Option.flatMap(JSON.Decode.string),
+        obj->Dict.get("access")->Option.flatMap(JSON.Decode.string),
+      ) {
+      | (Some(name), Some(access)) => accessByName->Dict.set(name, access)
+      | _ => ()
+      }
+    | None => ()
+    }
+  })
+
+  accessByName
+}
+
 describe("ToolRegistry", _t => {
   test("registers core browser tools for non-Astro frameworks", t => {
     let names = toolNames(Client__RuntimeConfig.Nextjs)
@@ -45,5 +70,13 @@ describe("ToolRegistry", _t => {
     t->expect(viteNames->Array.includes("get_astro_audit"))->Expect.toBe(false)
     t->expect(wordpressNames->Array.length)->Expect.toBe(8)
     t->expect(wordpressNames->Array.includes("get_astro_audit"))->Expect.toBe(false)
+  })
+
+  test("serializes browser tool access levels", t => {
+    let access = toolAccessByName(Client__RuntimeConfig.Nextjs)
+
+    t->expect(access->Dict.get("take_screenshot"))->Expect.toEqual(Some("read"))
+    t->expect(access->Dict.get("execute_js"))->Expect.toEqual(Some("read-write"))
+    t->expect(access->Dict.get("set_device_mode"))->Expect.toEqual(Some("write"))
   })
 })

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetAstroAudit.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetAstroAudit.res
@@ -13,6 +13,7 @@
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let name = Tool.ToolNames.getAstroAudit
+let access = Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
 
@@ -194,6 +195,7 @@ let make = (~getPreviewDoc: unit => option<Tool.previewContext>): module(Tool.Br
   module(
     {
       let name = name
+      let access = access
       let visibleToAgent = visibleToAgent
       let executionMode = executionMode
       let description = description

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__EditFile.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__EditFile.res
@@ -4,6 +4,7 @@ module CoreEditFile = Core.FrontmanCore__Tool__EditFile
 module EditFileWithLogCheck = Core.FrontmanCore__Tool__EditFileWithLogCheck
 
 let name = "edit_file"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite
 let visibleToAgent = true
 let description = CoreEditFile.description
 

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetContentCollections.res
@@ -5,6 +5,7 @@ module Path = FrontmanBindings.Path
 module PathContext = FrontmanAiFrontmanCore.FrontmanCore__PathContext
 
 let name = "get_content_collections"
+let access = Tool.Read
 let visibleToAgent = true
 
 let description = `Queries Astro content collections through astro:content.
@@ -154,6 +155,7 @@ let make = (~loadContentApi: unit => promise<contentApi>): module(Tool.ServerToo
   module(
     {
       let name = name
+      let access = access
       let visibleToAgent = visibleToAgent
       let description = description
       type input = input

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetPages.res
@@ -8,6 +8,7 @@ module PathContext = FrontmanAiFrontmanCore.FrontmanCore__PathContext
 module PathStringUtils = FrontmanAiFrontmanCore.FrontmanCore__PathStringUtils
 
 let name = "get_client_pages"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 
 let description = `Lists Astro client pages from the pages directory.

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
@@ -15,6 +15,7 @@ module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module Bindings = FrontmanBindings.Astro
 
 let name = "get_client_pages"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 
 let description = `Lists all routes resolved by Astro's router.
@@ -73,6 +74,7 @@ let make = (
   module(
     {
       let name = name
+      let access = access
       let visibleToAgent = visibleToAgent
       let description = description
       type input = input

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -82,6 +82,7 @@ let toolWireSchema = S.object(s => {
   {
     "name": s.field("name", S.string),
     "description": s.field("description", S.string),
+    "access": s.field("access", ToolTypes.accessSchema),
     "inputSchema": s.field("inputSchema", S.json),
     "visibleToAgent": s.field("visibleToAgent", S.bool),
     "executionMode": s.field("executionMode", executionModeSchema),
@@ -94,6 +95,7 @@ let serializeTool = (m: module(Tool.Tool)): JSON.t => {
   {
     "name": T.name,
     "description": T.description,
+    "access": T.access,
     "inputSchema": T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
     "visibleToAgent": T.visibleToAgent,
     "executionMode": T.executionMode,

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -102,6 +102,12 @@ let getToolsJson = (relay: t): array<JSON.t> => {
         dict{
           "name": JSON.Encode.string(tool.name),
           "description": JSON.Encode.string(tool.description),
+          "access": tool.access
+          ->Option.getOr(FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite)
+          ->S.decodeOrThrow(
+            ~from=FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.accessSchema,
+            ~to=S.json->S.noValidation(true),
+          ),
           "inputSchema": tool.inputSchema,
           "visibleToAgent": JSON.Encode.bool(tool.visibleToAgent),
         },

--- a/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
@@ -69,6 +69,7 @@ let serializeTool = (m: tool): Relay.remoteTool => {
   {
     name: T.name,
     description: T.description,
+    access: Some(T.access),
     inputSchema: T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
     visibleToAgent: T.visibleToAgent,
   }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
@@ -16,6 +16,7 @@ module ExnUtils = FrontmanCore__ExnUtils
 module Matcher = FrontmanCore__Tool__EditFile__Matcher
 
 let name = "edit_file"
+let access = Tool.ReadWrite
 let visibleToAgent = true
 let description = `Edits a file by replacing text using fuzzy matching.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
@@ -5,6 +5,7 @@ module SafePath = FrontmanCore__SafePath
 module FsUtils = FrontmanCore__FsUtils
 
 let name = Tool.ToolNames.fileExists
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Checks if a file or directory exists.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__GetLogs.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__GetLogs.res
@@ -3,6 +3,7 @@ module LogCapture = FrontmanCore__LogCapture
 module CircularBuffer = FrontmanCore__CircularBuffer
 
 let name = "get_logs"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let description = `Retrieves dev server logs from rotating 1024-entry buffer.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
@@ -6,6 +6,7 @@ module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathContext = FrontmanCore__PathContext
 
 let name = Tool.ToolNames.grep
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Searches **file contents** for text or regex patterns. Returns matching lines with file paths and line numbers.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Lighthouse.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Lighthouse.res
@@ -8,6 +8,7 @@ module LighthouseRunner = FrontmanCore__Lighthouse
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 let name = Tool.ToolNames.lighthouse
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Runs a Lighthouse audit on a URL to analyze performance, accessibility, best practices, and SEO.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListFiles.res
@@ -8,6 +8,7 @@ module PathContext = FrontmanCore__PathContext
 module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.listFiles
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Lists the **immediate contents** of a single directory — names, paths, and whether each entry is a file or directory.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
@@ -13,6 +13,7 @@ module PathRecovery = FrontmanCore__PathRecovery
 module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.listTree
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Returns a **recursive directory tree** of the project structure, with monorepo workspace detection.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__LoadAgentInstructions.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__LoadAgentInstructions.res
@@ -6,6 +6,7 @@ module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module SafePath = FrontmanCore__SafePath
 
 let name = Tool.ToolNames.loadAgentInstructions
+let access = Tool.Read
 let visibleToAgent = false
 let description = `Discovers and loads agent instruction files (Agents.md or CLAUDE.md) following Claude Code's discovery algorithm.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
@@ -11,6 +11,7 @@ module PathRecovery = FrontmanCore__PathRecovery
 module ToolPathHints = FrontmanCore__ToolPathHints
 
 let name = Tool.ToolNames.readFile
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Reads a file from the filesystem.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -9,6 +9,7 @@ module ToolPathHints = FrontmanCore__ToolPathHints
 module FilenamePattern = FrontmanCore__FilenamePattern
 
 let name = Tool.ToolNames.searchFiles
+let access = Tool.Read
 let visibleToAgent = true
 let description = `Searches **file names** across the project. Returns file paths whose name matches a pattern.
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
@@ -8,6 +8,7 @@ module FileTracker = FrontmanCore__FileTracker
 module ExnUtils = FrontmanCore__ExnUtils
 
 let name = Tool.ToolNames.writeFile
+let access = Tool.Write
 let visibleToAgent = true
 let description = `Writes content to a file.
 

--- a/libs/frontman-core/test/FrontmanCore__ToolRegistry.test.res
+++ b/libs/frontman-core/test/FrontmanCore__ToolRegistry.test.res
@@ -1,6 +1,7 @@
 open Vitest
 
 module ToolRegistry = FrontmanCore__ToolRegistry
+module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 describe("ToolRegistry", _t => {
   test("make creates empty registry", t => {
@@ -49,7 +50,17 @@ describe("ToolRegistry", _t => {
     | Some(tool) =>
       t->expect(tool.name)->Expect.toBe("read_file")
       t->expect(tool.description->String.length > 0)->Expect.toBe(true)
+      t->expect(tool.access)->Expect.toEqual(Some(Tool.Read))
     | None => ()
     }
+  })
+
+  test("serializes write and read-write access", t => {
+    let definitions = ToolRegistry.coreTools()->ToolRegistry.getToolDefinitions
+    let writeFile = definitions->Array.find(d => d.name == "write_file")->Option.getOrThrow
+    let editFile = definitions->Array.find(d => d.name == "edit_file")->Option.getOrThrow
+
+    t->expect(writeFile.access)->Expect.toEqual(Some(Tool.Write))
+    t->expect(editFile.access)->Expect.toEqual(Some(Tool.ReadWrite))
   })
 })

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__EditFile.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__EditFile.res
@@ -5,6 +5,7 @@ module EditFileWithLogCheck = Core.FrontmanCore__Tool__EditFileWithLogCheck
 module LogCapture = FrontmanNextjs__LogCapture
 
 let name = "edit_file"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite
 let visibleToAgent = true
 let description = CoreEditFile.description
 

--- a/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
+++ b/libs/frontman-nextjs/src/tools/FrontmanNextjs__Tool__GetRoutes.res
@@ -6,6 +6,7 @@ module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module PathStringUtils = FrontmanAiFrontmanCore.FrontmanCore__PathStringUtils
 
 let name = "get_routes"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let description = `Lists Next.js routes from the app or pages directory.
 

--- a/libs/frontman-protocol/schemas/relay/remoteTool.json
+++ b/libs/frontman-protocol/schemas/relay/remoteTool.json
@@ -7,6 +7,13 @@
     "description": {
       "type": "string"
     },
+    "access": {
+      "enum": [
+        "read",
+        "write",
+        "read-write"
+      ]
+    },
     "inputSchema": {},
     "visibleToAgent": {
       "type": "boolean"

--- a/libs/frontman-protocol/schemas/relay/toolsResponse.json
+++ b/libs/frontman-protocol/schemas/relay/toolsResponse.json
@@ -11,6 +11,13 @@
           "description": {
             "type": "string"
           },
+          "access": {
+            "enum": [
+              "read",
+              "write",
+              "read-write"
+            ]
+          },
           "inputSchema": {},
           "visibleToAgent": {
             "type": "boolean"

--- a/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
@@ -10,6 +10,7 @@ let protocolVersion = "1.0"
 type remoteTool = {
   name: string,
   description: string,
+  access: option<FrontmanProtocol__Tool.access>,
   inputSchema: JSON.t,
   visibleToAgent: bool,
 }

--- a/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
@@ -26,6 +26,13 @@ type serverExecutionContext = {
 //   (e.g. question tool waits for user to answer before resolving).
 type executionMode = Synchronous | Interactive
 
+type access =
+  | @as("read") Read
+  | @as("write") Write
+  | @as("read-write") ReadWrite
+
+let accessSchema = S.union([S.literal(Read), S.literal(Write), S.literal(ReadWrite)])
+
 // Context for browser tools that access the preview iframe
 type previewContext = {
   doc: WebAPI.DOMAPI.document,
@@ -62,6 +69,7 @@ module ToolNames = {
 module type BrowserTool = {
   let name: string
   let description: string
+  let access: access
   type input
   type output
   let inputSchema: S.t<input>
@@ -76,6 +84,7 @@ module type BrowserTool = {
 module type ServerTool = {
   let name: string
   let description: string
+  let access: access
   type input
   type output
   let inputSchema: S.t<input>

--- a/libs/frontman-vite/src/tools/FrontmanVite__Tool__EditFile.res
+++ b/libs/frontman-vite/src/tools/FrontmanVite__Tool__EditFile.res
@@ -4,6 +4,7 @@ module CoreEditFile = Core.FrontmanCore__Tool__EditFile
 module EditFileWithLogCheck = Core.FrontmanCore__Tool__EditFileWithLogCheck
 
 let name = "edit_file"
+let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite
 let visibleToAgent = true
 let description = CoreEditFile.description
 

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -28,6 +28,7 @@ class Frontman_Tool_Error extends \RuntimeException {}
 class Frontman_Tool_Definition {
 	public string $name;
 	public string $description;
+	public string $access;
 	public array  $input_schema;
 	public bool   $visible_to_agent;
 	public bool   $preserve_input_strings;
@@ -39,6 +40,7 @@ class Frontman_Tool_Definition {
 	 * @param string   $description      Human-readable description.
 	 * @param array    $input_schema     JSON Schema for input (as PHP array).
 	 * @param callable $handler          fn(array $input): array — returns plain data (JSON-serializable).
+	 * @param string|null $access              Tool access level: read, write, or read-write. Inferred from name when omitted.
 	 * @param bool     $visible_to_agent       Whether the agent can see this tool.
 	 * @param bool     $preserve_input_strings Whether schema sanitization should preserve raw string values for downstream API validation.
 	 */
@@ -47,11 +49,13 @@ class Frontman_Tool_Definition {
 		string $description,
 		array $input_schema,
 		callable $handler,
+		?string $access = null,
 		bool $visible_to_agent = true,
 		bool $preserve_input_strings = false
 	) {
 		$this->name                   = $name;
 		$this->description            = $description;
+		$this->access                 = $this->normalize_access( $access ?? self::infer_access( $name ) );
 		$this->input_schema           = $input_schema;
 		$this->handler                = $handler;
 		$this->visible_to_agent       = $visible_to_agent;
@@ -65,9 +69,34 @@ class Frontman_Tool_Definition {
 		return [
 			'name'           => $this->name,
 			'description'    => $this->description,
+			'access'         => $this->access,
 			'inputSchema'    => $this->input_schema,
 			'visibleToAgent' => $this->visible_to_agent,
 		];
+	}
+
+	private function normalize_access( string $access ): string {
+		if ( in_array( $access, [ 'read', 'write', 'read-write' ], true ) ) {
+			return $access;
+		}
+
+		return 'read-write';
+	}
+
+	private static function infer_access( string $name ): string {
+		foreach ( [ 'wp_list_', 'wp_read_', 'wp_get_', 'wc_get_', 'wc_list_' ] as $prefix ) {
+			if ( 0 === strpos( $name, $prefix ) ) {
+				return 'read';
+			}
+		}
+
+		foreach ( [ 'wp_create_', 'wp_duplicate_', 'wp_insert_', 'wp_upload_', 'wc_create_' ] as $prefix ) {
+			if ( 0 === strpos( $name, $prefix ) ) {
+				return 'write';
+			}
+		}
+
+		return 'read-write';
 	}
 }
 

--- a/libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
+++ b/libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
@@ -62,7 +62,8 @@ class Frontman_No_Filesystem_Tools_Test_Runner {
 		( new Frontman_Tool_Widgets() )->register( $tools );
 		( new Frontman_Tool_Cache() )->register( $tools );
 
-		$tool_names = array_column( $tools->all_definitions(), 'name' );
+		$definitions = $tools->all_definitions();
+		$tool_names = array_column( $definitions, 'name' );
 		$blocked = [
 			'load_agent_instructions',
 			'read_file',
@@ -84,6 +85,18 @@ class Frontman_No_Filesystem_Tools_Test_Runner {
 			$this->assert_false( in_array( $tool_name, $tool_names, true ), $tool_name . ' must not be exposed by the WordPress plugin' );
 		}
 
+		$access_by_name = [];
+		foreach ( $definitions as $definition ) {
+			$this->assert_true( isset( $definition['access'] ), $definition['name'] . ' declares access' );
+			$this->assert_true( in_array( $definition['access'], [ 'read', 'write', 'read-write' ], true ), $definition['name'] . ' has valid access' );
+			$access_by_name[ $definition['name'] ] = $definition['access'];
+		}
+
+		$this->assert_same( 'read', $access_by_name['wp_list_posts'], 'wp_list_posts access' );
+		$this->assert_same( 'write', $access_by_name['wp_create_post'], 'wp_create_post access' );
+		$this->assert_same( 'read-write', $access_by_name['wp_update_post'], 'wp_update_post access' );
+		$this->assert_same( 'read-write', $access_by_name['wp_clear_cache'], 'wp_clear_cache access' );
+
 		fwrite( STDOUT, "OK ({$this->assertions} assertions)\n" );
 	}
 
@@ -91,6 +104,20 @@ class Frontman_No_Filesystem_Tools_Test_Runner {
 		$this->assertions++;
 		if ( $condition ) {
 			throw new RuntimeException( $message );
+		}
+	}
+
+	private function assert_true( bool $condition, string $message ): void {
+		$this->assertions++;
+		if ( ! $condition ) {
+			throw new RuntimeException( $message );
+		}
+	}
+
+	private function assert_same( $expected, $actual, string $message ): void {
+		$this->assertions++;
+		if ( $expected !== $actual ) {
+			throw new RuntimeException( $message . ': expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true ) );
 		}
 	}
 }

--- a/libs/frontman-wordpress/tools/class-tool-woocommerce.php
+++ b/libs/frontman-wordpress/tools/class-tool-woocommerce.php
@@ -258,6 +258,7 @@ class Frontman_Tool_WooCommerce {
 			$description . ' Mirrors woocommerce-mcp-server method `' . $source_method . '` using local WordPress authentication; no WooCommerce REST API keys are required.',
 			$schema,
 			$handler,
+			null,
 			true,
 			true
 		) );


### PR DESCRIPTION
## Summary
- add read/write/read-write access metadata to ReScript tool contracts and relay serialization
- propagate access through backend, MCP, SwarmAi, and WordPress tool definitions
- update schemas, docs, tests, and changeset

## Verification
- make rescript-build
- make test (libs/frontman-core)
- make test (libs/frontman-client)
- yarn vitest run test/Client__ToolRegistry.test.res.mjs
- mix test test/frontman_server/tools/backend_test.exs test/frontman_server/tools/mcp_test.exs test/frontman_server/tools_test.exs test/frontman_server/tasks/execution/tool_executor_test.exs
- git diff --check origin/main...HEAD

## Notes
- make test-wordpress-core-tools could not run locally because php is not installed.
- full libs/client make test still has unrelated existing Radix/openBillingSettingsForErrorCategory failures; focused tool registry test passes.