### PR TITLE
Add verified WordPress 7 support

### DIFF
--- a/.changeset/wordpress-seven-support.md
+++ b/.changeset/wordpress-seven-support.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Add verified WordPress 7 support, including nested Gutenberg block paths, block-theme navigation tools, and WordPress 7.0.2 runtime coverage on PHP 7.4 and 8.4.

--- a/.github/workflows/wordpress-compatibility.yml
+++ b/.github/workflows/wordpress-compatibility.yml
@@ -1,0 +1,52 @@
+name: WordPress Compatibility
+
+on:
+  pull_request:
+    paths:
+      - "libs/frontman-wordpress/**"
+      - "scripts/test-wordpress-plugin-runtime.sh"
+      - "scripts/package-wordpress-plugin.sh"
+      - "scripts/validate-wordpress-plugin-release.sh"
+      - ".github/workflows/wordpress-compatibility.yml"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths:
+      - "libs/frontman-wordpress/**"
+      - "scripts/test-wordpress-plugin-runtime.sh"
+      - "scripts/package-wordpress-plugin.sh"
+      - "scripts/validate-wordpress-plugin-release.sh"
+      - ".github/workflows/wordpress-compatibility.yml"
+      - "Makefile"
+
+permissions:
+  contents: read
+
+jobs:
+  wordpress-7:
+    name: WordPress 7.0.2 / PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "7.4"
+          - "8.4"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run isolated PHP tests
+        run: |
+          docker run --rm \
+            -v "$PWD:/workspace:ro" \
+            -w /workspace \
+            "php:${{ matrix.php }}-cli" \
+            sh -c 'for test in libs/frontman-wordpress/tests/*Test.php; do php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php "$test" || exit 1; done'
+
+      - name: Run WordPress runtime tests
+        env:
+          WORDPRESS_VERSION: "7.0.2"
+          PHP_VERSION: ${{ matrix.php }}
+        run: bash scripts/test-wordpress-plugin-runtime.sh

--- a/Makefile
+++ b/Makefile
@@ -490,12 +490,16 @@ publish-wordpress-plugin-svn: package-wordpress-plugin ## Publish WordPress.org 
 	@VERSION=$(VERSION) bash ./scripts/publish-wordpress-plugin-svn.sh
 
 test-wordpress-core-tools: ## Run PHP tests for WordPress tool implementations
-	@php libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
-	@php libs/frontman-wordpress/tests/ElementorToolsTest.php
-	@php libs/frontman-wordpress/tests/MediaToolsTest.php
-	@php libs/frontman-wordpress/tests/WooCommerceToolsTest.php
-	@php libs/frontman-wordpress/tests/MutationSnapshotsTest.php
-	@php libs/frontman-wordpress/tests/RouterTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/ElementorToolsTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/MediaToolsTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/WooCommerceToolsTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/PluginDependenciesTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/RouterTest.php
+
+test-wordpress-runtime: ## Run plugin integration tests in WordPress 7.0.2 containers
+	@bash scripts/test-wordpress-plugin-runtime.sh
 
 ## REL_END
 

--- a/docs/specs/wordpress-7-support.md
+++ b/docs/specs/wordpress-7-support.md
@@ -1,0 +1,55 @@
+# Spec: WordPress 7 Support
+
+## Objective
+
+Verify Frontman against WordPress 7.0.2 and support WordPress 7 content models that
+the current plugin misses: nested Gutenberg blocks and block-theme navigation.
+
+## Commands
+
+- Unit tests: `make test-wordpress-core-tools`
+- WordPress runtime test: `bash scripts/test-wordpress-plugin-runtime.sh`
+- Package: `make package-wordpress-plugin VERSION=1.4.0`
+
+## Project Structure
+
+- `libs/frontman-wordpress/tools/`: PHP tool implementations
+- `libs/frontman-wordpress/tests/`: isolated PHP behavior tests
+- `libs/frontman-wordpress/tests/integration/`: tests executed inside real WordPress
+- `.github/workflows/`: compatibility CI
+
+## Code Style
+
+Keep existing WordPress PHP style and additive tool contracts. Existing numeric block
+indices continue to address visible top-level blocks; nested blocks use raw tree paths:
+
+```php
+[ 'post_id' => 42, 'path' => [ 0, 1, 2 ] ]
+```
+
+## Testing Strategy
+
+- Unit tests prove recursive block addressing and navigation CRUD behavior.
+- Runtime tests activate packaged source in WordPress 7.0.2, exercise real block
+  parsing/serialization and `wp_navigation` persistence, and fail on PHP notices.
+- CI runs runtime tests on PHP 7.4 and a current PHP 8 release.
+
+## Boundaries
+
+- Always preserve existing top-level `index` inputs.
+- Always require confirmation for destructive navigation deletion.
+- Never rewrite classic menu tools to return a new response shape.
+- Never mark WordPress 7 as tested unless runtime CI exists.
+
+## Success Criteria
+
+- Nested blocks are listed with paths and can be read, replaced, inserted, moved,
+  and deleted without losing sibling/freeform content.
+- Block-theme navigation entities can be listed, read, created, updated, and deleted.
+- WordPress 7.0.2 runtime CI covers PHP 7.4 and PHP 8.x.
+- All PHP tests, runtime tests, packaging validation, and syntax checks pass.
+- WordPress.org metadata declares testing through WordPress 7.0.
+
+## Open Questions
+
+None. Existing classic-menu and top-level block contracts remain supported.

--- a/libs/frontman-wordpress/readme.txt
+++ b/libs/frontman-wordpress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: frontmanai
 Tags: ai editor, website editor, elementor, woocommerce, ai
 Requires at least: 6.0
-Tested up to: 6.9.4
+Tested up to: 7.0.2
 Requires PHP: 7.4
 Stable tag: 1.4.0
 License: GPL-2.0-or-later

--- a/libs/frontman-wordpress/tests/ErrorHandler.php
+++ b/libs/frontman-wordpress/tests/ErrorHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+set_error_handler(
+	static function( int $severity, string $message, string $file, int $line ): bool {
+		if ( error_reporting() & $severity ) {
+			throw new ErrorException( $message, 0, $severity, $file, $line );
+		}
+		return false;
+	}
+);

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -121,6 +121,18 @@ if ( ! function_exists( 'get_post' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( array $args ): array {
+		return array_values( array_filter( $GLOBALS['frontman_test_posts'], static function( $post ) use ( $args ) {
+			if ( isset( $args['post_type'] ) && $post->post_type !== $args['post_type'] ) {
+				return false;
+			}
+
+			return ! isset( $args['post_status'] ) || 'any' === $args['post_status'] || $post->post_status === $args['post_status'];
+		} ) );
+	}
+}
+
 if ( ! function_exists( 'wp_insert_post' ) ) {
 	function wp_insert_post( array $post_data, bool $wp_error = false ) {
 		$post_data = wp_unslash( $post_data );
@@ -217,9 +229,37 @@ if ( ! function_exists( 'add_post_meta' ) ) {
 
 if ( ! function_exists( 'parse_blocks' ) ) {
 	function parse_blocks( string $content ): array {
+		if ( 'NESTED_BLOCK_FIXTURE' === $content ) {
+			return [
+				[
+					'blockName' => 'core/group',
+					'attrs' => [],
+					'innerHTML' => '<div></div>',
+					'innerContent' => [ '<div>', null, null, '</div>' ],
+					'innerBlocks' => [
+						[ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Nested one</p>', 'innerContent' => [ '<p>Nested one</p>' ], 'innerBlocks' => [], 'markup' => '<p>Nested one</p>' ],
+						[
+							'blockName' => 'core/group',
+							'attrs' => [],
+							'innerHTML' => '<div></div>',
+							'innerContent' => [ '<div>', null, '</div>' ],
+							'innerBlocks' => [
+								[ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Nested two</p>', 'innerContent' => [ '<p>Nested two</p>' ], 'innerBlocks' => [], 'markup' => '<p>Nested two</p>' ],
+							],
+						],
+					],
+				],
+				[ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Top level</p>', 'innerContent' => [ '<p>Top level</p>' ], 'innerBlocks' => [], 'markup' => '<p>Top level</p>' ],
+			];
+		}
+
 		$parts = array_values( array_filter( explode( "\n\n", $content ) ) );
 		$blocks = [];
 		foreach ( $parts as $part ) {
+			if ( 0 === strpos( $part, 'BLOCK:' ) ) {
+				$blocks[] = unserialize( base64_decode( substr( $part, 6 ) ) );
+				continue;
+			}
 			if ( 0 === strpos( $part, 'RAW:' ) || 0 === strpos( $part, '<div>' ) ) {
 				$markup = 0 === strpos( $part, 'RAW:' ) ? substr( $part, 4 ) : $part;
 				$blocks[] = [
@@ -246,7 +286,11 @@ if ( ! function_exists( 'parse_blocks' ) ) {
 
 if ( ! function_exists( 'serialize_block' ) ) {
 	function serialize_block( array $block ): string {
-		return $block['markup'];
+		if ( array_key_exists( 'markup', $block ) && empty( $block['innerBlocks'] ) ) {
+			return $block['markup'];
+		}
+
+		return 'BLOCK:' . base64_encode( serialize( $block ) );
 	}
 }
 
@@ -521,8 +565,10 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->test_posts_include_before_snapshots();
 		$this->test_blocks_include_before_snapshots();
 		$this->test_block_move_and_delete_snapshots();
+		$this->test_nested_blocks_use_stable_paths();
 		$this->test_duplicate_post_copies_page_metadata();
 		$this->test_menu_management_snapshots();
+		$this->test_block_navigation_management();
 		$this->test_menu_item_creation_includes_before_snapshot();
 		$this->test_menu_option_and_widget_updates_include_before_snapshots();
 		$this->test_theme_source_tools();
@@ -566,6 +612,25 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$slash_post->post_author = 1;
 		$slash_post->post_name = 'slash-before';
 		$GLOBALS['frontman_test_posts'][11] = $slash_post;
+
+		$nested_post = new WP_Post();
+		$nested_post->ID = 12;
+		$nested_post->post_title = 'Nested Blocks';
+		$nested_post->post_content = 'NESTED_BLOCK_FIXTURE';
+		$nested_post->post_excerpt = '';
+		$nested_post->post_status = 'publish';
+		$nested_post->post_type = 'page';
+		$GLOBALS['frontman_test_posts'][12] = $nested_post;
+
+		$navigation = new WP_Post();
+		$navigation->ID = 30;
+		$navigation->post_title = 'Header Navigation';
+		$navigation->post_content = '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->';
+		$navigation->post_excerpt = '';
+		$navigation->post_status = 'publish';
+		$navigation->post_type = 'wp_navigation';
+		$navigation->post_name = 'header-navigation';
+		$GLOBALS['frontman_test_posts'][30] = $navigation;
 
 		$GLOBALS['frontman_test_menu_terms'][7] = (object) [
 			'term_id' => 7,
@@ -726,6 +791,54 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_true( false !== strpos( $deleted['after']['post_content'], 'C:\\tmp\\file' ), 'wp_delete_block preserves existing backslash-sensitive block markup' );
 	}
 
+	private function test_nested_blocks_use_stable_paths(): void {
+		$tool = new Frontman_Tool_Blocks();
+		$listed = $tool->list_blocks( [ 'post_id' => 12 ] );
+
+		$this->assert_same( 2, $listed['block_count'], 'wp_list_blocks preserves top-level block count' );
+		$this->assert_same( 5, $listed['total_block_count'], 'wp_list_blocks includes nested named blocks' );
+		$this->assert_same( [ 0, 1, 0 ], $listed['all_blocks'][3]['path'], 'wp_list_blocks returns stable nested paths' );
+		$this->assert_same( 'core/paragraph', $tool->read_block( [ 'post_id' => 12, 'path' => [ 0, 1, 0 ] ] )['name'], 'wp_read_block reads nested blocks by path' );
+
+		$updated = $tool->update_block( [
+			'post_id' => 12,
+			'path' => [ 0, 1, 0 ],
+			'block_markup' => '<p>Updated nested</p>',
+		] );
+		$this->assert_same( '<p>Updated nested</p>', $updated['after']['block']['markup'], 'wp_update_block replaces a nested block by path' );
+
+		$inserted = $tool->insert_block( [
+			'post_id' => 12,
+			'parent_path' => [ 0, 1 ],
+			'index' => 1,
+			'block_markup' => '<p>Inserted nested</p>',
+		] );
+		$this->assert_same( 6, $inserted['after']['blocks']['total_block_count'], 'wp_insert_block inserts into a nested parent path' );
+
+		$moved = $tool->move_block( [
+			'post_id' => 12,
+			'from_path' => [ 0, 0 ],
+			'to_parent_path' => [ 0, 1 ],
+			'to_index' => 0,
+		] );
+		$this->assert_same( 'Nested one', $moved['after']['blocks']['all_blocks'][2]['innerText'], 'wp_move_block moves a block between nested parents' );
+
+		$deleted = $tool->delete_block( [ 'post_id' => 12, 'path' => [ 0, 0, 1 ], 'confirm' => true ] );
+		$this->assert_same( 5, $deleted['after']['blocks']['total_block_count'], 'wp_delete_block deletes nested blocks by path' );
+
+		$same_parent = new WP_Post();
+		$same_parent->ID = 13;
+		$same_parent->post_title = 'Same Parent Move';
+		$same_parent->post_content = '<p>First</p>' . "\n\n" . '<p>Second</p>';
+		$same_parent->post_excerpt = '';
+		$same_parent->post_status = 'publish';
+		$same_parent->post_type = 'page';
+		$GLOBALS['frontman_test_posts'][13] = $same_parent;
+		$forward = $tool->move_block( [ 'post_id' => 13, 'from_path' => [ 0 ], 'to_index' => 1 ] );
+		$this->assert_same( 'Second', $forward['after']['blocks']['blocks'][0]['innerText'], 'path-based forward moves use final destination indices' );
+		$this->assert_same( 0, $tool->read_block( [ 'post_id' => 13, 'path' => [ 0 ] ] )['index'], 'top-level path reads preserve legacy index output' );
+	}
+
 	private function test_duplicate_post_copies_page_metadata(): void {
 		$tool = new Frontman_Tool_Posts();
 		$duplicated = $tool->duplicate_post( [
@@ -764,6 +877,37 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 
 		$deleted = $tool->delete_menu( [ 'id' => $created['menu_id'], 'confirm' => true ] );
 		$this->assert_same( $created['menu_id'], $deleted['id'], 'wp_delete_menu reports deleted menu id' );
+	}
+
+	private function test_block_navigation_management(): void {
+		$tool = new Frontman_Tool_Menus();
+		$listed = $tool->list_navigation_menus( [] );
+		$this->assert_same( 1, count( $listed ), 'wp_list_navigation_menus lists wp_navigation posts' );
+		$this->assert_same( 'Header Navigation', $tool->read_navigation_menu( [ 'id' => 30 ] )['title'], 'wp_read_navigation_menu reads block navigation content' );
+
+		$created = $tool->create_navigation_menu( [
+			'title' => 'Footer Navigation',
+			'content' => '<!-- wp:navigation-link {"label":"Contact","url":"/contact"} /-->',
+		] );
+		$this->assert_same( 'wp_navigation', get_post( $created['id'] )->post_type, 'wp_create_navigation_menu creates wp_navigation posts' );
+
+		$updated = $tool->update_navigation_menu( [
+			'id' => 30,
+			'title' => 'Main Navigation',
+			'content' => '<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+		] );
+		$this->assert_same( 'Header Navigation', $updated['before']['title'], 'wp_update_navigation_menu captures previous navigation state' );
+		$this->assert_same( 'Main Navigation', $updated['after']['title'], 'wp_update_navigation_menu updates block navigation posts' );
+
+		$this->assert_error_contains(
+			static function() use ( $tool, $created ) {
+				$tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => false ] );
+			},
+			'explicit confirmation',
+			'wp_delete_navigation_menu requires confirm=true'
+		);
+		$deleted = $tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => true ] );
+		$this->assert_same( 'Footer Navigation', $deleted['before']['title'], 'wp_delete_navigation_menu returns deleted navigation snapshot' );
 	}
 
 	private function test_menu_option_and_widget_updates_include_before_snapshots(): void {

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -799,6 +799,19 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( 5, $listed['total_block_count'], 'wp_list_blocks includes nested named blocks' );
 		$this->assert_same( [ 0, 1, 0 ], $listed['all_blocks'][3]['path'], 'wp_list_blocks returns stable nested paths' );
 		$this->assert_same( 'core/paragraph', $tool->read_block( [ 'post_id' => 12, 'path' => [ 0, 1, 0 ] ] )['name'], 'wp_read_block reads nested blocks by path' );
+		$original_content = get_post( 12 )->post_content;
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->insert_block( [
+					'post_id' => 12,
+					'parent_path' => [ 0, 0 ],
+					'block_markup' => '<p>Invalid nested paragraph</p>',
+				] );
+			},
+			'does not support nested blocks',
+			'wp_insert_block rejects leaf blocks as nested parents'
+		);
+		$this->assert_same( $original_content, get_post( 12 )->post_content, 'wp_insert_block preserves content after rejecting a leaf parent' );
 
 		$updated = $tool->update_block( [
 			'post_id' => 12,

--- a/libs/frontman-wordpress/tests/RouterTest.php
+++ b/libs/frontman-wordpress/tests/RouterTest.php
@@ -48,6 +48,9 @@ class Frontman_Router_Test_Runner {
 		$this->classifyRoute = $reflection->getMethod( 'classify_route' );
 		$this->getRequestPath = $reflection->getMethod( 'get_request_path' );
 		$this->sendSseToolResult = $reflection->getMethod( 'send_sse_tool_result' );
+		$this->classifyRoute->setAccessible( true );
+		$this->getRequestPath->setAccessible( true );
+		$this->sendSseToolResult->setAccessible( true );
 	}
 
 	public function run(): void {

--- a/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
+++ b/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
@@ -1,0 +1,20 @@
+<?php
+
+set_error_handler(
+	static function( int $severity, string $message, string $file, int $line ): bool {
+		if ( error_reporting() & $severity ) {
+			throw new ErrorException( $message, 0, $severity, $file, $line );
+		}
+		return false;
+	}
+);
+
+require '/var/www/html/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$result = activate_plugin( 'frontman-agentic-ai-editor/frontman.php' );
+if ( is_wp_error( $result ) ) {
+	throw new RuntimeException( $result->get_error_message() );
+}
+
+restore_error_handler();

--- a/libs/frontman-wordpress/tests/integration/Dockerfile
+++ b/libs/frontman-wordpress/tests/integration/Dockerfile
@@ -1,7 +1,14 @@
 ARG PHP_VERSION=8.4
 FROM docker.io/library/php:${PHP_VERSION}-apache
 
-RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install mysqli \
+  && a2enmod rewrite \
+  && printf '%s\n' \
+    '<Directory /var/www/html/>' \
+    '  AllowOverride All' \
+    '</Directory>' \
+    > /etc/apache2/conf-available/wordpress.conf \
+  && a2enconf wordpress
 
 COPY wordpress.tar.gz /tmp/wordpress.tar.gz
 RUN tar -xzf /tmp/wordpress.tar.gz --strip-components=1 -C /var/www/html \

--- a/libs/frontman-wordpress/tests/integration/Dockerfile
+++ b/libs/frontman-wordpress/tests/integration/Dockerfile
@@ -1,0 +1,9 @@
+ARG PHP_VERSION=8.4
+FROM docker.io/library/php:${PHP_VERSION}-apache
+
+RUN docker-php-ext-install mysqli
+
+COPY wordpress.tar.gz /tmp/wordpress.tar.gz
+RUN tar -xzf /tmp/wordpress.tar.gz --strip-components=1 -C /var/www/html \
+  && rm /tmp/wordpress.tar.gz \
+  && chown -R www-data:www-data /var/www/html

--- a/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+set_error_handler(
+	static function( int $severity, string $message, string $file, int $line ): bool {
+		if ( error_reporting() & $severity ) {
+			throw new ErrorException( $message, 0, $severity, $file, $line );
+		}
+		return false;
+	}
+);
+
+require '/var/www/html/wp-load.php';
+require '/tmp/WordPressRuntimeTest.php';
+restore_error_handler();

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	throw new RuntimeException( 'WordPress must be loaded before the runtime test.' );
+}
+
+function frontman_runtime_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+frontman_runtime_assert( '7.0.2' === get_bloginfo( 'version' ), 'Runtime must use WordPress 7.0.2.' );
+frontman_runtime_assert( defined( 'FRONTMAN_VERSION' ), 'Frontman plugin was not activated.' );
+frontman_runtime_assert( null !== Frontman_Tools::instance()->get( 'wp_list_navigation_menus' ), 'Plugin bootstrap did not register navigation tools during init.' );
+
+$block_tool = new Frontman_Tool_Blocks();
+$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Nested one</p><!-- /wp:paragraph --><!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Nested two</p><!-- /wp:paragraph --></div><!-- /wp:group --></div><!-- /wp:group --><!-- wp:paragraph --><p>Top level</p><!-- /wp:paragraph -->';
+$post_id = wp_insert_post(
+	[
+		'post_type' => 'page',
+		'post_status' => 'publish',
+		'post_title' => 'Frontman WordPress 7 Runtime',
+		'post_content' => $content,
+	],
+	true
+);
+frontman_runtime_assert( ! is_wp_error( $post_id ), 'Could not create runtime block fixture.' );
+
+$listed = $block_tool->list_blocks( [ 'post_id' => $post_id ] );
+frontman_runtime_assert( 2 === $listed['block_count'], 'Top-level block count changed.' );
+frontman_runtime_assert( 5 === $listed['total_block_count'], 'Nested blocks were not recursively listed.' );
+frontman_runtime_assert( [ 0, 1, 0 ] === $listed['all_blocks'][3]['path'], 'Nested block path is incorrect.' );
+
+$block_tool->update_block(
+	[
+		'post_id' => $post_id,
+		'path' => [ 0, 1, 0 ],
+		'block_markup' => '<!-- wp:paragraph --><p>Updated nested</p><!-- /wp:paragraph -->',
+	]
+);
+$block_tool->insert_block(
+	[
+		'post_id' => $post_id,
+		'parent_path' => [ 0, 1 ],
+		'index' => 1,
+		'block_markup' => '<!-- wp:paragraph --><p>Inserted nested</p><!-- /wp:paragraph -->',
+	]
+);
+$block_tool->move_block(
+	[
+		'post_id' => $post_id,
+		'from_path' => [ 0, 0 ],
+		'to_parent_path' => [ 0, 1 ],
+		'to_index' => 0,
+	]
+);
+$block_tool->delete_block( [ 'post_id' => $post_id, 'path' => [ 0, 0, 1 ], 'confirm' => true ] );
+
+$saved_content = get_post( $post_id )->post_content;
+frontman_runtime_assert( false !== strpos( $saved_content, 'Nested one' ), 'Moving a nested block lost its content.' );
+frontman_runtime_assert( false !== strpos( $saved_content, 'Inserted nested' ), 'Nested insertion was not serialized.' );
+frontman_runtime_assert( false === strpos( $saved_content, 'Updated nested' ), 'Nested deletion was not serialized.' );
+frontman_runtime_assert( false !== strpos( $saved_content, 'Top level' ), 'Nested mutations lost a top-level sibling.' );
+
+$menu_tool = new Frontman_Tool_Menus();
+$registry = new Frontman_Tools();
+$menu_tool->register( $registry );
+$navigation_markup = '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->';
+$sanitized_navigation = $registry->sanitize_input(
+	'wp_create_navigation_menu',
+	[ 'title' => 'Runtime Navigation', 'content' => $navigation_markup ]
+);
+frontman_runtime_assert( $navigation_markup === $sanitized_navigation['content'], 'Tool sanitization changed navigation block markup.' );
+$created = $menu_tool->create_navigation_menu(
+	[
+		'title' => 'Runtime Navigation',
+		'content' => $navigation_markup,
+	]
+);
+frontman_runtime_assert( 'wp_navigation' === get_post_type( $created['id'] ), 'Navigation tool did not create a wp_navigation post.' );
+
+$updated = $menu_tool->update_navigation_menu(
+	[
+		'id' => $created['id'],
+		'title' => 'Updated Runtime Navigation',
+		'content' => '<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+	]
+);
+frontman_runtime_assert( 'Updated Runtime Navigation' === $updated['after']['title'], 'Navigation tool did not update the title.' );
+frontman_runtime_assert( 1 <= count( $menu_tool->list_navigation_menus( [] ) ), 'Navigation tool did not list wp_navigation posts.' );
+
+$deleted = $menu_tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => true ] );
+frontman_runtime_assert( 'Updated Runtime Navigation' === $deleted['before']['title'], 'Navigation deletion did not preserve its snapshot.' );
+frontman_runtime_assert( null === get_post( $created['id'] ), 'Navigation tool did not permanently delete the post.' );
+
+fwrite( STDOUT, "OK (WordPress 7.0.2, PHP " . PHP_VERSION . ")\n" );

--- a/libs/frontman-wordpress/tools/class-tool-blocks.php
+++ b/libs/frontman-wordpress/tools/class-tool-blocks.php
@@ -296,6 +296,10 @@ class Frontman_Tool_Blocks {
 
 		$raw_index = array_shift( $parent_path );
 		if ( empty( $parent_path ) ) {
+			$inner_content = $blocks[ $raw_index ]['innerContent'] ?? null;
+			if ( ! is_array( $inner_content ) || ! in_array( null, $inner_content, true ) ) {
+				throw new Frontman_Tool_Error( 'Parent block does not support nested blocks' );
+			}
 			$children = $blocks[ $raw_index ]['innerBlocks'] ?? [];
 			$index = min( $index, count( $children ) );
 			array_splice( $children, $index, 0, [ $block ] );

--- a/libs/frontman-wordpress/tools/class-tool-blocks.php
+++ b/libs/frontman-wordpress/tools/class-tool-blocks.php
@@ -23,7 +23,7 @@ class Frontman_Tool_Blocks {
 	public function register( Frontman_Tools $tools ): void {
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_list_blocks',
-			'Lists all Gutenberg blocks in a post\'s content. Returns each block\'s name, attributes, and index.',
+			'Lists Gutenberg blocks in a post. The blocks field preserves top-level indices; all_blocks recursively includes every named block with its path.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -53,8 +53,9 @@ class Frontman_Tool_Blocks {
 						'type'        => 'integer',
 						'description' => 'Zero-based index of the block to read.',
 					],
+					'path'    => $this->path_schema( 'Raw block-tree path returned by wp_list_blocks. Use this for nested blocks.' ),
 				],
-				'required' => [ 'post_id', 'index' ],
+				'required' => [ 'post_id' ],
 			],
 			[ $this, 'read_block' ]
 		) );
@@ -74,12 +75,13 @@ class Frontman_Tool_Blocks {
 						'type'        => 'integer',
 						'description' => 'Zero-based index of the block to replace.',
 					],
+					'path'         => $this->path_schema( 'Raw block-tree path returned by wp_list_blocks. Use this for nested blocks.' ),
 					'block_markup' => [
 						'type'        => 'string',
 						'description' => 'The new block markup (HTML with Gutenberg block comments, e.g. <!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->).',
 					],
 				],
-				'required' => [ 'post_id', 'index', 'block_markup' ],
+				'required' => [ 'post_id', 'block_markup' ],
 			],
 			[ $this, 'update_block' ]
 		) );
@@ -99,6 +101,7 @@ class Frontman_Tool_Blocks {
 						'type'        => 'integer',
 						'description' => 'Zero-based position to insert at. Appends to end if omitted.',
 					],
+					'parent_path'  => $this->path_schema( 'Raw path of the parent block. Omit to insert at the top level.' ),
 					'block_markup' => [
 						'type'        => 'string',
 						'description' => 'The block markup to insert (HTML with Gutenberg block comments).',
@@ -119,8 +122,10 @@ class Frontman_Tool_Blocks {
 					'post_id'    => [ 'type' => 'integer', 'description' => 'The post ID containing the block.' ],
 					'from_index' => [ 'type' => 'integer', 'description' => 'Zero-based source block index.' ],
 					'to_index'   => [ 'type' => 'integer', 'description' => 'Zero-based destination block index.' ],
+					'from_path'  => $this->path_schema( 'Raw source path returned by wp_list_blocks.' ),
+					'to_parent_path' => $this->path_schema( 'Raw destination parent path. Omit for the top level.' ),
 				],
-				'required' => [ 'post_id', 'from_index', 'to_index' ],
+				'required' => [ 'post_id', 'to_index' ],
 			],
 			[ $this, 'move_block' ]
 		) );
@@ -134,12 +139,21 @@ class Frontman_Tool_Blocks {
 				'properties'           => [
 					'post_id'  => [ 'type' => 'integer', 'description' => 'The post ID containing the block.' ],
 					'index'    => [ 'type' => 'integer', 'description' => 'Zero-based block index to delete.' ],
+					'path'     => $this->path_schema( 'Raw block-tree path returned by wp_list_blocks. Use this for nested blocks.' ),
 					'confirm'  => [ 'type' => 'boolean', 'description' => 'Must be true only after the user explicitly confirms deletion.' ],
 				],
-				'required' => [ 'post_id', 'index', 'confirm' ],
+				'required' => [ 'post_id', 'confirm' ],
 			],
 			[ $this, 'delete_block' ]
 		) );
+	}
+
+	private function path_schema( string $description ): array {
+		return [
+			'type'        => 'array',
+			'description' => $description,
+			'items'       => [ 'type' => 'integer' ],
+		];
 	}
 
 	/**
@@ -157,29 +171,40 @@ class Frontman_Tool_Blocks {
 	/**
 	 * Return visible named blocks with their raw indices preserved.
 	 *
-	 * @return array<int, array{raw_index:int, block:array}>
+	 * @return array<int, array{path:array, block:array, index?:int}>
 	 */
 	private function get_visible_blocks( int $post_id ): array {
 		$visible = [];
-		foreach ( $this->get_all_blocks( $post_id ) as $raw_index => $block ) {
-			if ( empty( $block['blockName'] ) ) {
-				continue;
+		$this->append_visible_blocks( $this->get_all_blocks( $post_id ), [], $visible );
+		return $visible;
+	}
+
+	private function append_visible_blocks( array $blocks, array $parent_path, array &$visible ): void {
+		$top_level_index = 0;
+		foreach ( $blocks as $raw_index => $block ) {
+			$path = array_merge( $parent_path, [ $raw_index ] );
+			if ( ! empty( $block['blockName'] ) ) {
+				$entry = [ 'path' => $path, 'block' => $block ];
+				if ( empty( $parent_path ) ) {
+					$entry['index'] = $top_level_index;
+					$top_level_index++;
+				}
+				$visible[] = $entry;
 			}
 
-			$visible[] = [
-				'raw_index' => $raw_index,
-				'block'     => $block,
-			];
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$this->append_visible_blocks( $block['innerBlocks'], $path, $visible );
+			}
 		}
-
-		return $visible;
 	}
 
 	/**
 	 * Resolve a visible block index to the raw parsed block array.
 	 */
 	private function resolve_visible_block( int $post_id, int $index ): array {
-		$visible = $this->get_visible_blocks( $post_id );
+		$visible = array_values( array_filter( $this->get_visible_blocks( $post_id ), static function( array $entry ) {
+			return 1 === count( $entry['path'] );
+		} ) );
 		if ( empty( $visible ) ) {
 			throw new Frontman_Tool_Error( "Post not found or has no blocks: {$post_id}" );
 		}
@@ -189,6 +214,142 @@ class Frontman_Tool_Blocks {
 		}
 
 		return $visible[ $index ];
+	}
+
+	private function resolve_block( int $post_id, array $input, string $index_key = 'index', string $path_key = 'path' ): array {
+		if ( isset( $input[ $path_key ] ) ) {
+			$path = $this->sanitize_path( $input[ $path_key ] );
+			$block = $this->block_at_path( $this->get_all_blocks( $post_id ), $path );
+			if ( empty( $block['blockName'] ) ) {
+				throw new Frontman_Tool_Error( 'Block path does not identify a named block' );
+			}
+			if ( 1 === count( $path ) ) {
+				foreach ( $this->get_visible_blocks( $post_id ) as $entry ) {
+					if ( isset( $entry['index'] ) && $path === $entry['path'] ) {
+						return $entry;
+					}
+				}
+			}
+			return [ 'path' => $path, 'block' => $block ];
+		}
+
+		if ( ! isset( $input[ $index_key ] ) ) {
+			throw new Frontman_Tool_Error( "Provide {$index_key} or {$path_key}" );
+		}
+
+		return $this->resolve_visible_block( $post_id, absint( $input[ $index_key ] ) );
+	}
+
+	private function sanitize_path( $path, bool $allow_empty = false ): array {
+		if ( ! is_array( $path ) || ( empty( $path ) && ! $allow_empty ) ) {
+			throw new Frontman_Tool_Error( 'Block path must be a non-empty array of indices' );
+		}
+
+		return array_map( 'absint', array_values( $path ) );
+	}
+
+	private function block_at_path( array $blocks, array $path ): array {
+		$cursor = $blocks;
+		$block  = null;
+		foreach ( $path as $raw_index ) {
+			if ( ! isset( $cursor[ $raw_index ] ) || ! is_array( $cursor[ $raw_index ] ) ) {
+				throw new Frontman_Tool_Error( 'Block path is out of range' );
+			}
+			$block  = $cursor[ $raw_index ];
+			$cursor = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+		}
+
+		return $block;
+	}
+
+	private function replace_block_at_path( array &$blocks, array $path, array $replacement ): void {
+		$raw_index = array_shift( $path );
+		if ( empty( $path ) ) {
+			$blocks[ $raw_index ] = $replacement;
+			return;
+		}
+
+		$this->replace_block_at_path( $blocks[ $raw_index ]['innerBlocks'], $path, $replacement );
+	}
+
+	private function remove_block_at_path( array &$blocks, array $path ): array {
+		$raw_index = array_shift( $path );
+		if ( empty( $path ) ) {
+			$removed = $blocks[ $raw_index ];
+			array_splice( $blocks, $raw_index, 1 );
+			return $removed;
+		}
+
+		$child_index = $path[0];
+		$removed = $this->remove_block_at_path( $blocks[ $raw_index ]['innerBlocks'], $path );
+		if ( 1 === count( $path ) ) {
+			$this->remove_inner_content_slot( $blocks[ $raw_index ], $child_index );
+		}
+		return $removed;
+	}
+
+	private function insert_block_at_path( array &$blocks, array $parent_path, int $index, array $block ): void {
+		if ( empty( $parent_path ) ) {
+			array_splice( $blocks, $index, 0, [ $block ] );
+			return;
+		}
+
+		$raw_index = array_shift( $parent_path );
+		if ( empty( $parent_path ) ) {
+			$children = $blocks[ $raw_index ]['innerBlocks'] ?? [];
+			$index = min( $index, count( $children ) );
+			array_splice( $children, $index, 0, [ $block ] );
+			$blocks[ $raw_index ]['innerBlocks'] = $children;
+			$this->insert_inner_content_slot( $blocks[ $raw_index ], $index );
+			return;
+		}
+
+		$this->insert_block_at_path( $blocks[ $raw_index ]['innerBlocks'], $parent_path, $index, $block );
+	}
+
+	private function remove_inner_content_slot( array &$parent, int $child_index ): void {
+		$parent['innerContent'] = isset( $parent['innerContent'] ) && is_array( $parent['innerContent'] ) ? $parent['innerContent'] : [];
+		$seen = 0;
+		foreach ( $parent['innerContent'] as $content_index => $chunk ) {
+			if ( null === $chunk ) {
+				if ( $seen === $child_index ) {
+					array_splice( $parent['innerContent'], $content_index, 1 );
+					return;
+				}
+				$seen++;
+			}
+		}
+	}
+
+	private function insert_inner_content_slot( array &$parent, int $child_index ): void {
+		$parent['innerContent'] = isset( $parent['innerContent'] ) && is_array( $parent['innerContent'] ) ? $parent['innerContent'] : [];
+		$seen = 0;
+		foreach ( $parent['innerContent'] as $content_index => $chunk ) {
+			if ( null === $chunk ) {
+				if ( $seen === $child_index ) {
+					array_splice( $parent['innerContent'], $content_index, 0, [ null ] );
+					return;
+				}
+				$seen++;
+			}
+		}
+
+		$insert_at = max( count( $parent['innerContent'] ) - 1, 0 );
+		array_splice( $parent['innerContent'], $insert_at, 0, [ null ] );
+	}
+
+	private function adjust_path_after_removal( array $path, array $removed_path ): array {
+		$removed_parent = array_slice( $removed_path, 0, -1 );
+		$removed_index = $removed_path[ count( $removed_path ) - 1 ];
+		if ( count( $path ) <= count( $removed_parent ) || array_slice( $path, 0, count( $removed_parent ) ) !== $removed_parent ) {
+			return $path;
+		}
+
+		$affected_depth = count( $removed_parent );
+		if ( $path[ $affected_depth ] > $removed_index ) {
+			$path[ $affected_depth ]--;
+		}
+		return $path;
 	}
 
 	/**
@@ -201,13 +362,17 @@ class Frontman_Tool_Blocks {
 	/**
 	 * Summarize a block for listing.
 	 */
-	private function summarize_block( array $block, int $index ): array {
-		return [
-			'index'      => $index,
-			'name'       => $block['blockName'],
-			'attributes' => $block['attrs'] ?? [],
-			'innerText'  => wp_strip_all_tags( $block['innerHTML'] ?? '' ),
+	private function summarize_block( array $entry ): array {
+		$summary = [
+			'path'       => $entry['path'],
+			'name'       => $entry['block']['blockName'],
+			'attributes' => $entry['block']['attrs'] ?? [],
+			'innerText'  => wp_strip_all_tags( $entry['block']['innerHTML'] ?? '' ),
 		];
+		if ( isset( $entry['index'] ) ) {
+			$summary['index'] = $entry['index'];
+		}
+		return $summary;
 	}
 
 	/**
@@ -222,17 +387,15 @@ class Frontman_Tool_Blocks {
 		}
 
 		$visible = $this->get_visible_blocks( $post_id );
-		$blocks  = array_map(
-			static function( array $entry ) {
-				return $entry['block'];
-			},
-			$visible
-		);
-
+		$top_level = array_values( array_filter( $visible, static function( array $entry ) {
+			return 1 === count( $entry['path'] );
+		} ) );
 		return [
-			'post_id'     => $post_id,
-			'block_count' => count( $blocks ),
-			'blocks'      => array_map( [ $this, 'summarize_block' ], $blocks, array_keys( $blocks ) ),
+			'post_id'           => $post_id,
+			'block_count'       => count( $top_level ),
+			'blocks'            => array_map( [ $this, 'summarize_block' ], $top_level ),
+			'total_block_count' => count( $visible ),
+			'all_blocks'        => array_map( [ $this, 'summarize_block' ], $visible ),
 		];
 	}
 
@@ -241,18 +404,21 @@ class Frontman_Tool_Blocks {
 	 */
 	public function read_block( array $input ): array {
 		$post_id = absint( $input['post_id'] ?? 0 );
-		$index   = absint( $input['index'] ?? 0 );
-		$entry  = $this->resolve_visible_block( $post_id, $index );
+		$entry  = $this->resolve_block( $post_id, $input );
 		$block  = $entry['block'];
 
-		return [
-			'index'        => $index,
+		$result = [
+			'path'         => $entry['path'],
 			'name'         => $block['blockName'],
 			'attributes'   => $block['attrs'] ?? [],
 			'innerHTML'    => $block['innerHTML'] ?? '',
 			'innerContent' => $block['innerContent'] ?? [],
 			'markup'       => serialize_block( $block ),
 		];
+		if ( isset( $entry['index'] ) ) {
+			$result['index'] = $entry['index'];
+		}
+		return $result;
 	}
 
 	/**
@@ -260,12 +426,11 @@ class Frontman_Tool_Blocks {
 	 */
 	public function update_block( array $input ): array {
 		$post_id      = absint( $input['post_id'] ?? 0 );
-		$index        = absint( $input['index'] ?? 0 );
 		$block_markup = $input['block_markup'] ?? '';
 		$post         = get_post( $post_id );
 
 		$all_blocks = $this->get_all_blocks( $post_id );
-		$entry      = $this->resolve_visible_block( $post_id, $index );
+		$entry      = $this->resolve_block( $post_id, $input );
 
 		if ( ! $post ) {
 			throw new Frontman_Tool_Error( "Post not found or has no blocks: {$post_id}" );
@@ -274,7 +439,7 @@ class Frontman_Tool_Blocks {
 		$before = [
 			'post_id'      => $post_id,
 			'post_content' => $post->post_content,
-			'block'        => $this->read_block( [ 'post_id' => $post_id, 'index' => $index ] ),
+			'block'        => $this->read_block( [ 'post_id' => $post_id, 'path' => $entry['path'] ] ),
 		];
 
 		$new_blocks = parse_blocks( $block_markup );
@@ -284,7 +449,7 @@ class Frontman_Tool_Blocks {
 			throw new Frontman_Tool_Error( 'Invalid block markup' );
 		}
 
-		$all_blocks[ $entry['raw_index'] ] = $new_block[0];
+		$this->replace_block_at_path( $all_blocks, $entry['path'], $new_block[0] );
 		$content = $this->serialize_blocks( $all_blocks );
 
 		$result = wp_update_post( wp_slash( [ 'ID' => $post_id, 'post_content' => $content ] ), true );
@@ -299,7 +464,7 @@ class Frontman_Tool_Blocks {
 			'after'   => [
 				'post_id'      => $post_id,
 				'post_content' => get_post( $post_id )->post_content,
-				'block'        => $this->read_block( [ 'post_id' => $post_id, 'index' => $index ] ),
+				'block'        => $this->read_block( [ 'post_id' => $post_id, 'path' => $entry['path'] ] ),
 			],
 		];
 	}
@@ -323,7 +488,7 @@ class Frontman_Tool_Blocks {
 		];
 
 		$all_blocks = $this->get_all_blocks( $post_id );
-		$visible    = $this->get_visible_blocks( $post_id );
+		$visible    = array_values( array_filter( $this->get_visible_blocks( $post_id ), static function( array $entry ) { return 1 === count( $entry['path'] ); } ) );
 
 		$new_blocks = parse_blocks( $block_markup );
 		$new_block  = array_values( array_filter( $new_blocks, function( $b ) { return ! empty( $b['blockName'] ); } ) );
@@ -332,16 +497,18 @@ class Frontman_Tool_Blocks {
 			throw new Frontman_Tool_Error( 'Invalid block markup' );
 		}
 
-		$index = isset( $input['index'] ) ? absint( $input['index'] ) : count( $visible );
-		$index = min( max( 0, $index ), count( $visible ) );
-
-		if ( $index >= count( $visible ) ) {
-			$raw_index = count( $all_blocks );
+		$parent_path = isset( $input['parent_path'] ) ? $this->sanitize_path( $input['parent_path'] ) : [];
+		if ( empty( $parent_path ) ) {
+			$index = isset( $input['index'] ) ? absint( $input['index'] ) : count( $visible );
+			$index = min( $index, count( $visible ) );
+			$raw_index = $index >= count( $visible ) ? count( $all_blocks ) : $visible[ $index ]['path'][0];
 		} else {
-			$raw_index = $visible[ $index ]['raw_index'];
+			$parent = $this->block_at_path( $all_blocks, $parent_path );
+			$index = min( absint( $input['index'] ?? count( $parent['innerBlocks'] ?? [] ) ), count( $parent['innerBlocks'] ?? [] ) );
+			$raw_index = $index;
 		}
 
-		array_splice( $all_blocks, $raw_index, 0, [ $new_block[0] ] );
+		$this->insert_block_at_path( $all_blocks, $parent_path, $raw_index, $new_block[0] );
 		$content = $this->serialize_blocks( $all_blocks );
 
 		$result = wp_update_post( wp_slash( [ 'ID' => $post_id, 'post_content' => $content ] ), true );
@@ -366,18 +533,31 @@ class Frontman_Tool_Blocks {
 	 */
 	public function move_block( array $input ): array {
 		$post_id    = absint( $input['post_id'] ?? 0 );
-		$from_index = absint( $input['from_index'] ?? 0 );
 		$to_index   = absint( $input['to_index'] ?? 0 );
 		$post       = get_post( $post_id );
 		$all_blocks = $this->get_all_blocks( $post_id );
-		$visible    = $this->get_visible_blocks( $post_id );
+		$visible    = array_values( array_filter( $this->get_visible_blocks( $post_id ), static function( array $entry ) { return 1 === count( $entry['path'] ); } ) );
 
 		if ( ! $post || empty( $visible ) ) {
 			throw new Frontman_Tool_Error( "Post not found or has no blocks: {$post_id}" );
 		}
 
-		if ( $from_index >= count( $visible ) || $to_index >= count( $visible ) ) {
-			throw new Frontman_Tool_Error( 'Block move indices are out of range' );
+		$source = $this->resolve_block( $post_id, $input, 'from_index', 'from_path' );
+		$from_path = $source['path'];
+		$to_parent_path = isset( $input['to_parent_path'] ) ? $this->sanitize_path( $input['to_parent_path'] ) : [];
+		$is_legacy_move = ! isset( $input['from_path'] );
+		if ( $is_legacy_move ) {
+			if ( ! empty( $to_parent_path ) || $to_index >= count( $visible ) ) {
+				throw new Frontman_Tool_Error( 'Block move indices are out of range' );
+			}
+			$to_index = $visible[ $to_index ]['path'][0];
+		}
+		if ( count( $to_parent_path ) >= count( $from_path ) && array_slice( $to_parent_path, 0, count( $from_path ) ) === $from_path ) {
+			throw new Frontman_Tool_Error( 'Cannot move a block into itself or one of its descendants' );
+		}
+		$destination_parent = empty( $to_parent_path ) ? [ 'innerBlocks' => $all_blocks ] : $this->block_at_path( $all_blocks, $to_parent_path );
+		if ( $to_index > count( $destination_parent['innerBlocks'] ?? [] ) ) {
+			throw new Frontman_Tool_Error( 'Block move destination is out of range' );
 		}
 
 		$before = [
@@ -386,15 +566,14 @@ class Frontman_Tool_Blocks {
 			'blocks'       => $this->list_blocks( [ 'post_id' => $post_id ] ),
 		];
 
-		$from_raw_index = $visible[ $from_index ]['raw_index'];
-		$to_raw_index   = $visible[ $to_index ]['raw_index'];
-		$block          = $all_blocks[ $from_raw_index ];
-
-		array_splice( $all_blocks, $from_raw_index, 1 );
-		if ( $from_raw_index < $to_raw_index ) {
-			$to_raw_index--;
+		$from_parent_path = array_slice( $from_path, 0, -1 );
+		$from_raw_index = $from_path[ count( $from_path ) - 1 ];
+		$block = $this->remove_block_at_path( $all_blocks, $from_path );
+		$to_parent_path = $this->adjust_path_after_removal( $to_parent_path, $from_path );
+		if ( $is_legacy_move && $from_parent_path === $to_parent_path && $from_raw_index < $to_index ) {
+			$to_index--;
 		}
-		array_splice( $all_blocks, $to_raw_index, 0, [ $block ] );
+		$this->insert_block_at_path( $all_blocks, $to_parent_path, $to_index, $block );
 		$content = $this->serialize_blocks( $all_blocks );
 
 		$result = wp_update_post( wp_slash( [ 'ID' => $post_id, 'post_content' => $content ] ), true );
@@ -418,7 +597,6 @@ class Frontman_Tool_Blocks {
 	 */
 	public function delete_block( array $input ): array {
 		$post_id = absint( $input['post_id'] ?? 0 );
-		$index   = absint( $input['index'] ?? 0 );
 		$post    = get_post( $post_id );
 		$all_blocks = $this->get_all_blocks( $post_id );
 		$visible    = $this->get_visible_blocks( $post_id );
@@ -431,18 +609,16 @@ class Frontman_Tool_Blocks {
 			throw new Frontman_Tool_Error( "Post not found or has no blocks: {$post_id}" );
 		}
 
-		if ( $index >= count( $visible ) ) {
-			throw new Frontman_Tool_Error( "Block index {$index} out of range" );
-		}
+		$entry = $this->resolve_block( $post_id, $input );
 
 		$before = [
 			'post_id'      => $post_id,
 			'post_content' => $post->post_content,
-			'block'        => $this->read_block( [ 'post_id' => $post_id, 'index' => $index ] ),
+			'block'        => $this->read_block( [ 'post_id' => $post_id, 'path' => $entry['path'] ] ),
 			'blocks'       => $this->list_blocks( [ 'post_id' => $post_id ] ),
 		];
 
-		array_splice( $all_blocks, $visible[ $index ]['raw_index'], 1 );
+		$this->remove_block_at_path( $all_blocks, $entry['path'] );
 		$content = $this->serialize_blocks( $all_blocks );
 
 		$result = wp_update_post( wp_slash( [ 'ID' => $post_id, 'post_content' => $content ] ), true );

--- a/libs/frontman-wordpress/tools/class-tool-menus.php
+++ b/libs/frontman-wordpress/tools/class-tool-menus.php
@@ -4,7 +4,7 @@
  *
  * Tools: wp_list_menus, wp_list_menu_locations, wp_read_menu, wp_create_menu,
  * wp_delete_menu, wp_assign_menu_location, wp_create_menu_item,
- * wp_update_menu_item, wp_delete_menu_item
+ * wp_update_menu_item, wp_delete_menu_item, and block-theme wp_navigation tools
  *
  * Handlers return plain data arrays on success, throw Frontman_Tool_Error on failure.
  *
@@ -206,6 +206,159 @@ class Frontman_Tool_Menus {
 			],
 			[ $this, 'delete_menu_item' ]
 		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_list_navigation_menus',
+			'Lists block-theme navigation menus stored as wp_navigation posts.',
+			[ 'type' => 'object', 'additionalProperties' => false, 'properties' => new \stdClass() ],
+			[ $this, 'list_navigation_menus' ]
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_read_navigation_menu',
+			'Reads a block-theme navigation menu and its complete block markup.',
+			[
+				'type' => 'object',
+				'additionalProperties' => false,
+				'properties' => [ 'id' => [ 'type' => 'integer', 'description' => 'The wp_navigation post ID.' ] ],
+				'required' => [ 'id' ],
+			],
+			[ $this, 'read_navigation_menu' ]
+		) );
+
+		$navigation_write_properties = [
+			'title' => [ 'type' => 'string', 'description' => 'Navigation menu title.' ],
+			'content' => [ 'type' => 'string', 'description' => 'Navigation block markup.' ],
+		];
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_create_navigation_menu',
+			'Creates a block-theme navigation menu stored as a wp_navigation post.',
+			[
+				'type' => 'object',
+				'additionalProperties' => false,
+				'properties' => $navigation_write_properties,
+				'required' => [ 'title', 'content' ],
+			],
+			[ $this, 'create_navigation_menu' ]
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_update_navigation_menu',
+			'Updates a block-theme navigation menu title or block markup.',
+			[
+				'type' => 'object',
+				'additionalProperties' => false,
+				'properties' => array_merge( [ 'id' => [ 'type' => 'integer', 'description' => 'The wp_navigation post ID.' ] ], $navigation_write_properties ),
+				'required' => [ 'id' ],
+			],
+			[ $this, 'update_navigation_menu' ]
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_delete_navigation_menu',
+			'Deletes a block-theme navigation menu. Ask the user for confirmation first and only call with confirm=true after approval.',
+			[
+				'type' => 'object',
+				'additionalProperties' => false,
+				'properties' => [
+					'id' => [ 'type' => 'integer', 'description' => 'The wp_navigation post ID.' ],
+					'confirm' => [ 'type' => 'boolean', 'description' => 'Must be true only after explicit confirmation.' ],
+				],
+				'required' => [ 'id', 'confirm' ],
+			],
+			[ $this, 'delete_navigation_menu' ]
+		) );
+	}
+
+	private function serialize_navigation_menu( \WP_Post $navigation ): array {
+		return [
+			'id' => (int) $navigation->ID,
+			'title' => (string) $navigation->post_title,
+			'slug' => (string) $navigation->post_name,
+			'content' => (string) $navigation->post_content,
+			'status' => (string) $navigation->post_status,
+		];
+	}
+
+	private function get_navigation_menu( int $id ): \WP_Post {
+		$navigation = get_post( $id );
+		if ( ! $navigation || 'wp_navigation' !== $navigation->post_type ) {
+			throw new Frontman_Tool_Error( "Block navigation menu not found: {$id}" );
+		}
+
+		return $navigation;
+	}
+
+	public function list_navigation_menus( array $input ): array {
+		unset( $input );
+		$posts = get_posts( [
+			'post_type' => 'wp_navigation',
+			'post_status' => 'any',
+			'posts_per_page' => -1,
+			'orderby' => 'title',
+			'order' => 'ASC',
+		] );
+
+		return array_map( [ $this, 'serialize_navigation_menu' ], $posts );
+	}
+
+	public function read_navigation_menu( array $input ): array {
+		return $this->serialize_navigation_menu( $this->get_navigation_menu( absint( $input['id'] ?? 0 ) ) );
+	}
+
+	public function create_navigation_menu( array $input ): array {
+		$title = sanitize_text_field( $input['title'] ?? '' );
+		$content = (string) ( $input['content'] ?? '' );
+		if ( '' === $title || '' === $content ) {
+			throw new Frontman_Tool_Error( 'Navigation title and content are required' );
+		}
+
+		$id = wp_insert_post( wp_slash( [
+			'post_type' => 'wp_navigation',
+			'post_status' => 'publish',
+			'post_title' => $title,
+			'post_content' => $content,
+		] ), true );
+		if ( is_wp_error( $id ) ) {
+			throw new Frontman_Tool_Error( $id->get_error_message() );
+		}
+
+		return [ 'created' => true, 'id' => (int) $id, 'after' => $this->read_navigation_menu( [ 'id' => $id ] ) ];
+	}
+
+	public function update_navigation_menu( array $input ): array {
+		$id = absint( $input['id'] ?? 0 );
+		$before = $this->read_navigation_menu( [ 'id' => $id ] );
+		$post_data = [ 'ID' => $id ];
+		if ( isset( $input['title'] ) ) {
+			$post_data['post_title'] = sanitize_text_field( $input['title'] );
+		}
+		if ( isset( $input['content'] ) ) {
+			$post_data['post_content'] = (string) $input['content'];
+		}
+		if ( 1 === count( $post_data ) ) {
+			throw new Frontman_Tool_Error( 'Provide title or content to update a navigation menu' );
+		}
+
+		$result = wp_update_post( wp_slash( $post_data ), true );
+		if ( is_wp_error( $result ) ) {
+			throw new Frontman_Tool_Error( $result->get_error_message() );
+		}
+
+		return [ 'updated' => true, 'before' => $before, 'after' => $this->read_navigation_menu( [ 'id' => $id ] ) ];
+	}
+
+	public function delete_navigation_menu( array $input ): array {
+		$id = absint( $input['id'] ?? 0 );
+		if ( empty( $input['confirm'] ) ) {
+			throw new Frontman_Tool_Error( 'Deletion requires explicit confirmation. Ask the user first, then call again with confirm=true.' );
+		}
+		$before = $this->read_navigation_menu( [ 'id' => $id ] );
+		if ( ! wp_delete_post( $id, true ) ) {
+			throw new Frontman_Tool_Error( "Failed to delete block navigation menu: {$id}" );
+		}
+
+		return [ 'deleted' => true, 'id' => $id, 'before' => $before ];
 	}
 
 	private function get_menu_locations_snapshot(): array {

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+RUNTIME="${CONTAINER_RUNTIME:-docker}"
+WORDPRESS_VERSION="${WORDPRESS_VERSION:-7.0.2}"
+PHP_VERSION="${PHP_VERSION:-8.4}"
+PLUGIN_VERSION="$(bash "$ROOT_DIR/scripts/validate-wordpress-plugin-release.sh")"
+RUN_ID="frontman-wp-runtime-$$"
+NETWORK="${RUN_ID}-network"
+DATABASE="${RUN_ID}-database"
+WORDPRESS="${RUN_ID}-wordpress"
+IMAGE="${RUN_ID}-image"
+BUILD_DIR="$(mktemp -d)"
+
+cleanup() {
+  "$RUNTIME" rm -f "$WORDPRESS" "$DATABASE" >/dev/null 2>&1 || true
+  "$RUNTIME" network rm "$NETWORK" >/dev/null 2>&1 || true
+  "$RUNTIME" image rm "$IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$BUILD_DIR"
+}
+trap cleanup EXIT
+
+make -C "$ROOT_DIR" package-wordpress-plugin VERSION="$PLUGIN_VERSION" >/dev/null
+curl -fsSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz" -o "$BUILD_DIR/wordpress.tar.gz"
+"$RUNTIME" build \
+  --build-arg PHP_VERSION="$PHP_VERSION" \
+  -f "$ROOT_DIR/libs/frontman-wordpress/tests/integration/Dockerfile" \
+  -t "$IMAGE" \
+  "$BUILD_DIR" >/dev/null
+
+"$RUNTIME" network create "$NETWORK" >/dev/null
+"$RUNTIME" run -d --name "$DATABASE" --network "$NETWORK" \
+  -e MARIADB_DATABASE=wordpress \
+  -e MARIADB_USER=wordpress \
+  -e MARIADB_PASSWORD=wordpress \
+  -e MARIADB_ROOT_PASSWORD=wordpress \
+  docker.io/library/mariadb:11 >/dev/null
+
+"$RUNTIME" run -d --name "$WORDPRESS" --network "$NETWORK" \
+  -e WORDPRESS_DB_HOST="$DATABASE" \
+  -e WORDPRESS_DB_USER=wordpress \
+  -e WORDPRESS_DB_PASSWORD=wordpress \
+  -e WORDPRESS_DB_NAME=wordpress \
+  "$IMAGE" >/dev/null
+
+for _ in $(seq 1 60); do
+  if "$RUNTIME" exec "$WORDPRESS" php -r '$db = @new mysqli(getenv("WORDPRESS_DB_HOST"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_NAME")); exit($db->connect_errno ? 1 : 0);' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+"$RUNTIME" exec "$WORDPRESS" php -r '$db = @new mysqli(getenv("WORDPRESS_DB_HOST"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_NAME")); if ($db->connect_errno) { throw new RuntimeException("Database did not become ready."); }'
+"$RUNTIME" exec "$WORDPRESS" php -r '$config = file_get_contents("/var/www/html/wp-config-sample.php"); $config = str_replace(["database_name_here", "username_here", "password_here", "localhost"], [getenv("WORDPRESS_DB_NAME"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_HOST")], $config); file_put_contents("/var/www/html/wp-config.php", $config);'
+"$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/plugins/frontman-agentic-ai-editor
+"$RUNTIME" cp "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/." "$WORDPRESS:/var/www/html/wp-content/plugins/frontman-agentic-ai-editor/"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php" "$WORDPRESS:/tmp/WordPressRuntimeTest.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php" "$WORDPRESS:/tmp/RunWordPressRuntimeTest.php"
+
+"$RUNTIME" exec "$WORDPRESS" php -r 'define("WP_INSTALLING", true); require "/var/www/html/wp-load.php"; require_once ABSPATH . "wp-admin/includes/upgrade.php"; if (!is_blog_installed()) { wp_install("Frontman Runtime", "admin", "admin@example.test", true, "", "frontman-runtime-password"); }'
+"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/ActivateWordPressPlugin.php
+"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/RunWordPressRuntimeTest.php


### PR DESCRIPTION
## Summary
- preserve legacy top-level block indices while adding path-based nested block mutations
- add CRUD tools for block-theme `wp_navigation` menus
- verify packaged plugin behavior on WordPress 7.0.2 across PHP 7.4 and 8.4
- update compatibility metadata and add a minor changeset

## Verification
- 1,012 PHP assertions pass on PHP 7.4
- 1,012 PHP assertions pass on PHP 8.4
- packaged plugin runtime test passes on WordPress 7.0.2 / PHP 7.4.33
- packaged plugin runtime test passes on WordPress 7.0.2 / PHP 8.4.23
- PHP syntax checks, shell syntax, packaging validation, and `git diff --check` pass