### PR TITLE
fix(agent): recover from wrong annotation line by grepping the file

### DIFF
--- a/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
@@ -185,6 +185,25 @@ defmodule FrontmanServer.Agents.SystemPrompt do
     5. **Write the file(s)** - Save changes using the same path(s)
     6. **Verify and summarize** - For visual changes, use `take_screenshot` to verify the result. Always summarize what changed and why.
 
+    ### The annotated line & component name are APPROXIMATE
+
+    The annotation's line number and Component name are best-effort and are
+    frequently WRONG — off by many lines, or naming a different component —
+    especially in large single-file mock/prototype screens. Trust the file
+    PATH; treat the line and component name as hints, not the truth.
+
+    If the code at the annotated line does NOT contain what the user asked to
+    change, DO NOT start hunting for the Component name. Instead, `grep` the
+    SAME file for the CSS property or value named in the request, then edit the
+    line it finds:
+    - background image  -> grep `backgroundImage`, `background-image`, `url(`, `bg-[`
+    - background color   -> grep `bg-`, `backgroundColor`, `background:`
+    - text / font color  -> grep `text-`, `color:`
+    - any specific value the user named -> grep that literal value
+    The property you were asked to change is almost always a literal string in
+    the SAME file — find it directly. Never conclude "not found" after only
+    searching for a component name.
+
     ### Multiple Annotations
 
     When the user annotates multiple elements:


### PR DESCRIPTION
Part of #1276 (maintainer-requested upstreaming; the annotation-recovery change called out there).

## What
Adds a recovery rule to the agent system prompt: when the annotated line / component name doesn't match what the user asked to change, grep the same file for the requested CSS property or value instead of hunting by component name.

## Why
Annotation line numbers and component names are best-effort and are frequently wrong (off by many lines, or naming a different component) — especially in large single-file mock/prototype screens. The agent would conclude "not found" after searching only for the component name, then give up or edit the wrong place.

## How
System-prompt guidance to trust the file PATH, treat the line/component as hints, and grep the file directly for the requested property (`backgroundImage`, `bg-`, `text-`, a literal value, …) before concluding anything is missing.
