### PR TITLE
Restrict Ecto.Query usage to schema modules

### DIFF
--- a/apps/frontman_server/.credo.exs
+++ b/apps/frontman_server/.credo.exs
@@ -41,7 +41,7 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: [],
+      requires: ["credo_checks/no_ecto_query_outside_schemas.ex"],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -84,6 +84,8 @@
           #
           {Credo.Check.Design.AliasUsage,
            [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {FrontmanServer.Credo.Checks.NoEctoQueryOutsideSchemas,
+           [ignored_path_patterns: [~r/^test\//, ~r/^lib\/mix\//]]},
           # You can also customize the exit_status of each check.
           # If you don't want TODO comments to cause `mix credo` to fail, just
           # set this value to 0 (zero).

--- a/apps/frontman_server/credo_checks/no_ecto_query_outside_schemas.ex
+++ b/apps/frontman_server/credo_checks/no_ecto_query_outside_schemas.ex
@@ -1,0 +1,149 @@
+defmodule FrontmanServer.Credo.Checks.NoEctoQueryOutsideSchemas do
+  @moduledoc false
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :design,
+    param_defaults: [ignored_path_patterns: []],
+    explanations: [
+      check: """
+      Ecto.Query should stay in Ecto schema modules.
+
+      Schema modules are the persistence boundary for schema-scoped query helpers.
+      Application contexts should call those helpers rather than importing Ecto.Query.
+      """,
+      params: [
+        ignored_path_patterns: "Regex patterns for source files skipped by this check."
+      ]
+    ]
+
+  @impl true
+  @spec run(Credo.SourceFile.t(), Keyword.t()) :: [Credo.Issue.t()]
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    case ignored_source_file?(source_file, params) do
+      true ->
+        []
+
+      false ->
+        source_file
+        |> SourceFile.ast()
+        |> modules()
+        |> Enum.flat_map(&issues_for_module(&1, issue_meta))
+    end
+  end
+
+  defp ignored_source_file?(source_file, params) do
+    params
+    |> Params.get(:ignored_path_patterns, __MODULE__)
+    |> Enum.any?(fn pattern -> Regex.match?(pattern, source_file.filename) end)
+  end
+
+  defp modules(ast) do
+    ast
+    |> Credo.Code.prewalk(&collect_module/2)
+    |> Enum.reverse()
+  end
+
+  defp collect_module({:defmodule, _meta, _args} = ast, modules) do
+    {ast, [ast | modules]}
+  end
+
+  defp collect_module(ast, modules), do: {ast, modules}
+
+  defp issues_for_module(module_ast, issue_meta) do
+    case ecto_schema_module?(module_ast) do
+      true -> []
+      false -> ecto_query_issues(module_ast, issue_meta)
+    end
+  end
+
+  defp ecto_schema_module?(module_ast) do
+    body = module_body(module_ast)
+
+    uses_ecto_schema? =
+      body
+      |> prewalk_module_body(&find_ecto_schema_use/2, false)
+
+    contains_schema? =
+      body
+      |> prewalk_module_body(&find_schema/2, false)
+
+    uses_ecto_schema? and contains_schema?
+  end
+
+  defp module_body({:defmodule, _meta, [_module_name, [do: body]]}), do: body
+  defp module_body(_module_ast), do: nil
+
+  defp prewalk_module_body(ast, fun, acc) do
+    Credo.Code.prewalk(ast, &skip_nested_modules(&1, &2, fun), acc)
+  end
+
+  defp skip_nested_modules({:defmodule, _meta, _args}, acc, _fun) do
+    {nil, acc}
+  end
+
+  defp skip_nested_modules(ast, acc, fun), do: fun.(ast, acc)
+
+  defp find_ecto_schema_use(ast, true), do: {ast, true}
+
+  defp find_ecto_schema_use(
+         {:use, _meta, [{:__aliases__, _alias_meta, [:Ecto, :Schema]} | _]} = ast,
+         false
+       ) do
+    {ast, true}
+  end
+
+  defp find_ecto_schema_use(ast, found), do: {ast, found}
+
+  defp find_schema(ast, true), do: {ast, true}
+
+  defp find_schema({:schema, _meta, [_source, [do: _body]]} = ast, false) do
+    {ast, true}
+  end
+
+  defp find_schema(ast, found), do: {ast, found}
+
+  defp ecto_query_issues(module_ast, issue_meta) do
+    module_ast
+    |> module_body()
+    |> prewalk_module_body(&find_ecto_query/2, [])
+    |> Enum.reverse()
+    |> Enum.map(&issue_for(&1, issue_meta))
+  end
+
+  defp find_ecto_query(
+         {operation, _meta,
+          [
+            {{:., _dot_meta, [{:__aliases__, ecto_meta, [:Ecto]}, :{}]}, _aliases_meta, aliases}
+            | _
+          ]} = ast,
+         issues
+       )
+       when operation in [:alias, :import, :require] do
+    case Enum.any?(aliases, &query_alias?/1) do
+      true -> {ast, [{ecto_meta, "Ecto"} | issues]}
+      false -> {ast, issues}
+    end
+  end
+
+  defp find_ecto_query({:__aliases__, meta, [:Ecto, :Query | _]} = ast, issues) do
+    {ast, [{meta, "Ecto.Query"} | issues]}
+  end
+
+  defp find_ecto_query(ast, issues), do: {ast, issues}
+
+  defp query_alias?({:__aliases__, _meta, [:Query]}), do: true
+  defp query_alias?(_ast), do: false
+
+  defp issue_for({meta, trigger}, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Ecto.Query is only allowed in Ecto schema modules.",
+      trigger: trigger,
+      line_no: meta[:line],
+      column: meta[:column]
+    )
+  end
+end

--- a/apps/frontman_server/lib/frontman_server/accounts.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts.ex
@@ -13,7 +13,6 @@ defmodule FrontmanServer.Accounts do
     deps: [FrontmanServer, FrontmanServer.Organizations],
     exports: [Scope, User, WorkOS.AuthError]
 
-  import Ecto.Query, warn: false
   alias FrontmanServer.Repo
 
   alias FrontmanServer.Accounts.{Scope, User, UserNotifier, UserToken, WorkOS}
@@ -152,8 +151,7 @@ defmodule FrontmanServer.Accounts do
       with {:ok, query} <- UserToken.verify_change_email_token_query(token, context),
            %UserToken{sent_to: email} <- Repo.one(query),
            {:ok, user} <- Repo.update(User.email_changeset(user, %{email: email})),
-           {_count, _result} <-
-             Repo.delete_all(from(UserToken, where: [user_id: ^user.id, context: ^context])) do
+           {_count, _result} <- Repo.delete_all(UserToken.by_user_and_context(user.id, context)) do
         {:ok, user}
       else
         _ -> {:error, :transaction_aborted}
@@ -306,7 +304,10 @@ defmodule FrontmanServer.Accounts do
   Deletes the signed token with the given context.
   """
   def delete_user_session_token(token) do
-    Repo.delete_all(from(UserToken, where: [token: ^token, context: "session"]))
+    token
+    |> UserToken.by_token_and_context("session")
+    |> Repo.delete_all()
+
     :ok
   end
 
@@ -317,7 +318,10 @@ defmodule FrontmanServer.Accounts do
       with {:ok, user} <- Repo.update(changeset) do
         tokens_to_expire = Repo.all_by(UserToken, user_id: user.id)
 
-        Repo.delete_all(from(t in UserToken, where: t.id in ^Enum.map(tokens_to_expire, & &1.id)))
+        tokens_to_expire
+        |> Enum.map(& &1.id)
+        |> UserToken.by_ids()
+        |> Repo.delete_all()
 
         {:ok, {user, tokens_to_expire}}
       end

--- a/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user_identity.ex
@@ -14,6 +14,7 @@ defmodule FrontmanServer.Accounts.UserIdentity do
 
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
 
   @providers ~w(github google)
 
@@ -60,5 +61,17 @@ defmodule FrontmanServer.Accounts.UserIdentity do
   """
   def touch_changeset(identity) do
     change(identity, last_signed_in_at: DateTime.utc_now(:second))
+  end
+
+  def for_user(query \\ __MODULE__, user_id) do
+    from(i in query, where: i.user_id == ^user_id)
+  end
+
+  def for_user_and_provider(query \\ __MODULE__, user_id, provider) do
+    from(i in query, where: i.user_id == ^user_id and i.provider == ^provider)
+  end
+
+  def for_provider_identity(query \\ __MODULE__, provider, provider_id) do
+    from(i in query, where: i.provider == ^provider and i.provider_id == ^provider_id)
   end
 end

--- a/apps/frontman_server/lib/frontman_server/accounts/user_token.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/user_token.ex
@@ -162,7 +162,19 @@ defmodule FrontmanServer.Accounts.UserToken do
     end
   end
 
+  def by_user_and_context(query \\ __MODULE__, user_id, context) do
+    from(t in query, where: t.user_id == ^user_id and t.context == ^context)
+  end
+
+  def by_ids(query \\ __MODULE__, ids) when is_list(ids) do
+    from(t in query, where: t.id in ^ids)
+  end
+
+  def by_token_and_context(query \\ __MODULE__, token, context) do
+    from(t in query, where: t.token == ^token and t.context == ^context)
+  end
+
   defp by_token_and_context_query(token, context) do
-    from UserToken, where: [token: ^token, context: ^context]
+    by_token_and_context(token, context)
   end
 end

--- a/apps/frontman_server/lib/frontman_server/accounts/workos.ex
+++ b/apps/frontman_server/lib/frontman_server/accounts/workos.ex
@@ -25,7 +25,6 @@ defmodule FrontmanServer.Accounts.WorkOS do
   alias FrontmanServer.Workers.SyncResendContact
 
   import Ecto.Changeset
-  import Ecto.Query
 
   @supported_providers ~w(github google)
   @workos_api_base "https://api.workos.com"
@@ -209,7 +208,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   """
   def list_identities(%User{} = user) do
     UserIdentity
-    |> where([i], i.user_id == ^user.id)
+    |> UserIdentity.for_user(user.id)
     |> Repo.all()
   end
 
@@ -218,7 +217,7 @@ defmodule FrontmanServer.Accounts.WorkOS do
   """
   def get_identity_by_provider(%User{} = user, provider) when is_binary(provider) do
     UserIdentity
-    |> where([i], i.user_id == ^user.id and i.provider == ^provider)
+    |> UserIdentity.for_user_and_provider(user.id, provider)
     |> Repo.one()
   end
 
@@ -348,16 +347,14 @@ defmodule FrontmanServer.Accounts.WorkOS do
 
   defp get_identity_by_provider_id(provider, provider_id) do
     UserIdentity
-    |> where([i], i.provider == ^provider and i.provider_id == ^provider_id)
+    |> UserIdentity.for_provider_identity(provider, provider_id)
     |> Repo.one()
   end
 
   defp get_user_by_email(email) when email in [nil, ""], do: nil
 
   defp get_user_by_email(email) when is_binary(email) do
-    User
-    |> where([u], u.email == ^email)
-    |> Repo.one()
+    Repo.get_by(User, email: email)
   end
 
   defp create_identity(user, profile) do

--- a/apps/frontman_server/lib/frontman_server/organizations.ex
+++ b/apps/frontman_server/lib/frontman_server/organizations.ex
@@ -26,8 +26,6 @@ defmodule FrontmanServer.Organizations do
     deps: [FrontmanServer],
     exports: [Organization]
 
-  import Ecto.Query, warn: false
-
   alias FrontmanServer.Organizations.{Membership, Organization}
   alias FrontmanServer.Repo
 

--- a/apps/frontman_server/lib/frontman_server/providers.ex
+++ b/apps/frontman_server/lib/frontman_server/providers.ex
@@ -10,7 +10,6 @@ defmodule FrontmanServer.Providers do
   use Boundary,
     deps: [FrontmanServer, FrontmanServer.Accounts]
 
-  import Ecto.Query, warn: false
   alias FrontmanServer.Repo
 
   alias FrontmanServer.Accounts
@@ -260,10 +259,8 @@ defmodule FrontmanServer.Providers do
   Lists providers with saved API keys for the user.
   """
   def list_api_key_providers(%Scope{user: %User{} = user}) do
-    ApiKey
-    |> ApiKey.for_user(user.id)
-    |> order_by([key], asc: key.provider)
-    |> select([key], key.provider)
+    user.id
+    |> ApiKey.provider_names_for_user()
     |> Repo.all()
   end
 

--- a/apps/frontman_server/lib/frontman_server/providers/api_key.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/api_key.ex
@@ -51,4 +51,8 @@ defmodule FrontmanServer.Providers.ApiKey do
   def for_user_and_provider(query \\ __MODULE__, user_id, provider) do
     from(k in query, where: k.user_id == ^user_id and k.provider == ^provider)
   end
+
+  def provider_names_for_user(query \\ __MODULE__, user_id) do
+    from(k in for_user(query, user_id), order_by: [asc: k.provider], select: k.provider)
+  end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -28,8 +28,6 @@ defmodule FrontmanServer.Tasks.Execution do
   alias SwarmAi.Message.ContentPart
   alias SwarmAi.Message.Tool
 
-  import Ecto.Query, only: [from: 2]
-
   @doc """
   Runs an agent execution for a task.
 
@@ -134,13 +132,9 @@ defmodule FrontmanServer.Tasks.Execution do
 
     InteractionSchema.for_task(task_id)
     |> InteractionSchema.of_type(:user_message)
-    |> where_id_in(user_message_ids)
+    |> InteractionSchema.by_ids(user_message_ids)
     |> InteractionSchema.ordered()
     |> Repo.all()
-  end
-
-  defp where_id_in(query, ids) do
-    from(i in query, where: i.id in ^ids)
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -110,6 +110,10 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
     from(i in query, where: i.type == ^type)
   end
 
+  def by_ids(query \\ __MODULE__, ids) when is_list(ids) do
+    from(i in query, where: i.id in ^ids)
+  end
+
   def data_equals(query \\ __MODULE__, field, value) do
     from(i in query, where: fragment("?->>?", i.data, ^field) == ^value)
   end

--- a/apps/frontman_server/test/frontman_server/credo/checks/no_ecto_query_outside_schemas_test.exs
+++ b/apps/frontman_server/test/frontman_server/credo/checks/no_ecto_query_outside_schemas_test.exs
@@ -1,0 +1,134 @@
+defmodule FrontmanServer.Credo.Checks.NoEctoQueryOutsideSchemasTest do
+  use Credo.Test.Case
+
+  Code.require_file(
+    Path.expand("../../../../credo_checks/no_ecto_query_outside_schemas.ex", __DIR__)
+  )
+
+  alias FrontmanServer.Credo.Checks.NoEctoQueryOutsideSchemas
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  test "allows Ecto.Query in modules that define Ecto schemas" do
+    """
+    defmodule Example.Schema do
+      use Ecto.Schema
+      import Ecto.Query
+
+      schema "records" do
+        field(:name, :string)
+      end
+    end
+    """
+    |> to_source_file("lib/example/schema.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> refute_issues()
+  end
+
+  test "reports Ecto.Query imports in modules without Ecto schemas" do
+    """
+    defmodule Example.Context do
+      import Ecto.Query
+
+      def list_records do
+        from(r in Example.Record)
+      end
+    end
+    """
+    |> to_source_file("lib/example/context.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Ecto.Query"
+      assert issue.line_no == 2
+    end)
+  end
+
+  test "reports aliases of Ecto.Query in modules without Ecto schemas" do
+    """
+    defmodule Example.Context do
+      alias Ecto.Query
+    end
+    """
+    |> to_source_file("lib/example/context.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Ecto.Query"
+      assert issue.line_no == 2
+    end)
+  end
+
+  test "reports multi-alias usage of Ecto.Query in modules without Ecto schemas" do
+    """
+    defmodule Example.Context do
+      import Ecto.{Changeset, Query}
+    end
+    """
+    |> to_source_file("lib/example/context.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Ecto"
+      assert issue.line_no == 2
+    end)
+  end
+
+  test "ignores test files" do
+    """
+    defmodule Example.ContextTest do
+      import Ecto.Query
+    end
+    """
+    |> to_source_file("test/example/context_test.exs")
+    |> run_check(NoEctoQueryOutsideSchemas, ignored_path_patterns: [~r/^test\//])
+    |> refute_issues()
+  end
+
+  test "ignores Mix tasks" do
+    """
+    defmodule Mix.Tasks.DebugTask do
+      import Ecto.Query
+    end
+    """
+    |> to_source_file("lib/mix/tasks/debug_task.ex")
+    |> run_check(NoEctoQueryOutsideSchemas, ignored_path_patterns: [~r/^lib\/mix\//])
+    |> refute_issues()
+  end
+
+  test "reports Ecto.Query in non-schema modules even when another module in the file is a schema" do
+    """
+    defmodule Example.Schema do
+      use Ecto.Schema
+
+      schema "records" do
+        field(:name, :string)
+      end
+    end
+
+    defmodule Example.Context do
+      import Ecto.Query
+    end
+    """
+    |> to_source_file("lib/example/mixed.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "Ecto.Query"
+      assert issue.line_no == 10
+    end)
+  end
+
+  test "does not report non-Ecto from calls" do
+    """
+    defmodule Example.Notifier do
+      def deliver(email) do
+        email
+        |> from("support@example.com")
+      end
+    end
+    """
+    |> to_source_file("lib/example/notifier.ex")
+    |> run_check(NoEctoQueryOutsideSchemas)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
## Summary
- add a custom Credo check that only permits Ecto.Query in modules defining Ecto schemas
- ignore configured paths for tests and Mix tasks
- move existing non-schema query fragments into schema query helpers

## Verification
- mix test
- mix test test/frontman_server/credo/checks/no_ecto_query_outside_schemas_test.exs
- mix credo --only FrontmanServer.Credo.Checks.NoEctoQueryOutsideSchemas

## Notes
- no changeset included because this is server-only lint/tooling and has no package release target