### PR TITLE
Fix Dependabot updates blocked by Git dependency

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,7 +8,7 @@ catalog:
   "@vitest/coverage-v8": 4.1.10
   "vite": ^8.1.4
   "vitest": 4.1.10
-  "rescript-vitest": "https://github.com/cometkim/rescript-vitest.git#commit=662019a08334dd1b188efe6b0b306c9c0bcdb75a"
+  "rescript-vitest": 2.1.1
   "@rescript/webapi": "*"
 
 packageExtensions:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,9 +6,9 @@ catalog:
   "sury-ppx": 11.0.0-alpha.8
   "dotenv": 17.2.3
   "@vitest/coverage-v8": 4.1.10
-  "vite": ^8.1.4
+  "vite": ^8.1.5
   "vitest": 4.1.10
-  "rescript-vitest": 2.1.1
+  "rescript-vitest": "https://github.com/cometkim/rescript-vitest/archive/662019a08334dd1b188efe6b0b306c9c0bcdb75a.tar.gz"
   "@rescript/webapi": "*"
 
 packageExtensions:

--- a/package.json
+++ b/package.json
@@ -38,14 +38,13 @@
 	"dependencies": {
 		"rescript": "catalog:"
 	},
-	"resolutions_comment": "Overrides for transitive vulnerabilities and known-compatible dependency metadata.",
+	"resolutions_comment": "Minimal security overrides for transitive deps whose upstream ranges still resolve vulnerable versions.",
 	"resolutions": {
 		"qs": ">=6.15.2",
 		"glob": ">=13.0.5",
 		"yaml": ">=2.8.3",
 		"esbuild": ">=0.28.1",
-		"postcss": ">=8.5.10",
-		"vitest": "4.1.10"
+		"postcss": ">=8.5.10"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,14 @@
 	"dependencies": {
 		"rescript": "catalog:"
 	},
-	"resolutions_comment": "Minimal security overrides for transitive deps whose upstream ranges still resolve vulnerable versions.",
+	"resolutions_comment": "Overrides for transitive vulnerabilities and known-compatible dependency metadata.",
 	"resolutions": {
 		"qs": ">=6.15.2",
 		"glob": ">=13.0.5",
 		"yaml": ">=2.8.3",
 		"esbuild": ">=0.28.1",
-		"postcss": ">=8.5.10"
+		"postcss": ">=8.5.10",
+		"vitest": "4.1.10"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16634,15 +16634,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rescript-vitest@npm:2.1.1":
+"rescript-vitest@https://github.com/cometkim/rescript-vitest/archive/662019a08334dd1b188efe6b0b306c9c0bcdb75a.tar.gz":
   version: 2.1.1
-  resolution: "rescript-vitest@npm:2.1.1"
+  resolution: "rescript-vitest@https://github.com/cometkim/rescript-vitest/archive/662019a08334dd1b188efe6b0b306c9c0bcdb75a.tar.gz"
   dependencies:
-    vitest: "npm:^3.1.4"
+    vitest: "npm:^4.1.7"
   peerDependencies:
     rescript: ^10.1.0 || ^11.0.0-0 || ^12.0.0-0
-    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/313752ed7cfbb20d2efd18a67dcee0a8acf3116eefe5965458de61654ab7ddedc8a572c2e81d85524b95c8065318d73340d5a5fad749d58c38ebf31b8e5ff553
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/20ce54b1d620587be1072936946cb6d9067607c730f30717f1ee85932d6dc9f7372c696e135f03b80f10c59d5eba94bf848f0d1b35ad3375c02420270013cfa0
   languageName: node
   linkType: hard
 
@@ -16814,7 +16814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:~1.1.4, rolldown@npm:~1.1.5":
+"rolldown@npm:~1.1.5":
   version: 1.1.5
   resolution: "rolldown@npm:1.1.5"
   dependencies:
@@ -19171,15 +19171,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.1.4":
-  version: 8.1.4
-  resolution: "vite@npm:8.1.4"
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.0.13, vite@npm:^8.1.5":
+  version: 8.1.5
+  resolution: "vite@npm:8.1.5"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
     picomatch: "npm:^4.0.5"
-    postcss: "npm:^8.5.16"
-    rolldown: "npm:~1.1.4"
+    postcss: "npm:^8.5.17"
+    rolldown: "npm:~1.1.5"
     tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
@@ -19224,7 +19224,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/4262cdd0dd00ca99b00a8aef91fc00e58b66e80b54adbef49353bfbbae7342c2d6ddf1180351956086ff53ad186bec03784f57b96e36ab4dad1246547236d79b
+  checksum: 10c0/3231e24dd4394d0bc8b4f0f5d6d6a2eda8737e5053042892b4163564456a03d67f953c4c7498621f9517eebc30a492ea136c728a767a122eb84bf6d7cf60e1e6
   languageName: node
   linkType: hard
 
@@ -19283,63 +19283,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.13":
-  version: 8.1.5
-  resolution: "vite@npm:8.1.5"
-  dependencies:
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.5"
-    postcss: "npm:^8.5.17"
-    rolldown: "npm:~1.1.5"
-    tinyglobby: "npm:^0.2.17"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.3.0
-    esbuild: ^0.27.0 || ^0.28.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/3231e24dd4394d0bc8b4f0f5d6d6a2eda8737e5053042892b4163564456a03d67f953c4c7498621f9517eebc30a492ea136c728a767a122eb84bf6d7cf60e1e6
-  languageName: node
-  linkType: hard
-
 "vitefu@npm:^1.1.2":
   version: 1.1.2
   resolution: "vitefu@npm:1.1.2"
@@ -19352,7 +19295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:4.1.10":
+"vitest@npm:4.1.10, vitest@npm:^4.1.7":
   version: 4.1.10
   resolution: "vitest@npm:4.1.10"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16634,15 +16634,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rescript-vitest@https://github.com/cometkim/rescript-vitest.git#commit=662019a08334dd1b188efe6b0b306c9c0bcdb75a":
+"rescript-vitest@npm:2.1.1":
   version: 2.1.1
-  resolution: "rescript-vitest@https://github.com/cometkim/rescript-vitest.git#commit=662019a08334dd1b188efe6b0b306c9c0bcdb75a"
+  resolution: "rescript-vitest@npm:2.1.1"
   dependencies:
-    vitest: "npm:^4.1.7"
+    vitest: "npm:^3.1.4"
   peerDependencies:
     rescript: ^10.1.0 || ^11.0.0-0 || ^12.0.0-0
-    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10c0/ef87dd2cdaf713fb42c2efbf9d016d96afd2359835fbacf713c18ac33da66b0f937853d88aac54c6931acaeb55a0f309e4c642e5ec6152b43e87b283ed2494c7
+    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10c0/313752ed7cfbb20d2efd18a67dcee0a8acf3116eefe5965458de61654ab7ddedc8a572c2e81d85524b95c8065318d73340d5a5fad749d58c38ebf31b8e5ff553
   languageName: node
   linkType: hard
 
@@ -19352,7 +19352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:4.1.10, vitest@npm:^4.1.7":
+"vitest@npm:4.1.10":
   version: 4.1.10
   resolution: "vitest@npm:4.1.10"
   dependencies:


### PR DESCRIPTION
## Summary
- replace Git protocol dependency with an immutable GitHub archive
- preserve upstream Vite 8 and Vitest 4 compatibility metadata
- update and deduplicate Vite to latest `8.1.5`; retain latest Vitest `4.1.10`
- avoid nested Yarn source bootstrap that bypasses Dependabot proxy

## Root cause
Dependabot package updates forced Yarn to pack the Git dependency from source. Its nested Yarn process connected directly to `registry.yarnpkg.com`, failed DNS resolution with `EAI_AGAIN`, and aborted unrelated updates such as `sharp`. The HTTP archive is fetched directly through Dependabot without source packing.

## Verification
- immutable Yarn install passed
- root ReScript build passed
- 992 tests passed across affected packages
- `libs/frontman-vite` build passed; test target has no matching test files
- lockfile contains only Vite `8.1.5` and Vitest `4.1.10` for compatible Vite 8/Vitest 4 ranges
- `git diff --check` passed

Related failed run: https://github.com/frontman-ai/frontman/actions/runs/29746451264