### PR TITLE
Fix mixed-key LLM usage persistence

### DIFF
--- a/.changeset/fix-mixed-usage-keys.md
+++ b/.changeset/fix-mixed-usage-keys.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix agent response persistence when LLM usage metadata contains mixed atom and string keys.

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -605,7 +605,7 @@ defmodule FrontmanServer.Tasks.Interaction do
 
       case usage do
         nil -> attrs
-        usage -> Map.put(attrs, :usage, usage_params(usage))
+        usage -> Map.put(attrs, :usage, usage)
       end
     end
 
@@ -644,7 +644,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     end
 
     defp usage_changeset(%__MODULE__.Usage{} = usage, attrs) do
-      changeset = cast(usage, attrs, @usage_fields)
+      changeset = cast(usage, usage_params(attrs), @usage_fields)
 
       Enum.reduce(@usage_fields, changeset, fn field, acc ->
         validate_number(acc, field, greater_than_or_equal_to: 0)
@@ -678,9 +678,26 @@ defmodule FrontmanServer.Tasks.Interaction do
       end
     end
 
-    defp usage_params(%__MODULE__.Usage{} = usage), do: Map.from_struct(usage)
-    defp usage_params(usage) when is_map(usage), do: usage
+    defp usage_params(%__MODULE__.Usage{} = usage),
+      do: usage |> Map.from_struct() |> usage_params()
+
+    defp usage_params(usage) when is_map(usage) do
+      Enum.reduce(@usage_fields, %{}, fn field, acc ->
+        case usage_value(usage, field) do
+          {:ok, value} -> Map.put(acc, field, value)
+          :error -> acc
+        end
+      end)
+    end
+
     defp usage_params(usage), do: usage
+
+    defp usage_value(usage, field) do
+      case Map.fetch(usage, field) do
+        {:ok, value} -> {:ok, value}
+        :error -> Map.fetch(usage, Atom.to_string(field))
+      end
+    end
 
     defp llm_response_metadata(response) do
       meta = response.metadata || %{}

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -183,17 +183,19 @@ defmodule FrontmanServer.TasksTest do
   end
 
   describe "swarm event persistence" do
-    test "persists known response usage fields and drops provider extras", %{scope: scope} do
+    test "persists mixed-key provider usage with known fields only", %{scope: scope} do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
 
       usage = %{
+        "cost" => 0.21366,
+        "cost_details" => %{"upstream_inference_cost" => 0.21366},
+        "cache_creation_tokens" => 10,
         input_tokens: 100,
         output_tokens: 50,
         reasoning_tokens: 15,
         cached_tokens: 25,
         total_tokens: 175,
-        cache_creation_tokens: 10,
         provider_exact_field: "preserved",
         nested_provider_data: %{"anything" => [1, 2, 3]}
       }
@@ -209,16 +211,16 @@ defmodule FrontmanServer.TasksTest do
                }
              ] = agent_responses(task_id)
 
-      assert %{
+      usage_attrs = Map.from_struct(stored_usage)
+
+      assert usage_attrs == %{
                input_tokens: 100,
                output_tokens: 50,
                reasoning_tokens: 15,
                cached_tokens: 25,
                total_tokens: 175,
                cache_creation_tokens: 10
-             } = Map.from_struct(stored_usage)
-
-      refute Map.has_key?(Map.from_struct(stored_usage), :provider_exact_field)
+             }
     end
 
     test "omits response usage when usage is absent", %{scope: scope} do


### PR DESCRIPTION
## Summary\n- normalize agent response usage inside the embedded usage changeset\n- keep only known token usage fields while accepting atom or string keys\n- add regression coverage for OpenRouter-style mixed-key usage metadata\n\nFixes ELIXIR-1JY\n\n## Verification\n- `mix test test/frontman_server/tasks_test.exs:186`\n- `mix test test/frontman_server/tasks_test.exs`\n- `make precommit`