### PR TITLE
Improve marketing 404 recovery

### DIFF
--- a/.changeset/spotty-vans-start.md
+++ b/.changeset/spotty-vans-start.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Improve the marketing 404 page with popular recovery links and remove its canonical tag.

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -23,6 +23,7 @@ type Props = {
 	ogImageWidth?: number
 	ogImageHeight?: number
 	ogImageAlt?: string
+	canonical?: boolean
 	noindex?: boolean
 	classes?: string
 	article?: {
@@ -43,6 +44,7 @@ const {
 	ogImageWidth,
 	ogImageHeight,
 	ogImageAlt,
+	canonical,
 	noindex,
 	classes,
 	article,
@@ -52,7 +54,7 @@ const {
 
 <!doctype html>
 <html lang="en" class="relative">
-	<Header title={title} description={description} ogImage={ogImage} ogImageWidth={ogImageWidth} ogImageHeight={ogImageHeight} ogImageAlt={ogImageAlt} noindex={noindex} article={article} breadcrumbs={breadcrumbs} />
+	<Header title={title} description={description} ogImage={ogImage} ogImageWidth={ogImageWidth} ogImageHeight={ogImageHeight} ogImageAlt={ogImageAlt} canonical={canonical} noindex={noindex} article={article} breadcrumbs={breadcrumbs} />
 	<body class:list={[{ [`${classes}`]: classes }]}>
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 		<NavigationBar />

--- a/apps/marketing/src/pages/404.astro
+++ b/apps/marketing/src/pages/404.astro
@@ -19,7 +19,7 @@ const SEO = {
 }
 ---
 
-<Layout title={SEO.title} description={SEO.description} noindex={true}>
+<Layout title={SEO.title} description={SEO.description} canonical={false} noindex={true}>
 	<Section>
 		<Row flex classes="text-center">
 			<Col span="2" />
@@ -134,6 +134,14 @@ const SEO = {
 				<p class="mx-auto max-w-xl text-neutral-300">The page may have moved or the link may be outdated.</p>
 				<Spacer size="2" desktopSize="4" />
 				<Button link="/"> Return to homepage <Icon name="long-arrow-right" /> </Button>
+				<nav class="mt-8" aria-label="Popular pages">
+					<p class="text-sm font-semibold text-neutral-800 dark:text-white">Popular pages</p>
+					<ul class="mt-3 flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-neutral-600 dark:text-neutral-300">
+						<li><a class="underline underline-offset-4" href="/docs/">Documentation</a></li>
+						<li><a class="underline underline-offset-4" href="/docs/installation/">Installation</a></li>
+						<li><a class="underline underline-offset-4" href="/changelog/">Changelog</a></li>
+					</ul>
+				</nav>
 			</Col>
 			<Col span="2" />
 		</Row>


### PR DESCRIPTION
## Summary
- add links to documentation, installation, and changelog on the marketing 404 page
- allow layouts to disable canonical tags and suppress canonical output for 404s
- add marketing changeset

## Testing
- `make -C apps/marketing build`
- Astro diagnostics: 0 errors, warnings, or hints
- broken-link checker: no broken links