### PR TITLE
Preserve raw tool input through ACP

### DIFF
--- a/.changeset/typed-tool-input.md
+++ b/.changeset/typed-tool-input.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-protocol": major
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/client": patch
+---
+Preserve structured tool arguments through ACP `rawInput`.

--- a/apps/frontman_server/lib/agent_client_protocol.ex
+++ b/apps/frontman_server/lib/agent_client_protocol.ex
@@ -392,7 +392,8 @@ defmodule AgentClientProtocol do
         title,
         kind,
         timestamp,
-        status \\ @tool_call_status_pending
+        status \\ @tool_call_status_pending,
+        raw_input \\ nil
       )
       when status in @tool_call_statuses do
     update = %{
@@ -404,16 +405,18 @@ defmodule AgentClientProtocol do
       "timestamp" => DateTime.to_iso8601(timestamp)
     }
 
+    update = if raw_input, do: Map.put(update, "rawInput", raw_input), else: update
+
     session_update_notification(session_id, update)
   end
 
   @doc """
   Updates an existing tool call (sessionUpdate: "tool_call_update").
 
-  Content should be an array of ACP content blocks if provided.
+  Content and raw input are included when provided.
   Per ACP spec: "All fields except toolCallId are optional in updates"
   """
-  def tool_call_update(session_id, tool_call_id, status, content \\ nil)
+  def tool_call_update(session_id, tool_call_id, status, content \\ nil, raw_input \\ nil)
       when status in @tool_call_statuses do
     update = %{
       "sessionUpdate" => "tool_call_update",
@@ -422,6 +425,7 @@ defmodule AgentClientProtocol do
     }
 
     update = if content, do: Map.put(update, "content", content), else: update
+    update = if raw_input, do: Map.put(update, "rawInput", raw_input), else: update
 
     session_update_notification(session_id, update)
   end

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -80,13 +80,9 @@ defmodule AgentClientProtocol.History do
             call.tool_call_id,
             call.tool_name,
             "other",
-            call.timestamp
-          ),
-          ACP.tool_call_update(
-            session_id,
-            call.tool_call_id,
+            call.timestamp,
             ACP.tool_call_status_pending(),
-            ACP.Content.from_tool_result(call.arguments)
+            call.arguments
           )
         ]
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -224,30 +224,30 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     announced = socket.assigns[:announced_tool_calls] || MapSet.new()
 
-    unless MapSet.member?(announced, tool_call.tool_call_id) do
-      pending_notification =
-        ACP.tool_call_create(
-          task_id,
-          tool_call.tool_call_id,
-          tool_call.tool_name,
-          "other",
-          DateTime.utc_now()
-        )
+    notification =
+      case MapSet.member?(announced, tool_call.tool_call_id) do
+        false ->
+          ACP.tool_call_create(
+            task_id,
+            tool_call.tool_call_id,
+            tool_call.tool_name,
+            "other",
+            DateTime.utc_now(),
+            ACP.tool_call_status_pending(),
+            tool_call.arguments
+          )
 
-      push(socket, @acp_message, pending_notification)
-    end
+        true ->
+          ACP.tool_call_update(
+            task_id,
+            tool_call.tool_call_id,
+            ACP.tool_call_status_pending(),
+            nil,
+            tool_call.arguments
+          )
+      end
 
-    args_content = ACP.Content.from_tool_result(tool_call.arguments)
-
-    args_notification =
-      ACP.tool_call_update(
-        task_id,
-        tool_call.tool_call_id,
-        ACP.tool_call_status_pending(),
-        args_content
-      )
-
-    push(socket, @acp_message, args_notification)
+    push(socket, @acp_message, notification)
 
     case Tools.execution_target(tool_call.tool_name) do
       :backend ->
@@ -275,7 +275,9 @@ defmodule FrontmanServerWeb.TaskChannel do
     else
       content = ACP.Content.from_tool_result(tool_result.result)
       status = ACP.tool_call_status(tool_result.is_error)
+
       notification = ACP.tool_call_update(task_id, tool_result.tool_call_id, status, content)
+
       push(socket, @acp_message, notification)
     end
 
@@ -415,7 +417,9 @@ defmodule FrontmanServerWeb.TaskChannel do
       {:ok, interaction, executor_status} ->
         status = ACP.tool_call_status(interaction.is_error)
         content = ACP.Content.from_tool_result(interaction.result)
+
         notification = ACP.tool_call_update(task_id, interaction.tool_call_id, status, content)
+
         push(socket, @acp_message, notification)
         Logger.info("Tool #{interaction.tool_name} #{status}")
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1109,25 +1109,25 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         }
       })
 
-      # Step 2: Send the full interaction (which normally would also send tool_call_create)
       tc =
         tool_call(tool_call_id, "write_file", %{"target_file" => "test.txt", "content" => "hello"})
 
       send(socket.channel_pid, interaction_event(tc, 1))
       :sys.get_state(socket.channel_pid)
 
-      # Should get a tool_call_update with args, but NOT a duplicate tool_call create
       assert_push("acp:message", %{
         "params" => %{
-          "update" => %{
-            "sessionUpdate" => "tool_call_update",
-            "toolCallId" => ^tool_call_id,
-            "status" => "pending"
-          }
+          "update" => update
         }
       })
 
-      # Verify no duplicate tool_call create was sent
+      assert update == %{
+               "sessionUpdate" => "tool_call_update",
+               "toolCallId" => tool_call_id,
+               "status" => "pending",
+               "rawInput" => %{"target_file" => "test.txt", "content" => "hello"}
+             }
+
       refute_push("acp:message", %{
         "params" => %{
           "update" => %{
@@ -1142,8 +1142,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       socket: socket,
       task_id: task_id
     } do
-      # Tool calls that arrive without a prior tool_call should still get
-      # the normal tool_call_create notification
       tool_call_id = "call_no_start_#{:rand.uniform(1_000_000)}"
 
       tc = tool_call(tool_call_id, "take_screenshot")
@@ -1151,26 +1149,17 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       send(socket.channel_pid, interaction_event(tc, 1))
       :sys.get_state(socket.channel_pid)
 
-      # Should get the standard tool_call create notification
       assert_push("acp:message", %{
         "params" => %{
           "sessionId" => ^task_id,
-          "update" => %{
-            "sessionUpdate" => "tool_call",
-            "toolCallId" => ^tool_call_id
-          }
+          "update" => update
         }
       })
 
-      # And the tool_call_update with arguments
-      assert_push("acp:message", %{
-        "params" => %{
-          "update" => %{
-            "sessionUpdate" => "tool_call_update",
-            "toolCallId" => ^tool_call_id
-          }
-        }
-      })
+      assert update["sessionUpdate"] == "tool_call"
+      assert update["toolCallId"] == tool_call_id
+      assert update["rawInput"] == %{}
+      refute Map.has_key?(update, "content")
     end
   end
 

--- a/apps/frontman_server/test/protocols/acp_contract_test.exs
+++ b/apps/frontman_server/test/protocols/acp_contract_test.exs
@@ -96,18 +96,20 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
   end
 
   describe "AgentClientProtocol.tool_call_update/4" do
-    test "without content validates against acp/sessionUpdateNotification schema" do
-      payload =
-        AgentClientProtocol.tool_call_update("session-123", "tc-1", "completed")
+    test "with raw input validates against acp/sessionUpdateNotification schema" do
+      raw_input = %{"path" => "file.res"}
 
+      payload =
+        AgentClientProtocol.tool_call_update("session-123", "tc-1", "pending", nil, raw_input)
+
+      assert get_in(payload, ["params", "update", "rawInput"]) == raw_input
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
     end
 
     test "with content validates against acp/sessionUpdateNotification schema" do
       content = [%{"type" => "content", "content" => %{"type" => "text", "text" => "result"}}]
 
-      payload =
-        AgentClientProtocol.tool_call_update("session-123", "tc-1", "completed", content)
+      payload = AgentClientProtocol.tool_call_update("session-123", "tc-1", "completed", content)
 
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
     end

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -40,11 +40,13 @@ defmodule AgentClientProtocol.HistoryTest do
     assert {:ok, replay} = build(rows)
     updates = Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
 
-    assert [first, second, answer, _tool_create, _tool_update, error] = updates
+    assert [first, second, answer, tool_create, error] = updates
     assert first["messageId"] == "user-row"
     assert second["messageId"] == "user-row"
     assert answer["messageId"] == "turn-row:1"
     assert answer["_meta"]["frontman.dev/agentId"] == "executor-id"
+    assert tool_create["rawInput"] == %{"path" => "file"}
+    refute Map.has_key?(tool_create, "content")
     assert error["_meta"]["frontman.dev/agentErrorId"] == "error-id"
   end
 

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -218,7 +218,7 @@ module Provider = {
       | GenericAgentMessageChunk(_) | GenericUserMessageChunk(_) =>
         failwith("Frontman UI requires negotiated agent attribution")
       | Unknown(_) => ()
-      | ToolCall({toolCallId, title, parentAgentId, spawningToolName, _}) =>
+      | ToolCall({toolCallId, title, rawInput, parentAgentId, spawningToolName, _}) =>
         Client__TextDeltaBuffer.flush()
         Client__State.Actions.toolCallReceived(
           ~taskId,
@@ -226,34 +226,30 @@ module Provider = {
             id: toolCallId,
             toolName: title,
             inputBuffer: "",
-            input: None,
+            input: rawInput,
             result: None,
             errorText: None,
-            state: Client__State__Types.Message.InputStreaming,
+            state: rawInput->Option.mapOr(Client__State__Types.Message.InputStreaming, _ =>
+              Client__State__Types.Message.InputAvailable
+            ),
             parentAgentId,
             spawningToolName,
           },
         )
-      | ToolCallUpdate({toolCallId, status, content}) =>
+      | ToolCallUpdate({toolCallId, status, content, rawInput}) =>
         Client__TextDeltaBuffer.flush()
-        let text =
+        let text = () =>
           content
           ->Option.flatMap(c => c->Array.get(0))
           ->Option.flatMap(i => i.content)
           ->Option.flatMap(getContentBlockText)
+        rawInput->Option.forEach(input => {
+          Client__State.Actions.toolInputReceived(~taskId, ~id=toolCallId, ~input)
+        })
         switch status {
-        | Some(Pending) =>
-          text
-          ->Option.flatMap(t =>
-            try {Some(JSON.parseOrThrow(t))} catch {
-            | _ => None
-            }
-          )
-          ->Option.forEach(input => {
-            Client__State.Actions.toolInputReceived(~taskId, ~id=toolCallId, ~input)
-          })
+        | Some(Pending) => ()
         | Some(Completed) =>
-          let result = text->Option.mapOr(JSON.Encode.null, t =>
+          let result = text()->Option.mapOr(JSON.Encode.null, t =>
             try {JSON.parseOrThrow(t)} catch {
             | _ => JSON.Encode.string(t)
             }
@@ -263,7 +259,7 @@ module Provider = {
           Client__State.Actions.toolErrorReceived(
             ~taskId,
             ~id=toolCallId,
-            ~error=text->Option.getOr("Unknown error"),
+            ~error=text()->Option.getOr("Unknown error"),
           )
         | Some(InProgress) => () // Normal transitional status for MCP tools
         | None => ()

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -866,7 +866,15 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
   | (Task.Loading(_) | Task.Loaded(_), ToolInputReceived({id, input})) => (
       Lens.updateMessage(task, id, msg =>
         switch msg {
-        | Message.ToolCall(tool) => Message.ToolCall({...tool, input: Some(input)})
+        | Message.ToolCall(tool) =>
+          Message.ToolCall({
+            ...tool,
+            input: Some(input),
+            state: switch tool.state {
+            | Message.InputStreaming => Message.InputAvailable
+            | state => state
+            },
+          })
         | _ => failwith(`[TaskReducer] ToolInputReceived but message ${id} is not a ToolCall`)
         }
       ),

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -451,7 +451,7 @@ describe("Client State Reducer - Tool Lifecycle", () => {
     }
   })
 
-  test("ToolCallReceived with complete input creates tool with InputAvailable", t => {
+  test("ToolInputReceived makes streaming input available", t => {
     // Create a task with an assistant message first (tools belong to tasks)
     let state = TestHelpers.makeStateWithTask(
       ~isAgentRunning=true,
@@ -477,21 +477,11 @@ describe("Client State Reducer - Tool Lifecycle", () => {
       ],
     )
 
-    let toolCall: Reducer.Message.toolCall = {
-      id: "call-1",
-      toolName: "read_file",
-      inputBuffer: "",
-      input: Some(JSON.parseOrThrow("{\"path\": \"test.res\"}")),
-      result: None,
-      errorText: None,
-      state: Reducer.Message.InputAvailable,
-      parentAgentId: None,
-      spawningToolName: None,
-    }
     let taskId = TestHelpers.getCurrentTaskId(state)->Option.getOrThrow
+    let expectedInput = JSON.parseOrThrow(`{"path":"test.res","range":{"start":12}}`)
     let action = Reducer.TaskAction({
       target: ForTask(taskId),
-      action: ToolCallReceived({toolCall: toolCall}),
+      action: ToolInputReceived({id: "call-1", input: expectedInput}),
     })
     let (nextState, _) = Reducer.next(state, action)
 
@@ -501,7 +491,7 @@ describe("Client State Reducer - Tool Lifecycle", () => {
     switch messages->Array.get(1) {
     | Some(Reducer.Message.ToolCall({state, input, _})) => {
         t->expect(state)->Expect.toBe(Reducer.Message.InputAvailable)
-        t->expect(input->Option.isSome)->Expect.toBe(true)
+        t->expect(input)->Expect.toEqual(Some(expectedInput))
       }
     | _ => t->expect("Got ToolCall message")->Expect.toBe("Expected ToolCall message")
     }

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -434,6 +434,7 @@
             "failed"
           ]
         },
+        "rawInput": {},
         "timestamp": {
           "type": "string"
         },
@@ -650,7 +651,8 @@
             ]
           },
           "type": "array"
-        }
+        },
+        "rawInput": {}
       },
       "required": [
         "sessionUpdate",

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -451,6 +451,7 @@
                     "failed"
                   ]
                 },
+                "rawInput": {},
                 "timestamp": {
                   "type": "string"
                 },
@@ -667,7 +668,8 @@
                     ]
                   },
                   "type": "array"
-                }
+                },
+                "rawInput": {}
               },
               "required": [
                 "sessionUpdate",

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -589,6 +589,7 @@ type sessionUpdate =
       title: string,
       kind: option<string>,
       status: option<toolCallStatus>,
+      rawInput: option<JSON.t>,
       timestamp: string,
       parentAgentId: option<string>, // If present, this is a sub-agent tool call
       spawningToolName: option<string>,
@@ -597,6 +598,7 @@ type sessionUpdate =
       toolCallId: string,
       status: option<toolCallStatus>,
       content: option<array<toolCallContentItem>>,
+      rawInput: option<JSON.t>,
     })
   | Plan({entries: array<planEntry>})
   | ConfigOptionUpdate({configOptions: array<sessionConfigOption>})
@@ -620,6 +622,7 @@ let commonSessionUpdateSchema = S.union([
       title: s.field("title", S.string),
       kind: s.field("kind", S.option(S.string)),
       status: s.field("status", S.option(toolCallStatusSchema)),
+      rawInput: s.field("rawInput", S.option(S.json)),
       timestamp: s.field("timestamp", S.string),
       parentAgentId: s.field("parentAgentId", S.option(S.string)),
       spawningToolName: s.field("spawningToolName", S.option(S.string)),
@@ -631,6 +634,7 @@ let commonSessionUpdateSchema = S.union([
       toolCallId: s.field("toolCallId", S.string),
       status: s.field("status", S.option(toolCallStatusSchema)),
       content: s.field("content", S.option(S.array(toolCallContentItemSchema))),
+      rawInput: s.field("rawInput", S.option(S.json)),
     })
   }),
   S.object(s => {


### PR DESCRIPTION
## Summary

- add stable ACP v1 `rawInput` to tool call and tool call update schemas
- project persisted MCP arguments directly into `rawInput` for live updates and history replay
- consume structured input in client state without display-content JSON guessing
- keep live and replayed tool-call state equivalent while preserving terminal states

## Delivery size

- hand-written source/test additions: 88
- hand-written source/test deletions: 93
- hand-written source/test changed lines: 181
- changeset additions: 6
- generated schema additions: 6
- generated schema deletions: 2

## Verification

- `make -C libs/frontman-client check` (97 tests passed)
- focused ACP contract, history, and channel tests (20 tests passed)
- client ReScript build and Biome lint
- server format check, warnings-as-errors compilation, and strict Credo
- pre-commit and pre-push hooks

The full UI client suite has 319 passing tests and 14 pre-existing failures in PromptInput, ChatGPT OAuth, and load-session tests.