### PR TITLE
Fix marketing site audit issues

### DIFF
--- a/.changeset/fix-marketing-site-audit.md
+++ b/.changeset/fix-marketing-site-audit.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Fix marketing crawl errors, weak internal linking, short metadata, and incomplete software rich-result markup found by the Ahrefs site audit.

--- a/apps/marketing/Makefile
+++ b/apps/marketing/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install test dev build deploy blog-cover
+.PHONY: help install test dev build deploy indexnow blog-cover
 
 PORT ?= 4321
 
@@ -20,6 +20,9 @@ build: ## Build for production
 
 deploy: build ## Build and deploy to Cloudflare Pages
 	op run --env-file=../../.env -- npx wrangler pages deploy dist --project-name=frontman-marketing --branch=main
+
+indexnow: build ## Submit sitemap URLs through IndexNow
+	node scripts/indexnow.mjs
 
 blog-cover: ## Generate blog cover image — usage: make blog-cover TITLE="Your Title" [FILE=output-name]
 	@test -n "$(TITLE)" || (echo "Usage: make blog-cover TITLE=\"Your Title\" [FILE=output-name]" && exit 1)

--- a/apps/marketing/public/_headers
+++ b/apps/marketing/public/_headers
@@ -26,6 +26,13 @@
 /rss.xml
   X-Robots-Tag: noindex
 
+# Keep Cloudflare email obfuscation from creating crawlable /cdn-cgi links.
+/contact/*
+  Cache-Control: no-transform
+
+/editorial-policy/*
+  Cache-Control: no-transform
+
 # Immutable cache for Astro hashed assets (images, JS, CSS)
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable

--- a/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
+++ b/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
@@ -90,17 +90,6 @@ const breadcrumbJsonLd = {
 			]
 		},
 		{
-			"@type": "SoftwareApplication",
-			"@id": "https://frontman.sh/#software",
-			"name": "Frontman",
-			"url": "https://frontman.sh/",
-			"description": "AI website editor for visual updates in WordPress, Next.js, Astro, Vite, React, Vue, Svelte, and SvelteKit sites.",
-			"applicationCategory": "BusinessApplication",
-			"operatingSystem": "Web, macOS, Windows, Linux",
-			"softwareRequirements": "Node.js or WordPress development environment",
-			"publisher": { "@id": "https://frontman.sh/#organization" }
-		},
-		{
 			"@type": "Service",
 			"@id": "https://frontman.sh/#service",
 			"name": "Frontman Pro",

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -66,10 +66,6 @@ export const footerNavigationData: FooterData = {
 					subCategoryLink: '/marketing-teams/'
 				},
 				{
-					subCategory: 'Pricing',
-					subCategoryLink: '/pricing/'
-				},
-				{
 					subCategory: 'About',
 					subCategoryLink: '/about/'
 				},

--- a/apps/marketing/src/config/footerNavigation.ts
+++ b/apps/marketing/src/config/footerNavigation.ts
@@ -66,6 +66,10 @@ export const footerNavigationData: FooterData = {
 					subCategoryLink: '/marketing-teams/'
 				},
 				{
+					subCategory: 'Pricing',
+					subCategoryLink: '/pricing/'
+				},
+				{
 					subCategory: 'About',
 					subCategoryLink: '/about/'
 				},
@@ -159,6 +163,10 @@ export const footerNavigationData: FooterData = {
 				{
 					subCategory: 'AI Releases',
 					subCategoryLink: '/open-source-ai-releases/'
+				},
+				{
+					subCategory: 'Blog Topics',
+					subCategoryLink: '/blog/tags/'
 				}
 			]
 		},

--- a/apps/marketing/src/config/navigationBar.ts
+++ b/apps/marketing/src/config/navigationBar.ts
@@ -46,6 +46,7 @@ export const navigationBarData: NavData = {
 			link: '/vs/',
 			submenu: [
 				{ name: 'All comparisons', link: '/vs/' },
+				{ name: 'vs OpenClaw', link: '/vs/openclaw/' },
 				{ name: 'vs Cursor', link: '/vs/cursor/' },
 				{ name: 'vs Copilot', link: '/vs/copilot/' },
 				{ name: 'vs Stagewise', link: '/vs/stagewise/' },

--- a/apps/marketing/src/content/docs/docs/reference/models.md
+++ b/apps/marketing/src/content/docs/docs/reference/models.md
@@ -1,6 +1,6 @@
 ---
 title: Models & Providers
-description: Complete list of AI providers, authentication methods, and available model IDs in Frontman.
+description: Compare AI providers supported by Frontman, including authentication methods, available model IDs, configuration details, and provider-specific limits.
 ---
 
 Frontman supports multiple AI providers. The available models depend on your provider and how you authenticate. See **[API Keys & Providers](/docs/api-keys/)** for setup instructions.

--- a/apps/marketing/src/content/seoMetadata.test.mjs
+++ b/apps/marketing/src/content/seoMetadata.test.mjs
@@ -1,0 +1,52 @@
+import {describe, expect, it} from 'vitest'
+import {readFile} from 'node:fs/promises'
+import {resolve} from 'node:path'
+
+const marketingRoot = resolve(import.meta.dirname, '../..')
+const readMarketingFile = (path) => readFile(resolve(marketingRoot, path), 'utf8')
+
+describe('site audit regressions', () => {
+  it('prevents Cloudflare from replacing support links with broken protection URLs', async () => {
+    const headers = await readMarketingFile('public/_headers')
+
+    expect(headers).toMatch(/\/contact\/\*\s+Cache-Control: no-transform/)
+    expect(headers).toMatch(/\/editorial-policy\/\*\s+Cache-Control: no-transform/)
+  })
+
+  it('gives the models reference an indexable search description', async () => {
+    const models = await readMarketingFile('src/content/docs/docs/reference/models.md')
+    const description = models.match(/^description:\s*(.+)$/m)?.[1]
+
+    expect(description?.length).toBeGreaterThanOrEqual(120)
+    expect(description?.length).toBeLessThanOrEqual(160)
+  })
+
+  it('links discoverable hubs and priority pages from relevant site sections', async () => {
+    const [blogIndex, footer, navigation, releasesRoute] = await Promise.all([
+      readMarketingFile('src/pages/blog/index.astro'),
+      readMarketingFile('src/config/footerNavigation.ts'),
+      readMarketingFile('src/config/navigationBar.ts'),
+      readMarketingFile('src/pages/open-source-ai-releases/[...id].astro'),
+    ])
+
+    expect(blogIndex).toContain('/blog/tags/')
+    expect(footer).toContain("subCategoryLink: '/blog/tags/'")
+    expect(footer).toContain("subCategoryLink: '/pricing/'")
+    expect(navigation).toContain("link: '/vs/openclaw/'")
+    expect(releasesRoute).toContain('relatedReleases')
+  })
+
+  it('does not claim Google software rich-result eligibility without review data', async () => {
+    const [globalSchema, wordpressPage, structuredDataFeed, schemaMap] = await Promise.all([
+      readMarketingFile('src/components/blocks/head/partials/StructuredData.astro'),
+      readMarketingFile('src/pages/wordpress.astro'),
+      readMarketingFile('src/pages/feeds/structured-data.jsonl.ts'),
+      readMarketingFile('src/pages/schema-map.xml.ts'),
+    ])
+
+    expect(globalSchema).not.toContain('"@type": "SoftwareApplication"')
+    expect(wordpressPage).not.toContain("'@type': 'SoftwareApplication'")
+    expect(structuredDataFeed).not.toContain("'@type': 'SoftwareApplication'")
+    expect(schemaMap).not.toContain('SoftwareApplication')
+  })
+})

--- a/apps/marketing/src/content/seoMetadata.test.mjs
+++ b/apps/marketing/src/content/seoMetadata.test.mjs
@@ -31,7 +31,7 @@ describe('site audit regressions', () => {
 
     expect(blogIndex).toContain('/blog/tags/')
     expect(footer).toContain("subCategoryLink: '/blog/tags/'")
-    expect(footer).toContain("subCategoryLink: '/pricing/'")
+    expect(footer).not.toContain("subCategoryLink: '/pricing/'")
     expect(navigation).toContain("link: '/vs/openclaw/'")
     expect(releasesRoute).toContain('relatedReleases')
   })

--- a/apps/marketing/src/layouts/ReleasesLayout.astro
+++ b/apps/marketing/src/layouts/ReleasesLayout.astro
@@ -1,5 +1,5 @@
 ---
-const { frontmatter, body } = Astro.props
+const { frontmatter, body, relatedReleases = [] } = Astro.props
 
 import Layout from './Layout.astro'
 import BlogPostHero from '../components/blocks/blog/BlogPostHero.astro'
@@ -78,6 +78,13 @@ const faqJsonLd = frontmatter.faq?.length
 		<slot />
 	</div>
 
+	<nav class="release-navigation" aria-label="Release archive navigation">
+		<a href="/open-source-ai-releases/">All open-source AI releases</a>
+		{relatedReleases.map((release: { id: string; title: string }) => (
+			<a href={`/open-source-ai-releases/${release.id}/`}>{release.title}</a>
+		))}
+	</nav>
+
 	{frontmatter.faq?.length && (
 		<section class="post-faq">
 			<div class="post-faq__container">
@@ -104,6 +111,12 @@ const faqJsonLd = frontmatter.faq?.length
 	@reference "../styles/global.css";
 	.post-body {
 		@apply mx-auto max-w-3xl px-6 py-12 lg:py-24;
+	}
+	.release-navigation {
+		@apply mx-auto flex max-w-3xl flex-col gap-3 border-t border-neutral-800 px-6 pb-12 pt-8 text-sm lg:pb-20;
+	}
+	.release-navigation a {
+		@apply text-primary-400 underline underline-offset-4 hover:text-primary-300;
 	}
 
 	.post-faq {

--- a/apps/marketing/src/pages/blog/index.astro
+++ b/apps/marketing/src/pages/blog/index.astro
@@ -54,5 +54,10 @@ const collectionJsonLd = {
 <Layout title={SEO.title} description={SEO.description}>
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(collectionJsonLd)} />
 	<Hero title={header.title} text={header.text} />
+	<nav class="flex justify-center bg-neutral-50 px-6 pb-4 dark:bg-neutral-950" aria-label="Blog topics">
+		<a href="/blog/tags/" class="text-sm font-semibold text-primary-600 underline-offset-4 hover:underline dark:text-primary-300">
+			Browse articles by topic
+		</a>
+	</nav>
 	<BlogPosts data={allPosts} />
 </Layout>

--- a/apps/marketing/src/pages/feeds/structured-data.jsonl.ts
+++ b/apps/marketing/src/pages/feeds/structured-data.jsonl.ts
@@ -18,13 +18,6 @@ const records = [
 	},
 	{
 		'@context': 'https://schema.org',
-		'@type': 'SoftwareApplication',
-		name: 'Frontman',
-		applicationCategory: 'DeveloperApplication',
-		operatingSystem: 'Web, macOS, Windows, Linux',
-	},
-	{
-		'@context': 'https://schema.org',
 		'@type': 'Service',
 		name: 'Frontman Pro',
 		serviceType: 'AI frontend coding agent',

--- a/apps/marketing/src/pages/open-source-ai-releases/[...id].astro
+++ b/apps/marketing/src/pages/open-source-ai-releases/[...id].astro
@@ -4,16 +4,25 @@ import { getCollection, render } from 'astro:content'
 
 export async function getStaticPaths() {
 	const entries = await getCollection('releases')
-	return entries.map((entry) => ({
+	const sortedEntries = [...entries].sort(
+		(a, b) => new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime()
+	)
+
+	return sortedEntries.map((entry, index) => ({
 		params: { id: decodeURI(entry.id) },
-		props: { entry }
+		props: {
+			entry,
+			relatedReleases: [sortedEntries[index - 1], sortedEntries[index + 1]]
+				.filter((relatedEntry) => relatedEntry !== undefined)
+				.map((relatedEntry) => ({ id: relatedEntry.id, title: relatedEntry.data.title }))
+		}
 	}))
 }
 
-const { entry } = Astro.props
+const { entry, relatedReleases } = Astro.props
 const { Content } = await render(entry)
 ---
 
-<Layout frontmatter={entry.data} body={entry.body}>
+<Layout frontmatter={entry.data} body={entry.body} relatedReleases={relatedReleases}>
 	<Content />
 </Layout>

--- a/apps/marketing/src/pages/schema-map.xml.ts
+++ b/apps/marketing/src/pages/schema-map.xml.ts
@@ -9,7 +9,7 @@ const schemaMap = `<?xml version="1.0" encoding="UTF-8"?>
     <loc>${origin}/feeds/structured-data.jsonl</loc>
     <type>application/ld+json-seq</type>
     <name>Frontman structured data feed</name>
-    <description>Machine-readable Organization, SoftwareApplication, Product, Service, and FAQ entities for Frontman.</description>
+    <description>Machine-readable Organization and Service entities for Frontman.</description>
   </feed>
   <feed>
     <loc>${origin}/rss.xml</loc>

--- a/apps/marketing/src/pages/wordpress.astro
+++ b/apps/marketing/src/pages/wordpress.astro
@@ -57,12 +57,13 @@ const pageJsonLd = {
 	'@context': 'https://schema.org',
 	'@graph': [
 		{
-			'@type': 'SoftwareApplication',
+			'@type': 'SoftwareSourceCode',
 			name: 'Frontman for WordPress',
-			applicationCategory: 'WordPress Plugin',
-			operatingSystem: 'WordPress',
 			description: SEO.description,
 			url: 'https://frontman.sh/wordpress/',
+			codeRepository: 'https://github.com/frontman-ai/frontman',
+			license: 'https://spdx.org/licenses/GPL-2.0-or-later.html',
+			runtimePlatform: 'WordPress',
 			sameAs: [pluginUrl, 'https://github.com/frontman-ai/frontman']
 		},
 		{


### PR DESCRIPTION
## Summary
- stop Cloudflare email obfuscation from generating broken crawl links
- strengthen internal linking for tags, OpenClaw, and release pages without exposing unannounced pricing
- fix short models metadata and remove incomplete software rich-result markup
- add SEO regression coverage and an IndexNow Make target

## Verification
- `make test` (19 tests passed)
- `make build` (145 pages, zero diagnostics or broken links)
- generated checks found zero short indexable descriptions, invalid structured data, or `SoftwareApplication` nodes
- `make indexnow` submitted 143 URLs successfully

## Post-deploy check
- verify `/contact/` and `/editorial-policy/` return `Cache-Control: no-transform` and contain no `/cdn-cgi/l/email-protection` links