### PR TITLE
Preserve typed multipart tool content through ACP

### DIFF
--- a/.changeset/typed-tool-content.md
+++ b/.changeset/typed-tool-content.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-protocol": major
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/client": patch
+---
+Preserve and generically render typed multipart MCP tool content through ACP.

--- a/apps/frontman_server/lib/agent_client_protocol/content.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/content.ex
@@ -11,20 +11,8 @@ defmodule AgentClientProtocol.Content do
   alias FrontmanServer.Tasks.Interaction
 
   def from_tool_result(%{"content" => content}) when is_list(content) do
-    Enum.map(content, fn
-      %{"type" => "text", "text" => text} when is_binary(text) ->
-        tool_content(text)
-
-      part ->
-        part |> Jason.encode!() |> tool_content()
-    end)
+    Enum.map(content, &tool_content/1)
   end
-
-  def from_tool_result(result) when is_map(result),
-    do: [result |> Jason.encode!() |> tool_content()]
-
-  def from_tool_result(result) when is_binary(result), do: [tool_content(result)]
-  def from_tool_result(result), do: [result |> inspect() |> tool_content()]
 
   def from_user_message(%Interaction.UserMessage{} = message) do
     Enum.map(message.messages, &%{"type" => "text", "text" => &1}) ++
@@ -144,9 +132,28 @@ defmodule AgentClientProtocol.Content do
     %{"type" => "resource", "_meta" => metadata, "resource" => content}
   end
 
-  defp tool_content(text) do
-    %{"type" => "content", "content" => %{"type" => "text", "text" => text}}
-  end
+  defp tool_content(%{"type" => "text", "text" => text} = content) when is_binary(text),
+    do: %{"type" => "content", "content" => content}
+
+  defp tool_content(%{"type" => type, "data" => data, "mimeType" => mime_type} = content)
+       when type in ["image", "audio"] and is_binary(data) and is_binary(mime_type),
+       do: %{"type" => "content", "content" => content}
+
+  defp tool_content(%{"type" => "resource_link", "name" => name, "uri" => uri} = content)
+       when is_binary(name) and is_binary(uri),
+       do: %{"type" => "content", "content" => content}
+
+  defp tool_content(
+         %{"type" => "resource", "resource" => %{"uri" => uri, "text" => text}} = content
+       )
+       when is_binary(uri) and is_binary(text),
+       do: %{"type" => "content", "content" => content}
+
+  defp tool_content(
+         %{"type" => "resource", "resource" => %{"uri" => uri, "blob" => blob}} = content
+       )
+       when is_binary(uri) and is_binary(blob),
+       do: %{"type" => "content", "content" => content}
 
   defp reject_nils(map), do: Map.reject(map, fn {_key, value} -> is_nil(value) end)
 end

--- a/apps/frontman_server/test/agent_client_protocol/content_test.exs
+++ b/apps/frontman_server/test/agent_client_protocol/content_test.exs
@@ -8,22 +8,20 @@ defmodule AgentClientProtocol.ContentTest do
   @timestamp ~U[2026-07-15 10:00:00.000000Z]
 
   describe "from_tool_result/1" do
-    test "formats binary as text" do
-      assert Content.from_tool_result("Hello") == [
-               %{
-                 "type" => "content",
-                 "content" => %{"type" => "text", "text" => "Hello"}
-               }
+    test "preserves typed multipart content in order" do
+      text = %{"type" => "text", "text" => "Hello"}
+      image = %{"type" => "image", "data" => "base64", "mimeType" => "image/png"}
+
+      assert Content.from_tool_result(%{"content" => [text, image]}) == [
+               %{"type" => "content", "content" => text},
+               %{"type" => "content", "content" => image}
              ]
     end
 
-    test "formats other types using inspect" do
-      assert Content.from_tool_result({:ok, 123}) == [
-               %{
-                 "type" => "content",
-                 "content" => %{"type" => "text", "text" => "{:ok, 123}"}
-               }
-             ]
+    test "rejects malformed known content" do
+      assert_raise FunctionClauseError, fn ->
+        Content.from_tool_result(%{"content" => [%{"type" => "image", "data" => "base64"}]})
+      end
     end
   end
 

--- a/libs/bindings/src/Bindings__Snapdom.res
+++ b/libs/bindings/src/Bindings__Snapdom.res
@@ -2,6 +2,7 @@
 // See: https://github.com/zumerlab/snapdom#options
 type captureOptions = {
   scale?: float,
+  dpr?: float,
   quality?: float,
 }
 

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -54,7 +54,6 @@ let makeToolCall = (
   }
 }
 
-// Extract text from a contentBlock (returns Some for TextContent, None for other variants)
 let getContentBlockText = (block: ContentBlock.t): option<string> =>
   switch block {
   | TextContent({text}) => Some(text)
@@ -287,10 +286,15 @@ module Provider = {
       | ToolCallUpdate({toolCallId, status, content, rawInput, rawOutput}) =>
         Client__TextDeltaBuffer.flush()
         let text = () =>
-          content
-          ->Option.flatMap(c => c->Array.get(0))
-          ->Option.flatMap(i => i.content)
-          ->Option.flatMap(getContentBlockText)
+          content->Option.flatMap(c =>
+            c->Array.findMap(
+              item =>
+                switch item {
+                | Content({content: TextContent({text})}) => Some(text)
+                | _ => None
+                },
+            )
+          )
         rawInput->Option.forEach(input => {
           Client__State.Actions.toolInputReceived(~taskId, ~id=toolCallId, ~input)
         })

--- a/libs/client/src/components/frontman/Client__ImagePreview.res
+++ b/libs/client/src/components/frontman/Client__ImagePreview.res
@@ -224,5 +224,5 @@ let make = (~src: string, ~onClose: unit => unit) => {
       onDoubleClick={handleDoubleClick}
       onClick={e => ReactEvent.Mouse.stopPropagation(e)}
     />
-  </div>
+  </div>->ReactDOM.createPortal(WebAPI.Document.body(WebAPI.Global.document)->Obj.magic)
 }

--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -23,9 +23,7 @@ let isInlineTool = (toolName: string): bool => {
 let renderContent = (item, setPreviewSrc) =>
   switch item {
   | ACP.Content({content: TextContent({text})}) =>
-    <pre className="font-mono text-[11px] whitespace-pre-wrap break-words text-zinc-400">
-      {React.string(text)}
-    </pre>
+    <pre className="whitespace-pre-wrap break-words"> {React.string(text)} </pre>
   | Content({content: ImageContent({data, mimeType})}) => {
       let src = `data:${mimeType};base64,${data}`
       <button
@@ -44,11 +42,16 @@ let renderContent = (item, setPreviewSrc) =>
     <audio controls=true src={`data:${mimeType};base64,${data}`} className="max-w-full" />
   | Content({content: ResourceLink({name, uri})}) =>
     <div className="font-mono text-zinc-400"> {React.string(`${name}: ${uri}`)} </div>
-  | Content({content: EmbeddedResource(_)}) =>
-    <div className="font-mono text-zinc-400"> {React.string("Embedded resource")} </div>
+  | Content({content: EmbeddedResource({resource: TextResourceContents({uri, text})})}) =>
+    <pre> {React.string(`${uri}\n${text}`)} </pre>
+  | Content({
+      content: EmbeddedResource({resource: BlobResourceContents({uri, mimeType, blob})}),
+    }) => {
+      let src = `data:${mimeType->Option.getOr("application/octet-stream")};base64,${blob}`
+      <a href=src download=uri> {React.string(`Download ${uri}`)} </a>
+    }
   | Diff({path}) => <div className="font-mono text-zinc-400"> {React.string(`Diff: ${path}`)} </div>
-  | Terminal({terminalId}) =>
-    <div className="font-mono text-zinc-400"> {React.string(`Terminal ${terminalId}`)} </div>
+  | Terminal({terminalId}) => <div> {React.string(`Terminal ${terminalId}`)} </div>
   }
 
 // Extract target path/URL, defaulting to "./" for list/file operations
@@ -140,7 +143,6 @@ let make = (
           </span>
         </div>
 
-        // Target path as purple link, or shimmer placeholder while streaming
         {switch (target, state, input) {
         | (_, InputStreaming, None) if isLink => {
             let placeholder = "Waiting for file path..."
@@ -210,7 +212,7 @@ let make = (
               }}
               {switch result {
               | Some({content}) if content->Array.length > 0 =>
-                <div>
+                <div className="font-mono text-[11px] text-zinc-400">
                   <div className="text-[11px] text-zinc-500 mb-1"> {React.string("Output:")} </div>
                   {content
                   ->Array.mapWithIndex((item, index) =>

--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -1,15 +1,12 @@
 /**
  * ToolCallBlock - Main tool call display component
  *
- * Displays tool calls with human-readable names in purple-themed style:
- *   Get Routes
- *   target_path (as purple link)
- *
  * Supports compact mode for grouped display and expand/collapse for details.
  */
 module Message = Client__State__Types.Message
 module ToolLabels = Client__ToolLabels
 module ToolNames = FrontmanAiFrontmanClient.FrontmanClient__MCP__Tool.ToolNames
+module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 // Normalize tool name for comparison
 let cleanToolName = (toolName: string): string => String.toLowerCase(toolName)
@@ -23,36 +20,36 @@ let isInlineTool = (toolName: string): bool => {
   }
 }
 
-// Screenshot tool detection and image extraction
-let isScreenshotTool = (toolName: string): bool => {
-  cleanToolName(toolName) == ToolNames.takeScreenshot
-}
-
-let getScreenshotSrc = (result: option<Message.toolResult>): option<string> => {
-  result
-  ->Option.flatMap(result => result.rawOutput)
-  ->Option.flatMap(JSON.Decode.object)
-  ->Option.flatMap(dict => dict->Dict.get("screenshot"))
-  ->Option.flatMap(JSON.Decode.string)
-  ->Option.flatMap(s => s != "" ? Some(s) : None)
-}
-
-let getDisplayOutput = (result: option<Message.toolResult>): option<string> =>
-  result->Option.flatMap(result =>
-    switch result.rawOutput {
-    | Some(json) => Some(JSON.stringify(json, ~space=2))
-    | None =>
-      result.content
-      ->Array.get(0)
-      ->Option.flatMap(item => item.content)
-      ->Option.flatMap(content =>
-        switch content {
-        | TextContent({text}) => Some(text)
-        | _ => None
-        }
-      )
+let renderContent = (item, setPreviewSrc) =>
+  switch item {
+  | ACP.Content({content: TextContent({text})}) =>
+    <pre className="font-mono text-[11px] whitespace-pre-wrap break-words text-zinc-400">
+      {React.string(text)}
+    </pre>
+  | Content({content: ImageContent({data, mimeType})}) => {
+      let src = `data:${mimeType};base64,${data}`
+      <button
+        type_="button"
+        ariaLabel="View image output"
+        onClick={event => {
+          ReactEvent.Mouse.stopPropagation(event)
+          setPreviewSrc(_ => Some(src))
+        }}
+        className="block cursor-zoom-in"
+      >
+        <img src alt="Tool output" className="max-h-32 rounded border border-[#8051CD]/30" />
+      </button>
     }
-  )
+  | Content({content: AudioContent({data, mimeType})}) =>
+    <audio controls=true src={`data:${mimeType};base64,${data}`} className="max-w-full" />
+  | Content({content: ResourceLink({name, uri})}) =>
+    <div className="font-mono text-zinc-400"> {React.string(`${name}: ${uri}`)} </div>
+  | Content({content: EmbeddedResource(_)}) =>
+    <div className="font-mono text-zinc-400"> {React.string("Embedded resource")} </div>
+  | Diff({path}) => <div className="font-mono text-zinc-400"> {React.string(`Diff: ${path}`)} </div>
+  | Terminal({terminalId}) =>
+    <div className="font-mono text-zinc-400"> {React.string(`Terminal ${terminalId}`)} </div>
+  }
 
 // Extract target path/URL, defaulting to "./" for list/file operations
 let getTarget = (toolName: string, input: option<JSON.t>): option<string> => {
@@ -96,7 +93,6 @@ let make = (
     let isInProgress = state == InputStreaming || state == InputAvailable
     let hasError = Option.isSome(errorText)
 
-    // Expandable tools show body when there's content
     let hasBody =
       !isLink &&
       ((state == InputStreaming && inputBuffer != "") ||
@@ -212,34 +208,17 @@ let make = (
                 </div>
               | _ => React.null
               }}
-              // Screenshot preview button when screenshot data is available
-              {switch (isScreenshotTool(toolName), getScreenshotSrc(result)) {
-              | (true, Some(src)) =>
-                <div className="mb-2">
-                  <button
-                    type_="button"
-                    onClick={e => {
-                      ReactEvent.Mouse.stopPropagation(e)
-                      setPreviewSrc(_ => Some(src))
-                    }}
-                    className="text-[11px] font-mono text-[#8051CD] hover:text-[#9d7be0] underline cursor-pointer"
-                  >
-                    {React.string("View Screenshot")}
-                  </button>
-                </div>
-              | _ => React.null
-              }}
-              {switch (getDisplayOutput(result), errorText) {
-              | (Some(output), _) =>
+              {switch result {
+              | Some({content}) if content->Array.length > 0 =>
                 <div>
                   <div className="text-[11px] text-zinc-500 mb-1"> {React.string("Output:")} </div>
-                  <pre
-                    className="font-mono text-[11px] whitespace-pre-wrap break-words text-zinc-400"
-                  >
-                    {React.string(output)}
-                  </pre>
+                  {content
+                  ->Array.mapWithIndex((item, index) =>
+                    <div key={index->Int.toString}> {renderContent(item, setPreviewSrc)} </div>
+                  )
+                  ->React.array}
                 </div>
-              | (None, Some(_)) => React.null // Error already shown inline in header
+              | None if Option.isSome(errorText) => React.null // Error already shown inline in header
               | _ if state == InputAvailable =>
                 <div className="text-sm text-zinc-400 italic py-1">
                   {React.string("Executing...")}
@@ -250,7 +229,6 @@ let make = (
           </div>
         : React.null}
 
-      // Screenshot lightbox preview
       {switch previewSrc {
       | Some(src) => <Client__ImagePreview src onClose={() => setPreviewSrc(_ => None)} />
       | None => React.null

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -161,7 +161,7 @@ let execute = async (
             switch viewportCrop {
             | Some((viewportW, viewportH, scrollX, scrollY)) =>
               // Viewport mode: render full page to canvas, then crop to visible area
-              let canvas = await captureResult.toCanvas({scale: scale})
+              let canvas = await captureResult.toCanvas({scale, dpr: 1.0})
               let dataUrl = _cropCanvasToViewport(
                 canvas,
                 ~scrollX,

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -413,10 +413,10 @@ describe("Client State Reducer - Tool Lifecycle", () => {
       }
     | _ => JsExn.throw("Expected partial ToolCall result")
     }
-    let content: ACP.toolCallContentItem = {
-      type_: "content",
-      content: Some(ContentBlock.TextContent({text: "done", _meta: None, annotations: None})),
-    }
+    let content: ACP.toolCallContentItem = Content({
+      content: ContentBlock.TextContent({text: "done", _meta: None, annotations: None}),
+      _meta: None,
+    })
     let contentAction = Reducer.TaskAction({
       target: ForTask(taskId),
       action: ToolResultReceived({

--- a/libs/client/test/Client__ToolCallBlock.test.res
+++ b/libs/client/test/Client__ToolCallBlock.test.res
@@ -4,7 +4,6 @@ module ToolCallBlock = Client__ToolCallBlock
 module Provider = Client__FrontmanProvider
 module Message = Client__State__Types.Message
 module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
-module ContentBlock = FrontmanAiFrontmanProtocol.FrontmanProtocol__ContentBlock
 
 describe("cleanToolName", _t => {
   test("lowercases without stripping any prefix", t => {
@@ -89,13 +88,4 @@ test("initial tool call retains output without overriding status", t => {
   t
   ->expect(call.result->Option.flatMap(result => result.rawOutput))
   ->Expect.toEqual(Some(rawOutput))
-})
-
-test("unstructured text is rendered directly", t => {
-  let content: ACP.toolCallContentItem = {
-    type_: "content",
-    content: Some(ContentBlock.TextContent({text: "true", _meta: None, annotations: None})),
-  }
-  let result: Message.toolResult = {rawOutput: None, content: [content]}
-  t->expect(ToolCallBlock.getDisplayOutput(Some(result)))->Expect.toEqual(Some("true"))
 })

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -630,7 +630,14 @@
                     "type": "string"
                   },
                   "oldText": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "newText": {
                     "type": "string"
@@ -897,7 +904,14 @@
                     "type": "string"
                   },
                   "oldText": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "newText": {
                     "type": "string"

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -436,182 +436,230 @@
         },
         "content": {
           "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "content": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "text"
-                      },
-                      "text": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "text"
-                    ]
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "content"
                   },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "image"
-                      },
-                      "data": {
-                        "type": "string"
-                      },
-                      "mimeType": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
+                  "content": {
+                    "anyOf": [
+                      {
                         "type": "object",
                         "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "data",
-                      "mimeType"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "audio"
-                      },
-                      "data": {
-                        "type": "string"
-                      },
-                      "mimeType": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "data",
-                      "mimeType"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "resource_link"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "uri": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "name",
-                      "uri"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "resource"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      },
-                      "resource": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "uri": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "text": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "uri",
-                              "text"
-                            ]
+                          "type": {
+                            "type": "string",
+                            "const": "text"
                           },
-                          {
+                          "text": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
                             "type": "object",
                             "properties": {
-                              "uri": {
-                                "type": "string"
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "text"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "image"
+                          },
+                          "data": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "data",
+                          "mimeType"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "audio"
+                          },
+                          "data": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "data",
+                          "mimeType"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "resource_link"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uri": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "name",
+                          "uri"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "resource"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          },
+                          "resource": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "uri",
+                                  "text"
+                                ]
                               },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "blob": {
-                                "type": "string"
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "uri",
+                                  "blob"
+                                ]
                               }
-                            },
-                            "required": [
-                              "uri",
-                              "blob"
                             ]
                           }
+                        },
+                        "required": [
+                          "type",
+                          "resource"
                         ]
                       }
-                    },
-                    "required": [
-                      "type",
-                      "resource"
                     ]
-                  }
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "content"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "diff"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "oldText": {
+                    "type": "string"
+                  },
+                  "newText": {
+                    "type": "string"
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "path",
+                  "newText"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "terminal"
+                  },
+                  "terminalId": {
+                    "type": "string"
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "terminalId"
                 ]
               }
-            },
-            "required": [
-              "type"
             ]
           },
           "type": "array"
@@ -655,182 +703,230 @@
         },
         "content": {
           "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "content": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "text"
-                      },
-                      "text": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "text"
-                    ]
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "content"
                   },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "image"
-                      },
-                      "data": {
-                        "type": "string"
-                      },
-                      "mimeType": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
+                  "content": {
+                    "anyOf": [
+                      {
                         "type": "object",
                         "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "data",
-                      "mimeType"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "audio"
-                      },
-                      "data": {
-                        "type": "string"
-                      },
-                      "mimeType": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "data",
-                      "mimeType"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "resource_link"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "uri": {
-                        "type": "string"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "name",
-                      "uri"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "const": "resource"
-                      },
-                      "_meta": {},
-                      "annotations": {
-                        "type": "object",
-                        "properties": {
-                          "_meta": {}
-                        }
-                      },
-                      "resource": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "uri": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "text": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "uri",
-                              "text"
-                            ]
+                          "type": {
+                            "type": "string",
+                            "const": "text"
                           },
-                          {
+                          "text": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
                             "type": "object",
                             "properties": {
-                              "uri": {
-                                "type": "string"
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "text"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "image"
+                          },
+                          "data": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "data",
+                          "mimeType"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "audio"
+                          },
+                          "data": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "data",
+                          "mimeType"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "resource_link"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uri": {
+                            "type": "string"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "name",
+                          "uri"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "resource"
+                          },
+                          "_meta": {},
+                          "annotations": {
+                            "type": "object",
+                            "properties": {
+                              "_meta": {}
+                            }
+                          },
+                          "resource": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "uri",
+                                  "text"
+                                ]
                               },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "blob": {
-                                "type": "string"
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "uri",
+                                  "blob"
+                                ]
                               }
-                            },
-                            "required": [
-                              "uri",
-                              "blob"
                             ]
                           }
+                        },
+                        "required": [
+                          "type",
+                          "resource"
                         ]
                       }
-                    },
-                    "required": [
-                      "type",
-                      "resource"
                     ]
-                  }
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "content"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "diff"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "oldText": {
+                    "type": "string"
+                  },
+                  "newText": {
+                    "type": "string"
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "path",
+                  "newText"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "terminal"
+                  },
+                  "terminalId": {
+                    "type": "string"
+                  },
+                  "_meta": {}
+                },
+                "required": [
+                  "type",
+                  "terminalId"
                 ]
               }
-            },
-            "required": [
-              "type"
             ]
           },
           "type": "array"

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -453,182 +453,230 @@
                 },
                 "content": {
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "content": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "text"
-                              },
-                              "text": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "text"
-                            ]
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "content"
                           },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "image"
-                              },
-                              "data": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
+                          "content": {
+                            "anyOf": [
+                              {
                                 "type": "object",
                                 "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "audio"
-                              },
-                              "data": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "resource_link"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "uri": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "name",
-                              "uri"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "resource"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              },
-                              "resource": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "uri": {
-                                        "type": "string"
-                                      },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "text": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "uri",
-                                      "text"
-                                    ]
+                                  "type": {
+                                    "type": "string",
+                                    "const": "text"
                                   },
-                                  {
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "uri": {
-                                        "type": "string"
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "text"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "image"
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "data",
+                                  "mimeType"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "audio"
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "data",
+                                  "mimeType"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "resource_link"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "name",
+                                  "uri"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "resource"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  },
+                                  "resource": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "uri",
+                                          "text"
+                                        ]
                                       },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "blob": {
-                                        "type": "string"
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "uri",
+                                          "blob"
+                                        ]
                                       }
-                                    },
-                                    "required": [
-                                      "uri",
-                                      "blob"
                                     ]
                                   }
+                                },
+                                "required": [
+                                  "type",
+                                  "resource"
                                 ]
                               }
-                            },
-                            "required": [
-                              "type",
-                              "resource"
                             ]
-                          }
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "content"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "diff"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "oldText": {
+                            "type": "string"
+                          },
+                          "newText": {
+                            "type": "string"
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "path",
+                          "newText"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "terminal"
+                          },
+                          "terminalId": {
+                            "type": "string"
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "terminalId"
                         ]
                       }
-                    },
-                    "required": [
-                      "type"
                     ]
                   },
                   "type": "array"
@@ -672,182 +720,230 @@
                 },
                 "content": {
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "content": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "text"
-                              },
-                              "text": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "text"
-                            ]
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "content"
                           },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "image"
-                              },
-                              "data": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
+                          "content": {
+                            "anyOf": [
+                              {
                                 "type": "object",
                                 "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "audio"
-                              },
-                              "data": {
-                                "type": "string"
-                              },
-                              "mimeType": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "resource_link"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "uri": {
-                                "type": "string"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "name",
-                              "uri"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "resource"
-                              },
-                              "_meta": {},
-                              "annotations": {
-                                "type": "object",
-                                "properties": {
-                                  "_meta": {}
-                                }
-                              },
-                              "resource": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "uri": {
-                                        "type": "string"
-                                      },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "text": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "uri",
-                                      "text"
-                                    ]
+                                  "type": {
+                                    "type": "string",
+                                    "const": "text"
                                   },
-                                  {
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "uri": {
-                                        "type": "string"
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "text"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "image"
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "data",
+                                  "mimeType"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "audio"
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "data",
+                                  "mimeType"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "resource_link"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "name",
+                                  "uri"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "const": "resource"
+                                  },
+                                  "_meta": {},
+                                  "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                      "_meta": {}
+                                    }
+                                  },
+                                  "resource": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "uri",
+                                          "text"
+                                        ]
                                       },
-                                      "mimeType": {
-                                        "type": "string"
-                                      },
-                                      "blob": {
-                                        "type": "string"
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "uri": {
+                                            "type": "string"
+                                          },
+                                          "mimeType": {
+                                            "type": "string"
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "uri",
+                                          "blob"
+                                        ]
                                       }
-                                    },
-                                    "required": [
-                                      "uri",
-                                      "blob"
                                     ]
                                   }
+                                },
+                                "required": [
+                                  "type",
+                                  "resource"
                                 ]
                               }
-                            },
-                            "required": [
-                              "type",
-                              "resource"
                             ]
-                          }
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "content"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "diff"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "oldText": {
+                            "type": "string"
+                          },
+                          "newText": {
+                            "type": "string"
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "path",
+                          "newText"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "terminal"
+                          },
+                          "terminalId": {
+                            "type": "string"
+                          },
+                          "_meta": {}
+                        },
+                        "required": [
+                          "type",
+                          "terminalId"
                         ]
                       }
-                    },
-                    "required": [
-                      "type"
                     ]
                   },
                   "type": "array"

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -647,7 +647,14 @@
                             "type": "string"
                           },
                           "oldText": {
-                            "type": "string"
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           },
                           "newText": {
                             "type": "string"
@@ -914,7 +921,14 @@
                             "type": "string"
                           },
                           "oldText": {
-                            "type": "string"
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           },
                           "newText": {
                             "type": "string"

--- a/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
+++ b/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
@@ -1,179 +1,227 @@
 {
-  "type": "object",
-  "properties": {
-    "type": {
-      "type": "string"
-    },
-    "content": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "text"
-            },
-            "text": {
-              "type": "string"
-            },
-            "_meta": {},
-            "annotations": {
-              "type": "object",
-              "properties": {
-                "_meta": {}
-              }
-            }
-          },
-          "required": [
-            "type",
-            "text"
-          ]
+  "anyOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "content"
         },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "image"
-            },
-            "data": {
-              "type": "string"
-            },
-            "mimeType": {
-              "type": "string"
-            },
-            "_meta": {},
-            "annotations": {
+        "content": {
+          "anyOf": [
+            {
               "type": "object",
               "properties": {
-                "_meta": {}
-              }
-            }
-          },
-          "required": [
-            "type",
-            "data",
-            "mimeType"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "audio"
-            },
-            "data": {
-              "type": "string"
-            },
-            "mimeType": {
-              "type": "string"
-            },
-            "_meta": {},
-            "annotations": {
-              "type": "object",
-              "properties": {
-                "_meta": {}
-              }
-            }
-          },
-          "required": [
-            "type",
-            "data",
-            "mimeType"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "resource_link"
-            },
-            "name": {
-              "type": "string"
-            },
-            "uri": {
-              "type": "string"
-            },
-            "_meta": {},
-            "annotations": {
-              "type": "object",
-              "properties": {
-                "_meta": {}
-              }
-            }
-          },
-          "required": [
-            "type",
-            "name",
-            "uri"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "resource"
-            },
-            "_meta": {},
-            "annotations": {
-              "type": "object",
-              "properties": {
-                "_meta": {}
-              }
-            },
-            "resource": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "uri": {
-                      "type": "string"
-                    },
-                    "mimeType": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "uri",
-                    "text"
-                  ]
+                "type": {
+                  "type": "string",
+                  "const": "text"
                 },
-                {
+                "text": {
+                  "type": "string"
+                },
+                "_meta": {},
+                "annotations": {
                   "type": "object",
                   "properties": {
-                    "uri": {
-                      "type": "string"
+                    "_meta": {}
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "text"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "image"
+                },
+                "data": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "_meta": {},
+                "annotations": {
+                  "type": "object",
+                  "properties": {
+                    "_meta": {}
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "data",
+                "mimeType"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "audio"
+                },
+                "data": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "_meta": {},
+                "annotations": {
+                  "type": "object",
+                  "properties": {
+                    "_meta": {}
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "data",
+                "mimeType"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "resource_link"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "uri": {
+                  "type": "string"
+                },
+                "_meta": {},
+                "annotations": {
+                  "type": "object",
+                  "properties": {
+                    "_meta": {}
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "name",
+                "uri"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "resource"
+                },
+                "_meta": {},
+                "annotations": {
+                  "type": "object",
+                  "properties": {
+                    "_meta": {}
+                  }
+                },
+                "resource": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "uri": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uri",
+                        "text"
+                      ]
                     },
-                    "mimeType": {
-                      "type": "string"
-                    },
-                    "blob": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "uri": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "blob": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uri",
+                        "blob"
+                      ]
                     }
-                  },
-                  "required": [
-                    "uri",
-                    "blob"
                   ]
                 }
+              },
+              "required": [
+                "type",
+                "resource"
               ]
             }
-          },
-          "required": [
-            "type",
-            "resource"
           ]
-        }
+        },
+        "_meta": {}
+      },
+      "required": [
+        "type",
+        "content"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "diff"
+        },
+        "path": {
+          "type": "string"
+        },
+        "oldText": {
+          "type": "string"
+        },
+        "newText": {
+          "type": "string"
+        },
+        "_meta": {}
+      },
+      "required": [
+        "type",
+        "path",
+        "newText"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "terminal"
+        },
+        "terminalId": {
+          "type": "string"
+        },
+        "_meta": {}
+      },
+      "required": [
+        "type",
+        "terminalId"
       ]
     }
-  },
-  "required": [
-    "type"
   ]
 }

--- a/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
+++ b/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
@@ -193,7 +193,14 @@
           "type": "string"
         },
         "oldText": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "newText": {
           "type": "string"

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -474,17 +474,36 @@ let configOptionsUpdatedSchema = S.object(s => {
   configOptions: s.field("configOptions", S.array(sessionConfigOptionSchema)),
 })
 
-// Tool call content item (for tool_call_update)
-type toolCallContentItem = {
-  @as("type")
-  type_: string,
-  content: option<FrontmanProtocol__ContentBlock.t>,
-}
+type toolCallContentItem =
+  | Content({content: FrontmanProtocol__ContentBlock.t, _meta: option<JSON.t>})
+  | Diff({path: string, oldText: option<string>, newText: string, _meta: option<JSON.t>})
+  | Terminal({terminalId: string, _meta: option<JSON.t>})
 
-let toolCallContentItemSchema = S.object(s => {
-  type_: s.field("type", S.string),
-  content: s.field("content", S.option(FrontmanProtocol__ContentBlock.schema)),
-})
+let toolCallContentItemSchema = S.union([
+  S.object(s => {
+    s.tag("type", "content")
+    Content({
+      content: s.field("content", FrontmanProtocol__ContentBlock.schema),
+      _meta: s.field("_meta", S.option(S.json)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "diff")
+    Diff({
+      path: s.field("path", S.string),
+      oldText: s.field("oldText", S.option(S.string)),
+      newText: s.field("newText", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+    })
+  }),
+  S.object(s => {
+    s.tag("type", "terminal")
+    Terminal({
+      terminalId: s.field("terminalId", S.string),
+      _meta: s.field("_meta", S.option(S.json)),
+    })
+  }),
+])
 
 // Tool call status
 type toolCallStatus =

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -491,7 +491,7 @@ let toolCallContentItemSchema = S.union([
     s.tag("type", "diff")
     Diff({
       path: s.field("path", S.string),
-      oldText: s.field("oldText", S.option(S.string)),
+      oldText: s.field("oldText", S.nullableAsOption(S.string)),
       newText: s.field("newText", S.string),
       _meta: s.field("_meta", S.option(S.json)),
     })


### PR DESCRIPTION
## Summary
- replace loose ACP tool content records with typed content, diff, and terminal variants
- preserve ordered MCP text, image, audio, link, and resource blocks through live updates and history replay
- render tool images generically in a full-screen portal and fix Retina viewport screenshot cropping
- render embedded text resources and provide blob-resource downloads
- accept explicit `oldText: null` for conforming ACP new-file diffs
- remove screenshot-specific parsing and generic JSON/string fallback conversions

## Delivery size
- changed hand-written source/test lines: 243 < 500
- hand-written additions: 121
- hand-written deletions: 122
- changeset additions: 6
- generated schema additions: 1080
- generated schema deletions: 805

## Verification
- root ReScript build and formatting passed
- dead-code analysis reported zero issues
- direct runtime verification confirmed `oldText: null` decodes to `None`
- server precommit passed, including 727 tests and strict Credo
- frontman-client: 82/82 tests passed
- UI client: 321 passing with the same 14 unrelated failures in ChatGPT OAuth, load-session flow, and PromptInput expanded-text tests
- git diff --check passed
- pre-commit and pre-push hooks passed