### PR TITLE
Advertise real browser tool output schemas

### DIFF
--- a/.changeset/honest-browser-output-schemas.md
+++ b/.changeset/honest-browser-output-schemas.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/frontman-protocol": major
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/client": patch
+---
+
+Advertise output schemas only for browser tools that return structured content.

--- a/libs/client/src/tools/Client__Tool__ExecuteJs.res
+++ b/libs/client/src/tools/Client__Tool__ExecuteJs.res
@@ -45,6 +45,8 @@ type output = {
   logs: array<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 // ---------------------------------------------------------------------------
 // Raw JS helper — console capture + eval must stay in raw JS because it
 // monkey-patches the iframe's window.console and uses `new win.Function`.

--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -75,6 +75,8 @@ type output = {
   error: option<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 // ============================================================================
 // Constants
 // ============================================================================

--- a/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
+++ b/libs/client/src/tools/Client__Tool__GetInteractiveElements.res
@@ -68,6 +68,8 @@ type output = {
   error: option<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 let execute = async (
   input: input,
   ~taskId as _taskId: string,

--- a/libs/client/src/tools/Client__Tool__InteractWithElement.res
+++ b/libs/client/src/tools/Client__Tool__InteractWithElement.res
@@ -65,6 +65,8 @@ type output = {
   error: option<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 // Dispatch hover events (mouseenter + mouseover) on an element
 let dispatchHoverEvents = (el: WebAPI.DOMAPI.element): unit => {
   let enterEvt = WebAPI.MouseEvent.make(

--- a/libs/client/src/tools/Client__Tool__Question.res
+++ b/libs/client/src/tools/Client__Tool__Question.res
@@ -48,6 +48,8 @@ type output = {
   cancelled: bool,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 let execute = async (
   input: input,
   ~taskId: string,

--- a/libs/client/src/tools/Client__Tool__SearchText.res
+++ b/libs/client/src/tools/Client__Tool__SearchText.res
@@ -64,6 +64,8 @@ type output = {
   error: option<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 let defaultMaxResults = 25
 let defaultContextChars = 80
 

--- a/libs/client/src/tools/Client__Tool__SetDeviceMode.res
+++ b/libs/client/src/tools/Client__Tool__SetDeviceMode.res
@@ -60,6 +60,8 @@ type output = {
   error: option<string>,
 }
 
+let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
+
 // Find a preset by name (case-insensitive exact match)
 let findPresetByName = (name: string): option<Client__DeviceMode.devicePreset> => {
   let lowerName = name->String.toLowerCase

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -7,7 +7,8 @@ let name = Tool.ToolNames.takeScreenshot
 let access = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Read
 let visibleToAgent = true
 let executionMode = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.Synchronous
-let description = "Take a screenshot of the current web preview page. By default captures only the visible viewport. Set fullPage to true to capture the entire scrollable page. Returns a base64-encoded JPEG image data URL."
+let description = "Take a screenshot of the current web preview page. By default captures only the visible viewport. Set fullPage to true to capture the entire scrollable page."
+let outputJsonSchema = None
 
 @schema
 type input = {
@@ -17,14 +18,6 @@ type input = {
     "When true, captures the entire scrollable page instead of just the visible viewport. Defaults to false."
   )
   fullPage: option<bool>,
-}
-
-@schema
-type output = {
-  @s.describe("Base64-encoded JPEG image data URL (data:image/jpeg;base64,...)") @live
-  screenshot: option<string>,
-  @s.describe("Error message if the screenshot could not be taken") @live
-  error: option<string>,
 }
 
 // Image limits and scale computation are shared via Client__ImageLimits

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -4,46 +4,26 @@ module ToolRegistry = Client__ToolRegistry
 module FrontmanClient = FrontmanAiFrontmanClient
 module Relay = FrontmanClient.FrontmanClient__Relay
 module MCPServer = FrontmanClient.FrontmanClient__MCP__Server
+module MCP = FrontmanAiFrontmanProtocol.FrontmanProtocol__MCP
 
-let toolNames = (framework): array<string> => {
+let toolDefinitions = framework => {
   let registry = ToolRegistry.forFramework(framework)
   let relay = Relay.make(~baseUrl="http://localhost:3000")
   let server = ToolRegistry.registerAll(registry, MCPServer.make(~relay))
-
   server
   ->MCPServer.getToolsJson
-  ->Array.filterMap(json =>
-    json
-    ->JSON.Decode.object
-    ->Option.flatMap(obj => obj->Dict.get("name"))
-    ->Option.flatMap(JSON.Decode.string)
+  ->Array.map(json => json->JSON.Decode.object->Option.getOrThrow)
+}
+
+let toolNames = framework =>
+  toolDefinitions(framework)->Array.map(obj =>
+    obj->Dict.get("name")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
   )
-}
 
-let toolAccessByName = (framework): Dict.t<string> => {
-  let registry = ToolRegistry.forFramework(framework)
-  let relay = Relay.make(~baseUrl="http://localhost:3000")
-  let server = ToolRegistry.registerAll(registry, MCPServer.make(~relay))
-  let accessByName = Dict.make()
-
-  server
-  ->MCPServer.getToolsJson
-  ->Array.forEach(json => {
-    switch json->JSON.Decode.object {
-    | Some(obj) =>
-      switch (
-        obj->Dict.get("name")->Option.flatMap(JSON.Decode.string),
-        obj->Dict.get("access")->Option.flatMap(JSON.Decode.string),
-      ) {
-      | (Some(name), Some(access)) => accessByName->Dict.set(name, access)
-      | _ => ()
-      }
-    | None => ()
-    }
-  })
-
-  accessByName
-}
+let toolByName = (framework, name) =>
+  toolDefinitions(framework)
+  ->Array.find(obj => obj->Dict.get("name") == Some(JSON.Encode.string(name)))
+  ->Option.getOrThrow
 
 describe("ToolRegistry", _t => {
   test("registers core browser tools for non-Astro frameworks", t => {
@@ -73,10 +53,30 @@ describe("ToolRegistry", _t => {
   })
 
   test("serializes browser tool access levels", t => {
-    let access = toolAccessByName(Client__RuntimeConfig.Nextjs)
+    let access = name => toolByName(Client__RuntimeConfig.Nextjs, name)->Dict.get("access")
 
-    t->expect(access->Dict.get("take_screenshot"))->Expect.toEqual(Some("read"))
-    t->expect(access->Dict.get("execute_js"))->Expect.toEqual(Some("read-write"))
-    t->expect(access->Dict.get("set_device_mode"))->Expect.toEqual(Some("write"))
+    t->expect(access("take_screenshot"))->Expect.toEqual(Some(JSON.Encode.string("read")))
+    t->expect(access("execute_js"))->Expect.toEqual(Some(JSON.Encode.string("read-write")))
+    t->expect(access("set_device_mode"))->Expect.toEqual(Some(JSON.Encode.string("write")))
+  })
+
+  test("advertises only structured browser output schemas", t => {
+    toolDefinitions(Client__RuntimeConfig.Astro)->Array.forEach(
+      tool => {
+        let isScreenshot = tool->Dict.get("name") == Some(JSON.Encode.string("take_screenshot"))
+        t->expect(tool->Dict.has("outputSchema"))->Expect.toBe(!isScreenshot)
+      },
+    )
+  })
+
+  test("screenshot data becomes image content", t => {
+    let result = Client__Tool__TakeScreenshot.imageResultFromDataUrl(
+      "data:image/jpeg;base64,image-data",
+    )
+
+    let json = result->S.decodeOrThrow(~from=MCP.CallToolResult.schema, ~to=S.json)
+    t
+    ->expect(JSON.stringify(json))
+    ->Expect.toBe(`{"content":[{"type":"image","data":"image-data","mimeType":"image/jpeg"}]}`)
   })
 })

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetAstroAudit.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetAstroAudit.res
@@ -200,9 +200,8 @@ let make = (~getPreviewDoc: unit => option<Tool.previewContext>): module(Tool.Br
       let executionMode = executionMode
       let description = description
       type input = input
-      type output = output
       let inputSchema = inputSchema
-      let outputSchema = outputSchema
+      let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
       let execute = async (_input, ~taskId as _, ~toolCallId as _) =>
         switch getPreviewDoc() {
         | None => emptyResult(~message="Preview iframe is not available")

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -61,29 +61,21 @@ let executionModeSchema = S.union([
   S.literal(ToolTypes.Interactive),
 ])
 
-// Tool wire format schema - serialized directly to JSON
-let toolWireSchema = S.object(s => {
-  {
-    "name": s.field("name", S.string),
-    "description": s.field("description", S.string),
-    "access": s.field("access", ToolTypes.accessSchema),
-    "inputSchema": s.field("inputSchema", S.json),
-    "visibleToAgent": s.field("visibleToAgent", S.bool),
-    "executionMode": s.field("executionMode", executionModeSchema),
-  }
-})
-
 // Serialize a tool module to JSON
 let serializeTool = (m: module(Tool.Tool)): JSON.t => {
   module T = unpack(m)
-  {
-    "name": T.name,
-    "description": T.description,
-    "access": T.access,
+  let definition = dict{
+    "name": JSON.Encode.string(T.name),
+    "description": JSON.Encode.string(T.description),
+    "access": T.access->S.decodeOrThrow(~from=ToolTypes.accessSchema, ~to=S.json),
     "inputSchema": T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
-    "visibleToAgent": T.visibleToAgent,
-    "executionMode": T.executionMode,
-  }->S.decodeOrThrow(~from=toolWireSchema, ~to=S.json->S.noValidation(true))
+    "visibleToAgent": JSON.Encode.bool(T.visibleToAgent),
+    "executionMode": T.executionMode->S.decodeOrThrow(~from=executionModeSchema, ~to=S.json),
+  }
+  T.outputJsonSchema->Option.forEach(schema =>
+    definition->Dict.set("outputSchema", jsonSchemaAsJson(schema))
+  )
+  JSON.Encode.object(definition)
 }
 
 // Get tools as JSON array for MCP tools/list response

--- a/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Tool.res
@@ -76,9 +76,8 @@ module type BrowserTool = {
   let description: string
   let access: access
   type input
-  type output
   let inputSchema: S.t<input>
-  let outputSchema: S.t<output>
+  let outputJsonSchema: option<JSONSchema.t>
   let execute: (input, ~taskId: string, ~toolCallId: string) => promise<MCP.CallToolResult.t>
   //some tools we want to execute manually, and never have the llm see them
   let visibleToAgent: bool


### PR DESCRIPTION
## Summary

- advertise generated MCP `outputSchema` metadata for every structured browser tool
- omit `outputSchema` for the content-only `take_screenshot` tool and remove its stale base64 output contract
- serialize optional browser output schemas through `tools/list` and verify screenshots remain MCP image content

## Scope

This is the browser-registry half of Deliverable 5. The server/relay registry is intentionally deferred as the plan-permitted split so each change remains independently honest and net negative. Backend tools continue to advertise no output schemas in this change.

```text
changed hand-written source/test lines: 133 < 500
hand-written additions: 65
hand-written deletions: 68 (68 > 65)
changeset additions: 7
```

## Verification

- root ReScript build passed
- protocol schema check passed with no generated changes
- frontman-client: 97/97 tests passed
- UI client: 323 tests passed; the same 14 unrelated existing failures remain in ChatGPT OAuth, load-session flow, and PromptInput expanded-text tests
- ReScript formatting passed
- Biome passed
- dead-code analysis reported zero issues
- pre-commit and pre-push hooks passed
- `git diff --check` passed