### PR TITLE
Sync new signups to Product Updates segment

### DIFF
--- a/.changeset/sync-product-update-signups.md
+++ b/.changeset/sync-product-update-signups.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ensure new Frontman signups receive future product updates and release announcements.

--- a/apps/frontman_server/config/config.exs
+++ b/apps/frontman_server/config/config.exs
@@ -171,7 +171,7 @@ config :frontman_server, FrontmanServerWeb.Endpoint,
 config :frontman_server, FrontmanServer.Mailer,
   adapter: Swoosh.Adapters.Local,
   contacts_url: "https://api.resend.com/contacts",
-  segment_id: "974ede17-1b25-4e48-a71d-6d5f0923f402"
+  segment_id: "5786d8bb-df16-413c-a06d-64d1a579cc2f"
 
 # Signup workers — disabled by default, enabled in prod and test.
 config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: false

--- a/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
@@ -30,7 +30,7 @@ defmodule FrontmanServer.Workers.SyncResendContactTest do
         assert payload["email"] == user.email
         assert payload["first_name"] == "Steve"
         assert payload["unsubscribed"] == false
-        assert payload["segments"] == [%{"id" => "974ede17-1b25-4e48-a71d-6d5f0923f402"}]
+        assert payload["segments"] == [%{"id" => "5786d8bb-df16-413c-a06d-64d1a579cc2f"}]
 
         Req.Test.json(conn, %{"object" => "contact", "id" => "abc-123"})
       end)


### PR DESCRIPTION
## Summary
- update Resend signup sync to use the active Product Updates segment
- verify contact payload targets the active segment
- add release-note changeset

## Verification
- focused worker tests: 6 passed
- `make precommit`: 727 tests, 0 failures
- compile, format, and Credo checks passed