### PR TITLE
feat(client): toggle to collapse the chat panel for full-width preview

### DIFF
--- a/.changeset/collapse-chat-panel.md
+++ b/.changeset/collapse-chat-panel.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Allow the chat panel to collapse into a compact Frontman logo control, giving the browser preview the full workspace.

--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -33,6 +33,9 @@ let make = (~apiBaseUrl: string) => {
   // Get resizable width for chatbox panel
   let (chatboxWidth, isResizing, handleResizeMouseDown) = Client__UseResizableWidth.use()
 
+  // Chat panel open/closed toggle — collapse the chat to see the full preview
+  let (chatOpen, setChatOpen) = React.useState(() => true)
+
   // Settings modal state
   let (settingsOpen, setSettingsOpen) = React.useState(() => false)
   let (settingsInitialTab, setSettingsInitialTab) = React.useState(() => None)
@@ -118,6 +121,8 @@ let make = (~apiBaseUrl: string) => {
     // Top bar (sits above the panel split)
     <Client__TopBar
       chatboxWidth
+      chatOpen
+      onToggleChat={() => setChatOpen(prev => !prev)}
       onSettingsClick={() => setSettingsOpen(_ => true)}
       showProviderNudgeBubble
       showProviderNudgeBadge
@@ -131,7 +136,7 @@ let make = (~apiBaseUrl: string) => {
       | true => <div className="fixed inset-0 z-50 cursor-col-resize" />
       | false => React.null
       }}
-      <div
+      {chatOpen ? <div
         style={{width: `${Int.toString(chatboxWidth)}px`}}
         className="h-full border-r flex flex-col overflow-hidden relative shrink-0"
       >
@@ -147,7 +152,7 @@ let make = (~apiBaseUrl: string) => {
           ]->Array.join(" ")}
           onMouseDown={handleResizeMouseDown}
         />
-      </div>
+      </div> : React.null}
       <div className="grow h-full min-w-0">
         <Client__WebPreview />
       </div>

--- a/libs/client/src/Client__App.res
+++ b/libs/client/src/Client__App.res
@@ -136,23 +136,26 @@ let make = (~apiBaseUrl: string) => {
       | true => <div className="fixed inset-0 z-50 cursor-col-resize" />
       | false => React.null
       }}
-      {chatOpen ? <div
-        style={{width: `${Int.toString(chatboxWidth)}px`}}
-        className="h-full border-r flex flex-col overflow-hidden relative shrink-0"
-      >
-        <Client__Chatbox onConfigureProvider=openSettingsProviders />
-        // Resize handle on right edge
-        <div
-          className={[
-            "absolute top-0 right-0 w-1 h-full cursor-col-resize transition-colors",
-            switch isResizing {
-            | true => "bg-zinc-500"
-            | false => "hover:bg-zinc-600"
-            },
-          ]->Array.join(" ")}
-          onMouseDown={handleResizeMouseDown}
-        />
-      </div> : React.null}
+      {chatOpen
+        ? <div
+            id="chat-panel"
+            style={{width: `${Int.toString(chatboxWidth)}px`}}
+            className="h-full border-r flex flex-col overflow-hidden relative shrink-0"
+          >
+            <Client__Chatbox onConfigureProvider=openSettingsProviders />
+            // Resize handle on right edge
+            <div
+              className={[
+                "absolute top-0 right-0 w-1 h-full cursor-col-resize transition-colors",
+                switch isResizing {
+                | true => "bg-zinc-500"
+                | false => "hover:bg-zinc-600"
+                },
+              ]->Array.join(" ")}
+              onMouseDown={handleResizeMouseDown}
+            />
+          </div>
+        : React.null}
       <div className="grow h-full min-w-0">
         <Client__WebPreview />
       </div>

--- a/libs/client/src/Client__ChatToggle.res
+++ b/libs/client/src/Client__ChatToggle.res
@@ -1,0 +1,46 @@
+module Icons = Client__UI__Icons
+module Button = Client__UI__Button
+module Tooltip = Client__UI__Tooltip
+
+@react.component
+let make = (~chatOpen: bool, ~onToggle: unit => unit, ~isAgentRunning: bool=false) => {
+  let (label, className, ariaControls) = switch chatOpen {
+  | true => ("Close chat", "ml-auto cursor-w-resize", Some("chat-panel"))
+  | false => ("Open chat", "group cursor-e-resize", None)
+  }
+  let logoClassName = switch isAgentRunning {
+  | true => "frontman-logo-pulse"
+  | false => ""
+  }
+
+  <Tooltip>
+    <Tooltip.Trigger
+      onClick={_ => onToggle()}
+      render={<Button
+        variant=Button.Variant.Ghost
+        size=Button.Size.IconSm
+        className
+        ariaLabel=label
+        ariaExpanded=chatOpen
+        ?ariaControls
+      />}
+    >
+      {switch chatOpen {
+      | true => <Icons.PanelLeftCloseIcon dataIcon="panel-left-close" />
+      | false =>
+        <>
+          <span
+            className="flex items-center justify-center group-hover:hidden group-focus-visible:hidden"
+          >
+            <Client__FrontmanLogo size=18 className=logoClassName />
+          </span>
+          <Icons.PanelLeftOpenIcon
+            dataIcon="panel-left-open"
+            className="hidden group-hover:block group-focus-visible:block"
+          />
+        </>
+      }}
+    </Tooltip.Trigger>
+    <Tooltip.Content sideOffset=4.> {React.string(label)} </Tooltip.Content>
+  </Tooltip>
+}

--- a/libs/client/src/Client__TopBar.res
+++ b/libs/client/src/Client__TopBar.res
@@ -112,15 +112,19 @@ let make = (
         }}
         className="flex items-center h-full shrink-0 px-1 gap-1 overflow-hidden"
       >
-        {renderToolbarButton(
-          ~label=chatOpen ? "Hide chat" : "Show chat",
-          ~onClick=_ => onToggleChat(),
-          ~children=<Icons.MessageCircle />,
-        )}
-        <div className="flex items-center justify-center w-7 h-7 shrink-0">
-          <FrontmanLogo size=18 className={isAgentRunning ? "frontman-logo-pulse" : ""} />
-        </div>
-        {chatOpen ? <Client__TopBar__TaskDropdown onNewTask={handleNewTask} /> : React.null}
+        {switch chatOpen {
+        | true =>
+          <>
+            <div className="flex items-center justify-center w-7 h-7 shrink-0">
+              <FrontmanLogo size=18 className={isAgentRunning ? "frontman-logo-pulse" : ""} />
+            </div>
+            <div className="flex-1 min-w-0 overflow-hidden">
+              <Client__TopBar__TaskDropdown onNewTask={handleNewTask} />
+            </div>
+          </>
+        | false => React.null
+        }}
+        <Client__ChatToggle chatOpen onToggle=onToggleChat isAgentRunning />
       </div>
       // Vertical divider — visually continues the panel border below
       <div className="w-px h-full bg-[#1e1538] shrink-0" />

--- a/libs/client/src/Client__TopBar.res
+++ b/libs/client/src/Client__TopBar.res
@@ -19,6 +19,8 @@ let renderToolbarButton = (~label, ~onClick, ~children, ~className="") =>
 @react.component
 let make = (
   ~chatboxWidth: int,
+  ~chatOpen: bool=true,
+  ~onToggleChat: unit => unit=() => (),
   ~onSettingsClick: unit => unit,
   ~showProviderNudgeBubble: bool=false,
   ~showProviderNudgeBadge: bool=false,
@@ -105,13 +107,20 @@ let make = (
     <div className="h-8 flex items-center shrink-0 bg-[#130d20] border-b border-[#1e1538]">
       // LEFT ZONE — width tracks the resizable chat panel
       <div
-        style={{width: `${Int.toString(chatboxWidth >= 240 ? chatboxWidth : 240)}px`}}
+        style={{
+          width: chatOpen ? `${Int.toString(chatboxWidth >= 240 ? chatboxWidth : 240)}px` : "auto",
+        }}
         className="flex items-center h-full shrink-0 px-1 gap-1 overflow-hidden"
       >
+        {renderToolbarButton(
+          ~label=chatOpen ? "Hide chat" : "Show chat",
+          ~onClick=_ => onToggleChat(),
+          ~children=<Icons.MessageCircle />,
+        )}
         <div className="flex items-center justify-center w-7 h-7 shrink-0">
           <FrontmanLogo size=18 className={isAgentRunning ? "frontman-logo-pulse" : ""} />
         </div>
-        <Client__TopBar__TaskDropdown onNewTask={handleNewTask} />
+        {chatOpen ? <Client__TopBar__TaskDropdown onNewTask={handleNewTask} /> : React.null}
       </div>
       // Vertical divider — visually continues the panel border below
       <div className="w-px h-full bg-[#1e1538] shrink-0" />

--- a/libs/client/src/ui/Client__UI__Icons.res
+++ b/libs/client/src/ui/Client__UI__Icons.res
@@ -63,6 +63,14 @@ module Monitor = {
   @module("lucide-react") external make: React.component<props> = "MonitorIcon"
 }
 
+module PanelLeftClose = {
+  @module("lucide-react") external make: React.component<props> = "PanelLeftCloseIcon"
+}
+
+module PanelLeftOpen = {
+  @module("lucide-react") external make: React.component<props> = "PanelLeftOpenIcon"
+}
+
 module Plus = {
   @module("lucide-react") external make: React.component<props> = "PlusIcon"
 }
@@ -102,6 +110,8 @@ module TrashIcon = Trash
 module ChatBubbleIcon = MessageCircle
 module MobileIcon = Smartphone
 module DesktopIcon = Monitor
+module PanelLeftCloseIcon = PanelLeftClose
+module PanelLeftOpenIcon = PanelLeftOpen
 module UpdateIcon = RefreshCw
 module CheckIcon = Check
 module CreditCardIcon = CreditCard

--- a/libs/client/test/Client__ChatToggle.interaction.test.mjs
+++ b/libs/client/test/Client__ChatToggle.interaction.test.mjs
@@ -1,0 +1,62 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { make as ChatToggle } from "../src/Client__ChatToggle.res.mjs";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root;
+let container;
+
+afterEach(() => {
+	act(() => root?.unmount());
+	container?.remove();
+});
+
+describe("Client__ChatToggle interaction", () => {
+	test("calls onToggle when clicked", async () => {
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+		let toggleCount = 0;
+
+		await act(async () => {
+			root.render(
+				React.createElement(ChatToggle, {
+					chatOpen: true,
+					onToggle: () => toggleCount++,
+				}),
+			);
+		});
+
+		await act(async () => {
+			container.querySelector('button[aria-label="Close chat"]').click();
+		});
+
+		expect(toggleCount).toBe(1);
+	});
+
+	test("preserves keyboard focus when the state changes", async () => {
+		let Harness = () => {
+			let [chatOpen, setChatOpen] = React.useState(true);
+			return React.createElement(ChatToggle, {
+				chatOpen,
+				onToggle: () => setChatOpen((open) => !open),
+			});
+		};
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+
+		await act(async () => root.render(React.createElement(Harness)));
+		let button = container.querySelector('button[aria-label="Close chat"]');
+		button.focus();
+
+		await act(async () => button.click());
+
+		expect(container.querySelector('button[aria-label="Open chat"]')).toBe(
+			button,
+		);
+		expect(document.activeElement).toBe(button);
+	});
+});

--- a/libs/client/test/Client__ChatToggle.test.res
+++ b/libs/client/test/Client__ChatToggle.test.res
@@ -1,0 +1,27 @@
+open Vitest
+
+@module("react-dom/server")
+external renderToStaticMarkup: React.element => string = "renderToStaticMarkup"
+
+describe("Client__ChatToggle", () => {
+  test("renders the close control while chat is expanded", t => {
+    let html = renderToStaticMarkup(<Client__ChatToggle chatOpen=true onToggle={() => ()} />)
+
+    t->expect(html->String.includes(`aria-label="Close chat"`))->Expect.toBe(true)
+    t->expect(html->String.includes(`aria-expanded="true"`))->Expect.toBe(true)
+    t->expect(html->String.includes(`aria-controls="chat-panel"`))->Expect.toBe(true)
+    t->expect(html->String.includes(`data-icon="panel-left-close"`))->Expect.toBe(true)
+    t->expect(html->String.includes("group-hover/chat-toggle:hidden"))->Expect.toBe(false)
+  })
+
+  test("renders the logo and open affordance while chat is collapsed", t => {
+    let html = renderToStaticMarkup(<Client__ChatToggle chatOpen=false onToggle={() => ()} />)
+
+    t->expect(html->String.includes(`aria-label="Open chat"`))->Expect.toBe(true)
+    t->expect(html->String.includes(`aria-expanded="false"`))->Expect.toBe(true)
+    t->expect(html->String.includes(`aria-controls="chat-panel"`))->Expect.toBe(false)
+    t->expect(html->String.includes(`data-icon="panel-left-open"`))->Expect.toBe(true)
+    t->expect(html->String.includes("group-hover:hidden"))->Expect.toBe(true)
+    t->expect(html->String.includes("group-focus-visible:block"))->Expect.toBe(true)
+  })
+})


### PR DESCRIPTION
Opened alongside the branches requested in #1276 as an additional, self-contained improvement (not one of the three the maintainer explicitly asked for there).

## What
Adds a compact, accessible control to collapse/expand the chat panel, so the editor preview can use the full window width.

## Why
Users sometimes want to hide the chat to see the full desktop/preview view.

## How
- `Client__App`: owns `chatOpen` state and conditionally renders the chat panel.
- `Client__TopBar`: keeps the toggle at the chat panel's top-right while expanded.
- Collapsed state becomes the Frontman logo; hover or keyboard focus reveals the open-chat icon.
- Uses Shadcn ghost button styling and Lucide panel icons.
- Preserves keyboard focus through collapse/expand transitions.
- Adds component, interaction, accessibility, and hover-state tests.
- Adds required client changeset.

## Verification
- `make -C libs/client test` (304 tests)
- `make -C libs/client lint`
- ReScript formatting and dead-code analysis via git hooks