### PR TITLE
Improve Google indexable content

### DIFF
--- a/.changeset/improve-google-index-content.md
+++ b/.changeset/improve-google-index-content.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Improve Google indexability with thin-tag controls, page-specific structured data, truthful sitemap dates, stronger documentation, and differentiated evidence-backed articles.

--- a/apps/marketing/Makefile
+++ b/apps/marketing/Makefile
@@ -10,7 +10,7 @@ install: ## Install dependencies
 	yarn install
 
 test: ## Run marketing tests
-	yarn run -T vitest run src/integrations/*.test.mjs src/content/*Metadata.test.mjs
+	yarn run -T vitest run src/integrations/*.test.mjs src/content/*.test.mjs
 
 dev: ## Start development server
 	yarn dev --port $(PORT)

--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -9,7 +9,10 @@ import fs from "node:fs";
 import hcStarlight from "hc-starlight";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
-import { isIndexableTagCount } from "./src/utils/tagIndexability.mjs";
+import {
+  isIndexableTagCount,
+  parseFrontmatterTags,
+} from "./src/utils/tagIndexability.mjs";
 
 const appRoot = path.resolve(import.meta.dirname);
 
@@ -43,11 +46,7 @@ for (const file of fs
     "utf-8",
   );
   const postDate = blogDateMap.get(file.replace(/\.md$/, ""));
-  const tags =
-    raw
-      .match(/^tags:\s*\[([^\]]*)\]/m)?.[1]
-      .split(",")
-      .map((tag) => tag.trim().replace(/^['"]|['"]$/g, "")) ?? [];
+  const tags = parseFrontmatterTags(raw);
   for (const tag of tags) {
     blogTagCounts.set(tag, (blogTagCounts.get(tag) ?? 0) + 1);
     if (

--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -6,9 +6,10 @@ import brokenLinksChecker from "astro-broken-links-checker";
 import consent from "./src/integrations/consent.mjs";
 import path from "node:path";
 import fs from "node:fs";
-import hcStarlight from 'hc-starlight';
+import hcStarlight from "hc-starlight";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
+import { isIndexableTagCount } from "./src/utils/tagIndexability.mjs";
 
 const appRoot = path.resolve(import.meta.dirname);
 
@@ -18,7 +19,8 @@ function buildDateMap(dir) {
   const map = new Map();
   for (const file of fs.readdirSync(dir).filter((f) => f.endsWith(".md"))) {
     const raw = fs.readFileSync(path.join(dir, file), "utf-8");
-    const match = raw.match(/^updatedDate:\s*(.+)$/m) ?? raw.match(/^pubDate:\s*(.+)$/m);
+    const match =
+      raw.match(/^updatedDate:\s*(.+)$/m) ?? raw.match(/^pubDate:\s*(.+)$/m);
     if (match) {
       const slug = file.replace(/\.md$/, "");
       map.set(slug, new Date(match[1].trim()));
@@ -28,8 +30,43 @@ function buildDateMap(dir) {
 }
 
 const blogDateMap = buildDateMap(path.resolve(appRoot, "src/content/blog"));
-const releasesDateMap = buildDateMap(path.resolve(appRoot, "src/content/releases"));
-const staticContentLastmod = new Date("2026-07-07T00:00:00Z");
+const releasesDateMap = buildDateMap(
+  path.resolve(appRoot, "src/content/releases"),
+);
+const blogTagCounts = new Map();
+const blogTagDates = new Map();
+for (const file of fs
+  .readdirSync(path.resolve(appRoot, "src/content/blog"))
+  .filter((entry) => entry.endsWith(".md"))) {
+  const raw = fs.readFileSync(
+    path.resolve(appRoot, "src/content/blog", file),
+    "utf-8",
+  );
+  const postDate = blogDateMap.get(file.replace(/\.md$/, ""));
+  const tags =
+    raw
+      .match(/^tags:\s*\[([^\]]*)\]/m)?.[1]
+      .split(",")
+      .map((tag) => tag.trim().replace(/^['"]|['"]$/g, "")) ?? [];
+  for (const tag of tags) {
+    blogTagCounts.set(tag, (blogTagCounts.get(tag) ?? 0) + 1);
+    if (
+      postDate &&
+      (!blogTagDates.has(tag) || postDate > blogTagDates.get(tag))
+    )
+      blogTagDates.set(tag, postDate);
+  }
+}
+const comparisonReviewSource = fs.readFileSync(
+  path.resolve(appRoot, "src/content/frontmanFacts.ts"),
+  "utf-8",
+);
+const comparisonReviewDateMatch = comparisonReviewSource.match(
+  /comparisonReviewCheckedAt\s*=\s*['"]([^'"]+)['"]/,
+);
+const comparisonReviewDate = comparisonReviewDateMatch
+  ? new Date(comparisonReviewDateMatch[1])
+  : undefined;
 const monorepoRoot = path.resolve(appRoot, "../..");
 
 function validateDocsDescriptions() {
@@ -73,11 +110,14 @@ function validateDocsDescriptions() {
     throw new Error(
       `[SEO] The following docs pages are missing a description in their frontmatter:\n${details}\n\n` +
         `Every docs page needs a description for SEO meta tags. Add one to the frontmatter:\n` +
-        `---\ntitle: My Page\ndescription: A short summary of this page for search engines.\n---`
+        `---\ntitle: My Page\ndescription: A short summary of this page for search engines.\n---`,
     );
   }
 
-  return { name: "validate-docs-descriptions", hooks: { "astro:config:done": () => {} } };
+  return {
+    name: "validate-docs-descriptions",
+    hooks: { "astro:config:done": () => {} },
+  };
 }
 
 // https://astro.build/config
@@ -130,22 +170,33 @@ export default defineConfig({
             { label: "Introduction", slug: "docs" },
             { label: "Installation", slug: "docs/installation" },
             { label: "API Keys & Providers", slug: "docs/api-keys" },
-
           ],
         },
         {
           label: "Using Frontman",
           collapsed: true,
           items: [
-            { label: "How the Agent Works", slug: "docs/using/how-the-agent-works" },
+            {
+              label: "How the Agent Works",
+              slug: "docs/using/how-the-agent-works",
+            },
             { label: "Sending Prompts", slug: "docs/using/sending-prompts" },
             { label: "Annotations", slug: "docs/using/annotations" },
             { label: "The Web Preview", slug: "docs/using/web-preview" },
-            { label: "Tool Capabilities", slug: "docs/using/tool-capabilities" },
+            {
+              label: "Tool Capabilities",
+              slug: "docs/using/tool-capabilities",
+            },
             { label: "The Question Flow", slug: "docs/using/question-flow" },
             { label: "Plans & Todo Lists", slug: "docs/using/plans-and-todos" },
-            { label: "Prompt Strategies", slug: "docs/using/prompt-strategies" },
-            { label: "Limitations & Workarounds", slug: "docs/using/limitations" },
+            {
+              label: "Prompt Strategies",
+              slug: "docs/using/prompt-strategies",
+            },
+            {
+              label: "Limitations & Workarounds",
+              slug: "docs/using/limitations",
+            },
           ],
         },
         {
@@ -162,17 +213,32 @@ export default defineConfig({
           label: "Reference",
           collapsed: true,
           items: [
-            { label: "Configuration Options", slug: "docs/reference/configuration" },
+            {
+              label: "Configuration Options",
+              slug: "docs/reference/configuration",
+            },
             { label: "Environment Variables", slug: "docs/reference/env-vars" },
             { label: "Models & Providers", slug: "docs/reference/models" },
-            { label: "Supported Frameworks", slug: "docs/reference/compatibility" },
-            { label: "Architecture Overview", slug: "docs/reference/architecture" },
-            { label: "Troubleshooting", slug: "docs/reference/troubleshooting" },
+            {
+              label: "Supported Frameworks",
+              slug: "docs/reference/compatibility",
+            },
+            {
+              label: "Architecture Overview",
+              slug: "docs/reference/architecture",
+            },
+            {
+              label: "Troubleshooting",
+              slug: "docs/reference/troubleshooting",
+            },
             { label: "Self-Hosting", slug: "docs/reference/self-hosting" },
           ],
         },
       ],
-      customCss: ["./src/styles/starlight.css", "./src/cookiebanner/styles.css"],
+      customCss: [
+        "./src/styles/starlight.css",
+        "./src/cookiebanner/styles.css",
+      ],
       editLink: {
         baseUrl:
           "https://github.com/frontman-ai/frontman/edit/main/apps/marketing/",
@@ -183,74 +249,98 @@ export default defineConfig({
     }),
     consent(),
     frontman({
-    projectRoot: appRoot,
-    sourceRoot: monorepoRoot,
-    basePath: "frontman",
-    serverName: "marketing",
-  }), icon(), brokenLinksChecker({ throwError: true, checkExternalLinks: false }), sitemap({
-    serialize: (item) => {
-      // Exclude integration redirect pages — they 301 to /docs/integrations/*,
-      // which are already in the sitemap.
-      if (/(?<!\/docs)\/integrations\/(astro|nextjs|vite)\/?$/.test(item.url)) return undefined;
-      // Exclude noindexed stub pages that exist only for sidebar navigation.
-      if (/\/docs\/guides\/?$/.test(item.url)) return undefined;
-      // Exclude explicit noindex pages from sitemap output.
-      if (/\/404\/?$/.test(item.url)) return undefined;
+      projectRoot: appRoot,
+      sourceRoot: monorepoRoot,
+      basePath: "frontman",
+      serverName: "marketing",
+    }),
+    icon(),
+    brokenLinksChecker({ throwError: true, checkExternalLinks: false }),
+    sitemap({
+      serialize: (item) => {
+        const tagMatch = item.url.match(/\/blog\/tags\/([^/]+)\/?$/);
+        if (
+          tagMatch &&
+          !isIndexableTagCount(blogTagCounts.get(tagMatch[1]) ?? 0)
+        )
+          return undefined;
+        // Exclude integration redirect pages — they 301 to /docs/integrations/*,
+        // which are already in the sitemap.
+        if (/(?<!\/docs)\/integrations\/(astro|nextjs|vite)\/?$/.test(item.url))
+          return undefined;
+        // Exclude noindexed stub pages that exist only for sidebar navigation.
+        if (/\/docs\/guides\/?$/.test(item.url)) return undefined;
+        // Exclude explicit noindex pages from sitemap output.
+        if (/\/404\/?$/.test(item.url)) return undefined;
 
-      // Use real publication dates where available. Static pages share a
-      // manual source date so child sitemap indexes do not appear undated.
-      const blogMatch = item.url.match(/\/blog\/([^/]+)\/?$/);
-      const releasesMatch = item.url.match(/\/open-source-ai-releases\/([^/]+)\/?$/);
-      if (blogMatch && blogDateMap.has(blogMatch[1])) {
-        item.lastmod = blogDateMap.get(blogMatch[1]);
-      } else if (releasesMatch && releasesDateMap.has(releasesMatch[1])) {
-        item.lastmod = releasesDateMap.get(releasesMatch[1]);
-      } else {
-        item.lastmod = staticContentLastmod;
-      }
+        // Use real content dates where available; omit unknown dates rather than
+        // presenting one synthetic modification date for unrelated pages.
+        const blogMatch = item.url.match(/\/blog\/([^/]+)\/?$/);
+        const releasesMatch = item.url.match(
+          /\/open-source-ai-releases\/([^/]+)\/?$/,
+        );
+        if (tagMatch && blogTagDates.has(tagMatch[1])) {
+          item.lastmod = blogTagDates.get(tagMatch[1]);
+        } else if (blogMatch && blogDateMap.has(blogMatch[1])) {
+          item.lastmod = blogDateMap.get(blogMatch[1]);
+        } else if (releasesMatch && releasesDateMap.has(releasesMatch[1])) {
+          item.lastmod = releasesDateMap.get(releasesMatch[1]);
+        } else if (/\/vs\/[^/]+\/?$/.test(item.url) && comparisonReviewDate) {
+          item.lastmod = comparisonReviewDate;
+        }
 
-      // Assign priority and changefreq by page type.
-      if (item.url === 'https://frontman.sh/') {
-        item.priority = 1.0;
-        item.changefreq = 'weekly';
-      } else if (/\/(pricing|features|how-it-works)\/?$/.test(item.url) || /\/use-cases\//.test(item.url)) {
-        item.priority = 0.9;
-        item.changefreq = 'monthly';
-      } else if (/\/vs\//.test(item.url) || /(?<!\/docs)\/integrations\//.test(item.url)) {
-        item.priority = 0.8;
-        item.changefreq = 'monthly';
-      } else if (/\/blog\/(?!tags\/)/.test(item.url) || /\/open-source-ai-releases\//.test(item.url)) {
-        item.priority = 0.7;
-        item.changefreq = 'never';
-      } else if (/\/docs\//.test(item.url)) {
-        item.priority = 0.7;
-        item.changefreq = 'monthly';
-      } else {
-        item.priority = 0.5;
-        item.changefreq = 'monthly';
-      }
+        // Assign priority and changefreq by page type.
+        if (item.url === "https://frontman.sh/") {
+          item.priority = 1.0;
+          item.changefreq = "weekly";
+        } else if (
+          /\/(pricing|features|how-it-works)\/?$/.test(item.url) ||
+          /\/use-cases\//.test(item.url)
+        ) {
+          item.priority = 0.9;
+          item.changefreq = "monthly";
+        } else if (
+          /\/vs\//.test(item.url) ||
+          /(?<!\/docs)\/integrations\//.test(item.url)
+        ) {
+          item.priority = 0.8;
+          item.changefreq = "monthly";
+        } else if (
+          /\/blog\/(?!tags\/)/.test(item.url) ||
+          /\/open-source-ai-releases\//.test(item.url)
+        ) {
+          item.priority = 0.7;
+          item.changefreq = "never";
+        } else if (/\/docs\//.test(item.url)) {
+          item.priority = 0.7;
+          item.changefreq = "monthly";
+        } else {
+          item.priority = 0.5;
+          item.changefreq = "monthly";
+        }
 
-      return item;
-    },
-    // Split sitemap into content-grouped child sitemaps instead of a
-    // single flat sitemap-0.xml. URLs that don't match any chunk land
-    // in the default sitemap-pages-0.xml.
-    chunks: {
-      posts: (item) => {
-        if (/\/blog\/(?!tags\/)/.test(item.url)) return item;
+        return item;
       },
-      releases: (item) => {
-        if (/\/open-source-ai-releases\//.test(item.url)) return item;
+      // Split sitemap into content-grouped child sitemaps instead of a
+      // single flat sitemap-0.xml. URLs that don't match any chunk land
+      // in the default sitemap-pages-0.xml.
+      chunks: {
+        posts: (item) => {
+          if (/\/blog\/(?!tags\/)/.test(item.url)) return item;
+        },
+        releases: (item) => {
+          if (/\/open-source-ai-releases\//.test(item.url)) return item;
+        },
+        comparisons: (item) => {
+          if (/\/vs\//.test(item.url)) return item;
+        },
+        integrations: (item) => {
+          if (/(?<!\/docs)\/integrations\//.test(item.url)) return item;
+        },
+        docs: (item) => {
+          if (/\/docs\//.test(item.url)) return item;
+        },
       },
-      comparisons: (item) => {
-        if (/\/vs\//.test(item.url)) return item;
-      },
-      integrations: (item) => {
-        if (/(?<!\/docs)\/integrations\//.test(item.url)) return item;
-      },
-      docs: (item) => {
-        if (/\/docs\//.test(item.url)) return item;
-      },
-    },
-  })],
+    }),
+  ],
 });

--- a/apps/marketing/src/components/blocks/head/Header.astro
+++ b/apps/marketing/src/components/blocks/head/Header.astro
@@ -48,35 +48,55 @@ const {
 } = Astro.props
 ---
 
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<meta name="color-scheme" content="dark light" />
-	<link rel="preload" href={interLatinUrl} as="font" type="font/woff2" crossorigin />
-	<link rel="preload" href={outfitLatinUrl} as="font" type="font/woff2" crossorigin />
-	{googleAnalyticsMeasurementID && <GoogleAnalytics />}
-	<GoogleSearchConsole />
-	<meta name="yandex-verification" content="f7cb42505a6da42d" />
-	<Seo
-		title={title}
-		description={description}
-		ogImage={ogImage}
-		ogImageWidth={ogImageWidth}
-		ogImageHeight={ogImageHeight}
-		ogImageAlt={ogImageAlt}
-		canonical={canonical}
-		noindex={noindex}
-		article={article}
-	/>
-	<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-	<link rel="icon" href="/favicon.ico" sizes="48x48" />
-	<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-	<link rel="manifest" href="/site.webmanifest" />
-	<link rel="sitemap" href="/sitemap-index.xml" />
-	<link rel="alternate" type="text/markdown" title="Frontman markdown homepage" href="/index.md" />
-	<link rel="service-desc" type="application/linkset+json" title="Frontman API catalog" href="/.well-known/api-catalog" />
-	<link rel="service-desc" type="application/json" title="Frontman agent card" href="/.well-known/agent-card.json" />
-	<link rel="service-desc" type="application/json" title="Frontman MCP server card" href="/.well-known/mcp/server-card.json" />
-	<link rel="alternate" type="application/rss+xml" title="Frontman Blog" href="/rss.xml" />
-	<meta name="generator" content={Astro.generator} />
-	<meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />
-	<meta name="theme-color" content="#020617" media="(prefers-color-scheme: dark)" />
-	<StructuredData noindex={noindex} breadcrumbs={breadcrumbs} />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="color-scheme" content="dark light" />
+<link rel="preload" href={interLatinUrl} as="font" type="font/woff2" crossorigin />
+<link rel="preload" href={outfitLatinUrl} as="font" type="font/woff2" crossorigin />
+{googleAnalyticsMeasurementID && <GoogleAnalytics />}
+<GoogleSearchConsole />
+<meta name="yandex-verification" content="f7cb42505a6da42d" />
+<Seo
+	title={title}
+	description={description}
+	ogImage={ogImage}
+	ogImageWidth={ogImageWidth}
+	ogImageHeight={ogImageHeight}
+	ogImageAlt={ogImageAlt}
+	canonical={canonical}
+	noindex={noindex}
+	article={article}
+/>
+<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+<link rel="icon" href="/favicon.ico" sizes="48x48" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+<link rel="manifest" href="/site.webmanifest" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="alternate" type="text/markdown" title="Frontman markdown homepage" href="/index.md" />
+<link
+	rel="service-desc"
+	type="application/linkset+json"
+	title="Frontman API catalog"
+	href="/.well-known/api-catalog"
+/>
+<link
+	rel="service-desc"
+	type="application/json"
+	title="Frontman agent card"
+	href="/.well-known/agent-card.json"
+/>
+<link
+	rel="service-desc"
+	type="application/json"
+	title="Frontman MCP server card"
+	href="/.well-known/mcp/server-card.json"
+/>
+<link rel="alternate" type="application/rss+xml" title="Frontman Blog" href="/rss.xml" />
+<meta name="generator" content={Astro.generator} />
+<meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#020617" media="(prefers-color-scheme: dark)" />
+<StructuredData
+	title={title}
+	description={description}
+	noindex={noindex}
+	breadcrumbs={breadcrumbs}
+/>

--- a/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
+++ b/apps/marketing/src/components/blocks/head/partials/StructuredData.astro
@@ -4,6 +4,7 @@
 // Description: Injects Organization and BreadcrumbList schema markup for SEO.
 
 import { legalInfo } from '../../../../data/legalInfo'
+import { createWebPageSchema } from '../../../../utils/structuredData.mjs'
 
 type BreadcrumbItem = {
 	name: string
@@ -11,14 +12,19 @@ type BreadcrumbItem = {
 }
 
 type Props = {
+	title: string
+	description: string
 	noindex?: boolean
 	breadcrumbs?: BreadcrumbItem[]
 }
 
-const { noindex = false, breadcrumbs } = Astro.props
+const { title, description, noindex = false, breadcrumbs } = Astro.props
 
 // Generate breadcrumb structured data from the current URL
 const url = new URL(Astro.request.url)
+url.search = ''
+url.hash = ''
+const pageUrl = url.href
 const pathname = url.pathname
 const segments = pathname.split('/').filter(Boolean)
 
@@ -40,78 +46,76 @@ const breadcrumbItems = (breadcrumbs ?? defaultBreadcrumbItems)
 const shouldEmitBreadcrumbs = !noindex && breadcrumbItems.length > 1
 
 const breadcrumbJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "BreadcrumbList",
-	"itemListElement": breadcrumbItems.map((item, index) => ({
-		"@type": "ListItem",
-		"position": index + 1,
-		"name": item.name,
-		"item": {
-			"@type": "WebPage",
-			"@id": item.url,
-			"name": item.name
+	'@context': 'https://schema.org',
+	'@type': 'BreadcrumbList',
+	itemListElement: breadcrumbItems.map((item, index) => ({
+		'@type': 'ListItem',
+		position: index + 1,
+		name: item.name,
+		item: {
+			'@type': 'WebPage',
+			'@id': item.url,
+			name: item.name
 		}
 	}))
 }
 ---
 
-<script is:inline type="application/ld+json" set:html={JSON.stringify({
-	"@context": "https://schema.org",
-	"@graph": [
-		{
-			"@type": "Organization",
-			"@id": "https://frontman.sh/#organization",
-			"name": "Frontman",
-			"url": "https://frontman.sh/",
-			"description": "Frontman is an AI website editor for existing WordPress, Next.js, Astro, and Vite sites. It lets site owners, marketers, and designers click the live page and request reviewable updates.",
-			"foundingDate": "2025",
-			"logo": "https://frontman.sh/logo.svg",
-			"contactPoint": {
-				"@type": "ContactPoint",
-				"email": legalInfo.supportEmail,
-				"contactType": "customer support",
-				"url": "https://frontman.sh/contact/"
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify({
+		'@context': 'https://schema.org',
+		'@graph': [
+			{
+				'@type': 'Organization',
+				'@id': 'https://frontman.sh/#organization',
+				name: 'Frontman',
+				url: 'https://frontman.sh/',
+				description:
+					'Frontman is an AI website editor for existing WordPress, Next.js, Astro, and Vite sites. It lets site owners, marketers, and designers click the live page and request reviewable updates.',
+				foundingDate: '2025',
+				logo: 'https://frontman.sh/logo.svg',
+				contactPoint: {
+					'@type': 'ContactPoint',
+					email: legalInfo.supportEmail,
+					contactType: 'customer support',
+					url: 'https://frontman.sh/contact/'
+				},
+				address: {
+					'@type': 'PostalAddress',
+					streetAddress: legalInfo.streetAddress,
+					postalCode: legalInfo.postalCode,
+					addressLocality: legalInfo.city,
+					addressCountry: legalInfo.country
+				},
+				sameAs: [
+					'https://github.com/frontman-ai/frontman',
+					'https://twitter.com/frontman_agent',
+					'https://bsky.app/profile/frontman.sh',
+					'https://medium.com/@frontmanai',
+					'https://www.reddit.com/r/frontman_ai/',
+					'https://www.linkedin.com/company/111717783',
+					'http://www.wikidata.org/entity/Q138753470'
+				]
 			},
-			"address": {
-				"@type": "PostalAddress",
-				"streetAddress": legalInfo.streetAddress,
-				"postalCode": legalInfo.postalCode,
-				"addressLocality": legalInfo.city,
-				"addressCountry": legalInfo.country
+			{
+				'@type': 'Service',
+				'@id': 'https://frontman.sh/#service',
+				name: 'Frontman Pro',
+				serviceType: 'AI website editor',
+				provider: { '@id': 'https://frontman.sh/#organization' },
+				areaServed: 'Worldwide',
+				url: 'https://frontman.sh/'
 			},
-			"sameAs": [
-				"https://github.com/frontman-ai/frontman",
-				"https://twitter.com/frontman_agent",
-				"https://bsky.app/profile/frontman.sh",
-				"https://medium.com/@frontmanai",
-				"https://www.reddit.com/r/frontman_ai/",
-				"https://www.linkedin.com/company/111717783",
-				"http://www.wikidata.org/entity/Q138753470"
-			]
-		},
-		{
-			"@type": "Service",
-			"@id": "https://frontman.sh/#service",
-			"name": "Frontman Pro",
-			"serviceType": "AI website editor",
-			"provider": { "@id": "https://frontman.sh/#organization" },
-			"areaServed": "Worldwide",
-			"url": "https://frontman.sh/"
-		},
-		{
-			"@type": "WebPage",
-			"@id": "https://frontman.sh/#webpage",
-			"url": "https://frontman.sh/",
-			"name": "Frontman: AI Website Editor for Existing Sites",
-			"speakable": {
-				"@type": "SpeakableSpecification",
-				"cssSelector": ["#intro .hero-section__subtitle", "#intro .hero-section__geo-lead"]
-			}
-		}
-	]
-})} />
+			createWebPageSchema({ url: pageUrl, title, description })
+		]
+	})}
+/>
 
 {/* BreadcrumbList - helps Google show breadcrumb trails in search results */}
-{shouldEmitBreadcrumbs && (
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
-)}
+{
+	shouldEmitBreadcrumbs && (
+		<script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+	)
+}

--- a/apps/marketing/src/components/starlight/Head.astro
+++ b/apps/marketing/src/components/starlight/Head.astro
@@ -2,71 +2,80 @@
 // Starlight Head component override
 // Adds OG image, breadcrumb structured data, and ensures description is set
 
-import type { StarlightRouteData } from '@astrojs/starlight/route-data';
-import StarlightHead from '@astrojs/starlight/components/Head.astro';
+import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+import StarlightHead from '@astrojs/starlight/components/Head.astro'
+import { createWebPageSchema } from '../../utils/structuredData.mjs'
 
-type Props = StarlightRouteData;
+type Props = StarlightRouteData
 
-const ogImage = new URL('/og.png', Astro.site).href;
-const ogImageAlt = 'Frontman — The AI agent that lives inside your framework';
+const ogImage = new URL('/og.png', Astro.site).href
+const ogImageAlt = 'Frontman — The AI agent that lives inside your framework'
 
 // Build breadcrumb structured data
-const routeData = Astro.locals.starlightRoute ?? Astro.props;
-const entry = routeData.entry;
-const breadcrumbItems = [];
+const routeData = Astro.locals.starlightRoute ?? Astro.props
+const entry = routeData.entry
+const breadcrumbItems = []
+const pathname = Astro.url.pathname.replace(/\/$/, '')
+const slug = pathname.split('/').pop() ?? ''
+const fallbackTitle = slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+const entryTitle = typeof entry?.data?.title === 'string' ? entry.data.title.trim() : ''
+const routeTitle = typeof routeData.title === 'string' ? routeData.title.trim() : ''
+const pageTitle = entryTitle || routeTitle || fallbackTitle
+const entryDescription =
+	typeof entry?.data?.description === 'string' ? entry.data.description.trim() : ''
+const routeDescription =
+	typeof routeData.description === 'string' ? routeData.description.trim() : ''
+const pageDescription = entryDescription || routeDescription
+const pageUrl = new URL(Astro.url.pathname, Astro.site).href
 
 // Always add Home
 breadcrumbItems.push({
-  "@type": "ListItem",
-  "position": 1,
-  "name": "Home",
-  "item": {
-    "@type": "WebPage",
-    "@id": new URL('/', Astro.site).href,
-    "name": "Home"
-  }
-});
+	'@type': 'ListItem',
+	position: 1,
+	name: 'Home',
+	item: {
+		'@type': 'WebPage',
+		'@id': new URL('/', Astro.site).href,
+		name: 'Home'
+	}
+})
 
 // Add Docs root
 breadcrumbItems.push({
-  "@type": "ListItem",
-  "position": 2,
-  "name": "Docs",
-  "item": {
-    "@type": "WebPage",
-    "@id": new URL('/docs/', Astro.site).href,
-    "name": "Docs"
-  }
-});
+	'@type': 'ListItem',
+	position: 2,
+	name: 'Docs',
+	item: {
+		'@type': 'WebPage',
+		'@id': new URL('/docs/', Astro.site).href,
+		name: 'Docs'
+	}
+})
 
 // Add current page if it's a docs subpage (not the docs index itself)
-const pathname = Astro.url.pathname.replace(/\/$/, '');
-const isDocsIndex = pathname === '/docs' || pathname === '';
+const isDocsIndex = pathname === '/docs' || pathname === ''
 if (!isDocsIndex) {
-  // Starlight exposes the page title as entry.data.title, but also passes
-  // it via the top-level props. Fall back to capitalising the URL slug.
-  const slug = pathname.split('/').pop() ?? '';
-  const fallbackTitle = slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  const entryTitle = typeof entry?.data?.title === 'string' ? entry.data.title.trim() : '';
-  const routeTitle = typeof routeData.title === 'string' ? routeData.title.trim() : '';
-  const pageTitle = entryTitle || routeTitle || fallbackTitle;
-  breadcrumbItems.push({
-    "@type": "ListItem",
-    "position": 3,
-    "name": pageTitle,
-    "item": {
-      "@type": "WebPage",
-      "@id": new URL(Astro.url.pathname, Astro.site).href,
-      "name": pageTitle
-    }
-  });
+	breadcrumbItems.push({
+		'@type': 'ListItem',
+		position: 3,
+		name: pageTitle,
+		item: {
+			'@type': 'WebPage',
+			'@id': new URL(Astro.url.pathname, Astro.site).href,
+			name: pageTitle
+		}
+	})
 }
 
 const breadcrumbSchema = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": breadcrumbItems
-};
+	'@context': 'https://schema.org',
+	'@type': 'BreadcrumbList',
+	itemListElement: breadcrumbItems
+}
+const pageSchema = {
+	'@context': 'https://schema.org',
+	...createWebPageSchema({ url: pageUrl, title: pageTitle, description: pageDescription })
+}
 ---
 
 <StarlightHead {...Astro.props} />
@@ -84,4 +93,5 @@ const breadcrumbSchema = {
 <meta name="twitter:image:alt" content={ogImageAlt} />
 
 <!-- Breadcrumb Structured Data -->
+<script is:inline type="application/ld+json" set:html={JSON.stringify(pageSchema)} />
 <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/apps/marketing/src/components/ui/blog/TagNavigation.astro
+++ b/apps/marketing/src/components/ui/blog/TagNavigation.astro
@@ -7,8 +7,12 @@ import Badge from '../Badge.astro'
 
 //Data
 import { getCollection } from 'astro:content'
+import { countPostsByTag, isIndexableTagCount } from '../../../utils/tagIndexability.mjs'
 const posts = await getCollection('blog')
-const tags = [...new Set(posts.map((post) => post.data.tags).flat())]
+const tagCounts = countPostsByTag(posts)
+const tags = [...tagCounts.entries()]
+	.filter(([, count]) => isIndexableTagCount(count))
+	.map(([tag]) => tag)
 const currentPath = new URL(Astro.request.url).pathname
 const pathSegments = currentPath.split('/').filter((segment) => segment.length > 0)
 const currentTag = pathSegments[pathSegments.length - 1] || ''

--- a/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
+++ b/apps/marketing/src/content/blog/ai-coding-agents-blind-to-ui.md
@@ -1,148 +1,134 @@
 ---
 title: 'Why AI Coding Agents Need UI Context'
 pubDate: 2026-02-18T05:00:00Z
-description: "Designers and PMs know exactly what needs to change in the UI. They just can\u2019t change it without engineering. Framework-aware AI fixes that."
+description: 'A practical checklist for testing whether an AI coding tool has enough browser, layout, state, and source context for reliable UI work.'
 image: '/blog/ai-coding-agents-blind-to-ui-cover.png'
 tags: ['design-systems', 'design-ops', 'cross-functional']
-updatedDate: 2026-03-20T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 faq:
-  - question: "Can designers make code changes without knowing how to code?"
+  - question: 'Can designers make code changes without knowing how to code?'
     answer: >-
-      Yes. Frontman connects to your running application and lets you click any
-      element in the browser to select it. You describe the change you want in
-      plain language — "make this spacing tighter," "swap this to our secondary
-      color" — and Frontman traces the element back to the source code, makes
-      the edit, and verifies it via hot-reload. No file names, no code syntax,
-      no terminal commands.
-  - question: "Will this break our design system?"
+      Some browser-first tools let a user select rendered elements and request
+      changes without navigating source files. That lowers the entry barrier,
+      but it does not remove the need for code review, automated checks, or an
+      engineer when a change affects behavior, data flow, or architecture.
+  - question: 'Will a UI-aware agent preserve our design system?'
     answer: >-
-      Frontman is aware of your component tree and design tokens. It edits the
-      actual component source, not a one-off override, so changes stay within
-      your system's structure. Every change produces a standard code diff that
-      goes through your team's normal review process before merging.
-  - question: "How is this different from Figma-to-code tools?"
+      Runtime context alone does not guarantee design-system compliance. Check
+      whether the tool can identify shared components and tokens, show the exact
+      diff, and let reviewers assess the change's blast radius before merging.
+  - question: 'How is this different from Figma-to-code tools?'
     answer: >-
-      Figma-to-code tools generate new code from designs. Frontman edits your
-      existing codebase — the real components your users see in production. It
-      works with whatever you already have: your framework, your design tokens,
-      your component library. Nothing is regenerated or overwritten.
-  - question: "Does engineering still review the changes?"
+      Figma-to-code workflows generally translate a design artifact into code.
+      UI-aware coding tools operate against an already-running application and
+      modify its existing source. Teams may use both for different stages of work.
+  - question: 'Do coding agents have browser access now?'
     answer: >-
-      Absolutely. Every change Frontman makes is a normal code diff — a pull
-      request that your engineering team reviews, approves, and merges through
-      your existing workflow. Designers and PMs get to initiate changes;
-      engineering keeps full control of what ships.
+      Many do. Cursor documents browser tools, Claude Code integrates with Chrome,
+      and Chrome DevTools MCP can expose a live browser to compatible agents.
+      The useful question is not whether a browser can open, but which runtime
+      evidence the agent receives and whether it maps that evidence to source.
 author: 'Danni Friedland'
 articleSection: 'Problem Diagnosis'
 imageAlt: 'AI coding agent connecting live UI context to frontend source code'
 ---
 
-You spot a spacing issue on the pricing page. The cards feel too cramped — the padding inside each feature block needs to breathe. You know exactly what's wrong. You've known for two weeks.
+“Can this coding agent see the UI?” is now the wrong test.
 
-You open a Jira ticket. You annotate a screenshot in Figma. You tag the frontend team. The ticket lands in the next sprint planning. A developer picks it up eight days later, asks a clarifying question in the ticket comments, you answer, they ship it the following Wednesday. Fifteen days for a change you could point to with your finger.
+Several general-purpose agents can open or control a browser. [Claude Code's Chrome integration](https://code.claude.com/docs/en/chrome) documents DOM inspection, console and network evidence, screenshots, and interaction. [Cursor documents browser tools](https://cursor.com/docs/agent/tools/browser), and [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) can give compatible agents browser automation and debugging tools.
 
-This is not a process problem. This is an access problem.
+Browser access is useful, but it is not one capability. Reliable UI work depends on a chain of context: reproducing the right state, identifying the intended element, reading resolved layout, connecting that element to maintainable source, and checking the result. Use this checklist to evaluate that chain.
 
-> **TL;DR:** Designers and PMs can see what's wrong in the UI but can't fix it without filing a ticket and waiting for engineering. Frontman bridges that gap — you click any element in your running application, describe the change in plain language, and the AI traces it back to the source code, edits it, and verifies the result via hot-reload. The change goes through code review like any other PR. Your design system stays intact. Engineering keeps control. Shipping gets faster.
+## 1. Can It Reproduce the Relevant State?
 
-## The Bottleneck No One Talks About
+A page URL is rarely a complete bug report. UI output can depend on viewport size, authentication, feature flags, loaded data, interaction state, theme, and scroll position.
 
-Your team has a mature design system. Tokens for spacing, color, and typography. A component library your engineers built and maintain. Figma files that mirror what's in production. The system works.
+Test the tool with a state-specific request:
 
-What doesn't work is the last mile. The gap between "I can see this needs to change" and "this change is live." That gap is not a design problem or an engineering problem — it's a handoff problem. And it costs your team weeks of calendar time on changes that take minutes to describe.
+- Open the mobile navigation at a named viewport.
+- Reach an authenticated empty state without replacing it with mock markup.
+- Trigger a validation error or hover/focus state.
+- Report which state it inspected before editing code.
 
-Every visual change — a spacing tweak, a color adjustment, a copy update, a component variant swap — follows the same path: designer or PM notices it, files a ticket, engineer context-switches into it days later, asks clarifying questions because the ticket lost nuance, ships it, designer reviews, requests a small adjustment, engineer context-switches again.
+Passing means the agent can demonstrate that it reached the same state you meant. A screenshot of the default route is not evidence that it reproduced the issue.
 
-Multiply that by every team touching the product. Multiply it by every sprint. That is your design velocity.
+## 2. Can It Identify the Intended Element?
 
-## Why AI Coding Agents Don't Solve This
+Visual selection and DOM selection solve different problems. Coordinates identify a region of pixels. A DOM node adds attributes, text, ancestry, and accessibility structure. Framework provenance can add the component and source location that produced that node.
 
-You might think AI coding agents like Cursor, Claude Code, or Copilot could help. They can't — at least not for this.
+Ask the tool to show its evidence before editing:
 
-These agents operate on source files and terminal output. They read code, but they never open a browser — [the runtime context gap](/blog/runtime-context-gap/) in action. They never see the rendered page. The information they need for visual changes — which element is which on screen, what the computed spacing actually is, how components map back to source files — exists only in the running browser.
+- Which DOM node is selected?
+- Which component owns it?
+- Which source file and location are candidates?
+- Is the source component shared elsewhere?
 
-For an engineer who already knows the codebase, this means some guesswork and a few rounds of correction. Annoying but workable.
+Do not assume browser automation includes component-to-source mapping. For example, [React Developer Tools](https://react.dev/learn/react-developer-tools) exposes a component inspector because framework component data is a distinct layer from ordinary browser DOM access.
 
-For a designer or PM, it's a wall. You would need to know the file name, the component structure, the class naming convention, and the build system — just to describe to the agent what you're looking at. That is exactly the knowledge gap the ticket was supposed to bridge.
+## 3. Can It Read Resolved Styles and Geometry?
 
-## What Framework-Aware AI Changes
+Source code records inputs to layout, not always the rendered result. CSS cascade, inheritance, custom properties, fonts, breakpoints, container queries, and parent geometry contribute to what appears on screen.
 
-Frontman takes a different approach - what we call [browser-aware AI](/blog/what-are-browser-aware-ai-coding-tools/). It is one example of a [frontend agent](/blog/frontend-agent/) built around rendered UI context instead of source files alone. Instead of reading files and guessing what the UI looks like, it hooks into your framework - Next.js, Astro, Vite - and connects to the running browser. It has access to:
+A useful evaluation asks the agent to distinguish:
 
-- **The live UI** — the actual rendered page, not a code approximation
-- **Your component tree** — which component renders which element, mapped back to source files
-- **Computed styles** — real resolved values, not token names or class strings
-- **Hot-reload** — instant visual verification that the change looks right
+- authored declaration from computed value;
+- element width from available parent width;
+- margin or `gap` from apparent visual spacing;
+- a local style from a shared token or component variant;
+- current viewport behavior from behavior at other breakpoints.
 
-You click an element. You say what you want. Frontman traces that element through the component tree to its source, makes the edit, and confirms the result rendered correctly.
+Require concrete evidence, such as computed values or bounding rectangles, rather than “this class probably causes it.” Browser APIs can provide that evidence; whether a tool collects and uses it is an implementation choice.
 
-**You don't need to know the file name. You don't need to know the code. You point and describe.**
+## 4. Can It Trace Runtime Evidence Back to Maintainable Source?
 
-## What This Looks Like in Practice
+Finding a matching string is not the same as finding the correct edit point. A rendered value might come from a utility class, CSS variable, component prop, theme token, generated stylesheet, or parent layout.
 
-Here is the current flow for a spacing change in your design system:
+Use a deliberately ambiguous test. Select one instance of a reused card or button, then ask:
 
-```text
-Designer: *notices card padding is too tight on pricing page*
-Designer: *opens Jira, writes ticket, annotates Figma screenshot*
-Engineer: *picks up ticket 8 days later*
-Engineer: "Did you mean the inner padding or the card wrapper?"
-Designer: *replies next day with clarification*
-Engineer: *ships the change*
-Designer: *reviews* "Close, but can we also bump the gap between cards?"
-Engineer: *context-switches back, ships a follow-up*
-Total: ~15 days
-```
+- Is this change local or global?
+- Which source definition controls it?
+- What other instances could change?
+- Why is the proposed edit preferable to an inline override?
 
-Here is the same change with Frontman:
+Strong tools expose uncertainty when more than one source path is plausible. A confident but unsupported file choice should fail the evaluation.
 
-```text
-Designer: *clicks the card content area in the browser*
-Designer: "Make the padding inside these cards more spacious"
-Frontman: *reads current spacing from the live element*
-          *traces it to PricingCard component source*
-          *edits the component, hot-reload fires*
-Designer: *sees the change instantly* "That's it."
-Designer: *opens PR for engineering review*
-Total: ~5 minutes + review time
-```
+## 5. Does Verification Match the Acceptance Criterion?
 
-Same outcome. Same code review process. Same design system integrity. Fifteen fewer days on the calendar.
+Hot reload is feedback, not proof. [Vite's HMR documentation](https://vite.dev/guide/api-hmr) shows that updates may be accepted, invalidated, or escalated to a full reload. The tool still needs to inspect the resulting state.
 
-## Your Design System Stays Safe
+For a visual change, ask it to verify:
 
-This is usually the first concern: "If non-engineers can edit code, won't they break our component library?"
+- the target state still reproduces;
+- the intended computed value or geometry changed;
+- nearby breakpoints and shared instances did not regress;
+- console errors, tests, and type checks remain clean where applicable;
+- the final diff matches the requested scope.
 
-Three things protect your system:
+Visual inspection and automated checks complement each other. Neither substitutes for the other.
 
-**Frontman edits components, not overrides.** It traces clicked elements back through the component tree to the actual source component. It edits the real thing — not a one-off style override that breaks the next time someone updates the system.
+## 6. Are Permissions and Review Boundaries Clear?
 
-**Every change is a standard code diff.** Frontman produces a pull request. Your engineering team reviews it, comments, requests changes, or approves it — exactly like any other PR. No code ships without engineering sign-off.
+Browser-connected agents may see authenticated pages, form contents, network data, and console output. Chrome DevTools MCP explicitly warns that connected clients can inspect and modify browser data; Anthropic documents site permissions and approval behavior for Claude in Chrome.
 
-**The AI sees your component boundaries.** Frontman understands which element belongs to which component. It won't edit a shared Button component when you meant to change the spacing in the specific card layout that contains it. It respects the architecture your engineers built.
+Before adoption, establish:
 
-## Common Concerns
+- which origins and browser profiles the tool may access;
+- whether credentials or production data enter model context;
+- which files and commands it may modify or run;
+- whether every edit produces a reviewable diff;
+- who approves changes to shared components and tokens.
 
-**"Our codebase is too complex for non-engineers to touch."**
-That's the point — they don't touch the codebase. They interact with the running UI. Frontman handles the translation from "this element on screen" to "this line in this file." The complexity stays where it belongs: in the tools, not in the workflow.
+## A Simple Evaluation Scorecard
 
-**"Figma is our source of truth. Changes should flow from design to code."**
-Frontman doesn't replace Figma. For net-new design work — new pages, new components, major redesigns — Figma stays the starting point. Frontman handles the long tail: the spacing tweaks, token adjustments, responsive fixes, and copy changes that pile up in your backlog because they're too small to justify a full design-to-handoff cycle but too important to ignore.
+| Dimension          | Fail                           | Partial                      | Strong                                            |
+| ------------------ | ------------------------------ | ---------------------------- | ------------------------------------------------- |
+| State reproduction | Opens a URL                    | Reaches state with prompting | Records and rechecks exact state                  |
+| Target identity    | Screenshot or coordinates only | DOM node identified          | DOM, component, and source provenance             |
+| Style evidence     | Infers from source             | Reads some browser values    | Connects computed values and geometry to source   |
+| Edit scope         | Makes plausible edit           | Shows diff                   | Explains local/shared blast radius                |
+| Verification       | Reports completion             | Refreshes or screenshots     | Rechecks state, runtime evidence, and code checks |
+| Governance         | Broad implicit access          | Some prompts                 | Explicit permissions and review gates             |
 
-**"What about changes that need to propagate across the system?"**
-When Frontman edits a shared component, the change propagates everywhere that component is used — same as when an engineer edits it. Your team can review the blast radius in the PR diff before merging. For design token changes, the same principle applies: the AI edits the token definition, and the system handles propagation.
+Score tools against your actual work, not a canned demo. A terminal agent with browser tooling may be ideal for an engineer debugging a network failure. A browser-first [frontend agent](/blog/frontend-agent/) may fit a designer selecting rendered elements. The distinction is workflow and evidence quality, not whether one product has a browser icon.
 
-**"We tried low-code/no-code tools before. They generated unmaintainable code."**
-Frontman does not generate code. It edits your existing code — the same files, the same components, the same conventions your engineers already maintain. The output is a clean diff that follows your codebase's patterns because it's modifying code that already follows them.
-
-## The Bigger Picture
-
-This is not about saving time on one padding change. It is about who gets to participate in shipping product.
-
-Today, your [design system is a shared language](/blog/team-collaboration/) — but only engineers can write in it. Designers and PMs can describe changes. They can annotate screenshots. They can file tickets. But the act of making a change requires engineering time, and engineering time is the scarcest resource at every growing company.
-
-When anyone who can see a problem can also fix it — with full code review, within your existing system, respecting your component architecture — the bottleneck shifts. Engineering reviews diffs instead of translating tickets. Designers iterate at the speed of their own judgment. PMs ship copy and layout tweaks the same day they notice them.
-
-The wall between "people who can describe a change" and "people who can make a change" disappears. Not because you lowered the bar — because you gave everyone the same tool your codebase already understands.
-
-[Try Frontman](https://frontman.sh) — works with your existing project and design system. Read about [how Frontman keeps your code safe](/blog/security/) or see [how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/).
+For the architecture behind these layers, read [the runtime context gap](/blog/runtime-context-gap/). For a workflow comparison, see [Frontman vs Cursor vs Claude Code](/blog/frontman-vs-cursor-vs-claude-code/). Frontman's approach starts with direct element selection and framework context; [try Frontman](https://frontman.sh) or review [how Frontman keeps code safe](/blog/security/).

--- a/apps/marketing/src/content/blog/edit-website-without-developer.md
+++ b/apps/marketing/src/content/blog/edit-website-without-developer.md
@@ -2,115 +2,112 @@
 title: 'How PMs Can Edit a Website Without Developers'
 seoTitle: 'Edit a Website Without a Developer'
 pubDate: 2026-04-17T05:00:00Z
-description: 'Edit website copy, spacing, CTAs, and UI polish without filing a developer ticket. Frontman turns browser feedback into reviewable code changes.'
+description: 'A governance model for safe self-service website editing: define scope, separate authorship from approval, require review, and keep engineering accountable for what ships.'
 author: 'Danni Friedland'
 articleSection: 'Tutorial'
 image: '/blog/edit-website-without-developer-cover.png'
 imageAlt: 'Product manager editing a website directly in the browser'
 tags: ['product-management', 'design-ops', 'cross-functional']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 faq:
   - question: 'Do I need to set up a development environment to use Frontman?'
-    answer: "No. Your engineering team installs Frontman once during initial setup. After that, you open the browser and start working. No terminal, no IDE, no local server setup required on your end. You work in the browser the same way you already review builds."
+    answer: 'An engineer must first install and configure the appropriate Frontman integration. After that, an authorized teammate can work from the Frontman browser workspace connected to the development app rather than navigating the codebase in an IDE.'
   - question: 'What kinds of changes can a PM make without a developer?'
-    answer: 'Spacing, typography, colors, copy, button labels, CTAs, responsive layout adjustments, and component prop changes. Essentially: anything where the acceptance criterion is "it looks right" rather than "the logic is correct." Logic changes, API integrations, and data flow are still engineering work.'
+    answer: 'A team can permit narrowly scoped copy and visual proposals, such as labels, spacing, typography, approved design-token use, and existing component props. Business logic, authentication, data access, permissions, billing, dependencies, and infrastructure should remain engineer-owned.'
   - question: 'Will I accidentally break something?'
-    answer: 'The same safeguards that protect the codebase from engineering mistakes protect it from yours. Every change Frontman makes is a pull request. Your engineering team reviews the diff before anything merges. CI runs. Nothing ships without approval. You initiate the change; engineering controls what goes out.'
-  - question: "How is this different from a CMS?"
-    answer: "A CMS lets you edit content in a content management layer: blog posts, product copy, structured data. Frontman edits the actual UI components in your codebase. That includes spacing, layout, design system values, and component structure. Text is just one part of what you can change. It's the difference between editing what a component says and editing what a component looks like."
+    answer: 'No tool can guarantee that an edit is safe. Reduce risk by working on a branch, reviewing the source diff and browser result, running required CI checks, and requiring an engineer or code owner to approve before merge.'
+  - question: 'How is this different from a CMS?'
+    answer: 'A CMS usually changes content stored in a content model. Frontman can propose edits to existing source files through a development integration. That broader reach requires code review, tests, access controls, and clear scope boundaries.'
 ---
 
-You caught a copy error on the pricing page at 4pm on a Tuesday. You know exactly what it should say. You could fix it yourself in about 30 seconds if someone handed you the right file.
+Editing a website without waiting for a developer should not mean editing production without engineering controls. It should mean **self-service authorship with governed approval**.
 
-Instead, you open Jira. You write a ticket. You label it "copy fix," assign it to the frontend team, set the priority, and attach a screenshot with an annotation. The ticket sits in the backlog until someone picks it up, usually 3 to 8 days later, depending on sprint priorities and who's on vacation. For a 30-second fix.
+A product manager often knows the intended copy, campaign requirement, or visible acceptance criterion. An engineer knows the codebase impact and owns technical approval. A safe process preserves both forms of expertise instead of making engineering transcribe every small request.
 
-This isn't a process problem you can fix with better ceremony. It's an access problem. PMs can see what needs to change. They just can't make the change.
+**Quick answer:** let product managers propose narrow content and visual changes from a development environment. Keep the work on a branch, require a focused diff and visual evidence, run normal CI, and require engineering approval before merge.
 
-**Quick answer:** PMs can edit a website without a developer when the change is visual, content-level, or UI polish, and the output still goes through code review. Frontman gives non-developers a browser workflow for those changes while engineering keeps control of what ships.
+## Start With Policy, Not a Tool
 
-Frontman solves the access problem directly.
+Before granting self-service access, agree on four things:
 
-## How It Works
+1. Which changes a product manager may propose.
+2. Which areas are always engineer-owned.
+3. Which evidence must accompany a change.
+4. Who can approve and merge it.
 
-Frontman runs alongside your engineering team's development server. When they build the app locally or in a staging environment, Frontman is running too, and you can open it in your browser.
+Tool access without these decisions only moves ambiguity closer to the codebase.
 
-You see the live application. Click any element on the page and Frontman shows you which component it is, where it's defined, the current visual properties (spacing, color, font, content), and whether it's shared across the app or scoped to this page.
+## Define a Narrow Editing Boundary
 
-Describe what you want to change. Frontman edits the source file and hot-reloads the page. You see the result immediately. If it looks right, open a pull request for engineering to review.
+Good self-service candidates are changes whose intent is visible and whose technical scope can stay small:
 
-No file names. No code. No terminal. No IDE. Just the browser you already use to review builds.
+- Button labels, headings, helper text, alt text, and empty-state copy
+- Spacing, alignment, typography, and responsive visual polish
+- Approved colors, tokens, utilities, and existing component variants
+- Content or presentation props already supported by a component
 
-## What You Can Change
+Keep these changes with engineers:
 
-Copy is the obvious starting point: button labels, CTAs, headlines, body text, navigation labels, alt text on images, error messages, empty states. Most of the words users read are fair game.
+- Authentication, authorization, billing, and security controls
+- Data fetching, mutations, caching, and application state
+- Routing behavior, analytics logic, and feature-flag semantics
+- Dependencies, build configuration, migrations, and infrastructure
+- Shared-component changes with uncertain downstream effects
 
-Layout and spacing work the same way. Padding inside components, gap between elements, responsive behavior at specific screen sizes. If something looks cramped on mobile, you click it, say "fix this on mobile," and Frontman handles the adjustment.
+This is a governance boundary, not a claim that visual code is always harmless. A one-line token change in a shared component can affect many pages. Scope and review still matter.
 
-Typography, background colors, border styles, component-level color changes: all accessible through the same click-and-describe workflow.
+## Separate Author, Approver, and Deployer
 
-What doesn't work: changes involving business logic, data fetching, API integrations, or application state. Those are engineering tasks. Frontman handles the visual layer, where "correct" means "it looks right in the browser."
+Self-service works when authorship does not imply authority to ship.
 
-## The Ticket You Will Stop Filing
+| Responsibility                                    | Recommended owner                      |
+| ------------------------------------------------- | -------------------------------------- |
+| State user-visible intent and acceptance criteria | Product manager                        |
+| Produce focused source edit                       | Product manager with an editing tool   |
+| Check design-system fit                           | Designer or design-system owner        |
+| Review source diff and technical impact           | Engineer or code owner                 |
+| Run automated checks                              | CI                                     |
+| Approve merge and deployment                      | Existing repository and release owners |
 
-The most common PM tickets in any frontend team's backlog:
+Do not give a self-service author a weaker review lane. Existing branch protection, required checks, code ownership, and deployment permissions should continue to apply.
 
-- "CTA copy should say X not Y"
-- "Increase padding on mobile"
-- "Button color should match the updated brand palette"
-- "Pricing page heading font is wrong"
-- "The hero section text is hard to read on tablet"
-- "Fix the spacing in the footer"
+## Turn the Boundary Into a Self-Service Policy
 
-Every one of these is a change the PM who filed the ticket could make directly if they had access. Every one of these takes a developer 10 minutes to fix and takes 3-5 days to reach them.
+This article defines who may author which changes. Use [How Teams Review UI Changes From Non-Engineers](/blog/review-ui-changes-from-non-engineers/) as the canonical approval workflow for every eligible proposal rather than creating a PM-specific review lane.
 
-Frontman collapses that timeline. The PM makes the change, opens the PR, and engineering reviews a diff instead of translating a ticket. The whole loop goes from a week to under an hour.
-
-## The Code Review Step
-
-This is the part that matters for trust.
-
-Every change you make through Frontman produces a standard pull request. Your engineering team sees exactly what changed, a diff against the existing code, line by line. They can comment, request changes, or approve. Nothing ships without that approval.
-
-It's the same workflow as always: open a PR and get it reviewed before merging. The only difference is that you're opening the PR instead of a developer. Engineering still controls what goes out.
-
-Your design system stays intact because you're editing the real components, not adding overrides. Your CI runs on your changes the same as any other PR. The codebase doesn't know you're not an engineer.
-
-## A Real Workflow Example
-
-Your marketing site is running a campaign. The hero section has a CTA button that says "Start Free Trial." Legal has asked that it say "Start Trial" before paid checkout launches.
-
-**Before Frontman:**
+Require the PM to state what users should see and where. Avoid broad prompts such as "improve this page."
 
 ```text
-Day 1: PM notices the copy, drafts ticket, assigns to frontend
-Day 2: Ticket lands in sprint planning
-Day 5: Developer picks it up, finds the component, makes the change
-Day 5: PM reviews staging, approves
-Day 6: Merged and deployed
-Total: 5 days, ~20 minutes of engineering time spread across context switches
+On the pricing page, change the primary CTA label from
+"Start Free Trial" to "Start Trial" at desktop and mobile widths.
+Do not change click behavior, routing, analytics, or other CTAs.
 ```
 
-**With Frontman:**
+This is an illustrative example, not a report of a customer request or production change.
 
-```text
-11:00am: PM opens staging environment in browser
-11:01am: PM clicks the CTA button in Frontman
-11:01am: PM types "Change this to 'Start Trial'"
-11:01am: Frontman edits the component, hot-reload confirms
-11:02am: PM opens PR
-11:30am: Engineer reviews the one-line diff, approves
-11:35am: Merged and deployed
-Total: 35 minutes, 5 minutes of engineering attention
-```
+Frontman connects its browser workspace to a running development app through a framework integration. An authorized PM can select the visible element, provide this requirement, and inspect the hot-reloaded result. Filesystem operations execute through the local integration; relevant task context passes through the Frontman server to the selected model provider. See the [security model](/blog/security/) for system boundaries.
 
-Same outcome. Same review process. Completely different calendar cost.
+Policy enforcement remains simple: if the proposed diff crosses the allowlist, stop self-service authorship and return the change to engineering ownership. Hot reload can help the PM refine intent, but it does not expand allowed scope or approve the result.
 
-## Getting Started
+## Measure the Process Without Inventing Savings
 
-Frontman is set up once by your engineering team. It takes about 10 minutes to integrate with Next.js, Vite, or Astro. Follow the [integration guide](/docs/integrations/nextjs/) for your framework.
+Do not assume every small edit becomes faster. Track evidence:
 
-After setup, you get access to the staging environment in your browser and start clicking. No new tools to learn. No development environment to configure. The browser you already use to review builds is the tool.
+- Time from proposed change to reviewed pull request
+- Review rounds per change
+- Percentage of diffs rejected for scope expansion
+- CI failure rate
+- Reverts or regressions after merge
+- Engineering review effort versus implementation effort
 
-Read about [how the code review workflow protects your codebase](/blog/security/), see [how designers and PMs use Frontman alongside engineers](/blog/team-collaboration/), or compare the full [AI frontend editing feature set](/features/).
+These measures reveal whether self-service reduces handoffs or merely moves work into review. Avoid promising fixed days or minutes without data from your own team.
 
-[Try Frontman](https://frontman.sh) — self-host in one command or use hosted Frontman Pro now. The browser client and JavaScript integrations are Apache-2.0, the WordPress plugin is GPL-2.0-or-later, and Frontman Server is AGPL-3.0-only with AI Supplementary Terms.
+## Roll Out in Stages
+
+Start with a small allowlist: one site area, named authors, copy-only changes, and mandatory engineering approval. Review the first set of changes together. Expand to styling or component props only after diffs remain focused and reviewers trust the process.
+
+The goal is not to remove developers from website work. It is to reserve engineering implementation time for changes that need engineering judgment while keeping engineering control over what ships.
+
+For ownership of shared tokens and components, read [Design System Collaboration Without Tickets](/blog/team-collaboration/). Apply the canonical [review workflow for UI changes from non-engineers](/blog/review-ui-changes-from-non-engineers/) to accepted self-service proposals.
+
+[Try Frontman](https://frontman.sh) in a governed development workflow, or start with the [installation guide](/docs/installation/).

--- a/apps/marketing/src/content/blog/frontman-vs-cursor-vs-claude-code.md
+++ b/apps/marketing/src/content/blog/frontman-vs-cursor-vs-claude-code.md
@@ -1,127 +1,122 @@
 ---
 title: 'Frontman vs Cursor vs Claude Code'
 pubDate: 2026-02-14T05:00:00Z
-description: 'You tried AI coding agents for visual work and hit a wall. Here is why — and what is actually built for designers and PMs who think visually.'
+description: 'Choose among browser-first, IDE-first, and terminal-first coding workflows based on task shape, operator, runtime evidence, and verification needs.'
 author: 'Danni Friedland'
 articleSection: 'Comparison or Buyer Guide'
 image: '/blog/frontman-vs-cursor-vs-claude-code-cover.png'
 imageAlt: 'Frontman, Cursor, and Claude Code workflow comparison'
 tags: ['comparison', 'ai', 'design-systems']
-updatedDate: 2026-03-20T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 faq:
   - question: 'What is the difference between Frontman, Cursor, and Claude Code?'
-    answer: 'Cursor and Claude Code are AI coding agents built for engineers — they read source code, run terminal commands, and reason about multi-file changes. Frontman is a browser-based agent built for visual work — it sees the live page, lets you click the element you want to change, and traces it back to the source file automatically. Designers and PMs use Frontman to update spacing, colors, typography, and copy directly, without needing to navigate the codebase.'
-  - question: 'Can designers and PMs use Frontman without knowing how to code?'
-    answer: 'Yes. Frontman works in the browser — you click the element you want to change and describe what you want in plain language. You do not need to know which file to edit, what the class names mean, or how the component tree is structured. Frontman traces the visual element back to the source code and makes the edit for you. Changes go through the same code review process as any other PR.'
-  - question: 'Will I break something if I make changes with Frontman?'
-    answer: 'Frontman edits the same source files your engineers work in, and every change goes through your existing review process — pull requests, CI checks, design review. You cannot deploy a broken change without someone approving it. The risk is the same as any other code change, with the same guardrails.'
-  - question: 'Is Frontman only for trivial CSS changes?'
-    answer: 'No. Spacing, typography, responsive layout, color systems, and component styling account for 30-40% of frontend work. Each individual change may be small, but the category is large. Multi-select lets you batch many visual fixes in one pass, and handling these changes directly means your engineering team can focus on structural work instead of pixel-pushing tickets.'
-  - question: 'Can Claude Code or Cursor take screenshots to see the UI?'
-    answer: 'They can, through browser automation plugins. But a screenshot is a flat image — it strips away the component structure, the design tokens, the responsive breakpoints, and the state. The agent has to guess what it is looking at. Frontman reads the live page directly and knows which component renders which element because it is connected to your framework, not scraping pixels.'
+    answer: 'Frontman starts from a running page and direct element selection. Cursor starts from an AI-enabled IDE. Claude Code is a general-purpose coding agent available in terminal, IDE, desktop, and web surfaces, with strong shell-oriented workflows. Cursor and Claude Code also offer browser integrations, so selection should be based on primary workflow and context depth rather than browser access alone.'
+  - question: 'Which tool is best for designers and product managers?'
+    answer: 'Frontman has the lowest-friction workflow when the user can identify a rendered element but does not know the source tree. Cursor fits users comfortable reviewing and editing in an IDE. Claude Code fits users comfortable directing a general coding agent and evaluating broader code or command changes.'
+  - question: 'Can these tools be used together?'
+    answer: 'Yes. A team can use Frontman to identify and iterate on a visual target, Cursor for IDE-centered implementation, and Claude Code for terminal-heavy investigation, tests, git, or cross-cutting work. Review overlapping edits carefully because all three may modify the same source files.'
+  - question: 'Can Cursor and Claude Code inspect a browser?'
+    answer: 'Yes. Cursor documents browser tools, and Claude Code documents a Chrome integration for DOM state, console and network evidence, screenshots, and browser interaction. Generic browser access does not necessarily provide framework component provenance or direct user-led element-to-source selection.'
+  - question: 'Where is the exact Frontman vs Claude Code comparison?'
+    answer: 'The dedicated /vs/claude-code/ page owns the detailed two-way feature, architecture, pricing, and licensing comparison. This article compares three workflow starting points and helps route tasks among them.'
 ---
 
-You have seen your engineering team use Cursor or Claude Code. The demos are impressive — they write functions, refactor entire modules, wire up APIs. So you tried it yourself. You wanted to fix the spacing on a card component. Update a button color to match the new brand palette. Change some copy on the landing page.
+Frontman, Cursor, and Claude Code overlap: each can participate in changing source code, and each can be part of a frontend workflow. They differ most in where work begins.
 
-It dropped you into a code editor. You were looking at a file called `CardGrid.tsx` with nested `div` elements and class names like `p-4 md:p-8 lg:p-12`. The agent asked you to describe the problem in text. You typed "the card has too much padding on mobile." It changed something. You switched to the browser. Wrong element. You tried again, with more detail. It changed something else. Still wrong. You gave up and filed a Jira ticket.
+- **Frontman begins in the running browser:** select rendered UI, gather project context, edit source, inspect the result.
+- **Cursor begins in an IDE:** navigate code, use editor context, delegate changes to an agent, run and review the project.
+- **Claude Code begins as a general coding agent:** commonly terminal-directed, but also available in IDE, desktop, web, and browser-connected workflows.
 
-This is not a skill issue. Cursor and Claude Code are built for engineers who think in code. They are excellent at that. But if you think visually — if you _see_ the problem on the page and just want to point at it — these tools do not work the way you work.
+This is a workflow guide, not a claim that tools stay inside one surface. [Cursor's official documentation](https://cursor.com/docs) covers its IDE and agent features. [Claude Code's overview](https://code.claude.com/docs/en/overview) documents terminal, IDE, desktop, and web surfaces, while its [Chrome integration](https://code.claude.com/docs/en/chrome) adds browser inspection and automation. Frontman's architecture is available in its [GitHub repository](https://github.com/frontman-ai/frontman).
 
-> **TL;DR:** Cursor and Claude Code are built for engineers — they read code, run commands, and reason about files. Frontman is built for visual work — you click the element you want to change, describe what you want, and it handles the code. Designers and PMs use Frontman for spacing, colors, typography, and copy. Engineers use their preferred coding agent for everything else. Everyone reviews PRs through the same process.
+## Compare the Primary Workflows
 
-!Table comparing file-level AI agents and browser-level AI agents across key capabilities: file access, terminal access, DOM access, computed styles, and visual verification.
+| Decision factor          | Frontman                                            | Cursor                                                      | Claude Code                                               |
+| ------------------------ | --------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
+| Primary starting point   | Rendered application                                | Source code in IDE                                          | Prompt plus repository/tools, often terminal              |
+| Natural operator context | “This element in this state”                        | “This symbol, file, or code region”                         | “Investigate and complete this engineering task”          |
+| Strong task shape        | Targeted visual edits and browser-to-source tracing | Interactive coding, code navigation, and editor-led changes | Shell-heavy, multi-file, test, git, and automation work   |
+| Browser capability       | Core interface and direct selection workflow        | Browser tools are available                                 | Chrome integration and external MCP options are available |
+| Framework provenance     | Supplied by supported local integrations            | Depends on project and connected tools                      | Depends on project and connected tools                    |
+| Terminal depth           | Not primary workflow                                | Integrated terminal and agent tools                         | Core strength in CLI workflows                            |
+| Main tradeoff            | Requires running app and supported integration      | Requires IDE-centered workflow                              | Broad capability requires precise direction and review    |
 
-## Why Coding Agents Do Not Work for Visual Tasks
+Rows describe product emphasis, not hard capability limits. Configuration changes what each tool can observe and do.
 
-Cursor, Claude Code, Windsurf, and Copilot are file-level agents. They read source code, understand how files connect, and edit across multiple files at once. For engineering work — writing functions, refactoring, building APIs — they are transformative.
+## Choose Frontman When Target Identity Is the Bottleneck
 
-But they have a fundamental limitation — [the runtime context gap](/blog/runtime-context-gap/): they cannot see the rendered page. They do not know what your design system components look like at a given screen size. They cannot tell which of three nested containers you are looking at. When you ask them to fix something visual, they edit the file and hope — this is fundamentally [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/). The verification step — "did it actually work?" — is entirely on you. You switch to the browser, look, switch back, try to describe what you see in words, and hope the agent infers what you meant.
+Frontman fits when a person can point to the correct rendered result faster than they can locate its implementation. Examples:
 
-For someone who lives in Figma or reviews builds in the browser, this is backwards. You can _see_ the problem. You should be able to point at it.
+- a responsive layout differs from the approved design in one state;
+- a reviewer wants to select a specific repeated component instance;
+- computed spacing or typography needs inspection before editing;
+- a designer or PM should initiate a bounded presentational change;
+- immediate visual iteration is central to acceptance.
 
-## How Frontman Works Differently
+Tradeoff: browser context does not replace tests or broad code reasoning. Changes affecting data flow, authorization, shared APIs, or architecture should move to an engineering-centered workflow even if the symptom appears in the UI.
 
-Frontman connects to your running app in the browser. Instead of starting from code, you start from the page — the same way you already review designs.
+## Choose Cursor When the IDE Is the Shared Workspace
 
-When you click an element in Frontman:
+Cursor fits developers who want AI inside code navigation and editing. The IDE keeps source, diffs, diagnostics, search, and terminal access close together. It is a natural choice when:
 
-- It sees the **live page** — the actual rendered result, not a source file
-- It understands the **visual properties** — the real spacing, colors, and typography as they appear on screen
-- It traces the element back to the **exact source file and component**, automatically
-- It applies the change and you see the result **immediately** — no switching tabs, no re-describing the problem
+- implementation starts from known files, symbols, or diagnostics;
+- a developer wants to steer changes while reading surrounding code;
+- code completion and interactive refactoring matter throughout the day;
+- the team already standardizes on a VS Code-style editor;
+- browser tools supplement, rather than define, the workflow.
 
-You do not need to know which file to open. You do not need to know the class names or the component hierarchy. You point at the thing that needs to change, say what you want, and Frontman handles the rest. See [how Frontman works differently](/blog/frontman-launch/) for the full architecture.
+Tradeoff: collaborators who do not work in an IDE may struggle to identify source targets or review implementation details there. Browser tooling can reduce this gap, but it does not turn every IDE workflow into direct element-to-source editing.
 
-## The Same Change, Two Workflows
+For exact Frontman-to-Cursor details, see [Frontman vs Cursor](/vs/cursor/).
 
-Your design system specifies 16px padding on cards at mobile breakpoints. A recent update broke it — cards now have 32px. You need to fix it across the product.
+## Choose Claude Code When Tool Orchestration Is the Bottleneck
 
-**What happens when you try Cursor or Claude Code:**
+Claude Code fits tasks that combine repository exploration, file edits, commands, tests, and git operations. Anthropic's official overview documents these capabilities across multiple surfaces. It is a natural choice when:
 
-```text
-You: "Fix the card padding on mobile in CardGrid.tsx"
-Agent: *reads the file, changes a class on line 23*
-You: *switch to browser* — still wrong, it changed the outer wrapper
-You: "It's the inner container, not the outer one"
-Agent: *reads the file again, edits line 31*
-You: *switch to browser* — padding is fixed but desktop layout broke
-You: *give up, file a ticket for engineering*
-```
+- a task spans backend and frontend code;
+- builds, tests, linters, logs, or migrations drive the feedback loop;
+- the agent must investigate before the correct files are known;
+- shell pipelines, git, CI, or repeatable automation are central;
+- browser inspection is one tool within a broader engineering task.
 
-**What happens in Frontman:**
+Claude Code can inspect and interact with Chrome, so it is inaccurate to describe it as blind to rendered applications. The relevant distinction is interaction design and context. Its Chrome documentation covers DOM state, screenshots, console and network evidence, and browser actions; it does not claim that every framework's component-to-source provenance is automatically available.
 
-```text
-You: *click the card in the browser* "Padding should be 16px on mobile"
-Frontman: *sees the current padding is 32px, traces to CardGrid.tsx:31*
-         *updates the class, change appears immediately*
-```
+For exact two-way feature, architecture, pricing, and licensing intent, use [Frontman vs Claude Code](/vs/claude-code/). This three-way article intentionally does not duplicate that page.
 
-The difference is not intelligence. Both agents are capable. The difference is that one can see what you are looking at and the other cannot.
+## Route Work by Acceptance Criterion
 
-## Who Should Use What
+| If success means...                                     | Start with...                              | Add another tool when...                                  |
+| ------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| Selected element matches a visual specification         | Frontman                                   | logic or shared architecture enters scope                 |
+| Code change is clear while reading implementation       | Cursor                                     | extensive shell automation or runtime selection is needed |
+| Tests, commands, and a cross-file diff complete a task  | Claude Code                                | visual target selection needs human direction             |
+| Browser flow reproduces and no runtime errors remain    | Claude Code with Chrome or browser tooling | framework provenance is needed to choose a safe edit      |
+| Non-engineer can propose a bounded UI change for review | Frontman                                   | engineer needs to restructure implementation              |
+| Developer wants continuous AI assistance while coding   | Cursor                                     | task should run autonomously outside editor interaction   |
 
-| Task | Who does it | Tool | Why |
-| --- | --- | --- | --- |
-| Fix spacing to match design specs | Designer | **Frontman** | Visual task — click, describe, done |
-| Update copy and CTAs on the marketing site | PM | **Frontman** | Content change, see it live before merging |
-| Adjust brand colors across components | Designer | **Frontman** | Design system change, needs visual verification |
-| Build a new API endpoint | Engineer | Cursor, Claude Code | Pure code, no visual output |
-| Refactor the authentication flow | Engineer | Cursor, Claude Code | Multi-file structural change |
-| Fix responsive layout issues flagged in QA | Designer or Engineer | **Frontman** | Visual problem at specific screen sizes |
-| Debug a state management bug | Engineer | Cursor, Claude Code | Deep code reasoning |
-| Align production UI with updated Figma specs | Designer | **Frontman** | Visual QA, point at what is wrong |
+These are starting points, not exclusive assignments.
 
-The pattern: if "correct" means _it looks right in the browser_, use the tool that can see the browser. If "correct" means _the tests pass_ or _the types check_, use the tool that reasons about code.
+## Common Combined Workflows
 
-## What About Breaking Things?
+### Frontman Plus Cursor
 
-This is the first question every designer and PM asks, and it is the right one.
+Use Frontman to identify the rendered target and inspect visual evidence. Use Cursor when the resulting change expands into component restructuring or a larger refactor. Both edit normal source files, so inspect current diffs before switching tools.
 
-Frontman edits the same source files your engineers work in. Every change produces a real code diff. That diff goes through your existing review process — pull requests, CI checks, automated tests, design review. Nothing ships without approval.
+### Frontman Plus Claude Code
 
-You are not pushing to production. You are opening a PR. The same guardrails that protect the codebase from a junior engineer's first commit protect it from your changes too. Your engineering team reviews the code. You review the visual result. The process works because it is the same process.
+Use Frontman for direct selection and browser feedback. Use Claude Code for tests, backend changes, git operations, or broader investigation. Keep the task boundary explicit so one agent does not overwrite the other's in-progress edit.
 
-## Common Questions
+### Cursor Plus Claude Code
 
-**"Do I need to set up a development environment?"**
-Your engineering team sets up Frontman once — it connects to the dev server that is already running. After that, you open the browser and start working. No terminal, no IDE, no environment setup.
+Use Cursor for interactive implementation and Claude Code for delegated terminal-heavy work. This pairing can be effective, but overlapping repository access requires normal branch, diff, and review discipline.
 
-**"Can't I just use Figma's Dev Mode or handoff tools?"**
-Handoff tools describe _what should change_. Frontman _makes the change_. Instead of annotating a screenshot with "padding should be 16px" and waiting for an engineer to pick up the ticket, you click the element, say "padding 16px," and open a PR. The feedback loop drops from days to minutes.
+## Questions to Ask Before Choosing
 
-**"Why not just ask an engineer? It only takes them five minutes."**
-It takes them five minutes of coding. But it takes a day of context-switching, ticket grooming, sprint planning, and waiting. Multiply that by every spacing fix, copy change, and color update across your design system, and you are looking at a significant chunk of engineering time spent on work that does not require engineering judgment. Let your engineers build features. Handle the visual layer yourself.
+1. Who is operating the tool: designer, PM, frontend engineer, or full-stack engineer?
+2. Is the target easiest to identify in browser state, source code, or command output?
+3. Does correctness depend on computed layout, framework provenance, tests, or all three?
+4. Must the task span backend, CI, git, or infrastructure?
+5. Which browser origins, files, commands, and credentials may the agent access?
+6. How will a reviewer verify both rendered result and code quality?
 
-**"What if the change I want is more complex than a style tweak?"**
-Then it is probably an engineering task. Frontman is not trying to replace your engineering team. It handles the visual layer — spacing, typography, colors, layout, responsive behavior, copy. The work where the acceptance criterion is _how it looks_. When the change involves logic, data flow, or architecture, that belongs in Cursor or Claude Code with your engineers.
-
-**"Claude Code can take screenshots to see what the page looks like."**
-It can, through browser automation plugins. But a screenshot is a flat image — it strips away the component structure, the design tokens, the responsive breakpoints, and the interactive state. The agent has to guess what it is looking at and reverse-engineer the structure from pixels. Frontman reads the live page directly. It knows which component renders which element because it is connected to your framework. There is nothing to guess.
-
-## The Takeaway
-
-You tried the AI coding agents. They are powerful, but they were not built for how you work. They think in files. You think in what you see on the page. That is not a limitation of yours — it is a limitation of theirs.
-
-Frontman is the tool that meets you where you are. Click what needs to change. Describe what you want. Review the result in the browser. Open a PR. Your engineering team stays focused on engineering. Your design system stays consistent. And you stop waiting three sprints for a padding fix.
-
-[Try Frontman](https://frontman.sh) — self-host in one command or use hosted Frontman Pro now. The browser client and JavaScript integrations are Apache-2.0, the WordPress plugin is GPL-2.0-or-later, and Frontman Server is AGPL-3.0-only with AI Supplementary Terms. Read about [how designers and PMs can use it alongside your team](/blog/team-collaboration/). For a detailed feature-by-feature breakdown, see [Frontman vs Cursor](/vs/cursor/).
+If runtime evidence is the unclear part, use the [UI-context evaluation checklist](/blog/ai-coding-agents-blind-to-ui/) and [runtime context taxonomy](/blog/runtime-context-gap/). If direct visual selection is the best starting point, [try Frontman](https://frontman.sh). If exact pairwise comparison is your intent, use [Frontman vs Cursor](/vs/cursor/) or [Frontman vs Claude Code](/vs/claude-code/).

--- a/apps/marketing/src/content/blog/gpt-5.4-support.md
+++ b/apps/marketing/src/content/blog/gpt-5.4-support.md
@@ -1,43 +1,58 @@
 ---
 title: 'GPT-5.4 Support in Frontman'
 pubDate: 2026-03-06T12:00:00Z
-description: 'GPT-5.4 brings a massive context window, native computer-use, and sharper reasoning to Frontman — so your design system gets implemented the way it was intended.'
+description: 'How to select GPT-5.4 in Frontman, which model IDs the integrations use, and where to verify current capabilities and pricing.'
 author: 'Danni Friedland'
 image: '/blog/gpt-5.4-support-cover.png'
 imageAlt: 'GPT-5.4 support in Frontman'
 articleSection: 'Product Announcement'
 tags: ['announcement', 'models']
-updatedDate: 2026-03-10T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-OpenAI released GPT-5.4 yesterday. Today, you can use it in Frontman.
+OpenAI released GPT-5.4 on March 5, 2026. Frontman added it to the model picker for direct OpenAI connections and added GPT-5.4 and GPT-5.4 Pro for OpenRouter connections.
 
-If you're managing a design system across multiple teams, this model matters. GPT-5.4 can hold your entire design system documentation, component specs, and conversation history in a single session — and it's better at translating visual intent into production-ready implementation.
+This page records what Frontman supports and points to model references that can be checked as availability, limits, and prices change.
 
-### What Changes for Your Workflow
+## Verified model support
 
-**Your full design system in context, all at once.** GPT-5.4 supports up to one million tokens — roughly 750,000 words. That's enough to hold your component library docs, spacing and typography tokens, brand guidelines, and the current task all in one session. Frontman's [distributed architecture](/blog/security/) keeps filesystem operations on your machine through the framework integration while sending relevant context through the orchestration server to your selected provider. No more re-explaining your system's conventions halfway through a build.
+Frontman's provider catalog currently contains these entries:
 
-**It can see and operate your browser.** GPT-5.4 has built-in computer-use capabilities that complement Frontman's [runtime context](/blog/runtime-context-gap/). It navigates your app, clicks through flows, and visually verifies that implementations match your specs. When your team ships a new component, Frontman can check that it actually looks right — not just that the code compiles.
+| Frontman provider | Picker label | Model ID sent by Frontman |
+| ----------------- | ------------ | ------------------------- |
+| OpenAI            | GPT-5.4      | `gpt-5.4`                 |
+| OpenRouter        | GPT-5.4      | `openai/gpt-5.4`          |
+| OpenRouter        | GPT-5.4 Pro  | `openai/gpt-5.4-pro`      |
 
-**Smarter tool usage across your stack.** Teams at scale use a lot of tools — Figma plugins, design token pipelines, CI checks. GPT-5.4 is significantly better at finding and using the right tool for the job without you having to guide it step by step. Less hand-holding, more shipping.
+You can verify those identifiers in Frontman's [provider configuration](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/config/providers.exs). The original support change is also recorded in the [Frontman changelog](https://github.com/frontman-ai/frontman/blob/main/CHANGELOG.md).
 
-**Faster reasoning, same quality.** GPT-5.4 solves problems with fewer intermediate steps than previous models. For you, that means quicker turnaround on component builds, layout adjustments, and responsive implementations. The back-and-forth shrinks.
+Provider catalogs evolve. If a model does not appear in your picker, update Frontman first, then confirm that the model is available to your OpenAI or OpenRouter account.
 
-**Stronger frontend output.** Compared to models powering other [AI coding tools](/blog/6-ai-coding-tools-production/), GPT-5.4 is noticeably better at complex frontend work — producing more polished, visually accurate results. Design system components come out closer to spec on the first pass, which means fewer review cycles between your design and engineering teams.
+## What OpenAI documents
 
-### How to Use It
+OpenAI's [GPT-5.4 release announcement](https://openai.com/index/introducing-gpt-5-4/) describes the model as a general-purpose reasoning model for professional work, coding, tool use, and computer use. Its durable [GPT-5.4 model reference](https://developers.openai.com/api/docs/models/gpt-5.4) lists:
 
-GPT-5.4 is now the default for OpenAI OAuth users in Frontman. If you've connected your OpenAI account, it's already available in the model picker.
+- model ID `gpt-5.4`;
+- text and image input with text output;
+- a 1,050,000-token context window and 128,000 maximum output tokens;
+- function calling, image input, MCP, computer use, and other supported tools.
 
-OpenRouter users can select GPT-5.4 or GPT-5.4 Pro from the model dropdown. Pro offers stronger performance on research-heavy and abstract reasoning tasks — useful when you're working through complex interaction patterns or auditing system-wide consistency.
+Those are provider capabilities, not a promise that every capability is exposed by Frontman. In Frontman, GPT-5.4 works through the tools Frontman makes available: browser inspection runs in the browser, file tools run through the local framework integration, and the hosted or self-hosted server orchestrates the loop. See [How the Agent Works](/docs/using/how-the-agent-works/) for that boundary.
 
-No setup needed. Open Frontman, pick the model, start building.
+## Pricing checked on July 30, 2026
 
-### Why This Matters for Growing Teams
+OpenAI's official model reference listed standard API prices of **$2.50 per million input tokens**, **$0.25 per million cached input tokens**, and **$15 per million output tokens** for GPT-5.4 when this page was updated. Long-context requests and other processing tiers can use different rates.
 
-Every team that scales past two or three squads hits the same problem: the [design system starts drifting](/blog/ai-coding-agents-blind-to-ui/). Components get re-implemented slightly differently. Spacing breaks. Brand consistency erodes one PR at a time.
+Do not treat those numbers as permanent. Check OpenAI's [current API pricing](https://developers.openai.com/api/docs/pricing) before estimating cost. OpenRouter users should check the live [OpenRouter GPT-5.4 page](https://openrouter.ai/openai/gpt-5.4), because routing and provider availability can affect effective pricing.
 
-GPT-5.4 in Frontman helps close that gap. It holds your entire system in memory, sees what's actually rendered in the browser, and builds with your conventions — not generic defaults. The model gets better, and your system stays tighter.
+## Select GPT-5.4 in Frontman
 
-Try it at [frontman.sh](https://frontman.sh), or follow our [getting started](/blog/getting-started/) guide.
+1. Open your project's `/frontman` route and sign in.
+2. In Frontman settings, connect OpenAI or OpenRouter using a supported account connection or credential.
+3. Open the model picker.
+4. Choose **GPT-5.4**. OpenRouter users can also choose **GPT-5.4 Pro** when their account has access.
+5. Start with a bounded task and review the resulting diff before keeping it.
+
+Model selection changes which provider model drives the agent. It does not change Frontman's filesystem, browser, persistence, or review boundaries. Relevant context and tool results pass through the Frontman server to the provider you select; generated edits still need your normal testing and code review.
+
+For installation, use the [getting started guide](/blog/getting-started/). For provider setup, see [API Keys and Providers](/docs/api-keys/).

--- a/apps/marketing/src/content/blog/gpt-5.4-support.md
+++ b/apps/marketing/src/content/blog/gpt-5.4-support.md
@@ -21,6 +21,7 @@ Frontman's provider catalog currently contains these entries:
 | Frontman provider | Picker label | Model ID sent by Frontman |
 | ----------------- | ------------ | ------------------------- |
 | OpenAI            | GPT-5.4      | `gpt-5.4`                 |
+| OpenAI            | GPT-5.4 Mini | `gpt-5.4-mini`            |
 | OpenRouter        | GPT-5.4      | `openai/gpt-5.4`          |
 | OpenRouter        | GPT-5.4 Pro  | `openai/gpt-5.4-pro`      |
 

--- a/apps/marketing/src/content/blog/introducing-frontman.md
+++ b/apps/marketing/src/content/blog/introducing-frontman.md
@@ -2,65 +2,87 @@
 title: 'Introducing Frontman: AI That Sees Your UI'
 seoTitle: 'Browser-Aware AI Coding Agent'
 pubDate: 2026-02-18T05:00:00Z
-description: 'What browser-aware AI coding agents can see that file-only agents miss: rendered DOM, computed CSS, layout, viewport state, and source context.'
+description: 'Why we built Frontman, what category it belongs to, where browser-aware editing helps, and where a browser-first workflow is the wrong tool.'
 author: 'Danni Friedland'
 image: '/blog/introducing-frontman-cover.png'
 imageAlt: 'Introducing Frontman browser-aware AI coding agent'
 articleSection: 'Product Announcement'
 tags: ['ai', 'frontend', 'developer-tools']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-Name any AI coding agent. Claude Code. Cursor. GitHub Copilot. Windsurf. They can all read your source files, trace your imports, and generate diffs that compile. For backend code, that is usually enough.
+Frontman began with a narrow observation: frontend changes are often described in the browser but implemented somewhere else.
 
-For frontend work, it is not even close.
+A reviewer points at a rendered element. An engineer translates that observation into a component, source file, style rule, and testable change. General-purpose coding agents improved the file-editing half of that workflow, but the translation step remained manual. We built Frontman to make that browser-to-source path explicit.
 
-**Quick answer:** a browser-aware AI coding agent connects source files to the running browser. It can inspect rendered DOM, computed CSS, responsive layout, and clicked elements, then use that runtime context to make more accurate frontend code edits.
+## The Product Thesis
 
-## What Your Agent Reads vs. What You See
+Frontman is a browser-first coding agent for existing web applications. It connects three kinds of evidence:
 
-Your source file says `className="p-4 md:p-8 lg:p-12"`. Your browser renders 32px of padding at the current viewport width. Your agent has the source. You have the screen. Neither of you has both.
+- the rendered page and current browser state;
+- framework and component context supplied by a local integration;
+- the source files that produce the selected UI.
 
-This gap exists for everything visual:
+The interaction starts from an element in the running application rather than a file tree or terminal prompt. Frontman can inspect browser evidence, propose source edits, and show the result through the application's normal development feedback loop.
 
-**Computed styles.** The source says `text-primary`. The browser resolves that through your theme tokens, CSS variables, media queries, and cascade rules to `color: #1a56db`. Your agent sees the class name. It does not know the color.
+That makes Frontman one example of [browser-aware AI](/blog/what-are-browser-aware-ai-coding-tools/) and, more specifically, a [frontend agent](/blog/frontend-agent/). It is not a new model category. It is an agent architecture and interaction model built around runtime UI context.
 
-**Component identity.** Your page has forty `div` elements. You are looking at the third card in a grid. Your agent does not know which `div` you mean, because the DOM is a runtime artifact — it does not exist in source code. The agent would need to trace your component tree, resolve props, evaluate conditional rendering, and map the result to what is on screen. It cannot do any of that.
+## Why Build a Separate Browser-First Tool?
 
-**Responsive layout.** You are on a 768px viewport. The hero section stacks vertically. The sidebar collapses into a hamburger menu. Your agent reads the same breakpoint classes you do, but it has no viewport. It does not know which branch of your responsive logic is active right now.
+Browser integrations now exist for general coding agents. [Claude Code can connect to Chrome](https://code.claude.com/docs/en/chrome), [Cursor documents browser tools](https://cursor.com/docs/agent/tools/browser), and [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) exposes browser debugging and automation to multiple clients. Those are meaningful improvements; “coding agents cannot use browsers” is no longer accurate.
 
-**Visual hierarchy.** Two elements overlap. One has `z-index: 10` from a utility class; the other inherits `z-index: auto` from a parent. Your agent can grep for z-index values, but computing stacking context requires rendering — and rendering requires a browser.
+Frontman's bet is narrower: direct, user-led element selection plus project-specific source context deserves a primary workflow, not only an optional tool call. Browser automation commonly starts with an agent deciding where to navigate and what to inspect. Frontman starts with a person identifying the exact rendered target, then adds component and source evidence around that target.
 
-## The Cycle Everyone Recognizes
+Neither interaction model dominates every task. Agent-led browsing works well for scripted flows and autonomous verification. User-led selection works well when a reviewer already knows which visual result is wrong.
 
-You tell your agent to fix the spacing on the hero section. It reads the file, picks a Tailwind class that looks right, and saves. You switch to the browser. Wrong element. You switch back, add more context — the exact file path, the line number, a hint about which div. The agent tries again. You check the browser again. Closer. One more round.
+## What Frontman Is For
 
-Three iterations and six tab switches to change a padding value. The agent had full access to the source code the entire time. It just could not see the page.
+Frontman is designed for changes whose acceptance criteria live in the rendered application:
 
-This is not a prompt engineering problem. You cannot solve it by adding more context to your instructions or switching to a different model. The information your agent needs — computed styles, resolved layout, component-to-DOM mapping, viewport state — does not exist in your source files. It exists only at runtime, in the browser.
+- spacing, typography, color, and responsive layout;
+- copy and presentational component changes;
+- visual QA findings tied to a specific element or state;
+- tracing a rendered element back to its source;
+- iterating while preserving a normal code-diff review process.
 
-## The Runtime Context Gap
+Designers and product managers can initiate such changes without first learning the repository layout. Engineers can use the same context to reduce source-to-screen investigation. In both cases, the output remains code that should pass the project's usual review and checks.
 
-We call this the [runtime context gap](/blog/runtime-context-gap/). It is the set of information that exists only when your application is running in a browser:
+## What Frontman Is Not For
 
-- **Computed styles** — the final resolved values after cascade, inheritance, and media queries
-- **Component tree** — which component rendered which DOM node, with which props
-- **Layout geometry** — actual positions, sizes, and spacing in pixels at the current viewport
-- **Visual state** — hover states, animation frames, scroll positions, focus rings
-- **Stacking context** — which elements are actually in front of which
+Frontman is not intended to replace a general-purpose coding agent, IDE, test suite, or engineer.
 
-Every AI coding agent today operates without this information. They read files and infer what the UI probably looks like. For a `div` with three Tailwind classes, the inference is often right. For a component that renders differently based on props, viewport, theme, and application state — inference is a guess.
+Use terminal- or IDE-centered tools for backend changes, broad refactors, dependency migrations, data modeling, CI work, and tasks where shell output or codebase-wide reasoning is primary. Use design tools for open-ended visual exploration before an implementation exists. Use dedicated browser automation or test frameworks when repeatable end-to-end coverage is the deliverable.
 
-## This Is an Architecture Problem
+Frontman can touch source outside styling, but capability is not the same as workflow fit. If a request changes authorization, persistence, business rules, or public interfaces, browser selection provides little of the evidence needed to judge correctness.
 
-The important thing to understand: this is not about model intelligence. GPT-5 will not fix it. Claude's next release will not fix it. A smarter model reading the same source files still cannot see computed styles, because computed styles do not exist in source files.
+## Honest Tradeoffs
 
-The gap is architectural. Today's coding agents are file-first tools — they read files, edit files, and run terminal commands. That architecture works for backend code where the source file is the truth. It fails for frontend code where the truth is the rendered output.
+### Runtime Context Costs Setup
 
-Closing this gap requires agents that can access the browser runtime — the DOM, the computed styles, the component tree, the viewport. Not screenshots (which lose structure and interactivity). Not build output (which is transformed beyond recognition). The actual live browser state that your users see.
+Frontman needs a running application and a supported local integration. A file-only task can start without either. Framework-specific context can provide better provenance, but it also creates integration and maintenance work that a framework-agnostic agent avoids.
 
-Until coding agents can see what users see, frontend AI assistance will remain a game of guess-and-check. The model is not the bottleneck. The information is.
+### Visual Feedback Can Encourage Shallow Fixes
 
----
+A change that looks correct may still bypass a token, modify a shared component unintentionally, or fail at another breakpoint. Frontman shows runtime evidence; it does not make engineering judgment automatic. Review the diff and blast radius.
 
-*We built [Frontman](/blog/frontman-launch/) to close this gap — a source-available agent with an Apache-2.0 browser client and JavaScript integrations, a GPL-2.0-or-later WordPress plugin, and an AGPL-3.0-only server plus AI Supplementary Terms. It connects to your browser and your dev server simultaneously. But whether you use Frontman or something else, the runtime context gap is the problem worth understanding. It explains why your AI agent keeps getting CSS wrong.*
+### Browser Access Expands the Trust Boundary
+
+Authenticated pages and browser state can contain sensitive data. Teams should use development data, limit accessible origins, understand model-provider data handling, and retain approval gates. See [Frontman's security model](/blog/security/) before connecting a project.
+
+### Browser-First Is Not Always Faster
+
+If an engineer already knows the file and needs a mechanical refactor, opening the rendered application adds no value. Frontman earns its place when target identification or visual verification is part of the hard problem.
+
+## Source Availability and Boundaries
+
+Frontman's code and license boundaries are visible in the [Frontman GitHub repository](https://github.com/frontman-ai/frontman). The browser client and JavaScript integrations use Apache-2.0, the WordPress plugin uses GPL-2.0-or-later, and Frontman Server uses AGPL-3.0-only with AI Supplementary Terms. “Source-available” describes the combined product more accurately than calling every part open source.
+
+That split is part of the product boundary: local integrations own project access and runtime context, while the server orchestrates the agent workflow. Teams evaluating self-hosting should review both the licenses and the data path rather than relying on a single label.
+
+## Where the Category Goes
+
+Browser access is becoming a standard agent capability. Differentiation will move toward context quality: exact state reproduction, element identity, framework provenance, source mapping, safe edit scope, and verification.
+
+That is the category Frontman is built around. The detailed technical model is in [the runtime context gap](/blog/runtime-context-gap/). The practical buying question is covered in [Frontman vs Cursor vs Claude Code](/blog/frontman-vs-cursor-vs-claude-code/).
+
+[Try Frontman](https://frontman.sh) on an existing project, with the same requirement we recommend for every coding agent: inspect and understand the diff before merging it.

--- a/apps/marketing/src/content/blog/lighthouse-audits-without-leaving-the-browser.md
+++ b/apps/marketing/src/content/blog/lighthouse-audits-without-leaving-the-browser.md
@@ -1,114 +1,81 @@
 ---
 title: 'Run Lighthouse Audits Inside Frontman'
 pubDate: 2026-02-21T05:00:00Z
-description: 'Frontman now runs Google Lighthouse audits as a built-in tool. Your agent sees the scores, reads the issues, and fixes them — all inside the browser you are already working in.'
+description: 'Use Frontman’s Lighthouse tool to capture repeatable performance, accessibility, best-practices, and SEO findings, then verify focused fixes.'
 author: 'Danni Friedland'
 image: '/blog/lighthouse-audits-cover.png'
 imageAlt: 'Lighthouse audits inside Frontman'
 articleSection: 'Product Announcement'
 tags: ['performance', 'ai', 'developer-tools']
-updatedDate: 2026-03-10T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-You run a Lighthouse audit in Chrome DevTools. You get a wall of scores and recommendations. You copy the URL of your failing resource, switch to your editor, search for the right file, try to map the Lighthouse recommendation to an actual code change, switch back to the browser, re-run the audit, and check if the score moved. Repeat for each issue.
+Frontman includes a `lighthouse` tool for auditing a URL from the same agent session used to inspect and edit a project. It does not replace Lighthouse or guarantee a higher score. It gives the agent a structured subset of a Lighthouse run so measurement and code changes can happen in one reviewable workflow.
 
-This is the standard workflow. It works. It is also entirely manual, context-destroying, and about five steps longer than it needs to be.
+Google describes [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview) as an automated tool for performance, accessibility, SEO, and other page-quality audits. Lighthouse findings are indicators: each failed audit still needs investigation, an appropriate fix, and another measurement.
 
-Frontman now runs Lighthouse audits as a built-in agent tool. Your agent launches Chrome, audits the URL you are looking at, reads the scores, and starts fixing the issues — all inside the browser you are already working in.
+## What Frontman actually runs
 
-<!-- VIDEO_PLACEHOLDER: Demo video showing Frontman running a Lighthouse audit and fixing issues in a single session -->
+The implementation in [`FrontmanCore__Tool__Lighthouse.res`](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-core/src/tools/FrontmanCore__Tool__Lighthouse.res) does the following:
 
-### How It Works
+1. Launches an installed Chrome instance with `chrome-launcher`.
+2. Runs Lighthouse for performance, accessibility, best practices, and SEO.
+3. Accepts an explicit `desktop` or `mobile` preset; `desktop` is the default.
+4. Returns each category score from 0 to 100.
+5. Returns up to three lowest-scoring issues per category.
+6. Includes issue IDs, titles, descriptions, display values, and up to three selectors, HTML snippets, resource URLs, or source locations when Lighthouse supplies them.
+7. Returns Lighthouse warnings and the audit fetch time.
 
-When your agent calls the Lighthouse tool, here is what happens under the hood:
+The integration packages include Lighthouse and `chrome-launcher`, so a separate global Lighthouse install is not required. Chrome itself must be installed, and the target URL must be reachable from the machine running the framework integration.
 
-1. **Chrome launches headless** — no manual setup, no global installs. Lighthouse and chrome-launcher are bundled as dependencies.
-2. **All four categories run** — Performance, Accessibility, Best Practices, and SEO. Every audit, every time.
-3. **Scores come back as 0–100** with the top three failing audits per category, including what failed and why.
-4. **The agent reads the results** and starts editing your code to fix them.
+The audit launches a separate headless Chrome instance. It does not inherit cookies, local storage, or authentication from the Frontman preview browser. Frontman's current Lighthouse input accepts only a URL and preset; it does not provide an authentication strategy. Do not assume that signing in to the preview makes an authenticated route auditable, and do not weaken application authentication to make an audit pass.
 
-The agent does not need you to copy scores from one tab and paste them into another. It ran the audit. It has the results. It can act on them.
+## Reproducible audit workflow
 
-### What the Agent Sees
+Use a fixed URL, preset, application state, and code revision. Otherwise, before-and-after scores are not comparable.
 
-When the audit completes, the agent gets structured data like this:
+1. Start the application in a deterministic state. Use a URL that the separate headless Chrome instance can access without relying on the preview's authenticated session.
+2. Record the current commit or working-tree state.
+3. Ask Frontman: `Run Lighthouse on http://localhost:3000/ with the mobile preset. Report the fetch time, four category scores, warnings, and issue IDs. Do not edit files yet.`
+4. Save the returned baseline in the task or your PR notes.
+5. Pick one reported issue. Ask the agent to inspect the supplied selector, snippet, resource URL, or source location and propose the smallest fix.
+6. Review the diff and confirm the page still behaves correctly.
+7. Re-run the same URL and preset from the same application state.
+8. Compare the specific audit result as well as category scores. Revert the change if it causes a regression elsewhere.
 
-```text
-Performance: 62/100
-  - Largest Contentful Paint element (7,240 ms)
-  - Eliminate render-blocking resources (saves 1,200 ms)
-  - Properly size images (saves 340 KiB)
+For a desktop comparison, repeat the process with `preset: "desktop"`. Frontman's current tool description tells the agent to consider active device emulation, but the tool input still has an explicit preset. State it in the prompt when reproducibility matters.
 
-Accessibility: 88/100
-  - Image elements do not have [alt] attributes
-  - Links do not have a discernible name
-  - Background and foreground colors do not have a sufficient contrast ratio
+## Output shape, not benchmark data
 
-Best Practices: 92/100
-  - Uses deprecated APIs
-  - Browser errors were logged to the console
-
-SEO: 78/100
-  - Document does not have a meta description
-  - Links are not crawlable
-  - Image elements do not have [alt] attributes
-```
-
-The agent reads "Largest Contentful Paint element" and knows exactly which element to investigate. It traces the element back through your component tree, finds the image that is 3 MB when it should be 200 KB, adds `next/image` with proper `width` and `height` attributes, and the LCP drops from 7.2 seconds to 1.8 seconds.
-
-No tab switching. No copy-pasting issue descriptions. No translating Lighthouse jargon into code changes yourself.
-
-### Why This Matters More Than You Think
-
-Running Lighthouse from the terminal is possible. Running it from a CI pipeline is common. But neither of those closes the [runtime context gap](/blog/runtime-context-gap/) — the agent needs the audit results _and_ the ability to fix them in the same session.
-
-Here is the standard coding-agent workflow for performance optimization:
+Actual values depend on your page and run. Frontman returns structured data with this shape; placeholders below are intentionally not claimed results:
 
 ```text
-You: "Improve the Lighthouse score on the homepage"
-Agent: *opens the source file, looks at the code, makes educated guesses*
-       *adds lazy loading to some images*
-       *defers a script tag*
-You: *opens Chrome DevTools, runs Lighthouse manually*
-You: "Performance went from 62 to 68. The LCP image is still too large."
-Agent: *reads your description, tries to find the image*
-You: *runs Lighthouse again*
-You: "Better. Now accessibility is failing on contrast ratios."
-Agent: *asks which elements*
-You: *copies the audit output, pastes it into the chat*
+URL: <audited URL>
+Fetch time: <timestamp from Lighthouse>
+Warnings: <warnings from this run>
+
+Performance: <0-100 score from this run>
+  - <issue ID>: <title>
+    <display value, selector, snippet, URL, or source location when available>
+
+Accessibility: <0-100 score from this run>
+Best Practices: <0-100 score from this run>
+SEO: <0-100 score from this run>
 ```
 
-Five rounds. You are the human bridge between Lighthouse and the agent. You run the audit, read the results, translate them into text, and feed them to the agent one issue at a time.
+Only three failing issues per category are returned. Fixing one can expose another that was previously ranked lower, so absence from Frontman's summary does not mean an audit passed.
 
-Here is Frontman:
+## How to interpret results
 
-```text
-You: "Run a Lighthouse audit on this page and fix the top issues"
-Frontman: *launches Chrome, runs full audit*
-         *reads: Performance 62, LCP element 7.2s, render-blocking resources*
-         *optimizes the hero image, adds lazy loading, defers non-critical JS*
-         *re-runs audit: Performance 89*
-         *reads: Accessibility 88, missing alt attributes*
-         *adds alt text to 4 images*
-         *re-runs audit: Accessibility 100*
-```
+Lighthouse is a lab test, not a measurement of every real user's experience. Scores can move because of machine load, network conditions, page state, Chrome or Lighthouse versions, third-party requests, and application changes. Run multiple times when a small score difference matters, and use field data where available for production decisions.
 
-One prompt. The agent runs the audit, reads the results, makes the fixes, and verifies the improvement by running the audit again. You are not the middleware. The agent is.
+Also preserve category boundaries:
 
-### Mobile and Desktop
+- A performance recommendation is not automatically a safe code change.
+- An automated accessibility pass does not replace keyboard, screen-reader, or other manual testing.
+- SEO audits cover a defined set of checks, not indexing or ranking guarantees.
+- Best-practices findings still require security and compatibility review.
 
-Frontman reads the `device_emulation` context from your current session. If you are viewing the page in mobile mode, the agent passes `preset: "mobile"` to Lighthouse automatically. You do not need to specify it. The audit matches what you are looking at.
+Frontman's advantage is operational: the agent receives the measured issue and any element or resource detail Lighthouse provides, can inspect the related source through the framework integration, and can run the audit again after a reviewed edit. The agent may still choose the wrong fix, and the score may still vary.
 
-This matters because mobile and desktop Lighthouse scores are often different. A page that scores 95 on desktop might score 62 on mobile because of an unoptimized hero image that only appears on small viewports, or a render-blocking script that desktop hardware chews through but mobile throttling exposes.
-
-The agent audits what you are seeing. Not a default it picked.
-
-### The Shift
-
-Performance optimization has always been a feedback loop: measure, identify the issue, fix it, measure again. The problem was never the fixing — it was the measuring, and the translation layer between measurement and action.
-
-When the agent can run Lighthouse itself, that translation layer disappears. The measurement _is_ the context. The agent reads the failing audit, traces it to the source, makes the change, and verifies the improvement — all in one continuous action.
-
-Your performance scores stop being a report you read and start being a problem the agent solves.
-
-[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started/), works with your existing project. Read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/), see [how Frontman compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/), or read the full [Frontman vs Cursor](/vs/cursor/) comparison.
+See [Tool Capabilities](/docs/using/tool-capabilities/#lighthouse) for the current Frontman interface and Google's [Lighthouse documentation](https://developer.chrome.com/docs/lighthouse/overview) for audit methodology.

--- a/apps/marketing/src/content/blog/multi-select.md
+++ b/apps/marketing/src/content/blog/multi-select.md
@@ -1,101 +1,128 @@
 ---
 title: 'Fix Design Drift With Multi-Select'
 pubDate: 2026-02-27T12:00:00Z
-description: 'Spot inconsistencies across teams? Shift-click every off-brand element, describe what it should look like, and Frontman fixes them all in one pass — real code changes, no tickets filed.'
+description: 'Use Frontman annotations to select multiple UI elements, attach element-specific instructions, submit one prompt, and review the resulting source changes as a batch.'
 author: 'Danni Friedland'
 image: '/blog/multi-select-cover.png'
 imageAlt: 'Frontman multi-select for fixing design drift'
 articleSection: 'Product Announcement'
 tags: ['announcement', 'design-systems', 'ai']
-updatedDate: 2026-03-10T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 video:
   name: 'Frontman Multi-Select Demo'
-  description: 'See how Frontman multi-select lets you Shift-click multiple UI elements in your running app, add instructions to each, and fix them all in one shot with real source code edits and hot reload.'
+  description: 'See how Frontman annotations let you select multiple UI elements in a running app, add instructions, and send their visual and source context in one prompt.'
   youtubeId: 'J3_OQzzEJPY'
   thumbnailUrl: '/blog/multi-select-cover.png'
 faq:
   - question: 'What is multi-select in Frontman?'
-    answer: 'Multi-select lets you hold Shift and click multiple UI elements in your running app, add separate instructions to each one, and have Frontman fix all of them in a single pass. Instead of filing separate tickets for every design inconsistency, you batch all your visual fixes into one operation that produces real code changes.'
+    answer: 'Frontman annotation mode lets you select multiple elements before sending a prompt. Use repeated clicks, or Meta+Shift and drag to annotate meaningful elements inside a rectangle. Each annotation is enriched with available visual, DOM, and source context.'
   - question: 'Can designers and PMs use multi-select without writing code?'
-    answer: 'Yes. You describe fixes in plain language — "match this to our primary button style," "fix the spacing to 16px," "update this copy." Frontman translates your instructions into real source code edits. No IDE, no pull request workflow, no waiting for a developer to pick up the ticket.'
+    answer: 'They can select rendered elements and add plain-language comments without locating source files manually. The output is still source code and should be reviewed, tested, and approved through the team repository workflow.'
   - question: 'Which frameworks support Frontman multi-select?'
-    answer: 'Multi-select is available in all Frontman integrations: Next.js, Astro, and Vite (React, Vue, Svelte). Install with npx @frontman-ai/nextjs install, npx @frontman-ai/vite install, or astro add @frontman-ai/astro.'
+    answer: 'Frontman documents annotation source detection for React, Vue 3, and Astro projects. Source location can be unavailable when framework metadata or source detection fails, but the annotation can still include screenshot, selector, and other captured context.'
   - question: 'How does multi-select help maintain a design system?'
-    answer: 'When multiple teams ship features against the same design system, inconsistencies are inevitable. Multi-select lets you open any page, Shift-click every element that drifts from the system — wrong spacing, off-brand colors, incorrect component variants — and fix them all at once. It turns design QA from a reporting step into a fixing step.'
+    answer: 'It packages several visible inconsistencies into one prompt with ordered annotations and optional element-specific comments. The agent may process them as independent tasks or one coordinated change; reviewers must still inspect actual diff scope and shared-component impact.'
 ---
 
-You're doing a design QA pass. The dashboard a feature team shipped last week has a button using the wrong variant. The spacing on the metric cards doesn't match your system. A header still says placeholder copy. The empty state uses an icon you deprecated two months ago.
+Design QA often finds several related issues on one screen: a stale label, inconsistent card spacing, and a button using wrong existing variant. Treating each observation as a separate prompt loses shared page context. Treating all of them as one vague instruction makes review harder.
 
-You know exactly what each fix should be. But you can't make them. You open a ticket for the button. Another for the spacing. Another for the copy. Another for the icon. Four tickets, four handoffs, four items competing for engineering bandwidth against actual feature work. Maybe they get fixed this sprint. Maybe next.
+Frontman annotations provide a concrete middle path: select each rendered element, attach its requirement, and send selected context together.
 
-This is the bottleneck nobody talks about in design systems at scale. The system is defined. The violations are obvious. But the people who spot them — designers, PMs, design system leads — can't fix them. The feedback loop between "seeing the problem" and "shipping the fix" runs through a ticket queue.
+> **TL;DR:** enter annotation mode, select multiple elements with clicks or rectangle selection, add optional comments, and submit one prompt. Frontman sends ordered annotation context to agent. Agent decides whether work is independent or coordinated. Review resulting source diff; multi-selection does not guarantee one file, conflict-free edits, or correct design-system usage.
 
-> **TL;DR:** Frontman multi-select lets you Shift-click multiple UI elements in the running app, describe the fix for each in plain language, and apply all changes in one shot. No tickets, no handoffs. It produces real code changes that match your design system — not a mockup that still needs implementation.
+## Exact Selection Workflow
 
-## How Multi-Select Works
-
-Open your running app. Hold Shift and click every element that doesn't match your design system. Describe the fix for each one in plain language. Hit go. Frontman makes real code changes for all of them at once.
-
-The workflow:
-
-1. **Click elements in the running app** — hold Shift to select multiple
-2. **Describe the fix for each** — "use the outline button variant", "match the system spacing (16px)", "update copy to 'Team Dashboard'"
-3. **Frontman fixes all of them** — real code changes, live preview, one pass
-
-No tickets filed. No developer context-switching away from feature work. You saw the problem, you described the fix, it's done.
+1. Open Frontman workspace and load relevant page in web preview.
+2. Click cursor icon to enter annotation mode. Cursor becomes crosshair and hovered elements highlight.
+3. Click elements one at a time. Each receives numbered badge and optional comment popup.
+4. For rectangle selection, hold **Meta+Shift** and drag over a group. Current client implementation checks browser `metaKey` and `shiftKey` values.
+5. Add element-specific comments when requirements differ.
+6. Wait until annotation enrichment finishes. Send is disabled while annotation remains in progress.
+7. Submit annotations with shared chat instruction, or submit annotated comments without extra text.
+8. Inspect rendered result and source diff before keeping change.
 
 <iframe width="100%" height="400" src="https://www.youtube-nocookie.com/embed/J3_OQzzEJPY" title="Frontman Multi-Select Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="border-radius: 8px; margin: 2rem 0;"></iframe>
 
-## Why the Ticket Queue Was the Real Bottleneck
+## What Each Selection Contains
 
-The problem was never that fixes are hard. A wrong button variant is a one-line change. Wrong spacing is a one-line change. But when the person who spots these issues can't make the change directly, every one-line fix becomes a ticket, a handoff, a prioritization decision, and a review cycle.
+Frontman attempts to enrich each annotation with:
 
-Multiply that across teams. Your design system serves three, four, five feature teams. Each team ships UI that mostly follows the system — but "mostly" means dozens of small violations per sprint. The design system team becomes a QA function that files tickets they can't resolve themselves.
+- Element screenshot
+- CSS selector, tag, classes, nearby text, and bounding box
+- Framework-derived component name and source location when available
+- Bounded component context where integration supports it
+- Comment entered by user
 
-Multi-select changes the economics. Instead of reporting violations, you fix them. Frontman resolves each clicked element to its actual source file, understands the component tree and design system context, and generates coordinated edits across all your selections. If three issues map to the same component, it handles them in one edit.
+Annotations are sent as structured resources alongside prompt. Agent receives ordered annotated-element context and screenshots. This reduces ambiguity about which rendered nodes user means; it does not prove which source change is correct.
 
-## What This Looks Like in Practice
+## Concrete Batch Example
 
-Your growth team just shipped a new onboarding flow. You're doing a QA pass and spot five issues:
+This example is illustrative, not a customer incident or benchmark.
 
-- The page title still says "Page Title" — placeholder copy that slipped through review
-- Card spacing is 8px instead of 16px — doesn't match the design system
-- The "Get Started" button uses the solid variant — should be outline per your system's CTA rules
-- A table header is misaligned with the rest of the page
-- The empty state message has a typo
+Suppose onboarding page has three independent observations:
 
-Before multi-select, this is five tickets. Five handoffs to a developer who has to context-switch away from feature work. Five items in a backlog competing with actual product priorities. Some of these might not get fixed for weeks.
+| Annotation       | Comment                                            | Constraint              |
+| ---------------- | -------------------------------------------------- | ----------------------- |
+| Page heading     | `Replace placeholder with "Create your workspace"` | Copy only               |
+| Card row         | `Use existing spacing-4 token between cards`       | No new token            |
+| Secondary action | `Use existing outline variant`                     | Preserve click behavior |
 
-With multi-select, you Shift-click all five elements, type a short instruction for each, and submit once. Frontman maps each element back to its source file through the live [DOM-to-source mapping](/blog/runtime-context-gap/) that comes from running inside the framework. All five fixes land at once. You see the corrected page immediately. If one fix isn't quite right, you adjust that one — the other four are done.
+Submit shared instruction:
 
-Total time from spotting the issues to shipping the fixes: under a minute.
-
-## Design System Consistency at Scale
-
-The real value isn't saving time on any single fix. It's closing the loop between the people who define the system and the code that implements it.
-
-When your design system serves multiple teams, drift is inevitable. Team A interprets the button guidelines one way, Team B another. Spacing gets approximated. Copy doesn't match the content spec. The design system team catches these in QA — but until now, catching them and fixing them were two completely separate steps with a ticket queue in between.
-
-Multi-select makes QA and fixing the same step. Browse the app, Shift-click everything that's off, describe each fix, submit. It works the way you already work in Figma — select multiple layers, adjust properties, done. Except these are real code changes in the actual codebase, not design file edits that still need to be implemented.
-
-This changes the dynamics between design and engineering. Instead of being the team that files polish tickets nobody prioritizes, the design system team becomes the team that [keeps the product consistent — directly](/blog/team-collaboration/).
-
-## How It Works Under the Hood
-
-Frontman runs inside your dev server - it's part of the app, not a browser extension or screenshot tool. This is how [browser-aware AI tools understand your design system](/blog/what-are-browser-aware-ai-coding-tools/) at the source level. When you click an element, it resolves the click to the actual source file and line number using the framework's source map. It sees the live DOM, the component tree, computed styles, and your [design system context](/blog/runtime-context-gap/).
-
-Multi-select collects all your selections and batches them into a single coordinated edit. Each selection carries its own instruction and source mapping. Frontman reasons about all of them together — if two fixes target the same component, both changes land in one clean edit without conflicts.
-
-## Try It
-
-Multi-select is available now in all Frontman integrations — [Next.js](/docs/integrations/nextjs/), [Astro](/docs/integrations/astro/), and [Vite](/docs/integrations/vite/) (React, Vue, Svelte). Install the package for your framework:
-
-```bash
-npx @frontman-ai/nextjs install
-npx @frontman-ai/vite install
-npx astro add @frontman-ai/astro
+```text
+Apply comments to these annotations. Keep changes on this page,
+reuse existing tokens and variants, and do not change routing,
+event handlers, state, or shared defaults.
 ```
 
-Then anyone on the team — designer, PM, design system lead — can open the `/frontman` workspace, hold Shift, click everything that drifts from the system, and fix it. Follow the [getting started guide](/blog/getting-started/) for the complete setup flow.
+Good result is not "three fixes happened at once." Good result is reviewable evidence:
 
-Star it on [GitHub](https://github.com/frontman-ai/frontman) if you've ever wished you could fix design inconsistencies yourself instead of filing tickets.
+- Diff touches only files required by requested changes
+- Existing token and variant APIs are reused
+- Event handlers and behavior remain unchanged
+- Browser result matches comments at relevant viewports
+- Automated checks pass
+
+## Selection Constraints
+
+### Rectangle selection is geometric
+
+Drag operation finds visible, meaningful elements whose bounding rectangles overlap selection rectangle, then favors more specific descendants over matching ancestors. It does not understand design intent. Review numbered annotations and remove accidental selections before sending.
+
+### Source detection can fail
+
+Framework metadata, source maps, cross-origin behavior, or timeout can prevent source location resolution. Annotation remains usable with available screenshot and DOM context, but agent may need to search. Do not claim every selected element maps directly to exact file and line.
+
+### Multiple selections are not atomic edits
+
+Agent decides whether to create independent tasks or coordinated change. Selected elements may resolve to one file, several files, shared component, or generated output. There is no guarantee of one edit, no conflicts, or unchanged unrelated usages.
+
+### Shared components expand blast radius
+
+Several selected instances can point to same component. Changing shared implementation may affect unselected pages. Prefer instance-level props when intent is local; require code-owner review when shared default changes.
+
+### Navigation clears live annotations
+
+Annotations refer to current DOM elements. Navigating or reloading destroys those references and clears active annotations. Batch one stable page state at a time.
+
+## Expected Diff and Review Behavior
+
+Before accepting output, inspect:
+
+1. **File scope:** Did only relevant source files change?
+2. **Selection coverage:** Does each requested annotation have corresponding change, and no extra change?
+3. **Shared impact:** Did agent alter reusable component or token definition rather than intended instance?
+4. **Instruction conflicts:** If comments conflict, did agent expose or silently choose between them?
+5. **Code quality:** Are existing components, tokens, utilities, and conventions preserved?
+6. **Behavior:** Did event handlers, accessibility semantics, responsive states, and data flow remain intact?
+7. **Verification:** Does browser result match request, and do project checks pass?
+
+Keep batch small enough that reviewer can map each annotation to diff hunk. Split unrelated pages or risk classes into separate prompts and pull requests. No universal selection count is safe; diff comprehensibility is governing limit.
+
+## When to Use Multi-Selection
+
+Use it for related, visible corrections sharing one page or review context. Avoid batching unrelated redesign, logic changes, dependency work, and shared-system migrations merely because elements can be selected together.
+
+For complete annotation behavior and fallback rules, read [Annotations](/docs/using/annotations/) and [Web Preview](/docs/using/web-preview/). For ownership of resulting changes, read [Design System Collaboration Without Tickets](/blog/team-collaboration/).
+
+Start with [Frontman installation](/docs/installation/), then test multi-selection on a branch with normal review controls.

--- a/apps/marketing/src/content/blog/runtime-context-gap.md
+++ b/apps/marketing/src/content/blog/runtime-context-gap.md
@@ -1,85 +1,132 @@
 ---
 title: 'Runtime Context Gap in AI Coding Tools'
 pubDate: 2026-02-20T05:00:00Z
-description: 'AI coding tools read your source files but never see the running application. Here is what that means technically — on both the client and server side — and which tools are building the bridge.'
+description: 'A technical taxonomy of static, process, browser, framework, and verification context, with examples of how coding agents can collect each layer.'
 author: 'Danni Friedland'
 articleSection: 'Technical Explainer'
 image: '/blog/runtime-context-gap-cover.png'
 imageAlt: 'Runtime Context Gap in AI Coding Tools cover'
 tags: ['ai', 'developer-tools']
-updatedDate: 2026-03-10T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-Current AI coding tools operate on source files. They read your code, predict what the application does, and generate edits. This works well for pure logic — functions with clear inputs and outputs, refactoring, type-level changes.
+The runtime context gap is not “AI cannot see a browser.” Modern coding agents can receive browser data through built-in integrations, automation libraries, or MCP servers. The more precise definition is:
 
-It falls apart when the source code isn't the whole story. And for any application with a runtime — a web app running in a browser, a server handling requests, a framework with middleware and compiled output — the source code is never the whole story.
+> A runtime context gap exists when evidence needed to decide or verify a code change is produced only while the system runs, but that evidence is absent from the agent's working context.
 
-This isn't just a frontend problem. The browser has computed styles and a rendered DOM that don't exist in your source files. But the server side has its own runtime context that source code alone can't capture: which routes are registered, what the compiled module graph looks like, what's in the server logs, what middleware is active and in what order.
+This definition is task-specific. Source text may be sufficient to rename a function. It is insufficient to prove which CSS rule wins at a particular viewport or which middleware handled a request.
 
-The question is whether connecting AI tools to this runtime state — both client and server — is a meaningful improvement or just a debugger hook with extra steps. Having worked on this problem, the honest answer is: it's a debugger hook with extra steps, _and_ it's a meaningful improvement. Those aren't contradictory.
+## A Five-Layer Context Taxonomy
 
-### The Gap Is Real (But Let's Be Precise)
+| Layer                | Typical evidence                                              | Question it answers                    |
+| -------------------- | ------------------------------------------------------------- | -------------------------------------- |
+| Static project       | source, config, types, dependency graph                       | What could the program do?             |
+| Process runtime      | logs, environment, loaded modules, routes, requests           | What did this running process do?      |
+| Browser document     | DOM, accessibility tree, computed styles, geometry, network   | What did this page render and request? |
+| Framework provenance | component tree, props, hydration boundaries, source locations | Which framework construct produced it? |
+| Verification         | tests, traces, screenshots, before/after runtime values       | Did the change satisfy the criterion?  |
 
-When an AI coding tool edits your project, it's working from source text. Here's what it doesn't have:
+Tools differ less by whether they are “runtime-aware” than by which layers they collect, how fresh that evidence is, and whether they correlate layers reliably.
 
-**Client-side runtime (the browser):**
+## Layer 1: Static Project Context
 
-- **Computed styles.** The final CSS applied to an element is the product of specificity, cascade order, media queries, CSS variables, container queries, and inheritance. The AI sees class names. The browser computes actual values.
-- **The rendered DOM.** Your JSX is not your DOM. Conditional rendering, portals, fragments, and framework transformations mean the actual tree looks different from what the source suggests.
-- **Layout geometry.** Is there 16px or 24px between the sidebar and content area? The AI can read `gap-4` in a Tailwind class but can't see that a parent's padding also contributes to the visual spacing.
+Static context includes source files, build configuration, type information, lockfiles, and relationships an agent can infer without running the application. This is the strongest layer for API changes, refactors, and repository-wide consistency checks.
 
-**Server-side runtime (the dev server):**
+Static context can show that a component contains `padding: var(--space-4)`. It cannot establish the final value of that custom property in a particular document state, whether another rule overrides the declaration, or the element's resulting geometry.
 
-- **Compiled module graph.** Frameworks like Next.js, Vite, and Astro transform your source before serving it. The AI sees source files; the dev server sees the compiled, bundled, tree-shaken output.
-- **Registered routes and middleware.** File-based routing means the route table is a runtime artifact. Middleware ordering, redirect chains, and rewrite rules exist in the server's state, not in any single source file.
-- **Server logs and errors.** A component that renders fine might be throwing warnings server-side. The AI editing your code doesn't see `stdout`.
-- **Framework-specific context.** Astro island hydration directives, Next.js server/client component boundaries, Vite's HMR module graph - these are framework runtime concepts that source code only partially describes - which is why [browser-aware AI coding tools](/blog/what-are-browser-aware-ai-coding-tools/) take a different approach.
+The gap begins only when one of those facts matters to the task.
 
-### An Uncomfortable Question
+## Layer 2: Process Runtime Context
 
-If your code is so decoupled from its runtime behavior that neither you nor an AI can predict what it does, you might have an architecture problem that no tool will fix. Deeply nested utility classes, conditional rendering spread across five files, CSS overrides cascading through three abstraction layers — an AI with runtime access can patch around this, but it can't solve it.
+Process context is evidence from a running development server, application server, worker, or test process:
 
-This doesn't invalidate the tooling argument. Even well-structured codebases have the source-to-runtime gap. But runtime-aware AI is most valuable when your code is already reasonable, and least valuable when it's used to paper over a mess you should be simplifying.
+- emitted logs and stack traces;
+- environment-dependent configuration;
+- observed requests and responses;
+- loaded or transformed modules;
+- route and middleware behavior;
+- hot-update events and build errors.
 
-### What "Runtime-Aware" Actually Means
+Example: source inspection may show several possible request handlers. A request trace or server log identifies which handler ran with the current host, flags, and middleware order. That is observed behavior, not a prediction from files.
 
-Strip away the marketing and the architecture is straightforward: you give an AI agent access to runtime information from both the browser _and_ the dev server, then let it correlate that information back to source files.
+Development servers also maintain runtime state. [Vite's HMR API](https://vite.dev/guide/api-hmr) documents update boundaries, invalidation, and client/server HMR events. Reading a source import graph is related to, but not identical with, observing how the active dev server handles an update.
 
-Modern web frameworks already bridge client and server — Next.js, Astro, and Vite all have dev servers that know about your component tree, module graph, and build output. A tool that hooks into the framework middleware gets both sides for free — this is the approach behind [Frontman](/blog/frontman-launch/).
+## Layer 3: Browser Document Context
 
-```text
-┌──────────────────────────┐    ┌──────────────────────────┐
-│ Client Runtime (Browser) │    │ Server Runtime (Dev Svr)  │
-│                          │    │                           │
-│  DOM tree                │    │  Route table              │
-│  Computed styles         │    │  Compiled module graph    │
-│  Component tree          │    │  Server logs / errors     │
-│  Console output          │    │  Middleware state          │
-│  Client state            │    │  HMR module map           │
-└────────────┬─────────────┘    └─────────────┬─────────────┘
-             │                                │
-             └──────────┬─────────────────────┘
-                        ▼
-                 Runtime Bridge (MCP tools)
-                        │
-                        ▼
-              AI Agent + Source file mapping
-```
+Browser context includes data exposed by the live page and browser tooling:
 
-The critical piece is the **source mapping** — connecting "this DOM element at runtime" back to "this component in this file at this line." Different tools achieve this at different depths: framework middleware (deepest, framework-specific), browser proxy (client-only), or MCP server (varies).
+- rendered DOM and accessibility structure;
+- computed CSS and matched rules;
+- element bounding boxes and viewport state;
+- console messages and exceptions;
+- network requests, responses, and timing;
+- focus, selection, scroll, and interaction state.
 
-### The Tools Building This
+These are distinct evidence types. A screenshot can prove visible output but loses DOM identity. A DOM snapshot gives structure but may omit interaction history. Computed styles show resolved values but not necessarily the maintainable source edit.
 
-A few projects are working on this — letting you [click any element in your running application](/blog/tutorial-nextjs-runtime-context/) and describe changes in plain language — each with different tradeoffs. [Frontman](https://frontman.sh) hooks into the framework as middleware for the deepest integration. [Stagewise](https://stagewise.io) uses a browser proxy approach with more polish. [Tidewave](https://tidewave.ai) goes deep on backend runtime for Phoenix/Rails/Django. Chrome DevTools MCP exposes browser state to any agent; our [Puppeteer MCP alternatives](/blog/puppeteer-mcp-alternatives-claude-code/) guide explains that browser-only path for Claude Code. For a category definition, read our [frontend agent explainer](/blog/frontend-agent/). For detailed comparisons, see our [roundup of browser-aware AI tools](/blog/browser-aware-ai-tools-2026/) or the [best AI coding agent for frontend](/blog/best-frontend-coding-agent/) guide.
+[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) documents browser automation, DOM snapshots, console and network inspection, screenshots, emulation, and performance traces. [Claude Code's Chrome integration](https://code.claude.com/docs/en/chrome) documents a similar class of browser tasks. These integrations close parts of the browser gap; they do not automatically close every other layer.
 
-### The Maintenance Trap
+## Layer 4: Framework Provenance
 
-Runtime-aware AI makes it very easy to iterate on changes. Click, describe, hot reload, done. This is genuinely useful for prototyping, design tweaks, and CSS fixes where you can see the result is correct.
+The browser owns DOM nodes. A framework owns higher-level concepts such as components, props, state, server/client boundaries, or hydration units. Mapping between them is framework-specific.
 
-But "it looks right" is not the same as "I understand what changed." If an AI rewrites your Tailwind classes, restructures your JSX, or adds inline styles to fix a layout — and you ship it without understanding the diff — you've created maintenance debt — and compromised your [design system integrity](/blog/ai-coding-agents-blind-to-ui/).
+[React Developer Tools](https://react.dev/learn/react-developer-tools), for example, provides Components and Profiler panels to inspect React components, props, state, and performance. That capability exists because a component tree is not equivalent to an HTML DOM tree.
 
-The rule should be the same as it's always been: **don't commit code you don't understand.** Whether a blind AI wrote it, a seeing AI wrote it, or you wrote it while sleep-deprived — if you can't explain the diff to a colleague, it shouldn't be merged.
+For coding agents, useful provenance can include:
 
-Runtime-aware tools are better inputs to AI, not substitutes for engineering judgment. They reduce the guess-and-check cycle, which is real waste. They don't reduce the need to understand your own codebase.
+- component display name and ownership chain;
+- source file and line associated with a rendered element;
+- props or state relevant to the selected output;
+- whether a component or token is shared;
+- framework diagnostics from the development server.
 
-[Frontman](https://frontman.sh) is source-available on [GitHub](https://github.com/frontman-ai/frontman): the browser client and JavaScript framework integrations are Apache-2.0, the WordPress plugin is GPL-2.0-or-later, and Frontman Server is AGPL-3.0-only with AI Supplementary Terms. The runtime context gap is real regardless of which tool you use to address it.
+This is where framework integrations can add information that generic browser control does not document. Depth varies by framework, build mode, and tool; “has DOM access” should not be used as a proxy for source provenance.
+
+## Layer 5: Verification Context
+
+Collection before an edit helps choose a change. Collection after an edit determines whether it worked.
+
+Verification should match the acceptance criterion:
+
+- For layout: compare computed values, geometry, and relevant viewports.
+- For behavior: replay the user flow and inspect resulting state.
+- For network bugs: compare requests, responses, and console/server errors.
+- For performance: collect a trace under controlled conditions.
+- For code health: run tests, type checks, lint, and inspect the diff.
+
+“The file changed” is not runtime verification. “The page refreshed” is not proof that the target state is correct. Conversely, “the screenshot looks right” does not prove shared components, tests, or accessibility remain correct.
+
+## Three Integration Patterns
+
+### Browser Automation
+
+An agent drives a browser through an extension or automation protocol. This is portable and effective for navigation, user flows, screenshots, DOM inspection, and browser diagnostics. It may require the agent to discover the target and correlate browser evidence with source.
+
+### DevTools or MCP Bridge
+
+A server exposes selected browser or process capabilities as structured tools. MCP standardizes how an agent invokes those tools, not the depth or accuracy of the underlying evidence. A browser MCP server and a framework MCP server can expose very different context.
+
+### Framework Integration
+
+A plugin or middleware layer gathers framework-specific metadata and may connect runtime entities to source. This can improve provenance but costs implementation effort, framework coverage, and compatibility maintenance.
+
+Frontman combines browser tools with local framework integrations; see the [Frontman repository](https://github.com/frontman-ai/frontman) for the implementation and license boundaries. Other tools choose different combinations. [Browser-aware AI tools](/blog/browser-aware-ai-tools-2026/) compares products, while the [UI-context checklist](/blog/ai-coding-agents-blind-to-ui/) explains how to evaluate their evidence.
+
+## Failure Modes to Test
+
+Runtime access can still produce wrong conclusions:
+
+- **Stale state:** evidence was captured before the relevant interaction or update.
+- **Wrong target:** the agent inspected a visually similar node or component instance.
+- **Missing provenance:** it found a DOM value but guessed the controlling source.
+- **Unrepresentative environment:** development flags, data, fonts, or viewport differ from the failing case.
+- **Shallow verification:** one state improved while another regressed.
+- **Excessive access:** browser or process data entered agent context without appropriate controls.
+
+Runtime-aware systems should make evidence and uncertainty visible, not merely add more opaque context.
+
+## The Architectural Takeaway
+
+No single context layer is the truth for every task. Source describes intent and possible behavior. Runtime instruments provide observations. Framework metadata provides provenance. Tests and review decide whether a proposed change is acceptable.
+
+Better coding-agent architecture connects those layers without pretending observation replaces engineering judgment. For workflow selection across browser, IDE, and terminal tools, read [Frontman vs Cursor vs Claude Code](/blog/frontman-vs-cursor-vs-claude-code/). For hands-on setup, see the [Next.js runtime context tutorial](/blog/tutorial-nextjs-runtime-context/).

--- a/apps/marketing/src/content/blog/security.md
+++ b/apps/marketing/src/content/blog/security.md
@@ -2,117 +2,168 @@
 title: "Frontman's AI Coding Agent Security Model"
 seoTitle: 'AI Coding Agent Security Model'
 pubDate: 2026-02-17T05:00:00Z
-description: "Frontman's AI coding agent security model: development-only runtime, scoped file edits, BYOK providers, encrypted API keys, and reviewable git diffs."
+description: 'A due-diligence guide to Frontman’s browser, server, provider, filesystem, persistence, legal, and human-review boundaries.'
 author: 'Danni Friedland'
 articleSection: 'Technical Explainer'
 image: '/blog/security-cover.png'
 imageAlt: 'Frontman AI coding agent security model cover'
 tags: ['security', 'open-source']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 faq:
   - question: 'Is Frontman safe to use?'
-    answer: 'Yes. Frontman client integrations run exclusively in your local development environment as dev dependencies. They never ship to production — client code is removed at compile time by tree-shaking. Browser tools run in your browser, filesystem tools run locally through the framework integration, and the orchestration server has no direct filesystem access. Every change produces a standard git diff that goes through your normal PR review process. Frontman cannot deploy code, run arbitrary shell commands, or modify files outside your project directory.'
+    answer: 'No development tool can be guaranteed safe for every environment. Frontman separates browser tools, local filesystem tools, server orchestration, and external AI-provider processing. Teams should assess those boundaries, connected providers, data categories, deployment configuration, and generated diffs against their own threat model before use.'
   - question: 'Does Frontman run in production?'
-    answer: 'No. Frontman client integrations activate only when NODE_ENV=development. In a production build, Frontman client code is not included — not disabled, not present. The tree-shaker removes it because nothing imports it outside of dev mode. This is a compile-time guarantee.'
+    answer: 'The JavaScript integrations are intended for development workflows, but Next.js middleware or proxy code can remain active in a production build unless you add an environment guard or remove it. The WordPress plugin is a live-site integration and can mutate production WordPress data. Verify deployed routes, restrict access, test built artifacts, and use staging or current backups before production changes.'
   - question: 'What does the AI agent see when using Frontman?'
-    answer: 'The AI sees context relevant to the current edit, which may include file content, components, styles, DOM information, screenshots, logs, metadata, tool results, and generated output. This passes through the Frontman orchestration server to the AI provider you choose (Anthropic, OpenAI, or OpenRouter). The server persists task history, and your key is stored encrypted on the Frontman server and never exposed to the browser.'
+    answer: 'Depending on the task and tools used, Customer Content can include prompts, source-code snippets, project files, DOM and component information, computed CSS, screenshots, logs, routes, source maps, build errors, metadata, tool results, generated output, and task history. Relevant content passes through the Frontman server to the customer-selected AI provider.'
   - question: 'Can Frontman edit any file on my system?'
-    answer: 'No. Frontman edits source files in your project directory only. It does not touch node_modules, config files outside the project root, or files in .gitignore. It cannot run arbitrary shell commands, deploy code, or merge its own PRs.'
+    answer: 'Frontman file tools resolve paths under the source root exposed by the framework integration, and the hosted server has no direct filesystem access. Treat this as one control, not a complete sandbox: review the configured root, integration version, available tools, symlink and repository layout, and resulting git diff before approving changes.'
   - question: 'What if Frontman writes bad code?'
-    answer: 'Your code review catches it — the same way it catches bad suggestions from Copilot or bugs in Cursor-generated code. Frontman does not bypass your review process. Every change shows up in git status, hot-reload shows the visual result immediately, and git checkout undoes any change instantly.'
+    answer: 'Generated edits can be incorrect, incomplete, insecure, or unsuitable. Frontman does not remove the need for source review, tests, security checks, backups, branch protection, CI, and deployment approval. Reject or revert changes that do not pass those controls.'
 ---
 
-You already let AI agents edit your codebase. Cursor writes directly to your files. Claude Code runs shell commands. Copilot suggests code inline and you tab-accept it without reading every line. That is the reality of how developers work now.
+Security review should start with data flow and authority, not a yes-or-no label. In the JavaScript integrations, browser tools inspect the running page and file tools execute through a framework integration on the machine that owns the project. In WordPress, tools execute inside the authenticated live site and mutate WordPress data rather than a local source tree. A hosted or self-hosted server orchestrates the agent loop and persists task history, and a customer-selected AI provider generates responses and tool calls.
 
-So when you hear "Frontman edits your source files," the question is not _whether_ you trust an agent to touch your code. You already made that call. The question is what constraints are in place when it does.
+This guide maps those boundaries to evidence you can inspect. It is not a certification, penetration-test report, warranty, or guarantee that Frontman is appropriate for your environment.
 
-Here is every hard question you should ask, and our answers.
+## Evidence set for due diligence
 
-> **TL;DR:** Frontman is a dev-only tool that produces git diffs. Browser tools run in your browser, filesystem tools run on your machine through the framework integration, and the hosted or self-hosted server orchestrates the agent loop and persists task history. Relevant context passes through that server to your chosen AI provider. Frontman cannot run in production (compile-time guarantee), deploy, run shell commands, or push code. Everything goes through your normal code review.
+Review current sources before adoption because software, infrastructure, providers, and policies change:
 
-## Where Does It Run?
+- [Architecture documentation](/docs/reference/architecture/) for execution environments, tool routing, and persistence
+- [Tool capabilities](/docs/using/tool-capabilities/) for exposed browser and dev-server operations
+- [Limitations and workarounds](/docs/using/limitations/) for visibility and execution limits
+- [Source repository](https://github.com/frontman-ai/frontman) for implementation and package licenses
+- [Security policy](https://github.com/frontman-ai/frontman/blob/main/SECURITY.md) for supported versions, scope, and private vulnerability reporting
+- [Privacy Policy](/privacy/) for data categories, retention, hosting, diagnostics, and credentials
+- [Data Processing Agreement](/dpa/) and [Technical and Organizational Measures](/toms/) for business-customer processing terms and stated controls
+- [Subprocessor list](/subprocessors/) for hosted-service dependencies
+- [Terms of Use](/terms/) for customer responsibilities, provider boundaries, output limitations, and warranty terms
 
-Frontman's client integrations run exclusively in your local development environment as dev dependencies. They never ship to production, run in CI, or touch your deployed application. The separate hosted or self-hosted server provides orchestration and task-history persistence during development.
+Repository visibility lets you inspect claims; it does not establish that your deployed instance is correctly configured or free of vulnerabilities.
 
-The framework integrations — Next.js, Astro, Vite — activate only when `NODE_ENV=development`. In a production build, Frontman's code is not included. Not disabled. Not present. The tree-shaker removes it because nothing imports it outside of dev mode.
+## Data-flow boundaries
 
-This is not a toggle. It is a compile-time guarantee. Frontman client code _cannot_ run in production because it does not exist in the production bundle.
+### 1. Browser
 
-## What Can It Change?
+The browser client hosts chat and the live preview. Browser-side tools can inspect the preview DOM, take screenshots, search visible text, navigate, interact with elements, and change device mode. Their visibility is limited to the preview context described in [Limitations](/docs/using/limitations/); other tabs, DevTools, and cross-origin iframe content are not generally exposed through those tools.
 
-Your source files. That is it.
+Risk questions:
 
-Frontman edits the same files you edit, in the same working directory, tracked by the same Git repository. This is the same model as Cursor or Claude Code — direct file edits. Every change produces a standard diff:
+- Can previews contain customer, employee, authentication, or production-derived data?
+- Are screenshots, DOM text, URLs, or browser logs likely to contain secrets or personal data?
+- Do users understand which page state is being attached to a task?
 
-```bash
-$ git diff
-diff --git a/src/components/Hero.tsx b/src/components/Hero.tsx
-index 3a1f2c8..7b4e9d1 100644
---- a/src/components/Hero.tsx
-+++ b/src/components/Hero.tsx
-@@ -12,7 +12,7 @@
--    <div className="p-4 max-w-2xl mx-auto">
-+    <div className="p-6 max-w-2xl mx-auto">
-```
+### 2. JavaScript dev server and filesystem
 
-That diff shows up in `git status`. It goes through your normal PR review. If it is wrong, `git checkout -- src/components/Hero.tsx` undoes it. No hidden state, no shadow copies, no parallel universe where the agent's version of your code diverges from yours.
+For Next.js, Astro, and Vite, file and project tools execute through the framework integration. The Frontman server relays requests but does not directly mount your filesystem. Current read, write, and edit tools resolve requested paths under the integration's configured source root; edits to existing files also require a prior read in the active tool process.
 
-**The change _is_ the code.** It cannot drift because it is not stored anywhere else.
+That narrows authority but does not make generated edits trustworthy. The tools can modify source under the exposed root. Review:
 
-## What Does the AI Agent See?
+- configured project and source roots;
+- monorepo and symlink behavior;
+- package version and enabled tool registry;
+- OS permissions of the dev-server process;
+- untracked files and secrets located inside the exposed root;
+- git diff plus changes to generated or ignored files.
 
-Context that bridges [the runtime context gap](/blog/runtime-context-gap/) — including relevant file content, components, styles, DOM information, screenshots, logs, metadata, tool results, and generated output — passes through the Frontman orchestration server to the AI provider you choose. The server persists task history. It has no direct access to your filesystem; file reads and edits execute on your machine through the framework integration.
+Frontman's current agent toolset has no general-purpose terminal tool. Internal implementation may invoke fixed subprocesses for specific features such as search or Lighthouse; that is different from granting the model arbitrary shell access. Verify the current tool registry rather than relying on this page indefinitely.
 
-You bring your own API key. You pick your provider:
+### 3. Frontman server
 
-- **Claude** via Anthropic
-- **OpenAI**
-- **OpenRouter** for access to multiple models
+The hosted or self-hosted Phoenix server handles authentication, credential resolution, agent orchestration, WebSocket transport, tool routing, and persistence. Task interactions are persisted in PostgreSQL before broadcast, including messages, tool calls, tool results, pauses, retries, and completion events.
 
-Your key is stored securely in Frontman's server database, encrypted at rest. It is never exposed to the browser. The request goes from Frontman's server to the AI provider using your key, and the result is streamed back to your browser. This is the same trust model you already accepted when you pasted your API key into Cursor's settings or configured Claude Code with your Anthropic key.
+For the hosted service, the [Privacy Policy](/privacy/) states that conversation and task history remains until user deletion, with deleted data potentially retained in backups for up to three months. It also states that hosted infrastructure is in the European Union on Hetzner. Confirm contractual and regional requirements against current legal documents before onboarding sensitive projects.
 
-## What Can It Not Do?
+### 4. AI provider
 
-This list matters more than the feature list:
+Frontman uses customer-selected providers. Relevant prompts, code context, screenshots, logs, metadata, tool results, and generated output can pass through the Frontman server to that provider. Provider terms, retention, training controls, data location, availability, and security are separate review items controlled partly by your provider account and contract.
 
-- It cannot deploy code
-- It cannot access production environments
-- It cannot run arbitrary shell commands
-- It cannot modify files outside your project directory
-- It cannot bypass your Git hooks or CI checks
-- It cannot merge its own PRs
+The [Terms](/terms/) and [DPA](/dpa/) assign customers responsibility for selecting providers, configuring provider-side controls, and ensuring they are authorized to transmit Customer Content. Do not assume bring-your-own-key means content bypasses Frontman's hosted server.
 
-That last point is worth emphasizing. Cursor and Claude Code can both run `git push` if you let them. Frontman produces diffs. Humans review and ship those diffs. That boundary is not a limitation — it is the design.
+## Credentials and authentication
 
-## Source-Available and Auditable
+The hosted-service [Privacy Policy](/privacy/#api-keys-and-credentials) states that stored API keys and provider credentials use server-side application-level encryption. Authorized personnel and systems may access or decrypt credentials when needed to provide, secure, maintain, troubleshoot, or support the service.
 
-Frontman is source-available. Every prompt template, every tool call, and every edit operation is visible in the repository, so you can audit what the agent sees and what actions it can take.
+Before adoption:
 
-- **Source**: [github.com/frontman-ai/frontman](https://github.com/frontman-ai/frontman)
-- **License**: Apache-2.0 (browser client and JavaScript framework integrations), GPL-2.0-or-later (WordPress plugin), AGPL-3.0-only plus [AI Supplementary Terms](https://github.com/frontman-ai/frontman/blob/main/AI-SUPPLEMENTARY-TERMS.md) (server)
+1. Use provider credentials dedicated to Frontman where the provider supports it.
+2. Apply least privilege, spend limits, usage alerts, and rotation procedures.
+3. Review Frontman account authentication and offboarding.
+4. For JavaScript integrations, test access to `/frontman` and related endpoints in development, preview, and production builds. For WordPress, restrict `/frontman` to intended administrators and protect administrator sessions.
+5. Do not place secrets in prompts, screenshots, filenames, URLs, logs, DOM text, or source files exposed to the tool root.
 
-If you do not trust a claim on this page, read the code. That is the point of source availability.
+No encryption statement eliminates endpoint compromise, access-control mistakes, provider risk, or accidental disclosure through submitted content.
 
-## Common Objections
+## JavaScript development and production boundary
 
-**"What if the agent writes malicious code?"**
-Then your code review catches it. The same way it catches a bad suggestion from Copilot that you tab-accepted without reading, or a subtle bug in a Cursor-generated function (see [Frontman vs. Cursor vs. Claude Code](/blog/frontman-vs-cursor-vs-claude-code/) for a detailed comparison). Frontman does not bypass your review process. It feeds into it. If you are shipping AI-authored code without review, the agent is not your biggest problem.
+The Next.js, Astro, and Vite integrations are designed for development workflows and do not deploy customer code. That product intent is not a substitute for deployment verification.
 
-**"What about API key security?"**
-Your API key is stored encrypted in Frontman's server database. It never touches your browser. Requests to your chosen AI provider are made server-side over HTTPS, so the key is never exposed in client-side code or network traffic visible to the browser. This is a stronger security posture than storing a key in a `.env` file or your Cursor config.
+For each framework and release:
 
-**"What if it edits the wrong file?"**
-You see the diff immediately. Hot-reload shows you the result in the browser in the same action. If it is wrong, you undo it. This is less risky than a blind agent edit from Cursor, where you accept the change and then have to manually switch to the browser to verify. Frontman shows you the visual result before you decide to keep it.
+1. Inspect installer changes to middleware, proxy, instrumentation, and dependencies.
+2. Build the application with production settings.
+3. Confirm whether Frontman client code or routes are present and whether they are reachable.
+4. Apply network and authentication controls appropriate to any reachable route.
+5. Keep code deployment, secrets, production credentials, and approval authority outside the agent workflow.
 
-**"Can I restrict which files it can edit?"**
-Yes. Frontman edits source files in your project directory. It does not touch `node_modules`, config files outside the project root, or files in `.gitignore`. You can further constrain it through your `agents.md` conventions — the same file your other agents already read.
+Next.js needs particular attention: the [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write middleware for Next.js 15 and earlier or a proxy for Next.js 16 and later. Those generated handlers and matchers contain no `NODE_ENV` guard. Next.js 15 middleware declares the Node.js runtime; Next.js 16 proxy uses its supported default runtime because the generated proxy omits the runtime field. If the files remain in a production build, Frontman request handling can remain present. Add an explicit environment guard or remove the integration for deployment, then build and test the deployed artifact. Avoid absolute claims such as “cannot exist in production” unless your own artifact and controls prove that statement.
 
-## The Security Model in One Sentence
+## WordPress live-site threat model
 
-Frontman is a dev tool that produces diffs. Browser tools run in your browser, filesystem tools run locally through the framework integration, and the server orchestrates the loop, persists task history, and sends relevant context to your chosen AI provider. Everything else — review, testing, deployment — is your existing workflow, unchanged.
+WordPress is not a source-code development integration. When the plugin is active on a production site, `/frontman` and tool calls run against that site's database, media library, caches, and optional Elementor or WooCommerce data. The router requires a valid WordPress login with `manage_options`; POST tool calls also require the Frontman WordPress nonce. Those checks limit who can invoke tools, but an authorized or compromised administrator session can still cause live customer-facing and business-data changes.
 
-The better world looks like this: a designer changes the hero padding, a developer reviews a one-line diff in the PR, and nobody spent a single second worrying about whether the AI touched something it should not have. Because the constraints are structural, not behavioral. The agent _cannot_ deploy. It _cannot_ push. It produces a diff. You review it. Same as everything else.
+The plugin [registers its core tools](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-wordpress/frontman.php) and conditionally registers Elementor and WooCommerce tools when those plugins are available. Current mutation classes include:
 
-Security model changes do not page anyone at 3am.
+- creating, duplicating, updating, trashing, or permanently deleting posts and pages;
+- updating, inserting, moving, or deleting Gutenberg blocks;
+- uploading media;
+- creating, assigning, updating, moving, or deleting classic and block-theme menus, menu items, and widgets;
+- updating allowlisted site options, replacing Additional CSS, updating block templates/template parts, and clearing supported plugin or object caches;
+- when Elementor is active, replacing page data and adding, updating, duplicating, moving, removing, restoring, or CSS-flushing Elementor elements;
+- when WooCommerce is active, creating or changing products, taxonomy terms, variations, reviews, orders, notes, refunds, customers, shipping, tax, coupon, payment, settings, metadata, and system-status data, plus deletion where a delete tool exists.
 
-[Get started with Frontman](/blog/getting-started/) in under five minutes, or read about [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/).
+Confirmation is selective, not a transaction boundary. Core WordPress delete tools require `confirm=true`; Additional CSS replacement, full Elementor page replacement, Elementor element removal, and Elementor rollback restoration also require confirmation. Granular creates and updates generally execute without that confirmation field. WooCommerce `PUT` and `DELETE` operations and metadata writes require `confirm=true`, while WooCommerce `POST` creates do not. Confirmation records user intent before one tool call; it does not provide multi-call approval, database isolation, or protection against a mistaken confirmed payload.
+
+Rollback is also selective. [Elementor page-data and element mutations](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-wordpress/tools/class-tool-elementor.php) save private snapshots, retain at most 20 per post, and expose list/restore tools. Other WordPress tools often return before/after values and WordPress may provide trash or revisions, but Frontman exposes no general rollback transaction for posts, blocks, menus, widgets, templates, options, media, cache clears, or WooCommerce mutations. Permanent deletes and external effects such as refunds can require recovery outside Frontman. Use staging for broad changes, take application-and-database backups, verify restore procedures, and review each live mutation before approval.
+
+## Human and delivery controls
+
+For JavaScript integrations, Frontman can write files; it does not make those changes safe to merge. Minimum controls should include:
+
+- isolated branches or worktrees;
+- clean working-tree snapshots or backups before broad edits;
+- review of tracked and untracked changes;
+- project tests, linting, type checks, and security scanning;
+- branch protection and independent approval for sensitive code;
+- separate deployment credentials and production access;
+- incident and rollback procedures.
+
+Git improves visibility and recovery for tracked files, but it does not automatically capture ignored files, untracked files, external side effects, or secrets already disclosed to a provider.
+
+These source-control controls do not cover WordPress database or media mutations. Apply the WordPress staging, backup, access, confirmation, and restore controls above separately.
+
+## Licensing boundary
+
+Do not classify the entire system from one package. Frontman uses package-specific licenses. Check the license files in the [repository](https://github.com/frontman-ai/frontman) and the [AI Supplementary Terms](https://github.com/frontman-ai/frontman/blob/main/AI-SUPPLEMENTARY-TERMS.md) that apply to server use. Legal review should use the exact component, version, deployment model, and intended use.
+
+## Adoption checklist
+
+Before approving Frontman for a team, document answers to these questions:
+
+1. Which repositories, roots, routes, users, and environments are in scope?
+2. Which data may appear in source, prompts, DOM, screenshots, logs, and history?
+3. Will the hosted server or a self-hosted server be used, and where will it store data?
+4. Which AI provider account and data terms apply?
+5. Which subprocessors and transfer regions are acceptable?
+6. How are provider credentials limited, rotated, and revoked?
+7. What code-review, CI, branch-protection, and deployment controls remain mandatory?
+8. How will production builds be checked for Frontman routes and assets?
+9. Who handles deletion, offboarding, incidents, and vulnerability reports?
+10. What evidence must be re-reviewed after upgrades or architecture changes?
+
+## Reporting vulnerabilities
+
+Follow Frontman's [Security Policy](https://github.com/frontman-ai/frontman/blob/main/SECURITY.md). Report vulnerabilities through [GitHub private vulnerability reporting](https://github.com/frontman-ai/frontman/security/advisories/new), not a public issue. The policy lists the latest version as supported and identifies server, client libraries, and protocol code as in scope.
+
+Security outcome depends on Frontman's current code, your configuration, connected providers, submitted data, surrounding controls, and user decisions. Evaluate all of them; no architecture diagram or marketing page can provide an absolute guarantee.

--- a/apps/marketing/src/content/blog/team-collaboration.md
+++ b/apps/marketing/src/content/blog/team-collaboration.md
@@ -1,77 +1,111 @@
 ---
 title: 'Design System Collaboration Without Tickets'
 pubDate: 2026-02-16T05:00:00Z
-description: 'You built the system. You maintain it across teams. But every token tweak still routes through a developer. Frontman changes that.'
+description: 'A design-system governance model for classifying local and shared changes, assigning accountable owners, and escalating changes with broad impact.'
 author: 'Danni Friedland'
 articleSection: 'Problem Diagnosis'
 image: '/blog/team-collaboration-cover.png'
 imageAlt: 'Design system collaboration without tickets cover'
 tags: ['collaboration', 'workflow', 'design-systems']
-updatedDate: 2026-03-20T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-You spent months building your design system. Tokens, components, spacing scales, the whole thing. Two product teams use it now. It works. Mostly.
+Design-system collaboration fails when ownership is implicit. A designer may own visual intent, a product manager may own content, and an engineer may own implementation, but nobody knows who decides whether a token change is local or system-wide.
 
-Then someone on the growth team notices the card component has 24px padding and it should be 16px to match the updated token. Here is what happens next:
+Removing a ticket does not resolve that ambiguity. It only makes a faster path to an unclear decision.
 
-1. You file a ticket: "Update card padding to match spacing-4 token"
-2. It sits in the backlog. The engineers are shipping the new onboarding flow
-3. Two days later a developer picks it up, asks which card variant you mean
-4. You send a Figma link and a screenshot with a red circle
-5. The developer makes the change, opens a PR
-6. You review it — close, but they used a hardcoded value instead of the token
-7. Another round. Another day
-8. Merged. Four days for a token alignment
+**Quick answer:** define who may propose each change, who is accountable for its outcome, who must be consulted, and who approves the source diff. Use one review process for ticket-originated, engineer-authored, and tool-assisted changes.
 
-Four days. For a change you could describe in one sentence. Not because the developers are slow — they are doing real work. Your design system update just cannot compete with the onboarding deadline.
+## Classify the Change Before Assigning It
 
-This is the part that stings: you _own_ this system. You know exactly what the change should be. But you cannot make it yourself, because only developers can touch the code.
+Design-system work falls into different risk classes:
 
-### The Real Cost
+| Change class              | Example                                       | Default owner                  |
+| ------------------------- | --------------------------------------------- | ------------------------------ |
+| Content instance          | Label on one page                             | Product owner                  |
+| Component instance        | Existing `size` or `variant` prop             | Product team                   |
+| Token usage correction    | Replace arbitrary spacing with approved token | Design-system owner            |
+| Shared component behavior | Change default padding for every card         | Component code owner           |
+| New token or variant      | Add a new semantic color or button state      | Design-system governance group |
+| Application logic         | Change state, data, permissions, or routing   | Engineering owner              |
 
-You have felt this. Every designer and PM at a growing startup has. The system drifts. Not because anyone decided to let it drift, but because the queue of trivial visual fixes never reaches the top of the sprint. There is always something more urgent.
+The key distinction is blast radius. A local instance correction and a shared default change may look identical in one browser view but require different reviewers.
 
-So the card padding stays wrong for three weeks. Then another team copies that card into a new feature. Now the wrong padding is in two places. Then someone notices the button tokens are stale too. The system you built to create consistency is _losing_ consistency because you cannot maintain it at the speed it needs.
+## A Lightweight RACI
 
-The problem is not tooling. The problem is access. The people who care most about the design system — who built it, who maintain it, who notice when it drifts — are locked out of the one place where it actually lives: the code.
+RACI means Responsible, Accountable, Consulted, and Informed. Use it to prevent review from becoming a group decision with no clear owner.
 
-### What It Looks Like When You Can Just Fix It
+| Activity                        | Designer / system owner | Product manager | Product engineer | Code owner |
+| ------------------------------- | ----------------------- | --------------- | ---------------- | ---------- |
+| Define visual standard          | A/R                     | C               | C                | I          |
+| Define page-specific content    | C                       | A/R             | I                | I          |
+| Propose local visual correction | R                       | C               | C                | A          |
+| Assess shared-component impact  | C                       | I               | R                | A          |
+| Run implementation checks       | I                       | I               | R                | A          |
+| Approve source change           | C                       | C               | R                | A          |
+| Approve release                 | I                       | I               | R                | A          |
 
-With Frontman, you open the app in your browser. You click the card. You type: "Use spacing-4 token for padding." Frontman edits the source file and hot-reloads. You see the result. If it looks right, you commit. The engineer reviews a clean one-line diff in the PR.
+This table is a starting point. A team with dedicated accessibility, content-design, security, or release roles should add them where their approval is required.
 
-Five minutes. No ticket. No waiting for sprint capacity. The engineer still reviews the code — nothing ships without their sign-off. But they review a _finished change_ instead of spending three days playing telephone about which card variant you meant. This [framework-aware AI approach](/blog/ai-coding-agents-blind-to-ui/) means the tool sees what you see.
+Two rules keep the model useful:
 
-Your PM can do this too. That CTA copy that has said "Get Started" since launch even though you repositioned the product two months ago? They open the page, click the button, type the new copy, commit. Done before the next standup.
+1. Give each activity one accountable owner.
+2. Do not make the change author its only approver.
 
-### How This Works at Your Scale
+## Govern the Design-System Decision
 
-You have two, maybe three product teams now. You are past the stage where one designer and one developer sit next to each other and just talk. But you are not so big that you need a platform team or a formal RFC process for spacing changes. You are in the middle — big enough that coordination hurts, small enough that adding process feels wrong.
+This article governs classification, ownership, and escalation for design-system work. It does not define a second approval process. Once a change has an owner and scope, use [How Teams Review UI Changes From Non-Engineers](/blog/review-ui-changes-from-non-engineers/) as the canonical branch, evidence, CI, and approval workflow regardless of who authored it.
 
-Frontman fits this stage. Here is what each role gets:
+Before implementation, the accountable owner determines blast radius:
 
-- **You (design)** maintain the system directly. Token updates, spacing fixes, component tweaks — you make them in the browser, describe what you want, and commit. No IDE. No file paths. No asking someone else to translate your Figma redlines into code.
-- **Your PM** fixes copy, updates CTAs, and adjusts content without filing tickets. The landing page actually reflects the positioning you agreed on last week, not the positioning from three sprints ago.
-- **Your engineers** review PRs instead of making trivial visual changes. They focus on the onboarding flow, the API integration, the performance work — the problems that actually need engineering judgment.
+- Is selected element an instance or shared component?
+- Does existing token or variant already express intended design?
+- Which usages may change?
+- Does request touch logic, accessibility behavior, or data?
 
-Every change still goes through code review. Every change is a standard Git diff. Your branch protection rules apply. Nothing bypasses the process — only the routing changes.
+Shared defaults, new variants, and uncertain impact move to engineer-led work. A visual editing tool does not remove that escalation path.
 
-### The Objections You Are Already Thinking
+Design-system governance contributes decisions that general review cannot infer: whether existing standard already covers request, whether change belongs at instance or shared layer, and which consumers form blast radius. Record those decisions with proposal so reviewers can evaluate implementation against intended system rule.
 
-**"What if someone breaks something?"**
-Every change is a Git commit on a branch. It goes through the same PR process as engineering work. If the diff is bad, it does not get merged. Frontman shows you the result via hot-reload before you commit — if the layout breaks, you see it immediately and undo it. The code review gate catches everything else.
+## Example Decision Path
 
-**"We tried giving non-devs access to the repo before."**
-Giving people VS Code access is not the same thing. Frontman [differs from general-purpose agents](/blog/what-are-browser-aware-ai-coding-tools/) - it's a constrained tool. You click an element, describe a change in plain English, and Frontman edits the source file. You cannot accidentally refactor the state management. You can update the padding. That is the right level of access for the right people.
+This example is illustrative.
 
-**"Our engineers will push back on this."**
-Show them their PR queue. Count the tickets that say "update spacing," "fix typo," "change button color." Ask them if those are the problems they want to spend their week on. Every designer-authored PR is a PR the engineer did not have to write. They still review it — they just did not have to context-switch to create it.
+A reviewer sees `24px` padding on one card where system guidance specifies `spacing-4`.
 
-### What Changes
+1. Designer identifies mismatch and links rule.
+2. Author determines whether value lives on page instance or shared card component.
+3. If local, author proposes token replacement and captures relevant viewports.
+4. If shared, code owner checks all usages before deciding whether default should change.
+5. CI validates code; design reviews rendered result; code owner approves or requests revision.
 
-Right now your design system is a shared asset that only one discipline can touch. That constraint made sense when the codebase was new and the team was three people. It does not make sense now — and understanding [how Frontman actually sees the browser](/blog/frontman-launch/) shows why. You have a real system, real tokens, real components — and the people who built them should be able to maintain them.
+No elapsed-time promise is implied. Shared impact can make a visually small request technically substantial.
 
-Move the visual maintenance to the people who own it. Your engineers get their sprint capacity back. Your design system stays consistent across teams. Your PM stops waiting three days to fix a typo. Nobody is blocked on anyone else for changes that take thirty seconds to make and thirty seconds to review.
+## Use Tickets for Coordination, Not Translation
 
-That is not a workflow hack. That is your team actually working the way it already should.
+"Without tickets" should mean that a ticket is not mandatory when author can produce a complete, reviewable change. Tickets remain useful for prioritization, cross-team dependencies, risky migrations, and work that cannot proceed immediately.
 
-[Try Frontman](https://frontman.sh) — [one install command](/blog/getting-started/), works with your existing project. Read about [how Frontman keeps every change safe and reviewable](/blog/security/).
+Avoid two extremes:
+
+- Requiring engineering to translate every visual observation into code
+- Letting tool-assisted changes bypass ownership and review
+
+Pull requests can become intake artifact for narrow changes because they combine intent, implementation, evidence, and approval in one place. Larger changes still benefit from an issue or design proposal before code exists.
+
+## Operating Rules
+
+Adopt concise rules:
+
+1. Classify local versus shared impact before editing.
+2. Keep one accountable owner per decision.
+3. Require code-owner approval for shared components and tokens.
+4. Require visual evidence for visual changes.
+5. Keep auth, data, billing, permissions, and infrastructure engineer-owned.
+6. Use same CI and branch protection regardless of author.
+7. Escalate uncertain scope instead of guessing.
+
+This model makes collaboration explicit. Designers own standards. Product managers own product intent. Engineers own technical integrity. Code owners control shared-system changes. Tools can reduce translation work, but responsibility stays with people.
+
+For PM self-service eligibility and rollout, read [How PMs Can Edit a Website Without Developers](/blog/edit-website-without-developer/). For approval, use the canonical [review workflow for UI changes from non-engineers](/blog/review-ui-changes-from-non-engineers/).
+
+[Try Frontman](https://frontman.sh) for browser-to-source editing inside this review model, and read the [security boundaries](/blog/security/) before team rollout.

--- a/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
+++ b/apps/marketing/src/content/blog/tutorial-nextjs-runtime-context.md
@@ -1,126 +1,152 @@
 ---
 title: 'Add Runtime Context to AI Coding in Next.js'
 pubDate: 2026-02-23T07:00:00Z
-description: 'Step-by-step: install Frontman in a Next.js project, connect your AI key, and fix a CSS layout bug by clicking the broken element instead of describing it.'
+description: 'Build a reproducible mobile-overflow bug in a Next.js page, select it in Frontman, apply a scoped CSS Module fix, and verify the result.'
 author: 'Danni Friedland'
 articleSection: 'Tutorial'
 image: '/blog/tutorial-nextjs-runtime-context-cover.png'
 imageAlt: 'Next.js runtime context tutorial cover'
 tags: ['tutorial', 'getting-started', 'ai']
-updatedDate: 2026-03-10T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 ---
 
-This is a practical walkthrough. We'll take a Next.js app with a layout bug, install Frontman - one of the [browser-aware AI tools](/blog/what-are-browser-aware-ai-coding-tools/) - and fix the bug by clicking the broken element in the browser instead of describing it to an AI that cannot see it.
+This tutorial starts after installation. You will create a deliberate mobile overflow bug, point Frontman at the rendered element, request a constrained fix, and verify the result in the browser and source diff. For installation details, use the [Next.js integration guide](/docs/integrations/nextjs/).
 
-By the end you'll know whether runtime-aware AI coding actually saves time or is just a debugger with extra steps. Spoiler: it's both.
+The example uses a CSS Module, an officially supported Next.js styling method. See the [Next.js CSS documentation](https://nextjs.org/docs/app/getting-started/css#css-modules).
 
-### Prerequisites
+## Prerequisites
 
-- A Next.js 14 or 15 project (or `npx create-next-app@latest` to create one)
-- An API key from Claude, OpenAI, or OpenRouter
-- 5 minutes
+- A Next.js 15 or 16 project using the App Router
+- Frontman installed with `npx @frontman-ai/nextjs install`
+- Your development server running
+- An AI provider connected in Frontman
+- A root layout that imports `app/globals.css`
 
-### Step 1: Install Frontman
+Open `http://localhost:3000/frontman` and confirm that your application loads in the preview before continuing.
 
-```bash
-npx @frontman-ai/nextjs install
+## 1. Create a page with a known bug
+
+First, make the viewport assumptions explicit. Ensure `app/globals.css`, imported by your root layout, contains:
+
+```css
+html,
+body {
+	margin: 0;
+	padding: 0;
+}
 ```
 
-That's it for setup. Start your dev server:
+These rules remove browser body spacing. The route styles below explicitly set box sizing, so an existing project-wide `border-box` reset cannot prevent the reproduction.
 
-```bash
-npm run dev
-```
-
-When you open your app in the browser, navigate to `localhost:3000/frontman`. You'll see the Frontman interface — chat on the left, your live app on the right. Connect an AI provider such as Anthropic, OpenAI, or OpenRouter. Provider credentials are encrypted on the Frontman server and never exposed to the browser; relevant task context passes through the server to your selected provider.
-
-### Step 2: The Bug
-
-Here's a card grid component with a subtle problem:
+Create `app/runtime-context/page.tsx`:
 
 ```tsx
-// src/components/CardGrid.tsx
-export function CardGrid({ items }: { items: Item[] }) {
+import styles from './page.module.css'
+
+export default function RuntimeContextPage() {
 	return (
-		<div className="grid grid-cols-3 gap-6 p-8">
-			{items.map((item) => (
-				<div key={item.id} className="rounded-lg bg-white p-6 shadow-sm">
-					<h3 className="text-lg font-semibold">{item.title}</h3>
-					{item.featured && (
-						<span className="mt-2 inline-block rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800">
-							Featured
-						</span>
-					)}
-					<p className="mt-4 text-gray-600">{item.description}</p>
-				</div>
-			))}
-		</div>
+		<main className={styles.page}>
+			<section className={styles.panel}>
+				<p className={styles.eyebrow}>Runtime context exercise</p>
+				<h1>Ship the page, not the guess</h1>
+				<p>
+					This panel is intentionally wider than a mobile viewport. Select it in Frontman and ask
+					for a scoped fix.
+				</p>
+				<button type="button">Review change</button>
+			</section>
+		</main>
 	)
 }
 ```
 
-Looks fine in source code. But when 2 of 6 items are `featured`, the cards with the badge are taller than the ones without. The bottom row doesn't align. The `gap-6` interacts with the conditional badge in a way that isn't obvious from reading the JSX.
+Create `app/runtime-context/page.module.css`:
 
-### What Cursor Would Do
+```css
+.page {
+	box-sizing: border-box;
+	width: 100%;
+	min-height: 100vh;
+	padding: 24px;
+	background: #f2f0e8;
+}
 
-You'd describe the bug: "The cards in CardGrid aren't aligning properly — some are taller than others."
+.panel {
+	box-sizing: content-box;
+	width: 520px;
+	padding: 32px;
+	border: 1px solid #222;
+	background: #fff;
+}
 
-The AI reads the source, sees `grid-cols-3 gap-6`, and suggests `h-full` on the cards (might work, might cause other issues), `min-h-[200px]` (arbitrary, fragile), or restructures the component entirely (overkill). It can't see that the actual problem is the conditional featured badge pushing content down. The AI is guessing because it doesn't see the rendered layout — this is [why coding agents are blind to your UI](/blog/ai-coding-agents-blind-to-ui/).
-
-### Step 3: Fix It With Runtime Context
-
-With Frontman running, open the page in your browser. You can see the misaligned cards.
-
-**Click the misaligned card.** Frontman highlights it and shows you the component location (`CardGrid` at `src/components/CardGrid.tsx:5`), the computed styles (actual padding, dimensions, flex/grid properties), the parent layout (grid container with resolved gap, column widths, and row heights), and the children (including the conditional badge).
-
-Now describe the fix:
-
-> "Make all cards the same height and align the description text at the bottom, regardless of whether the Featured badge is present."
-
-Frontman sends the AI your description, the source code, the computed layout showing actual height differences, and the component tree context. The AI generates a targeted edit — adding `flex flex-col` to the card wrapper and `mt-auto` to the description paragraph. It knows this is the right fix because it can see the _actual_ height difference.
-
-The edit is applied to your source file. Hot reload shows the result immediately. Cards align.
-
-### What Happened Under the Hood
-
-```text
-1. You clicked an element in the browser
-2. Frontman's client-side code identified the React component
-   and resolved it to a source file:line via sourcemaps
-3. The click target + component info were sent to
-   Frontman running inside the Next.js dev server
-4. The Next.js integration gathered:
-   - Source code of the component
-   - Computed styles from the browser
-   - Component tree (parent/child relationships)
-   - Server-side context (routes, module graph)
-5. All packaged as MCP tool responses alongside your description
-6. The AI generated a source code edit
-7. The edit was written to disk
-8. Next.js HMR hot-reloaded the change
-9. The browser updated — you see the fix immediately
+.eyebrow {
+	font-size: 0.75rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
 ```
 
-The AI didn't guess what the layout looks like. It _knew_ — because Frontman gave it the computed layout data from the browser.
+Visit `http://localhost:3000/runtime-context`. At a 390-pixel viewport, the border-box page has 342 pixels of content width after 24-pixel padding on each side. The panel explicitly declares a 520-pixel content-box width, and its padding and border make the rendered box wider still. Horizontal overflow is therefore expected regardless of starter-template reset styles.
 
-### Beyond CSS
+## 2. Capture runtime context
 
-The card grid example is simple. More realistic scenarios where runtime context helps:
+In Frontman:
 
-**Debugging a 404.** Your page returns a 404 but the file exists. Ask Frontman "Why is /api/users/me returning 404?" — it gives the AI access to the registered route table and middleware state. The AI can see that a middleware redirect is firing before the route matches.
+1. Navigate the preview to `/runtime-context`.
+2. Switch to a mobile viewport, such as 390 pixels wide.
+3. Select the overflowing white panel as an annotation.
+4. Send this prompt:
 
-**Fixing a hydration mismatch.** A component renders differently on server and client. Click the component — Frontman shows the server-rendered HTML vs the client-rendered DOM, plus the source location. The AI sees the mismatch directly.
+> Fix horizontal overflow for the selected panel at a 390px viewport. Keep 24px page padding, keep the current markup, and edit only `app/runtime-context/page.module.css`. Explain the CSS sizing cause, then show the diff. Do not change typography or colors.
 
-**Understanding an unfamiliar codebase.** Click the dashboard sidebar. Frontman tells you: `DashboardLayout > Sidebar` at `src/layouts/DashboardLayout.tsx:23`. Answer in 2 seconds instead of grepping through the component tree.
+The annotation gives the task a concrete rendered target. Depending on framework and source-map availability, Frontman can attach a selector, screenshot, component metadata, and source location. The agent can also use browser tools for the DOM and screenshot, then use dev-server tools to read and edit the project file. See [How the Agent Works](/docs/using/how-the-agent-works/) for the verified tool flow.
 
-### When NOT to Use This
+## 3. Review the fix
 
-Runtime-aware AI coding is not a silver bullet:
+One minimal valid result is:
 
-- **Complex state logic** — the visual output doesn't tell you if your reducer is correct
-- **Performance optimization** — Frontman sees the DOM, not your render cycles or bundle size
-- **As a substitute for understanding your code** — if you can't explain the AI's diff to a colleague, don't commit it
+```css
+.panel {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 520px;
+	padding: 32px;
+	border: 1px solid #222;
+	background: #fff;
+}
+```
 
-[The runtime context gap](/blog/runtime-context-gap/) is real, and closing it saves time on a specific class of problems. It doesn't replace engineering judgment. It just means the AI guesses less.
+Why it works:
 
-[Get started with Frontman](https://frontman.sh) — works with Next.js, Astro, and Vite. Or [see how it compares to Cursor and Claude Code](/blog/frontman-vs-cursor-vs-claude-code/). For a broader buyer guide to build frontend with AI, read the [best frontend coding agent comparison](/blog/best-frontend-coding-agent/).
+- `width: 100%` lets the panel use available content width instead of forcing 520 pixels.
+- `max-width: 520px` preserves the intended desktop limit.
+- `box-sizing: border-box` includes padding and border inside that width.
+
+Do not accept the edit only because it resembles this snippet. Check the actual diff. The prompt limits file scope, but model output still requires review.
+
+## 4. Verify browser and build behavior
+
+Verify all of these before keeping the change:
+
+1. At 390 pixels, no horizontal scrollbar appears and 24-pixel outer padding remains visible.
+2. At desktop width, the panel stops growing at 520 pixels.
+3. Button, heading, copy, colors, and markup remain unchanged.
+4. `git diff -- app/runtime-context/page.module.css` contains only the intended sizing edit.
+5. Run your project's normal lint, test, and `next build` checks.
+
+Next.js applies CSS updates immediately during development through Fast Refresh, but its documentation recommends checking the production build because CSS output and ordering can differ between development and production.
+
+## What runtime context contributed
+
+This bug is solvable from source alone. Runtime context reduces ambiguity about which rendered element, route, and viewport the request concerns. Frontman's distributed flow is:
+
+1. Browser tools inspect the selected element and current page.
+2. The Frontman server sends relevant task context to your selected AI provider and orchestrates tool calls.
+3. File reads and edits execute on your machine through the Next.js integration.
+4. Next.js refreshes the preview after the edit.
+5. You inspect the rendered result and git diff.
+
+Frontman does not prove the edit is correct, run every project check, or replace code review. It supplies runtime evidence to a normal development workflow.
+
+Continue with [annotations](/docs/using/annotations/) or review [Frontman's limitations](/docs/using/limitations/) before using it on larger changes.

--- a/apps/marketing/src/content/blog/vibe-coding-problems.md
+++ b/apps/marketing/src/content/blog/vibe-coding-problems.md
@@ -1,114 +1,155 @@
 ---
-title: 'Why Vibe Coding Breaks Production Apps'
-seoTitle: 'Why Vibe Coding Tools Break Production Apps'
+title: 'Vibe Coding and the Risk of Verification Debt'
+seoTitle: 'Vibe Coding and Verification Debt in Production'
 pubDate: 2026-04-15T05:00:00Z
-description: 'Why vibe coding tools often fail in production: verification debt, inconsistent architecture, missing edge cases, and how to use AI code safely.'
+description: 'Assess verification-debt risk in AI-assisted code: identify deferred evidence, match checks to consequences, and measure delivery beyond generation speed.'
 author: 'Danni Friedland'
 articleSection: 'Problem Diagnosis'
 image: '/blog/vibe-coding-problems-cover.png'
-imageAlt: 'Why vibe coding breaks production apps cover'
+imageAlt: 'Vibe coding and verification debt cover'
 tags: ['ai', 'developer-tools', 'code-quality']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-07-30T00:00:00Z
 faq:
   - question: 'What is vibe coding?'
-    answer: "Vibe coding is the practice of generating code with an AI tool and shipping it without fully understanding what it does, relying on the fact that it looks right or passes tests. The term captures the feeling: you're going on vibes rather than engineering judgment."
+    answer: 'In this article, vibe coding means accepting AI-generated software based mainly on plausible output or a successful demo while deferring evidence about requirements, correctness, security, maintainability, and operations. AI assistance itself is not the problem; unverified acceptance is.'
   - question: "Isn't fast iteration better than slow, careful iteration?"
-    answer: "Fast iteration on code you understand is better. Fast iteration on code you don't understand creates verification debt: the cost of all the checks you skipped. That debt compounds. The first three months feel like superpowers. Month six, you're debugging production fires caused by edge cases the AI didn't anticipate and you didn't catch."
-  - question: "How is Frontman different from vibe coding tools?"
-    answer: "Vibe coding tools generate new code and give it to you to ship. Frontman edits your existing code, the code you already understand and maintain. There is no generated codebase to become responsible for. Every change Frontman makes is a diff against code your team wrote and reviewed. You can read it, understand it, and own it."
+    answer: 'Fast iteration is useful when validation cost remains visible. If generated changes are faster to create but slower to understand, review, test, secure, or operate, implementation speed can hide verification debt rather than reduce total delivery time.'
+  - question: 'How is Frontman different from vibe coding tools?'
+    answer: 'Frontman focuses on edits to an existing development project using browser and source context. That can make visual intent and resulting diffs easier to inspect, but it does not make generated code correct. Teams still need review, tests, security checks, and deployment controls appropriate to change risk.'
 ---
 
-Somewhere between late 2024 and now, "vibe coding" became shorthand for a real engineering practice: prompt an AI, ship what it generates, worry about understanding it later. The productivity gains are real. So are the consequences.
+AI can reduce cost of producing code. It does not automatically reduce cost of proving that code belongs in production.
 
-AI coding tools are genuinely useful. The problem is a specific failure mode, one that's invisible during the honeymoon period and expensive when it surfaces.
+That gap is **verification debt**: required evidence deferred when a change is accepted because it looks plausible, passes a narrow check, or produces a convincing demo. Debt may be harmless for a disposable prototype. It becomes dangerous when code has users, data, permissions, dependencies, or an on-call owner.
 
-**Quick answer:** vibe coding breaks production apps when AI-generated code ships before the team understands, tests, and owns it. The issue is not speed by itself. The issue is verification debt: every assumption, edge case, and architecture decision you skipped while the demo looked good.
+**Quick answer:** vibe coding creates production risk when generation outruns verification. Manage that risk by tracking which claims about a change have evidence, assigning checks by consequence, and counting review, rework, incidents, and operational load as part of delivery cost.
 
-## What Verification Debt Is
+## Evidence Supports Caution, Not a Universal Failure Story
 
-When you ship code you don't understand, you create verification debt: the accumulated cost of all the checks you skipped.
+There is no credible basis for a fixed "month one to month six" collapse narrative. Outcomes depend on model, task, developer experience, repository context, and quality bar.
 
-Every line of code you own comes with an implicit question: "Do I understand what this does, under what conditions it fails, and what other things it touches?" When you write code yourself, you answer that question as you write. When you generate code and ship it, you defer it indefinitely.
+Current evidence is mixed and should be read narrowly:
 
-Verification debt looks like:
-- A function that works for the happy path but breaks on empty arrays in production
-- A component that renders correctly in development but causes hydration errors at scale
-- A database query that hits an unindexed column and runs fine until you have 50k rows
-- Auth middleware that handles the documented flow but misses a redirect edge case the AI didn't know about
+- [Stack Overflow's 2025 Developer Survey](https://survey.stackoverflow.co/2025/ai) reported broad AI-tool use alongside more respondents distrusting output accuracy than trusting it. It also found "almost right" answers and time spent debugging generated code among common reported frustrations. This is self-reported survey evidence, not an incident rate.
+- A peer-reviewed CCS 2023 user study, [Do Users Write More Insecure Code with AI Assistants?](https://doi.org/10.1145/3576915.3623157), found participants using a Codex-based assistant produced less secure solutions in studied security tasks and were more likely to believe their code was secure. Results concern that model, study design, and task set; they do not establish that every modern assistant makes every developer less secure.
+- METR's early-2025 randomized study found experienced open-source developers took longer on its sampled tasks with then-current AI tools. METR's [February 2026 update](https://metr.org/blog/2026-02-24-uplift-update/) says those older results no longer represent current tools and that its newer estimates are unreliable because of selection and measurement effects. Useful lesson: productivity claims need current, task-specific measurement.
+- [NIST Secure Software Development Framework 1.1](https://doi.org/10.6028/NIST.SP.800-218) recommends integrating secure development practices into each software development lifecycle. It does not create a separate lower standard for AI-generated code.
 
-None of these are the AI's fault. They're the predictable result of shipping code before you understand it.
+These sources support verification discipline. They do not support fabricated production incidents, universal timelines, or claims that AI-generated code is inherently defective.
 
-## The Anatomy of a Vibe-Coded Codebase
+## Verification Debt as a Ledger
 
-Three months of fast iteration on a greenfield project with an AI coding tool produces a specific kind of codebase. It's not bad code, exactly. It's *unfamiliar* code, generated to match the prompt, not to be understood by the person shipping it.
+For each change, separate implementation from claims that must be true.
 
-The inconsistency is the first thing you notice. The AI generates each feature independently, so the auth flow uses one pattern for error handling, the data layer uses another, and the components use a third. Nothing is wrong. Nothing is coherent. Refactoring later means understanding each piece from scratch.
+| Claim                           | Evidence before merge                              | Debt if skipped    |
+| ------------------------------- | -------------------------------------------------- | ------------------ |
+| Requirement is correct          | Acceptance criteria and owner sign-off             | Product debt       |
+| Behavior is correct             | Tests and manual scenario checks                   | Functional debt    |
+| Change fits architecture        | Diff review by code owner                          | Comprehension debt |
+| Inputs and permissions are safe | Threat-focused review and security tests           | Security debt      |
+| Dependencies are acceptable     | Lockfile review, provenance, and scanning          | Supply-chain debt  |
+| Change can run reliably         | Logs, metrics, failure handling, and rollback plan | Operational debt   |
+| Team can maintain it            | Clear ownership and explainable design             | Ownership debt     |
 
-Then there are the implicit assumptions. Generated code makes assumptions about its context: what shape the incoming data is, what state the application is in when the code runs. When those assumptions break, you have to reverse-engineer what the code was expecting before you can understand why it failed.
+Debt is not number of generated lines. A large generated test fixture may create little risk. A one-line authorization change may demand extensive evidence.
 
-AI-generated tests have the same problem. They test the happy path, because that's what was in the prompt. The edge cases, the ones that actually cause production incidents, require knowing what might go wrong. You can't prompt for a test you haven't thought of.
+## How Debt Accumulates
 
-And when something does break, you can't trace it. In a codebase you wrote, you follow the logic from input to output. In a vibe-coded codebase, each file is a black box. You know what it does (you prompted for it). You don't know *how* it does it.
+### Unstated requirements
 
-## The Months 1–6 Arc
+Prompt describes desired happy path but omits tenancy, accessibility, localization, retries, or retention rules. Generated output can satisfy prompt while violating system requirement never provided.
 
-Here's the honest trajectory:
+### Plausibility substitutes for comprehension
 
-Month 1 is incredible. Features that would take weeks land in days. Demos look polished. Investors are impressed.
+Fluent code is easy to skim. Reviewer recognizes familiar patterns and misses incorrect assumption. Risk rises when no one can explain data flow, failure behavior, and blast radius without asking model again.
 
-Month 2 brings some weird bugs. They get fixed by prompting the AI again. You don't fully understand the fix, but it seems to work.
+### Tests mirror implementation
 
-Month 3 brings a production incident. The root cause is in a piece of generated code that was shipping fine until an edge case hit at scale. Debugging it takes longer than it should because no one fully understands the file.
+If same prompt or model generates implementation and tests, both can share same missing assumption. Passing tests show consistency with tested examples, not completeness of requirement.
 
-By month 4, you've hired an engineer to "clean up the codebase." They spend the first two weeks just reading code. They say things like "I don't understand why this is done this way," and neither do you.
+### Local success hides system effects
 
-Month 5: new features are slower because every change carries the risk of breaking something in the generated codebase that nobody fully understands.
+Component renders in one viewport while changing shared styles elsewhere. Query works on sample dataset but lacks production index. Retry handles timeout but duplicates non-idempotent write. These are illustrative failure modes, not claims about specific Frontman users or incidents.
 
-Month 6: you're doing the rewrite you swore you'd never do.
+### Ownership stays implicit
 
-This is not hypothetical. It's the pattern.
+Generated change merges, but no person becomes accountable for future behavior. When alert fires, team first reconstructs intent and design before diagnosing fault.
 
-## Why AI-Generated Code Is Specifically Risky
+## Match Verification to Risk
 
-Static analysis catches some of what you'd catch by reading. Tests catch some of what you'd catch by thinking through edge cases. Neither catches the class of bug that comes from not understanding the code well enough to know what to test or analyze.
+Use risk tiers rather than one rule for all AI output.
 
-AI-generated code has specific failure modes worth understanding.
+### Tier 1: Reversible presentation changes
 
-It optimizes for the prompt, not the system. A function generated to "fetch user data and handle errors" will handle the errors the AI considers typical. It will miss the error you'd catch if you thought carefully about all the ways this particular integration fails in your particular environment.
+Examples: copy, spacing, approved token, static layout.
 
-It doesn't know your operational context. The AI doesn't know your database has a 30-second query timeout. It doesn't know your CDN strips certain headers. It doesn't know your mobile users have spotty connections. Generated code doesn't account for things that aren't in the prompt.
+Evidence:
 
-The hardest problem: generated code is fluent without necessarily being correct. It reads like code written by a competent senior engineer. Code written by someone who doesn't know what they're doing usually *looks* like it was written by someone who doesn't know what they're doing. Generated code that is subtly wrong looks like code that's probably fine.
+- Focused diff review
+- Relevant viewport and accessibility check
+- Existing CI
+- Clear rollback
 
-## The Discipline Hasn't Changed
+### Tier 2: Application behavior
 
-Understanding what you ship is the standard. It's what makes code review worthwhile. It's why "don't commit code you don't understand" exists as a rule. It's why test-driven development has traction. AI didn't create the standard; it made violating it much easier.
+Examples: state transitions, forms, caching, API integration.
 
-Tools that let you work on your *existing* codebase, where every edit is a diff against code you already understand, don't create this problem. When Frontman edits a padding value in your `PricingCard` component, you can read the diff. You know what changed. You know why. You own it the same way you owned it before.
+Evidence:
 
-That's the difference between AI that augments your judgment and AI that replaces it.
+- Explicit edge cases and failure paths
+- Unit and integration tests independent of generated implementation
+- Architecture-owner review
+- Logs or metrics for new failure modes
 
-## What to Actually Do
+### Tier 3: High-impact boundaries
 
-Use AI coding tools, but make the output earn its way into the codebase:
+Examples: authentication, authorization, billing, personal data, migrations, infrastructure.
 
-- Review the diff before shipping, not after a bug report.
-- Add the edge-case tests you would have written by hand.
-- Keep generated code inside your existing architecture instead of letting every feature invent a new pattern.
-- Prefer targeted edits in code you already maintain over wholesale generated codebases you have to reverse-engineer later.
+Evidence:
 
-If you're building something new, treat AI output as a first draft. Review it before shipping. If you can't explain the diff to a colleague, it's not ready.
+- Threat model or abuse-case review
+- Security and domain-owner approval
+- Migration and rollback rehearsal where relevant
+- Staged rollout and operational monitoring
+- Independent validation beyond model that generated change
 
-Write your own tests. Use the AI to scaffold them, but add the edge cases yourself. You know your system's failure modes better than the AI does.
+This approach follows ordinary software risk management. AI changes production economics of authorship, not accountability.
 
-And maintain a coherent architecture. AI tools generate whatever pattern is consistent with the context you give them. Prompt consistently, enforce a clear structure, and the generated code stays coherent.
+## A Verification-Debt Review
 
-If you're inheriting a vibe-coded codebase, start with behavior rather than code. Write integration tests that document what the system does before you touch anything. That gives you a safety net.
+Ask these questions before merge:
 
-Then refactor to understand, not to improve. The goal isn't better code; it's code you can reason about. Isolate each component, read it, rewrite anything you don't understand in your own style.
+1. What user or system requirement does change satisfy?
+2. Which assumptions came from prompt, repository, or model guess?
+3. Can reviewer explain changed behavior without relying on generated summary?
+4. Which happy paths, edge cases, abuse cases, and rollback paths were tested?
+5. Did tests come from independent requirement or merely mirror implementation?
+6. What shared components, data, permissions, or dependencies can change affect?
+7. What evidence will reveal failure after deployment?
+8. Who owns correction if assumption proves false?
 
-And be honest about what you're dealing with. A codebase you don't understand is a liability. Put it on the roadmap as technical debt with a real cost, not "cleanup we'll get to someday."
+Any unanswered question is visible debt. Team can decide to accept it, but decision should be explicit.
 
-The velocity gains from AI coding tools are real. So is the verification debt. Staying honest about both is how you capture one without getting buried in the other.
+## Measure Net Delivery, Not Generation Speed
 
-Read more: [The Runtime Context Gap](/blog/runtime-context-gap/) on why AI tools that can see your running application catch the bugs that file-only agents miss, or compare the broader category in our [frontend coding agent guide](/blog/best-frontend-coding-agent/).
+Useful measures include:
+
+- Lead time through review and CI, not time until first generated patch
+- Review rounds and rejected diff size
+- Escaped defects and reverts by change risk
+- Time spent understanding or rewriting generated code
+- Security findings and dependency exceptions
+- Operational alerts attributable to recent changes
+- Percentage of changes with named owner and rollback path
+
+Compare AI-assisted and non-assisted work within similar task classes. Model capability, tooling, and team practice change quickly, so publish date and context with any result.
+
+## How Frontman Fits
+
+Frontman can narrow some visual verification gaps by connecting selected rendered elements, screenshots, DOM context, source locations when available, source edits, and hot-reload feedback. Result remains ordinary code in project working tree.
+
+That helps answer "did this edit target visible element and produce intended visual result?" It does not answer every question about security, accessibility, shared-component impact, business logic, or production operation. A reviewable diff is evidence, not approval.
+
+Use AI for speed where it helps. Keep evidence bar tied to consequences. Verification debt becomes dangerous not when it exists, but when team mistakes unverified output for completed work.
+
+For browser-context limits, read [The Runtime Context Gap](/blog/runtime-context-gap/). For review controls around UI edits, read [How Teams Review UI Changes From Non-Engineers](/blog/review-ui-changes-from-non-engineers/).

--- a/apps/marketing/src/content/docs/docs/api-keys.md
+++ b/apps/marketing/src/content/docs/docs/api-keys.md
@@ -1,42 +1,91 @@
 ---
-title: API Keys & Providers
-description: Configure AI model access in Frontman, choose a provider, bring your own API key, connect OAuth, and control model selection and usage costs.
+title: Configure Frontman API Keys & Providers
+description: Connect, verify, replace, or disconnect the provider credentials Frontman uses to run its coding agent.
 ---
 
-Frontman needs access to a large language model (LLM) to power the coding agent. Connect a supported provider with OAuth or a saved API key.
+Frontman needs a credential for the provider behind your selected model. You can connect a supported account with OAuth or save your own provider API key in Frontman settings.
 
-## Provider access
+This page owns credential setup and lifecycle. For current models and model IDs, use [Models & Providers](/docs/reference/models/).
 
-Frontman does not include a built-in server key or no-key free tier. Runs require a provider credential for the selected model.
+## Before you start
 
-:::note
-If a run fails with a missing API key error, connect OAuth or save an API key for the selected provider.
-:::
+1. [Install Frontman](/docs/installation/) and open `/frontman` in your running development app.
+2. Sign in to Frontman.
+3. Obtain a credential from a provider you want to use.
 
-## Bring your own key (BYOK)
+Frontman does not include a built-in model credential. A run fails before agent output when the selected model has no usable OAuth connection or saved API key.
 
-Use your own API key from any supported provider for control over model selection and costs.
+## Connect a provider
 
-### Supported providers
+Open the Frontman chat panel, select the **settings icon**, then open **Providers**.
 
-| Provider | Model examples | How to get a key |
-|----------|---------------|-----------------|
-| **Anthropic** | Claude Opus, Sonnet, Haiku | [console.anthropic.com](https://console.anthropic.com/) |
-| **OpenRouter** | GPT, Claude, Gemini, Kimi, MiniMax | [openrouter.ai](https://openrouter.ai) |
-| **Fireworks AI** | Kimi models | [fireworks.ai](https://fireworks.ai/) |
-| **NVIDIA** | Kimi, DeepSeek, MiniMax, Qwen | [build.nvidia.com](https://build.nvidia.com/) |
+### OAuth
 
-### Setting your key
+Frontman currently offers account connections for:
 
-Open the Frontman chat panel in your browser and click the **settings icon**. Paste your API key in the provider field and select your preferred model.
+- **Anthropic Claude Pro/Max:** click **Connect with Anthropic**, authorize in the page that opens, then paste the returned authorization code into Frontman.
+- **OpenAI:** click **Connect with OpenAI**, open the verification URL, and enter the device code shown by Frontman. Frontman waits for authorization and updates the connection status.
 
-Your key is stored encrypted in Frontman's database and used by the server when running the agent.
+When OAuth succeeds, the provider card shows **Connected**. For Anthropic, an OAuth connection takes priority over a saved Anthropic API key.
 
-## OAuth
+### Saved API key
 
-Connect supported provider accounts directly. Frontman currently supports Anthropic OAuth for Claude Pro/Max and OpenAI device OAuth.
+Frontman settings currently accepts saved API keys for these providers:
+
+| Provider         | Create or manage keys                                                              |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| **Anthropic**    | [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys) |
+| **OpenRouter**   | [openrouter.ai/keys](https://openrouter.ai/keys)                                   |
+| **Fireworks AI** | [app.fireworks.ai/api-keys](https://app.fireworks.ai/api-keys)                     |
+| **NVIDIA**       | [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys)   |
+
+Paste the key into its provider card and click **Save**. Frontman clears the input after submission and shows **Saved** when the request succeeds. The card then shows **User key** without displaying the saved value.
+
+## Verify model access
+
+1. Confirm the provider card shows **Connected** or **User key**.
+2. Close settings and open the model selector in the chat header.
+3. Confirm models from that provider are available.
+4. Send a small prompt. A successful run starts producing agent output or tool activity instead of a missing-key error.
+
+Saving or connecting a credential refreshes the available model options. If the expected models do not appear, reopen settings and check the provider status before retrying.
+
+## Replace or disconnect credentials
+
+### Replace a saved key
+
+Enter the new key in the same provider card and click **Save**. Frontman stores one saved key per user and provider, so a successful save replaces that provider's previous key.
+
+Frontman does not currently expose a delete action for saved API keys. To stop an existing key from working, revoke it in the provider's key-management page. You can then save a replacement in Frontman if needed.
+
+### Disconnect OAuth
+
+Open the connected Anthropic or OpenAI card and click **Disconnect**. The provider's OAuth-backed models stop being available unless another supported credential grants access.
+
+## Common failures
+
+**The run reports that no API key is available.**
+The selected model does not have a matching credential. Connect its provider, save a key, or select a model from a connected provider.
+
+**Saving a key shows an error.**
+Check that the field is not blank and that you are still signed in. Frontman stores the submitted credential but does not claim to validate every provider key before the first model request; retry a prompt to confirm provider acceptance.
+
+**A provider is connected but its models do not appear.**
+Reopen **Settings → Providers** to refresh status. If OAuth has expired or been revoked, disconnect and reconnect it.
+
+**The provider rejects the request.**
+Check the provider account for key validity, model access, quota, or billing restrictions. These controls belong to the provider, not Frontman. See [Troubleshooting](/docs/reference/troubleshooting/#api-key-or-model-errors) for broader diagnosis.
+
+## Credential boundaries
+
+- Saved provider credentials are attached to your Frontman account, not stored only in the browser.
+- Frontman's API-key status endpoint returns provider names, not saved key values.
+- Saved credentials are encrypted server-side using application-level encryption and are used by the server to call your selected provider.
+- Provider pricing, quotas, retention, and model access remain subject to that provider's terms.
+
+See the [Privacy Policy](/privacy/) for data handling details. Self-hosters must configure the server encryption key described in [Self-Host the Frontman Server](/docs/reference/self-hosting/).
 
 ## Next steps
 
-- **[How the Agent Works](/docs/using/how-the-agent-works/)** — Understand the screenshot → read → edit loop
-- **[Sending Prompts](/docs/using/sending-prompts/)** — Write effective prompts
+- **[Models & Providers](/docs/reference/models/)** — choose among models exposed by your connected providers
+- **[Sending Prompts](/docs/using/sending-prompts/)** — run your first task

--- a/apps/marketing/src/content/docs/docs/installation.md
+++ b/apps/marketing/src/content/docs/docs/installation.md
@@ -1,9 +1,29 @@
 ---
-title: Installation
-description: Install Frontman in Astro, Next.js, Vite, or WordPress, then open the browser agent in your app or site.
+title: Install Frontman
+description: Choose the right Frontman integration, install it, open the agent, verify setup, and remove it when needed.
 ---
 
-Frontman ships as framework-specific integrations for JavaScript apps and as a WordPress plugin — pick the guide that matches your project.
+Frontman attaches to a supported development server through a framework integration, or to WordPress through its plugin. Choose one path below; do not install multiple Frontman integrations for the same app.
+
+This page owns the end-to-end installation outcome. Integration guides own manual configuration and framework-specific troubleshooting, while [Frontman Framework Compatibility](/docs/reference/compatibility/) owns supported versions.
+
+## Prerequisites
+
+- A project using Next.js, Astro, Vite, or WordPress
+- A local development server for JavaScript integrations, or WordPress administrator access for the plugin
+- A GitHub or Google account for hosted Frontman sign-in
+- A supported AI provider connection or API key
+
+Check exact framework, Node.js, WordPress, and PHP requirements in [Frontman Framework Compatibility](/docs/reference/compatibility/) before installing.
+
+## Choose an integration
+
+| Your project                                                           | Install                   |
+| ---------------------------------------------------------------------- | ------------------------- |
+| Next.js App Router or Pages Router                                     | `@frontman-ai/nextjs`     |
+| Astro                                                                  | `@frontman-ai/astro`      |
+| React, Vue, Svelte, SolidJS, SvelteKit, or another app running on Vite | `@frontman-ai/vite`       |
+| WordPress                                                              | Frontman WordPress plugin |
 
 ## Astro
 
@@ -11,7 +31,7 @@ Frontman ships as framework-specific integrations for JavaScript apps and as a W
 npx astro add @frontman-ai/astro
 ```
 
-Then follow the [Astro integration guide →](/docs/integrations/astro/)
+The Astro installer adds the integration to your Astro config. Continue with the [Astro integration guide](/docs/integrations/astro/) for manual setup, monorepos, or a custom Frontman host.
 
 ## Next.js
 
@@ -19,7 +39,7 @@ Then follow the [Astro integration guide →](/docs/integrations/astro/)
 npx @frontman-ai/nextjs install
 ```
 
-Then follow the [Next.js integration guide →](/docs/integrations/nextjs/)
+The installer detects your Next.js version and writes the appropriate middleware or proxy entrypoint. Continue with the [Next.js integration guide](/docs/integrations/nextjs/) if your project already has middleware, uses a `src/` layout, or needs manual setup.
 
 ## Vite
 
@@ -27,14 +47,60 @@ Then follow the [Next.js integration guide →](/docs/integrations/nextjs/)
 npx @frontman-ai/vite install
 ```
 
-Then follow the [Vite integration guide →](/docs/integrations/vite/)
+The installer adds `frontmanPlugin()` to your Vite config. Continue with the [Vite integration guide](/docs/integrations/vite/) for plugin ordering, manual setup, or framework-specific notes.
 
 ## WordPress (Beta)
 
 Install **Frontman - Agentic AI Editor** from the [WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/) in wp-admin. No npm package required.
 
-See the [WordPress setup guide →](/docs/integrations/wordpress/)
+Activate the plugin, then open `/frontman` on your site. See [Install and Use Frontman for WordPress](/docs/integrations/wordpress/) for requirements, sign-in, supported workflows, and WordPress-specific troubleshooting.
+
+## Verify installation
+
+For Next.js, Astro, or Vite:
+
+1. Start the normal development server for your app.
+2. Open `/frontman` on the same local origin, such as `http://localhost:3000/frontman`.
+3. Sign in with GitHub or Google if redirected to Frontman's hosted server.
+4. Confirm the Frontman chat and live preview load.
+5. Open **Settings → Providers** and [connect a provider](/docs/api-keys/).
+6. Confirm the model selector offers a model from the connected provider.
+
+Use the framework's development server for this functional installation check. Then run the normal production build and deployment verification for your app: confirm whether Frontman routes and client assets are present, whether `/frontman` is reachable, and whether your intended environment or network controls block access.
+
+Next.js differs from Astro and Vite here. Its [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write request middleware for Next.js 15 and earlier or a proxy for Next.js 16 and later. Generated code has no automatic development-only guard, so it can compile into and run with a production deployment while its matcher includes Frontman routes. Add your own environment guard or remove the integration before deployment when Frontman must be absent, then verify the built artifact rather than assuming `next build` removes it.
+
+For WordPress, verify that an administrator can open `/frontman`, complete hosted sign-in, and see the site preview beside chat.
+
+## Update Frontman
+
+JavaScript integrations are project dependencies. Update the relevant `@frontman-ai/*` package with the package manager used by your project, then restart the development server. Review the [changelog](/changelog/) before adopting changes that affect integration setup.
+
+WordPress uses the normal plugin update flow in wp-admin.
+
+## Remove Frontman
+
+For a JavaScript project:
+
+1. Remove the Frontman integration call from `astro.config.*` or `vite.config.*`, or remove the Frontman middleware/proxy code from the Next.js entrypoint.
+2. Remove the matching `@frontman-ai/astro`, `@frontman-ai/nextjs`, or `@frontman-ai/vite` dependency with your package manager.
+3. Restart the development server and confirm `/frontman` is no longer mounted by the integration.
+
+If the Next.js installer added a dedicated middleware or proxy file, delete that file only when it contains no non-Frontman logic. If Frontman was merged into an existing file, remove only the Frontman import, handler, and matcher entries.
+
+For WordPress, deactivate and delete the plugin through **Plugins** in wp-admin. Deactivation removes the Frontman route from normal use; it does not revoke provider credentials stored on your Frontman account. Manage those separately through [API Keys & Providers](/docs/api-keys/).
+
+## Setup problems
+
+- **`/frontman` returns 404 during setup:** confirm the integration is registered and restart the development server. For production or preview behavior, inspect and test the built artifact instead of using a 404 as the installation criterion.
+- **Sign-in completes on the hosted page but does not return:** reopen `/frontman` on your local app. Custom local hostnames may not be accepted as return URLs.
+- **Chat loads but a run cannot start:** configure a credential for the selected model in [API Keys & Providers](/docs/api-keys/).
+- **File tools cannot reach expected files:** check `projectRoot` and `sourceRoot` in [Configuration Options](/docs/reference/configuration/).
+
+Use [Troubleshooting](/docs/reference/troubleshooting/) for connection, tool, or preview failures after installation.
 
 ## Next steps
 
-1. **[API Keys & Providers](/docs/api-keys/)** — configure your AI model
+1. **[Configure Frontman API Keys & Providers](/docs/api-keys/)** — connect model access
+2. **[Sending Prompts](/docs/using/sending-prompts/)** — run a focused first task
+3. **[Annotations](/docs/using/annotations/)** — point Frontman at an exact UI element

--- a/apps/marketing/src/content/docs/docs/integrations/wordpress.md
+++ b/apps/marketing/src/content/docs/docs/integrations/wordpress.md
@@ -1,11 +1,11 @@
 ---
-title: WordPress (Beta)
-description: Install the Frontman WordPress plugin to edit posts, blocks, Elementor pages, menus, templates, widgets, and settings through an AI interface.
+title: Install and Use Frontman for WordPress (Beta)
+description: Install the Frontman WordPress plugin, connect model access, verify the editor, and troubleshoot supported site changes.
 ---
 
 The Frontman WordPress plugin adds an AI agent directly to your WordPress site. Navigate to `/frontman`, describe what you want to change, and the agent handles the supported workflow inside the site preview — no code editor or terminal required for those supported changes.
 
-For the product overview, see [Frontman for WordPress](/wordpress/).
+This guide owns WordPress installation and use. For the cross-platform support matrix, see [Frontman Framework Compatibility](/docs/reference/compatibility/). For the product overview, see [Frontman for WordPress](/wordpress/).
 
 > **Beta:** This is experimental software. Start on a staging site, keep backups, and review changes before deploying to production.
 
@@ -34,7 +34,7 @@ Install Frontman from the [WordPress Plugin Directory](https://wordpress.org/plu
 2. Navigate to `/frontman` on your site (e.g. `https://yoursite.com/frontman`).
 3. If prompted, sign in to Frontman at `api.frontman.sh` with GitHub or Google. This is separate from your WordPress admin login.
 4. Once signed in, return to `/frontman` on your site. Frontman redirects back automatically when the site URL is accepted.
-5. Connect a supported AI provider with OAuth or add an API key.
+5. Connect a supported AI provider with OAuth or add an API key by following [Configure Frontman API Keys & Providers](/docs/api-keys/).
 6. Describe what you want to change in the chat interface beside the live preview.
 
 Frontman attempts to return you to the same site URL after hosted sign-in. If the hosted page remains open instead, reopen `/frontman` on your site after signing in. Frontman does not include a built-in model credential; see [API Keys & Providers](/docs/api-keys/).
@@ -43,14 +43,25 @@ You can also open Frontman while browsing any page — just append `/frontman` t
 
 ## What the Agent Can Do
 
-- Create, edit, and delete posts and pages
-- Insert, update, move, and delete Gutenberg blocks
-- Edit Elementor pages with Elementor-aware tools
-- Add and update navigation menu items
-- Read and change site options (title, tagline, permalinks, etc.)
-- Browse and update block templates and template parts
-- Manage widgets
-- Flush the WordPress cache
+This inventory reflects Frontman WordPress plugin 2.0.0 source, verified July 30, 2026. WordPress uses dedicated `wp_*` tools, not the file and Lighthouse tools provided by Astro, Next.js, and Vite. For shared browser and backend tools, see [Frontman Agent Tool Capabilities](/docs/using/tool-capabilities/).
+
+- **Posts, pages, and Gutenberg:** list, read, create, duplicate, update, and delete posts or pages; list, read, insert, update, move, and delete blocks.
+- **Elementor, when active:** inspect page data and widgets; add, update, duplicate, move, remove, or generate elements; replace complete page data; flush generated CSS; list and restore Frontman rollback snapshots.
+- **Navigation, templates, and widgets:** manage classic menus, menu items, menu locations, block-theme navigation menus, block templates, template parts, widget areas, and supported widget types.
+- **Site settings:** read and update allowlisted core options such as title, tagline, front-page selection, permalink structure, and comment settings. Arbitrary option access is not available.
+- **Additional CSS:** read active-theme Additional CSS and replace its complete contents with `wp_update_custom_css`. This site-wide write requires explicit confirmation and returns before/after CSS.
+- **Theme settings:** list active-theme Customizer/theme mods or read one mod. Plugin 2.0.0 does not expose a generic theme-mod write tool.
+- **Media:** upload a user-attached image into Media Library with optional title, alt text, caption, description, and parent post. Maximum decoded upload size is 20 MB. Plugin does not expose general media browsing, editing, or deletion tools.
+- **WooCommerce, when active:** `wc_*` tools cover products, categories, tags, attributes and terms, variations, reviews, orders, notes, refunds, customers, shipping, taxes, coupons, payment gateways, reports, settings, system status, store data, and product/order/customer metadata.
+- **Cache:** inspect supported cache plugins and request cache clearing.
+
+## Confirmation and Rollback
+
+- Frontman must ask for approval before calling plugin tools whose schema requires `confirm=true`. This includes WordPress delete tools, complete Elementor page replacement, Elementor element removal and rollback restoration, Additional CSS replacement, and WooCommerce `PUT`/`DELETE` mutations plus metadata updates/deletes.
+- Post and page deletion moves content to trash by default; `force=true` permanently deletes it. Other delete tools do not promise trash or automatic restoration.
+- Many mutation results include before/after state for review, but those snapshots are not a general undo system.
+- Elementor content mutation tools save private rollback snapshots and return rollback IDs. `wp_elementor_list_rollbacks` finds them; `wp_elementor_restore_rollback` restores one after separate confirmation.
+- No plugin-wide one-click rollback exists for Gutenberg, menus, templates, widgets, options, Additional CSS, media, or WooCommerce. Use WordPress revisions/trash where applicable and maintain site backups.
 
 ## Security
 
@@ -80,4 +91,4 @@ A WordPress login screen means you must log in as an administrator first. A Fron
 Use the `wp_clear_cache` tool in the chat, or flush your caching plugin manually (WP Rocket, W3 Total Cache, etc.).
 
 **Something went wrong and I want to undo a change.**
-Many WordPress mutation tools return before/after snapshots in tool history, but Frontman does not guarantee one-click undo for every WordPress change. Keep normal site backups and review changes before relying on them.
+Use Elementor's Frontman rollback tools only for Elementor changes. For posts and pages, check WordPress revisions or trash when applicable. Other mutations have no plugin-managed rollback; use your site backup or manually restore the recorded before state.

--- a/apps/marketing/src/content/docs/docs/reference/compatibility.md
+++ b/apps/marketing/src/content/docs/docs/reference/compatibility.md
@@ -1,25 +1,27 @@
 ---
-title: Supported Frameworks
-description: See what Frontman supports across Next.js, Astro, Vite-based apps, and WordPress, including version requirements and integration limits.
+title: Frontman Framework Compatibility
+description: Check Frontman support and minimum versions for Next.js, Astro, Vite-based apps, and WordPress before choosing an integration.
 ---
+
+This page owns framework support, versions, and integration choice. Use [Installation](/docs/installation/) for commands and success checks, [Configuration Options](/docs/reference/configuration/) for settings, and [Frontman Agent Tool Capabilities](/docs/using/tool-capabilities/) for individual tool parameters.
 
 Frontman has two compatibility layers:
 
 1. **The browser UI and agent runtime** — the same Frontman interface and hosted orchestration server.
 2. **The local integration** — the package or plugin that exposes your project to the agent through framework-specific tools.
 
-Compatibility depends on the local integration. Frontman does not attach directly to arbitrary applications. It works when a supported integration is installed and the app is running in development mode.
+Compatibility depends on the local integration. Frontman does not attach directly to arbitrary applications. Supported setup and day-to-day workflows use the framework development server for JavaScript integrations; deployed behavior must still be verified because framework build semantics differ.
 
 If you want the end-to-end execution model behind that split, read [How the Agent Works](/docs/using/how-the-agent-works/) and [Architecture Overview](/docs/reference/architecture/).
 
 ## Compatibility summary
 
-| Platform | Package / integration | Status | Minimum versions | What Frontman can access |
-|----------|------------------------|--------|------------------|--------------------------|
-| Next.js | `@frontman-ai/nextjs` | Supported | Next.js 13.2+, Node.js 18+ | Files, route manifest, dev logs, optional OpenTelemetry spans |
-| Astro | `@frontman-ai/astro` | Supported | Astro 5.x, 6.x, or 7.x; Node.js 22.19+ | Files, resolved routes, dev logs, Astro and Frontman source annotations |
-| Vite-based apps | `@frontman-ai/vite` | Supported | Vite 5.x or 6.x, Node.js 18+ | Files, dev logs, framework-aware client context |
-| WordPress | Frontman WordPress plugin | Beta | WordPress 6.0+, PHP 7.4+ | Site content, Elementor, templates, widgets, menus, and settings through WordPress tools |
+| Platform        | Package / integration     | Status    | Minimum versions                       | What Frontman can access                                                                 |
+| --------------- | ------------------------- | --------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Next.js         | `@frontman-ai/nextjs`     | Supported | Next.js 13.2+, Node.js 18+             | Files, route manifest, dev logs, optional OpenTelemetry spans                            |
+| Astro           | `@frontman-ai/astro`      | Supported | Astro 5.x, 6.x, or 7.x; Node.js 22.19+ | Files, resolved routes, dev logs, Astro and Frontman source annotations                  |
+| Vite-based apps | `@frontman-ai/vite`       | Supported | Vite 5.0+, Node.js 18+                 | Files, dev logs, framework-aware client context                                          |
+| WordPress       | Frontman WordPress plugin | Beta      | WordPress 6.0+, PHP 7.4+               | Site content, Elementor, templates, widgets, menus, and settings through WordPress tools |
 
 ## How compatibility works
 
@@ -40,10 +42,12 @@ For the full request/tool flow, see [Architecture Overview](/docs/reference/arch
 `@frontman-ai/nextjs` integrates through Next.js middleware or proxy entrypoints, depending on your Next.js version.
 
 **Supported versions**
+
 - Next.js 13.2 or later
 - Node.js 18 or later
 
 **What the integration provides**
+
 - File access within `projectRoot` / `sourceRoot`
 - `get_routes` for App Router and Pages Router discovery
 - `get_logs` for console output, build output, and uncaught errors
@@ -52,7 +56,9 @@ For the full request/tool flow, see [Architecture Overview](/docs/reference/arch
 See [Tool Capabilities](/docs/using/tool-capabilities/) for the shared file, log, and browser tools that work alongside these Next.js-specific capabilities.
 
 **Notes**
-- Frontman runs in development only.
+
+- The [generated middleware/proxy](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) contains no automatic development-only guard. Next.js 15 and earlier use generated middleware with `runtime: 'nodejs'`; Next.js 16 and later use proxy without a runtime declaration, matching Next.js proxy runtime requirements.
+- If that entrypoint remains in the application, its Frontman route matcher can be included in production builds. Add an explicit environment guard or remove it when deployed Frontman access is not intended, and verify the production build and route behavior.
 - App Router and Pages Router can coexist in the same project.
 - The integration works with both Webpack and Turbopack because it hooks at the Next.js request-entrypoint layer, not the bundler layer.
 
@@ -63,16 +69,19 @@ See [Next.js integration](/docs/integrations/nextjs/).
 `@frontman-ai/astro` integrates through Astro lifecycle hooks and the underlying Vite dev server.
 
 **Supported versions**
+
 - Astro 5.x, 6.x, or 7.x
 - Node.js 22.19 or later
 
 **What the integration provides**
+
 - File access within `projectRoot` / `sourceRoot`
 - `get_client_pages` for Astro route discovery
 - `get_logs` for Astro and Vite dev output
 - Source mapping through Astro 5/6 Dev Toolbar annotations, Frontman-owned Astro 7 annotations, and content-file metadata
 
 **Notes**
+
 - On Astro 5+, route discovery uses the resolved route manifest, which includes content collections, redirects, API endpoints, and integration-injected routes.
 - On older behavior paths, filesystem scanning is less complete. Current documentation and support target Astro 5+.
 - Astro 5 and 6 require Dev Toolbar annotations for exact element locations. Astro 7 uses Frontman-owned annotations because its Rust compiler does not emit the legacy attributes.
@@ -85,16 +94,19 @@ See [Astro integration](/docs/integrations/astro/).
 `@frontman-ai/vite` supports applications that run on a standard Vite dev server.
 
 **Supported versions**
-- Vite 5.x or 6.x
+
+- Vite 5.0 or later
 - Node.js 18 or later
 
 **What the integration provides**
+
 - File access within `projectRoot` / `sourceRoot`
 - `get_logs` for Vite console, build, and error output
 - Framework-aware client context when supported framework plugins are detected
 - Vue SFC source mapping through a dev-only source plugin
 
 **Supported framework families on Vite**
+
 - React
 - Vue
 - Svelte
@@ -103,6 +115,7 @@ See [Astro integration](/docs/integrations/astro/).
 - Other Vite-based apps that do not require framework-specific server hooks
 
 **Notes**
+
 - Vite compatibility is based on the dev server and plugin chain. If your project runs on Vite, Frontman can attach through the Vite integration even when the framework itself is not listed separately.
 - Framework-specific introspection is strongest for projects whose Vite plugin is explicitly detected.
 - SvelteKit works through its Vite dev server path.
@@ -114,15 +127,18 @@ See [Vite integration](/docs/integrations/vite/).
 The Frontman WordPress plugin is separate from the JavaScript framework integrations.
 
 **Supported versions**
+
 - WordPress 6.0 or later
 - PHP 7.4 or later
 - Administrator access
 
 **What the integration provides**
+
 - Post, page, block, Elementor, menu, widget, template, and settings tools
 - A live preview inside the site itself
 
 **Notes**
+
 - WordPress support is currently beta.
 - Supported workflows differ from the code-first integrations because the primary surface is WordPress content and configuration, not a local codebase.
 
@@ -146,18 +162,21 @@ A framework may still be usable if it runs through a supported integration path.
 
 ### Production environments
 
-Frontman integrations are development tools. They do not support attaching to production builds or preview deployments as a general workflow.
+JavaScript integrations are intended for development workflows. Production builds and preview deployments are not the supported editing workflow, but that does not guarantee integration code is absent.
 
 In practice, that means:
+
 - Astro support applies to `astro dev`, not `astro build` or `astro preview`
 - Vite support applies to `vite dev`, not `vite build` or `vite preview`
-- Next.js support applies to local development entrypoints, not production middleware in deployed environments
+- Next.js middleware/proxy can execute in a production deployment if the generated or manually integrated entrypoint remains. Frontman does not add an environment guard; deployment owners must add one or remove the integration when needed.
+
+For every integration, run the framework's production build and inspect the deployed result. Confirm whether Frontman routes, middleware/proxy logic, and client assets are emitted and reachable, then apply environment, authentication, reverse-proxy, and network controls appropriate to that result.
 
 ### Access outside the integration boundary
 
 Even on supported frameworks, Frontman is limited to what the integration exposes:
 
-- file tools are scoped to the configured project root
+- file tools resolve paths against the configured `sourceRoot`, subject to the symlink caveat documented in [Limitations & Workarounds](/docs/using/limitations/)
 - browser tools only see the embedded preview, not other tabs or devtools
 - there is no shell or terminal access
 - private-network `web_fetch` targets are blocked

--- a/apps/marketing/src/content/docs/docs/reference/self-hosting.md
+++ b/apps/marketing/src/content/docs/docs/reference/self-hosting.md
@@ -1,658 +1,235 @@
 ---
-title: Self-Hosting
-description: Run the Frontman server yourself — architecture, requirements, deployment options, and commercial considerations.
+title: Self-Host the Frontman Server
+description: Build, configure, migrate, and verify your own Frontman orchestration server using repository-supported deployment paths.
 ---
 
-## Overview
+Self-hosting runs Frontman's Phoenix orchestration server and PostgreSQL persistence in your infrastructure. It does not replace the framework integration in your app or the browser client that executes preview tools.
 
-Frontman uses a split architecture:
+This page owns server deployment. [Architecture Overview](/docs/reference/architecture/) owns component and data flow, [Configuration Options](/docs/reference/configuration/) owns framework integration settings, and [Configure Frontman API Keys & Providers](/docs/api-keys/) owns per-account model credentials.
 
-- **Browser client and JavaScript framework integrations** — bundled into your app via npm packages (`@frontman-ai/nextjs`, `@frontman-ai/astro`, `@frontman-ai/vite`) to run browser tools in the browser and filesystem tools on your machine
-- **Server** (AI agent orchestration) — Elixir/Phoenix application that queries MCP tools, sends relevant context to the selected LLM provider, generates edits, and persists task history. Filesystem tools execute on your machine through the framework integration; the server has no direct filesystem access.
-
-For local development, the server runs at `api.frontman.sh` (our hosted instance). **Self-hosting is only needed if you want to run your own instance of the orchestration server** — for data sovereignty, deployments where every required service and model is locally available, or custom modifications.
-
-:::caution[Self-hosting does not disable authentication]
-Production users who open `/frontman` are redirected to your Frontman server's login page and must sign in with GitHub or Google through WorkOS. Configure WorkOS credentials and redirect URIs before inviting users. After sign-in, Frontman returns users to accepted project URLs; if a custom local hostname is not accepted, they can reopen `/frontman` after signing in.
-
-Frontman account authentication is separate from model access. Each user must also connect a supported AI provider with OAuth or add an API key before sending a prompt. Email/password login is available only in development and test environments.
+:::caution[Review licensing before deployment]
+The server under `apps/frontman_server/` is licensed under AGPL-3.0-only with the repository's [AI Supplementary Terms](https://github.com/frontman-ai/frontman/blob/main/AI-SUPPLEMENTARY-TERMS.md). Client and JavaScript framework libraries use Apache-2.0, while the WordPress plugin uses GPL-2.0-or-later. Review the actual license files for your use case; this page is not legal advice.
 :::
 
-:::note[When to self-host]
-**Most users don't need to self-host.** The Apache-2.0 client libraries run browser tools in your browser and filesystem tools on your machine through the framework integration. The hosted server at `api.frontman.sh` orchestrates the agent loop and persists task history. It has no direct filesystem access, but relevant file content, screenshots, logs, metadata, tool results, and generated output may pass through it to your selected LLM provider.
+## What self-hosting changes
 
-Consider self-hosting if you:
-- Can provide every required service and model inside an air-gapped environment
-- Have strict data residency requirements
-- Want to fork and modify the server codebase
-- Need guaranteed uptime SLAs not covered by the hosted service
-:::
+With hosted Frontman, `api.frontman.sh` orchestrates the agent loop and stores account and task data. With self-hosting, your server deployment performs those jobs.
 
----
+Self-hosting does **not** move every operation into the Phoenix container:
 
-## Architecture
+- Browser tools still run in the user's Frontman browser session.
+- File tools still run through the framework integration on the machine serving the development app.
+- Relevant prompts, file content, screenshots, logs, metadata, tool results, and generated output can pass through your Frontman server to the selected LLM provider.
+- Users still need model access through a supported OAuth connection or saved API key.
 
-```
-┌─────────────────────────────────────────────────┐
-│ Your Machine                                    │
-│ ┌─────────────────┐  ┌────────────────────────┐ │
-│ │ Dev Server      │  │ Browser                 │ │
-│ │ (Next/Astro/    │  │ (Frontman overlay)      │ │
-│ │  Vite)          │  │                         │ │
-│ │                 │  │ Browser-side MCP Server │ │
-│ │ Server-side     │  │ (DOM, CSS, screenshots) │ │
-│ │ MCP tools       │  └───────────┬─────────────┘ │
-│ │ (routes, logs,  │              │               │
-│ │  build errors)  │              │               │
-│ └────────┬────────┘              │               │
-└──────────┼───────────────────────┼───────────────┘
-           │                       │
-           │    WebSocket/HTTPS    │
-           └───────────┬───────────┘
-                       │
-┌──────────────────────┼───────────────────────────┐
-│ Frontman Server      │  (Elixir/Phoenix)         │
-│  ┌───────────────────▼──────────────────────┐    │
-│  │ AI Agent Orchestrator                    │    │
-│  │ - Queries MCP tools (browser + server)   │    │
-│  │ - Calls LLM (Claude/GPT/OpenRouter)      │    │
-│  │ - Generates code edits                   │    │
-│  │ - Writes to source files via MCP         │    │
-│  │ - Triggers hot reload                    │    │
-│  └──────────────────────────────────────────┘    │
-│                                                   │
-│  PostgreSQL (user accounts, task history)        │
-│  Oban (background jobs: email, webhooks)         │
-│  Phoenix/Ecto telemetry metrics                  │
-└───────────────────────────────────────────────────┘
-```
-
-The server is stateless except for PostgreSQL. Horizontal scaling is supported via Elixir's distributed runtime (RELEASE_DISTRIBUTION=name).
-
----
+The server has no direct access to the user's project filesystem. See [Architecture Overview](/docs/reference/architecture/) for the request and tool relay.
 
 ## Requirements
 
-### Runtime
-- **Elixir** 1.19+ and **Erlang/OTP** 28+ (BEAM VM)
-- **PostgreSQL** 17+ (for user accounts and task history)
-- **Node.js** 24+ (for building assets — not needed in production)
-- **Linux** x86_64 or ARM64 (Ubuntu 24.04 LTS recommended)
+Choose infrastructure that provides:
 
-### Build-time (optional, for Docker or releases)
-- **Yarn** 4+ (monorepo dependency management)
-- **ReScript** 12+ (client library compilation)
+- A PostgreSQL database reachable by the Frontman server
+- An HTTPS endpoint with WebSocket support
+- GitHub and Google sign-in configured through WorkOS for production users
+- Outbound HTTPS access to WorkOS, whichever LLM providers users connect, and the built-in Sentry endpoint unless you modify the server source
+- Persistent PostgreSQL backups appropriate for your environment
 
-### Resources (production)
-- **Minimum:** 1 vCPU, 2GB RAM, 20GB disk
-- **Recommended:** 2 vCPU, 4GB RAM, 50GB disk (allows PostgreSQL tuning and room for logs)
-- **Storage:** Database grows with task history. Plan ~1GB/month for 100 active users. Backups require 2x database size.
+The repository's production image builds with Elixir 1.20, Erlang/OTP 29, and Node.js 24, then runs on Debian Bookworm without build tools. If you use the supplied Dockerfile, those build versions are already defined in the image.
 
-### Network
-- Outbound HTTPS to LLM APIs (Anthropic, OpenAI, OpenRouter)
-- Inbound HTTPS (443) for client connections
-- WebSocket support required (Phoenix Channels)
+No repository source establishes universal CPU, memory, disk, user-capacity, monthly-storage, uptime, or cost requirements. Size and monitor your deployment from observed workload rather than using fixed estimates.
 
----
+## Required production configuration
 
-## Deployment Options
+The production runtime reads these values:
 
-### Option 1: Bare Metal / VM (Recommended for Production)
+| Variable           | Purpose                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `DATABASE_URL`     | PostgreSQL connection string, such as `ecto://user:pass@host/database` |
+| `SECRET_KEY_BASE`  | Phoenix cookie and application secret                                  |
+| `CLOAK_KEY`        | Key used by Cloak for stored provider credentials                      |
+| `WORKOS_API_KEY`   | WorkOS API credential for hosted sign-in                               |
+| `WORKOS_CLIENT_ID` | WorkOS client ID                                                       |
+| `PHX_HOST`         | Public hostname used in generated server URLs                          |
+| `PHX_SERVER=true`  | Starts the Phoenix HTTP endpoint outside the supplied image            |
 
-This is how we run `api.frontman.sh` — a single Hetzner server with blue/green deploys.
+Common deployment settings:
 
-**Prerequisites:**
-- Ubuntu 24.04 LTS server
-- DNS A record pointing to server IP (we use Cloudflare DNS-only mode)
-- SSH access as root
+| Variable                        | Default              | Purpose                                                          |
+| ------------------------------- | -------------------- | ---------------------------------------------------------------- |
+| `PORT`                          | `4000`               | HTTP port inside the runtime                                     |
+| `DATABASE_SSL`                  | `true` in production | Set `false` only when the database connection should not use SSL |
+| `POOL_SIZE`                     | `10`                 | Ecto database connection pool size                               |
+| `ECTO_IPV6`                     | `false`              | Enables IPv6 socket options when set to a supported true value   |
+| `DNS_CLUSTER_QUERY`             | unset                | DNS query used by the included cluster configuration             |
+| `RESEND_API_KEY`                | unset                | Enables welcome-email and contact-sync workers when non-empty    |
+| `DISCORD_NEW_USERS_WEBHOOK_URL` | unset                | Enables new-user notification worker when non-empty              |
 
-**Setup:**
-```bash
-# 1. Run server setup script (installs PostgreSQL, Caddy, systemd services)
-ssh root@<server-ip> 'bash -s' < infra/production/server-setup.sh
+Generate `SECRET_KEY_BASE` with `mix phx.gen.secret`. The repository environment template uses `openssl rand -base64 32` for `CLOAK_KEY`. Store both outside source control. Changing `CLOAK_KEY` without a credential migration prevents existing encrypted provider credentials from being decrypted.
 
-# 2. Fill in environment secrets
-ssh deploy@<server-ip>
-nano /opt/frontman/blue/env
-# Set CLOAK_KEY, WORKOS_API_KEY, WORKOS_CLIENT_ID, etc.
+Production registration is disabled; users sign in through configured OAuth providers. Configure matching callback and redirect URLs in WorkOS before testing sign-in.
 
-# 3. Deploy first release (GitHub Actions workflow builds and deploys on push to main)
-# Or manually:
-git clone https://github.com/frontman-ai/frontman.git
-cd frontman
-make -C apps/frontman_server release
-scp apps/frontman_server/_build/prod/frontman_server-*.tar.gz deploy@<server>:/tmp/
-ssh deploy@<server> '/opt/frontman/deploy.sh /tmp/frontman_server-*.tar.gz'
-```
+## Built-in telemetry egress
 
-**What the setup script does:**
-- Installs PostgreSQL 17 with production tuning (auto-detects RAM)
-- Creates `frontman` database user and `frontman_server_prod` database
-- Installs Caddy reverse proxy (auto TLS via Let's Encrypt)
-- Creates `/opt/frontman/{blue,green}` directories for blue/green deploys
-- Installs systemd services (`frontman-blue.service`, `frontman-green.service`)
-- Sets up nightly PostgreSQL backups (cron at 3:00 AM)
-- Configures UFW firewall (22, 80, 443) and fail2ban
+Self-hosting does not make the supplied source telemetry-free:
 
-**Blue/Green Deployment:**
-The deploy script (`/opt/frontman/deploy.sh`) extracts the release to the inactive slot, runs migrations, smoke tests the new version, then swaps Caddy's upstream. Zero-downtime deploys. Rollback via `/opt/frontman/rollback.sh`.
+- In production, [`config/runtime.exs`](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/config/runtime.exs) assigns the server Sentry DSN directly to Frontman's `o4510512511320064.ingest.de.sentry.io` project. Server exceptions and reported errors can therefore leave the deployment for that Sentry project. The runtime source does not read a Sentry DSN or disable flag from the environment.
+- The browser client calls `Client__Heap.init()` at startup. [`Client__Heap.res`](https://github.com/frontman-ai/frontman/blob/main/libs/client/src/Client__Heap.res) loads `https://cdn.us.heap-api.com/config/<env-id>/heap_config.js` and uses Heap environment `349428408` when `import.meta.env.DEV` is true (or unavailable, because [`Client__Env.isDev`](https://github.com/frontman-ai/frontman/blob/main/libs/client/src/Client__Env.res) falls back to `true`) and `218974947` in a production Vite build. The source provides no runtime setting to replace the Heap environment or disable initialization.
 
-**Monitoring (optional):**
-```bash
-# Install Prometheus, Alertmanager, Blackbox Exporter
-ssh root@<server> 'bash -s' < infra/production/monitoring/setup-monitoring.sh
-```
+The documented environment variables cannot disable either integration. If policy forbids this egress, modify and rebuild the relevant server/client source before deployment and enforce outbound network policy as defense in depth. Blocking the destinations without rebuilding can produce failed telemetry requests in server or browser logs; it is not a supported disable control.
 
----
+## Deploy with Railway
 
-### Option 2: Railway
+The repository root includes `railway.json`. It points Railway at `apps/frontman_server/Dockerfile`, runs database migrations before deployment, checks `/health`, and restarts the service on failure.
 
-Use Railway when you want the fastest managed self-hosted Frontman server: one Phoenix service, one PostgreSQL service, automatic HTTPS, and migrations before each deploy.
-
-Railway does not replace the Docker path. Use Railway for managed hosting, or use Docker directly when you want to run the same server image on your own infrastructure.
-
-**Deploy from GitHub:**
-1. Create a new Railway project from `https://github.com/frontman-ai/frontman`.
+1. Create a Railway project from the Frontman repository.
 2. Add a PostgreSQL service.
-3. Set the Frontman service build config to use `apps/frontman_server/Dockerfile`. The repository includes `railway.json` with this setting.
-4. Add the required Frontman service variables below.
-5. Deploy. Railway runs `/app/bin/frontman_server eval "FrontmanServer.Release.migrate()"` before starting the server and checks `/health` after deploy.
+3. Configure the Frontman service with `apps/frontman_server/Dockerfile` if Railway does not apply `railway.json` automatically.
+4. Set the required production variables above, using Railway references for the public hostname and PostgreSQL URL where appropriate.
+5. Deploy and inspect the pre-deploy migration and health-check results.
+6. Open `/health/ready` to verify that the running application can query PostgreSQL.
 
-**Required Frontman service variables:**
-```dotenv
-PHX_SERVER=true
-PHX_HOST=${{Frontman.RAILWAY_PUBLIC_DOMAIN}}
-DATABASE_URL=${{Postgres.DATABASE_URL}}
-DATABASE_SSL=true
-SECRET_KEY_BASE=<generate a 64+ character secret>
-CLOAK_KEY=<generate with: openssl rand -base64 32>
-WORKOS_API_KEY=<your WorkOS API key>
-WORKOS_CLIENT_ID=<your WorkOS client ID>
-```
+Railway is one supported configuration path, not a published one-click template in this repository.
 
-Use the exact Railway service names from your project when referencing variables. If your app service is named `Frontman Server`, use `${{Frontman Server.RAILWAY_PUBLIC_DOMAIN}}`. If your database service is named `Postgres`, `${{Postgres.DATABASE_URL}}` works as shown.
+## Deploy with Docker
 
-**Optional Frontman service variables:**
-```dotenv
-RESEND_API_KEY=<enables welcome emails and contact sync>
-DISCORD_NEW_USERS_WEBHOOK_URL=<enables new-user signup notifications>
-POOL_SIZE=10
-```
+Build from the repository root so the Dockerfile can copy monorepo workspaces:
 
-`RESEND_API_KEY` and `DISCORD_NEW_USERS_WEBHOOK_URL` are optional. Frontman disables those background workers when the values are not present.
-
-**Publishing a one-click Railway template:**
-1. Create the Railway project above and confirm deploy succeeds.
-2. In Railway, publish the project as a template.
-3. Mark `SECRET_KEY_BASE` and `CLOAK_KEY` as generated secret variables.
-4. Mark `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` as required user-provided variables with descriptions.
-5. Set category to developer tools or productivity.
-6. Use this template description:
-
-   `Self-host Frontman, the browser-native AI frontend agent. Includes the Phoenix orchestration server, PostgreSQL, automatic migrations, OAuth via WorkOS, and optional Resend/Discord integrations.`
-
-After publishing, Railway generates a page like `https://railway.com/deploy/frontman` and a deploy URL like `https://railway.com/new/template/<template-id>`.
-
----
-
-### Option 3: Docker
-
-**Build the image:**
 ```bash
-cd apps/frontman_server
-docker build -t frontman-server .
+docker build -f apps/frontman_server/Dockerfile -t frontman-server .
 ```
 
-**Run (single instance):**
+Run the image with production variables supplied by your deployment system:
+
 ```bash
-docker run -d \
+docker run --rm \
   --name frontman-server \
-  -p 4000:4000 \
+  -p 127.0.0.1:4000:4000 \
   -e DATABASE_URL='ecto://user:pass@postgres-host/frontman_server_prod' \
-  -e SECRET_KEY_BASE='<generate via: mix phx.gen.secret>' \
-  -e CLOAK_KEY='<generate via: openssl rand -base64 32>' \
-  -e WORKOS_API_KEY='<your-workos-api-key>' \
-  -e WORKOS_CLIENT_ID='<your-workos-client-id>' \
+  -e DATABASE_SSL=false \
+  -e PHX_HOST='frontman.example.com' \
+  -e SECRET_KEY_BASE='<generated-secret>' \
+  -e CLOAK_KEY='<generated-key>' \
+  -e WORKOS_API_KEY='<workos-api-key>' \
+  -e WORKOS_CLIENT_ID='<workos-client-id>' \
   frontman-server
 ```
 
-**Environment variables:** See `infra/production/env.template` for full list. Required:
-- `DATABASE_URL` — PostgreSQL connection string
-- `SECRET_KEY_BASE` — Session encryption (generate: `mix phx.gen.secret`)
-- `CLOAK_KEY` — API key encryption at rest (generate: `openssl rand -base64 32`)
-- `WORKOS_API_KEY`, `WORKOS_CLIENT_ID` — OAuth (GitHub, Google login)
+The example publishes the container port only on host loopback. Put a TLS-terminating reverse proxy with WebSocket support in front of it, and restrict proxy and host-network access to intended users and networks. Do not publish port 4000 on every host interface. The database hostname and TLS setting are placeholders; use a hostname reachable from the container, and set `DATABASE_SSL` to match that database.
 
-Optional:
-- `DISCORD_NEW_USERS_WEBHOOK_URL` — New user signup notifications
-- `RESEND_API_KEY` — Email delivery (welcome emails, password resets)
+Run migrations against the same environment before directing users to a new release:
 
-**PostgreSQL setup:**
 ```bash
-# Run postgres container
-docker run -d \
-  --name frontman-postgres \
-  -e POSTGRES_DB=frontman_server_prod \
-  -e POSTGRES_USER=frontman \
-  -e POSTGRES_PASSWORD='<random-password>' \
-  -v frontman-pg-data:/var/lib/postgresql/data \
-  postgres:17-alpine
-
-# Run migrations (first time only)
-docker exec frontman-server /app/bin/frontman_server eval "FrontmanServer.Release.migrate()"
+docker run --rm \
+  -e DATABASE_URL='ecto://user:pass@postgres-host/frontman_server_prod' \
+  -e DATABASE_SSL=false \
+  -e SECRET_KEY_BASE='<generated-secret>' \
+  -e CLOAK_KEY='<generated-key>' \
+  -e WORKOS_API_KEY='<workos-api-key>' \
+  -e WORKOS_CLIENT_ID='<workos-client-id>' \
+  frontman-server \
+  /app/bin/frontman_server eval "FrontmanServer.Release.migrate()"
 ```
 
----
+How the database hostname resolves depends on your Docker network or hosting platform. The repository does not provide a complete Docker Compose production stack.
 
-### Option 4: From Source (Development)
+## Deploy with repository VM scripts
 
-**Prerequisites:**
-- Elixir 1.19+, Erlang 28+, Node.js 24+, PostgreSQL 17+
-- Yarn 4+ (enable via `corepack enable`)
+`infra/production/` contains the scripts used for Frontman's VM deployment layout:
 
-**Setup:**
+- `server-setup.sh` installs PostgreSQL, Caddy, systemd units, firewall rules, fail2ban, and a daily database-backup cron.
+- `deploy.sh` deploys a release tarball to the inactive blue/green slot, runs migrations, checks health, and changes the Caddy upstream.
+- `rollback.sh` checks the previous slot before changing Caddy back to it.
+- `backup-pg.sh` writes daily PostgreSQL dumps and prunes backups according to the script's configured retention.
+
+These scripts assume their documented Ubuntu host layout, paths under `/opt/frontman`, privileged package installation, and local PostgreSQL. Read and adapt them before running them on an existing server. Their presence does not establish an uptime or recovery-time guarantee.
+
+## Run from source for development
+
+Repository development uses Elixir 1.20, Node.js 24, Yarn, and PostgreSQL. From the repository root:
+
 ```bash
-git clone https://github.com/frontman-ai/frontman.git
-cd frontman
-
-# 1. Install dependencies
 yarn install
 cd apps/frontman_server
-mix deps.get
-
-# 2. Create database
-mix ecto.create
-mix ecto.migrate
-
-# 3. Install assets (esbuild, tailwind)
-mix setup
-
-# 4. Configure platform and authentication secrets
-# Update envs/.dev.secrets.env with your 1Password references
-# Provider credentials are configured per account in Frontman settings
-
-# 5. Start server
-mix phx.server
-# Visit http://localhost:4000
+make setup
+make dev
 ```
 
-**Configuration:** Uses Dotenvy to load env files in this order:
-1. `envs/.env` (base config, checked into git)
-2. `envs/.dev.env` (dev defaults)
-3. `envs/.dev.overrides.env` (local overrides, gitignored)
-4. System environment variables (highest precedence)
+The server Makefile starts Phoenix through `op run` and `envs/.dev.secrets.env`, whose values are 1Password `op://` references. If you do not use that workflow, supply required application secrets through your process environment and run the appropriate Mix server command directly.
 
-Development platform and authentication secrets, such as WorkOS credentials, are stored in `envs/.dev.secrets.env` as `op://` references (1Password CLI). The Makefile wraps `mix phx.server` with `op run --env-file=envs/.dev.secrets.env` to inject them at runtime. If you don't use 1Password, provide those application secrets through your process environment. Configure model access per account with provider OAuth or a saved API key in Frontman settings; provider keys are not loaded from the server environment.
+Development environment files load in this order, with later values taking precedence:
 
----
+1. `envs/.env`
+2. `envs/.dev.env`
+3. `envs/.dev.overrides.env`
+4. Process environment variables
 
-## Configuration
+This source path is for development. Use a release image or release tarball for production.
 
-### Required Environment Variables
+## Connect an app to your server
 
-#### Application
-- `PHX_HOST` — Public hostname (e.g., `api.frontman.sh`)
-- `PHX_SERVER=true` — Start Phoenix HTTP endpoint
-- `PORT` — HTTP port (default: 4000)
+Set the framework integration's `host` option or `FRONTMAN_HOST` to your server hostname. Restart the app's development server, open `/frontman`, and complete sign-in against your deployment.
 
-#### Database
-- `DATABASE_URL` — PostgreSQL connection string
-  - Format: `ecto://user:pass@host/database`
-  - Example: `ecto://frontman:secretpass@localhost/frontman_server_prod`
-- `DATABASE_SSL` — Enable SSL (default: true in prod)
-  - Set to `false` for local PostgreSQL without SSL
-
-#### Security
-- `SECRET_KEY_BASE` — Phoenix session encryption
-  - Generate: `mix phx.gen.secret`
-  - Must be 64+ characters
-- `CLOAK_KEY` — API key encryption at rest (Cloak Ecto)
-  - Generate: `openssl rand -base64 32`
+Do not change `clientUrl`, `clientCssUrl`, or `entrypointUrl` unless your deployment serves those assets or endpoints from custom locations. [Configuration Options](/docs/reference/configuration/) owns those integration settings.
 
-#### Authentication (WorkOS)
-Frontman uses WorkOS for OAuth (GitHub, Google login). Required for production:
-- `WORKOS_API_KEY` — WorkOS API secret
-- `WORKOS_CLIENT_ID` — WorkOS OAuth client ID
+## Verify a deployment
 
-Get these from [WorkOS Dashboard](https://dashboard.workos.com/).
+1. Request `GET /health`; it should return `{"status":"ok"}` when the application process is serving requests.
+2. Request `GET /health/ready`; it should return `{"status":"ready","database":"connected"}` when PostgreSQL is reachable.
+3. Open the server root and complete GitHub or Google sign-in.
+4. Point a supported framework integration at the server and open `/frontman` in the development app.
+5. Connect a model provider, send a small prompt, and confirm browser and file tool calls return through the integration.
+6. Restart the browser session and confirm task history can be loaded from PostgreSQL.
 
-### Optional Environment Variables
+Health endpoints prove process and database readiness only. They do not test WorkOS, provider credentials, browser tools, file relay, backups, or external LLM availability.
 
-#### Notifications
-- `DISCORD_NEW_USERS_WEBHOOK_URL` — Discord webhook for new user signups (omit to disable)
+## Updates and rollback
 
-#### Email (Resend)
-- `RESEND_API_KEY` — Required for welcome emails and password resets in production
+Before updating:
 
-#### Database Tuning
-- `POOL_SIZE` — Ecto connection pool size (default: 10)
-- `ECTO_IPV6` — Set to `true` or `1` to use IPv6
+1. Read the repository [changelog](https://github.com/frontman-ai/frontman/blob/main/CHANGELOG.md).
+2. Back up PostgreSQL and verify that the backup can be restored in your environment.
+3. Build the target commit or image.
+4. Run `FrontmanServer.Release.migrate()` with the new release environment.
+5. Check `/health/ready`, sign-in, and one end-to-end agent task before completing rollout.
 
-#### Clustering (Distributed Elixir)
-- `RELEASE_NODE` — Node name (e.g., `frontman@localhost`)
-- `RELEASE_COOKIE` — Erlang distribution cookie (shared secret for clustering)
-- `RELEASE_DISTRIBUTION=name` — Enable distributed mode
-- `DNS_CLUSTER_QUERY` — DNS SRV query for node discovery (e.g., `_frontman._tcp.internal.local`)
-
----
+Database migrations do not imply automatic downgrade compatibility. Use the supplied rollback script only with the VM layout it expects, and review migrations before attempting an application or database rollback.
 
-## Database Management
+## Security boundaries
 
-### Migrations
-```bash
-# Production (inside release)
-/app/bin/frontman_server eval "FrontmanServer.Release.migrate()"
+- Terminate HTTPS in front of production HTTP and WebSocket traffic.
+- Restrict inbound access at the reverse proxy, firewall, private network, or identity-aware access layer. The production endpoint binds all interfaces inside its runtime, and the Docker example relies on host-loopback publishing to keep that HTTP listener off external interfaces.
+- Production [`runtime.exs`](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/config/runtime.exs) hard-codes Phoenix `check_origin: false`. This disables Phoenix socket Origin validation; it does not mean “same origin only.” There is no environment variable in current source to enable or configure allowed origins. Treat authentication, TLS, and network access controls as required, and modify the endpoint configuration if your threat model requires socket Origin enforcement.
+- Protect `SECRET_KEY_BASE`, `CLOAK_KEY`, WorkOS credentials, database credentials, and optional integration secrets outside source control.
+- Back up PostgreSQL; it stores users, task history, OAuth records, and encrypted provider credentials.
+- The `CLOAK_KEY` protects stored provider credentials at the application layer. Database encryption does not remove the need to protect that key and restrict server access.
+- Self-hosting controls the orchestration and persistence environment. It does not prevent data from reaching a user-selected LLM provider.
 
-# Development
-mix ecto.migrate
-```
-
-### Backups
-The setup script installs a daily backup cron (3:00 AM) that dumps PostgreSQL to `/opt/frontman/backups/daily/`. Retention: 7 days. Adjust in `/opt/frontman/backup-pg.sh`.
-
-**Manual backup:**
-```bash
-pg_dump -U frontman frontman_server_prod | gzip > backup-$(date +%Y%m%d).sql.gz
-```
-
-**Restore:**
-```bash
-gunzip < backup-YYYYMMDD.sql.gz | psql -U frontman frontman_server_prod
-```
-
-### Rollback
-```bash
-# Via deploy script (rolls back to previous release)
-ssh deploy@<server> '/opt/frontman/rollback.sh'
-
-# Manual Ecto rollback (dev)
-mix ecto.rollback --step 1
-```
-
----
-
-## Security Considerations
-
-### Data Flow
-- **Source code:** Filesystem tools read and write files on your machine through the framework integration; the Frontman server has no direct filesystem access. Relevant file content and tool results may pass through the orchestration server to your selected LLM provider.
-- **Browser context:** Browser tools capture DOM context, screenshots, logs, and metadata in the browser. Relevant results pass through the orchestration server to the selected LLM provider.
-- **Task history:** The hosted or self-hosted server persists task history in PostgreSQL.
-- **Secrets:** LLM API keys are encrypted at rest in PostgreSQL using Cloak Ecto (AES-256-GCM). The `CLOAK_KEY` env var decrypts them.
-- **OAuth tokens:** WorkOS handles GitHub/Google OAuth. Frontman receives an auth code, exchanges it for user info, and stores a session cookie (Phoenix signed sessions).
-
-### Transport Security
-- **HTTPS required in production.** Caddy auto-provisions Let's Encrypt TLS certificates.
-- **WebSocket encryption:** Phoenix Channels run over WSS (WebSocket Secure) in production.
-
-### Authentication
-- **OAuth via WorkOS** — GitHub and Google SSO
-- **Session-based** — Phoenix signed cookies (`SECRET_KEY_BASE`)
-- **No password storage** — OAuth-only (no email/password login)
-
-### Firewall
-The setup script configures UFW to allow only SSH (22), HTTP (80), HTTPS (443). PostgreSQL (5432) is bound to localhost only.
-
-### Secrets Management
-**Never commit secrets to git.** Use:
-- Environment files (`.env`) for non-sensitive config (gitignored)
-- Secret managers (1Password CLI, AWS Secrets Manager, HashiCorp Vault) for production
-
-Example with 1Password CLI (used in our dev workflow):
-```bash
-# .dev.secrets.env
-WORKOS_API_KEY=op://vault/WorkOS/API_Key
-
-# Run server with secrets injected
-op run --env-file=envs/.dev.secrets.env mix phx.server
-```
-
----
-
-## Monitoring & Observability
-
-### Health Checks
-- **HTTP:** `GET /health` → `{"status": "ok"}`
-- **Readiness:** `GET /health/ready` checks database connectivity
-- **Database:** Phoenix Dashboard at `/dashboard` (dev only)
-
-### Logs
-- **Development:** Console output (colorized via Phoenix Logger)
-- **Production:** Systemd journal (`journalctl -u frontman-blue -f`)
-- **Structured logging:** JSON format via Logger (configurable in `config/prod.exs`)
-
-### Metrics (Prometheus)
-Optional setup script installs Prometheus + Alertmanager + Blackbox Exporter. Scrapes:
-- System metrics via Node Exporter (CPU, memory, disk, network)
-- PostgreSQL metrics via Postgres Exporter
-- Health endpoint uptime via Blackbox Exporter
-- Prometheus self-monitoring metrics
-
-Alerts fire to Alertmanager → Discord webhook on:
-- Active Frontman service down for 2 minutes
-- Health endpoint unreachable for 2 minutes
-- Database backup stale for more than 25 hours
-- PostgreSQL connection count above threshold
-
----
-
-## Scaling & High Availability
-
-### Horizontal Scaling
-Frontman is stateless except for PostgreSQL. To scale horizontally:
-
-1. **Run multiple instances** behind a load balancer (e.g., Caddy with `lb_policy round_robin`)
-2. **Shared PostgreSQL** — all instances connect to the same database
-3. **Distributed Elixir** — set `RELEASE_NODE`, `RELEASE_COOKIE`, `RELEASE_DISTRIBUTION=name`, and `DNS_CLUSTER_QUERY` for node discovery
-
-Example (3 nodes):
-```bash
-# Node 1
-RELEASE_NODE=frontman1@node-a RELEASE_COOKIE=<cookie> /app/bin/server
-
-# Node 2
-RELEASE_NODE=frontman2@node-b RELEASE_COOKIE=<cookie> /app/bin/server
-
-# Node 3
-RELEASE_NODE=frontman3@node-c RELEASE_COOKIE=<cookie> /app/bin/server
-```
-
-Nodes will form a cluster. Phoenix PubSub messages (task updates, hot reload triggers) are distributed across all nodes.
-
-### Database HA
-For production, use:
-- **PostgreSQL replication** (streaming replication + failover via Patroni or Stolon)
-- **Managed databases** (AWS RDS, GCP Cloud SQL, Azure PostgreSQL)
-
-### Backup Strategy
-- **Automated daily backups** (setup script installs cron)
-- **Offsite storage** (rsync to S3, GCS, or Backblaze B2)
-- **Test restores regularly** (quarterly is recommended)
-
----
-
-## Commercial Considerations
-
-### Licensing
-The combined product is source-available because the server's supplementary terms impose field-of-use restrictions.
-
-- **Browser client and JavaScript framework integrations** — Apache-2.0 (permissive, commercial use allowed)
-- **WordPress plugin** (`libs/frontman-wordpress/`) — GPL-2.0-or-later
-- **Server** (`apps/frontman_server/`) — AGPL-3.0-only plus [AI Supplementary Terms](https://github.com/frontman-ai/frontman/blob/main/AI-SUPPLEMENTARY-TERMS.md) restricting AI training and AI-assisted competitive reproduction
-
-If you self-host, you must:
-- Provide source code to users who interact with your modified server (AGPL network clause)
-- Disclose modifications if you distribute the server
-
-**Commercial licenses available** — contact us if the server terms don't fit your use case (e.g., SaaS white-label, proprietary forks).
-
-### Support
-Self-hosted deployments are community-supported via:
-- [GitHub Issues](https://github.com/frontman-ai/frontman/issues) (bug reports, feature requests)
-- [Discord](https://discord.gg/xk8uXJSvhC) (community help)
-
-**Enterprise support** available (SLA-backed, private Slack channel, dedicated engineer). Includes:
-- Custom deployment consulting
-- Priority bug fixes and backports
-- Security patches with 24-hour SLA
-- Performance tuning and database optimization
-
-Contact us through the [contact page](/contact/) for enterprise support details.
-
-### Cloud Marketplaces
-Not currently available on AWS/GCP/Azure marketplaces. Roadmap item for 2025. Track progress in [issue #123](https://github.com/frontman-ai/frontman/issues/123).
-
-### Multi-Tenancy
-The hosted `api.frontman.sh` runs a single instance serving all users. Self-hosted deployments can run:
-- **Single-tenant** (one org, one database)
-- **Multi-tenant** (multiple orgs, shared database with row-level security)
-
-Multi-tenancy is implemented via `organization_id` foreign keys + Ecto query scoping. See `apps/frontman_server/lib/frontman_server/organizations.ex` for details.
-
-### Cost Estimates
-
-#### Hosted (api.frontman.sh)
-- **Paid hosted service** — Hosted Frontman Pro is available now
-- **BYOK** — you pay your LLM provider directly (Anthropic, OpenAI, OpenRouter) at standard API rates
-
-#### Self-Hosted (estimated monthly costs)
-- **Hetzner CCX13** (2 vCPU, 8GB RAM, 80GB NVMe) — €15/month (~$16 USD)
-- **PostgreSQL** (included on VM)
-- **Backups** (Hetzner Backup +20%) — €3/month (~$3 USD)
-- **Total:** ~€18/month (~$19 USD)
-
-Compare to:
-- **Cursor Pro** — $20/month/user
-- **GitHub Copilot Pro** — $10/month/user
-- **v0 Premium** — $20/month/user
-
-Self-hosting is cost-effective for teams of 2+ users.
-
----
+Review [Frontman Limitations & Workarounds](/docs/using/limitations/) for client and tool boundaries and the [Privacy Policy](/privacy/) for hosted-service data handling.
 
 ## Troubleshooting
 
-### Server won't start
-```bash
-# Check systemd logs
-journalctl -u frontman-blue -f
+**The container exits during startup.**
+Check logs for a missing `DATABASE_URL`, `SECRET_KEY_BASE`, or `CLOAK_KEY`, an invalid boolean environment value, or database connection failure.
 
-# Common issues:
-# 1. DATABASE_URL incorrect → check /opt/frontman/blue/env
-# 2. SECRET_KEY_BASE missing → generate: mix phx.gen.secret
-# 3. Port already in use → check: sudo lsof -i :4000
-```
+**`/health` works but `/health/ready` returns 503.**
+The application is running but its `SELECT 1` database check failed. Verify database hostname, credentials, network access, and `DATABASE_SSL`.
 
-### Database connection errors
-```bash
-# Test PostgreSQL connection
-psql -U frontman -h localhost frontman_server_prod
+**Users cannot sign in.**
+Verify WorkOS API credentials and callback/redirect configuration for the public `PHX_HOST`. Production does not expose public registration as an alternative.
 
-# Check PostgreSQL status
-systemctl status postgresql
+**The app's `/frontman` still uses the hosted server.**
+Set `host` or `FRONTMAN_HOST` in the framework integration and restart the app's development server.
 
-# Check pg_hba.conf auth
-sudo cat /etc/postgresql/17/main/pg_hba.conf | grep frontman
-```
+**A provider model is unavailable.**
+Provider access is configured per Frontman account. Follow [Configure Frontman API Keys & Providers](/docs/api-keys/) on the self-hosted instance.
 
-### Migrations fail
-```bash
-# Run manually with debug output
-/app/bin/frontman_server eval "FrontmanServer.Release.migrate()" --verbose
+For non-deployment failures, continue with [Troubleshooting](/docs/reference/troubleshooting/).
 
-# Rollback and retry
-mix ecto.rollback --step 1
-mix ecto.migrate
-```
+## Repository references
 
-### WebSocket connections drop
-- **Caddy timeout:** Increase `timeout` in Caddyfile (default: 5 minutes)
-- **Firewall:** Ensure TCP 443 allows long-lived connections (disable stateful inspection if needed)
-
-### Out of memory (OOM)
-```bash
-# Check BEAM memory usage
-/app/bin/frontman_server remote
-
-# In IEx console:
-:erlang.memory()
-# Look for 'total' — should be < 80% of available RAM
-
-# Tune VM (add to env):
-ERL_AFLAGS="+MBas aoffcbf +MBac false +MBlmbcs 512"
-```
-
-### High database load
-```bash
-# Check slow queries (inside psql):
-SELECT * FROM pg_stat_statements ORDER BY mean_exec_time DESC LIMIT 10;
-
-# Add indexes (migrations in apps/frontman_server/priv/repo/migrations/)
-# Run: mix ecto.gen.migration add_index_to_tasks
-```
-
----
-
-## Upgrade Guide
-
-### Minor Versions (0.x.y → 0.x.z)
-Safe to deploy without downtime (backward-compatible migrations):
-```bash
-# Deploy via GitHub Actions (push to main)
-git push origin main
-
-# Or manually:
-ssh deploy@<server> '/opt/frontman/deploy.sh /tmp/new-release.tar.gz'
-```
-
-### Major Versions (0.x → 1.0)
-May require manual migration steps:
-1. **Read CHANGELOG.md** for breaking changes
-2. **Backup database** (`/opt/frontman/backup-pg.sh`)
-3. **Deploy to green slot** (test before swapping)
-4. **Run migrations** (deploy script does this automatically)
-5. **Smoke test** (deploy script checks health endpoint)
-6. **Swap Caddy upstream** (deploy script updates Caddyfile)
-
-Rollback if needed: `/opt/frontman/rollback.sh`
-
----
-
-## FAQ
-
-### Do I need to self-host?
-**No** — most users should use `api.frontman.sh` (our hosted instance). Self-host only if you need data sovereignty, can provide every required service and model in an air-gapped environment, or want custom server modifications. Self-hosting moves orchestration and persistence to your infrastructure; it does not by itself prevent transmission to your configured LLM provider.
-
-### Can I run Frontman without a server?
-**No** — the server orchestrates AI agent execution. The client libraries (Next.js/Astro/Vite plugins) are just MCP servers that expose dev server context to the agent.
-
-### Is the database required?
-**Yes** — stores user accounts, OAuth tokens, task history, and encrypted API keys.
-
-### Can I use MySQL instead of PostgreSQL?
-**No** — Ecto migrations use PostgreSQL-specific features (JSONB, UUID extensions). MySQL support is not planned.
-
-### How do I change the domain?
-1. Update `PHX_HOST` in `/opt/frontman/blue/env` and `/opt/frontman/green/env`
-2. Update Caddy config: `/etc/caddy/Caddyfile`
-3. Reload Caddy: `sudo systemctl reload caddy`
-4. Update DNS A record to point to your server
-
-### Can I disable OAuth and use email/password?
-**Not currently supported.** OAuth via WorkOS is the only auth method. Email/password login is a roadmap item for 2025 (track in [issue #456](https://github.com/frontman-ai/frontman/issues/456)).
-
-### How do I add a new LLM provider?
-See the [Models & Providers](/docs/reference/models/) reference for currently supported providers. To add a new provider in a self-hosted fork:
-1. Add provider config to `apps/frontman_server/config/config.exs`
-2. Implement API adapter in `apps/frontman_server/lib/frontman_server/providers/`
-3. Add OAuth flow if needed (WorkOS or custom)
-
----
-
-## Resources
-
-- [GitHub Repository](https://github.com/frontman-ai/frontman)
-- [Production Deployment Scripts](https://github.com/frontman-ai/frontman/tree/main/infra/production)
-- [Dockerfile](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/Dockerfile)
-- [Environment Template](https://github.com/frontman-ai/frontman/blob/main/infra/production/env.template)
-- [Discord Community](https://discord.gg/xk8uXJSvhC)
-
-For enterprise support or commercial licensing questions, contact us through the [contact page](/contact/).
+- [Frontman server Dockerfile](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/Dockerfile)
+- [Railway configuration](https://github.com/frontman-ai/frontman/blob/main/railway.json)
+- [Production scripts](https://github.com/frontman-ai/frontman/tree/main/infra/production)
+- [Production environment template](https://github.com/frontman-ai/frontman/blob/main/infra/production/env.template)
+- [Server license](https://github.com/frontman-ai/frontman/blob/main/apps/frontman_server/LICENSE)
+- [AI Supplementary Terms](https://github.com/frontman-ai/frontman/blob/main/AI-SUPPLEMENTARY-TERMS.md)

--- a/apps/marketing/src/content/docs/docs/using/annotations.md
+++ b/apps/marketing/src/content/docs/docs/using/annotations.md
@@ -1,11 +1,13 @@
 ---
-title: Annotations
-description: Select elements in the live preview to give the Frontman agent precise visual and source-level context for your changes.
+title: Annotate UI Elements for Frontman
+description: Select elements in Frontman's live preview, add change instructions, and verify the source context sent with your prompt.
 ---
 
-Annotations let you **point at elements** instead of describing them in text. Click an element in the [live preview](/docs/using/web-preview/), and Frontman captures its exact source file location, a screenshot, CSS selector, and surrounding context — then sends all of it to the agent alongside your prompt.
+Annotations let you **point at elements** instead of describing them in text. Click an element in the [live preview](/docs/using/web-preview/), and Frontman captures a screenshot, CSS selector, surrounding context, and source location when the active framework can resolve one. It sends that context to the agent alongside your prompt.
 
-The result: the agent knows exactly which element you mean, which file to open, and what line to edit — no guessing, no searching.
+The result: the agent knows which rendered element you mean and can go directly to its source when source metadata is available. If source resolution fails, the screenshot, selector, and DOM context still make the annotation usable.
+
+This page owns the annotation workflow. [Frontman Agent Tool Capabilities](/docs/using/tool-capabilities/) owns browser-tool parameters, and [Frontman Framework Compatibility](/docs/reference/compatibility/) owns framework support.
 
 ## Enabling annotation mode
 
@@ -27,18 +29,18 @@ You can annotate multiple elements before sending your prompt. Each gets its own
 
 When you click an element, Frontman immediately captures several layers of context:
 
-| Data | Source | Purpose |
-|------|--------|---------|
-| **Source file & line** | Framework integration (Astro `data-astro-source-*` attributes, React fiber tree, or source maps) | Agent reads the exact file and line |
-| **Screenshot** | Element-level capture via the preview iframe | Agent can see the visual state |
-| **CSS selector** | Generated unique selector | Agent can locate the element in DOM tools |
-| **Tag name** | DOM element tag (e.g., `<button>`, `<h2>`) | Provides structural context |
-| **CSS classes** | Element's `class` attribute | Helps identify styling |
-| **Component name** | Detected from framework metadata (e.g., `Hero`, `PricingCard`) | Agent understands the component hierarchy |
-| **Component props** | Extracted from framework dev tooling (Astro integration) | Agent sees the data driving the component |
-| **Nearby text** | `textContent` of the element (truncated to 200 chars) | Gives content context |
-| **Bounding box** | `getBoundingClientRect()` coordinates | Positional context for layout changes |
-| **Your comment** | What you type in the annotation popup | Tells the agent what you want changed |
+| Data                   | Source                                                         | Purpose                                              |
+| ---------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| **Source file & line** | Framework metadata, when resolution succeeds                   | Agent can open the relevant source location directly |
+| **Screenshot**         | Element-level capture via the preview iframe                   | Agent can see the visual state                       |
+| **CSS selector**       | Generated unique selector                                      | Agent can locate the element in DOM tools            |
+| **Tag name**           | DOM element tag (e.g., `<button>`, `<h2>`)                     | Provides structural context                          |
+| **CSS classes**        | Element's `class` attribute                                    | Helps identify styling                               |
+| **Component name**     | Detected from framework metadata (e.g., `Hero`, `PricingCard`) | Agent understands the component hierarchy            |
+| **Component props**    | Extracted from framework dev tooling (Astro integration)       | Agent sees the data driving the component            |
+| **Nearby text**        | `textContent` of the element (truncated to 200 chars)          | Gives content context                                |
+| **Bounding box**       | `getBoundingClientRect()` coordinates                          | Positional context for layout changes                |
+| **Your comment**       | What you type in the annotation popup                          | Tells the agent what you want changed                |
 
 This all happens asynchronously in the background. The badge pulses while data is loading and turns solid purple when enrichment is complete.
 
@@ -65,6 +67,7 @@ You can annotate as many elements as you need before sending a prompt. Each gets
 ![The web preview showing multiple annotated elements on different parts of a page, each with its own numbered purple badge and purple border highlight](../../../../assets/docs/multiple-annotations.png)
 
 **Independent changes** — annotate each element with its own comment:
+
 ```text
 Annotation 1 (on a heading): "Make this larger"
 Annotation 2 (on a button): "Change the color to red"
@@ -72,6 +75,7 @@ Chat message: "Apply these changes"
 ```
 
 **Related changes** — annotate the elements, then describe the change in the chat:
+
 ```text
 Annotation 1 (on card 1)
 Annotation 2 (on card 2)
@@ -116,17 +120,17 @@ When you hit send, annotations go through this pipeline:
 4. **Include screenshots** — element screenshots are sent as image content parts so the LLM can see each annotated element
 5. **System prompt guidance** — when annotations are present, the agent's system prompt includes specific instructions for the annotation workflow: read the file at the exact location, examine the source, apply changes, and verify
 
-The agent is instructed to **go directly to the annotated file and line** — no exploring or searching. This makes annotation-based prompts significantly faster than text-only descriptions.
+When a source location is present, the agent is instructed to read that file at the annotated location before editing. Without one, it uses the remaining visual and DOM context to locate the implementation.
 
 ## Enrichment status
 
 The annotation badge color indicates its current state:
 
-| Badge | Meaning |
-|-------|---------|
-| **Purple (pulsing)** | Enrichment in progress — screenshot and source location are being captured |
-| **Purple (solid)** | Fully enriched — all data captured successfully |
-| **Amber** | Enrichment failed — some data couldn't be captured (the annotation is still usable) |
+| Badge                | Meaning                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| **Purple (pulsing)** | Enrichment in progress — screenshot and source location are being captured          |
+| **Purple (solid)**   | Fully enriched — all data captured successfully                                     |
+| **Amber**            | Enrichment failed — some data couldn't be captured (the annotation is still usable) |
 
 :::note
 The send button is disabled while any annotation is still enriching. Wait for badges to stop pulsing before sending your message.

--- a/apps/marketing/src/content/docs/docs/using/limitations.md
+++ b/apps/marketing/src/content/docs/docs/using/limitations.md
@@ -1,21 +1,24 @@
 ---
-title: Limitations & Workarounds
-description: What Frontman can't do, and practical workarounds for auth-gated pages, viewport limits, timeouts, and stuck loops.
+title: Frontman Limitations & Workarounds
+description: Work around Frontman's preview, authentication, filesystem, network, timeout, and development-server boundaries.
 ---
 
-Frontman is opinionated about safety and scope. In the [distributed architecture](/docs/reference/architecture/), browser tools run in the browser, filesystem tools run on your machine through the framework integration, and the server orchestrates the agent loop and persists task history. Relevant file content, DOM context, screenshots, logs, metadata, tool results, and generated output may pass through the server to your selected LLM provider. That design prevents entire classes of mistakes—but it also creates limits you should know about. This page collects the common "why can't it…" questions and shows how to work around them.
+This page owns operational limits and workarounds. [Architecture Overview](/docs/reference/architecture/) owns system and data flow, [Frontman Framework Compatibility](/docs/reference/compatibility/) owns supported integrations, and [Frontman Agent Tool Capabilities](/docs/using/tool-capabilities/) owns exact tool parameters.
+
+Browser tools run in the browser, filesystem tools run on your machine through the framework integration, and the server orchestrates the agent loop and persists task history. Relevant file content, DOM context, screenshots, logs, metadata, tool results, and generated output may pass through the server to your selected LLM provider. Those boundaries create limits you should know about.
 
 ## What the agent can (and can’t) see
 
-| Capability | Supported? | Details |
-|------------|------------|---------|
-| **Rendered DOM in the preview iframe** | ✅ | Anything in the preview at the current URL and viewport is fair game (via screenshots, DOM inspection, text search, and element interaction). |
-| **Other browser tabs, devtools, or cross-origin iframes** | ❌ | The agent only sees the embedded preview. Popped-out tabs, browser extensions, and remote iframes are invisible. |
-| **Source files inside the current workspace** | ✅ | The framework plugin exposes files under your repo root. |
-| **Files outside the repo, `.env` secrets, shell access** | ❌ | Tools like `read_file`/`edit_file` are sandboxed to your project root. There is no terminal/shell tool, so the agent can’t run commands or read arbitrary files on your machine. |
-| **Remote URLs** | ⚠️ | `web_fetch` blocks private networks/localhost (SSRF protection in `FrontmanServer.Tools.WebFetch`). Public URLs are fine but capped at 5 MB and 60 s per request. |
+| Capability                                                | Supported? | Details                                                                                                                                                                |
+| --------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rendered DOM in the preview iframe**                    | ✅         | Anything in the preview at the current URL and viewport is fair game (via screenshots, DOM inspection, text search, and element interaction).                          |
+| **Other browser tabs, devtools, or cross-origin iframes** | ❌         | The agent only sees the embedded preview. Popped-out tabs, browser extensions, and remote iframes are invisible.                                                       |
+| **Files under the configured source root**                | ✅         | JavaScript integrations expose file tools under `sourceRoot`, which defaults to `projectRoot`. Files such as `.env` are not excluded when they are inside that root.   |
+| **Other filesystem paths and shell access**               | ⚠️         | Lexical path checks reject `..` traversal outside `sourceRoot`, but configuration and symlinks affect the effective boundary. There is no general terminal/shell tool. |
+| **Remote URLs**                                           | ⚠️         | `web_fetch` blocks private networks/localhost (SSRF protection in `FrontmanServer.Tools.WebFetch`). Public URLs are fine but capped at 5 MB and 60 s per request.      |
 
 ### Workarounds
+
 1. **Navigate first** — open the exact route/state you care about before prompting so the agent’s first screenshot is already relevant.
 2. **Annotate elements** — when multiple similar elements exist, annotations eliminate ambiguity.
 3. **Paste out-of-band context** — logs, stack traces, or code that lives outside the repo can be pasted or attached as files/images.
@@ -25,6 +28,7 @@ Frontman is opinionated about safety and scope. In the [distributed architecture
 Frontman can’t complete OAuth pop-ups, 2FA prompts, or third-party SSO flows because the preview iframe can’t leave your dev origin.
 
 **Workarounds**
+
 1. **Log in manually** — authenticate in your dev build, then prompt the agent. Frontman inherits your session cookies because it runs in the same browser context.
 2. **Use dev-only bypasses** — add `NODE_ENV === 'development'` switches, seed accounts, or feature flags that keep the page accessible without third-party auth.
 3. **Stub data** — for flows that require real API calls (Stripe checkout, etc.), inject mock responses or local fixtures so the page renders without hitting the gated endpoint.
@@ -36,24 +40,30 @@ Frontman can’t complete OAuth pop-ups, 2FA prompts, or third-party SSO flows b
 - Fixed-position overlays can block clicks. Temporarily hide them (dev flag, Esc to close) or annotate underlying elements after dismissing the overlay yourself.
 
 **Workarounds**
+
 - Provide scrolling instructions: “Scroll to the pricing section and …”
 - Break work into sections: “First fix the hero, then I’ll send a new prompt for the footer.”
 
 ## External requests, APIs, and SSRF protections
 
 `web_fetch` and all dev-server tools assume the target is safe:
+
 - URLs must be HTTP(S), public, and ≤5 MB responses.
 - Hosts that resolve to `localhost`, `10.x.x.x`, `192.168.x.x`, `fc00::/7`, etc., are rejected (`Requests to private/internal addresses are not allowed`).
 - Redirect chains >10 hops fail.
 
 **Workarounds**
+
 1. Mirror private docs to a public URL (e.g., a temporary share link) if you need the agent to read them via `web_fetch`.
 2. Paste the relevant excerpts instead of fetching gated sites.
 3. For API responses, save fixtures under `src/mock-data/` and point the agent at those files.
 
 ## File-system and tooling limits
 
-- The agent can only edit files under the workspace root that the plugin exposes. Monorepos work fine, but sibling repos or parent directories are invisible.
+- In the JavaScript integrations, `projectRoot` identifies the app for project operations such as route discovery. `sourceRoot` controls file-tool path resolution and defaults to `projectRoot`; both can be configured, and their default is `PROJECT_ROOT`, then `PWD`, then `.`. See the [Next.js configuration source](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/FrontmanNextjs__Config.res); Astro and Vite use the same root defaults.
+- A parent or monorepo directory configured as `sourceRoot` can expose sibling packages or repositories beneath it. A narrower `sourceRoot` makes those paths unavailable through normal lexical paths.
+- [`FrontmanCore__SafePath.resolve`](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-core/src/FrontmanCore__SafePath.res) applies `Path.resolve`/`Path.normalize` and a string-prefix check. It rejects absolute and `..` paths that normalize outside `sourceRoot`, but it does not call `realpath` or otherwise resolve symlink targets. A symlink located inside `sourceRoot` can therefore lead a filesystem operation outside the configured root. Do not place links to sensitive paths under an exposed root; isolate the dev-server OS account or container and review repository symlinks before use.
+- No filename rule protects `.env` or other secret files inside `sourceRoot`. Keep secrets outside the exposed root or restrict the dev-server process so it cannot read them.
 - No shell access: build scripts, migrations, or seeds must be run manually. If a change requires `make something`, mention that you’ll run it afterward.
 - Binary assets: `write_file` can save attachments, but there’s no image editor. Provide ready-to-use assets or handle image manipulation yourself.
 
@@ -64,8 +74,9 @@ Frontman can’t complete OAuth pop-ups, 2FA prompts, or third-party SSO flows b
 - If the agent seems stuck in a loop (repeating the same screenshot/edit cycle without progress), click **Stop** in the chat UI, clarify the instruction, or split the task.
 
 **Workarounds**
+
 1. **Scope aggressively** — “Change the CTA button copy” instead of “Finish the entire landing page redesign.”
-2. **Plan multi-step work** — let the agent finish one todo before queuing the next; it automatically maintains a todo list for 3+ item tasks.
+2. **Plan multi-step work** — let the agent finish one todo before queuing the next; see [Use Frontman Plans & Todo Lists](/docs/using/plans-and-todos/) for when plans are created and how they change.
 3. **Answer questions promptly** — the [Question Flow](/docs/using/question-flow/) pauses execution until you respond.
 
 ## Handling errors & flaky dev servers

--- a/apps/marketing/src/content/docs/docs/using/plans-and-todos.md
+++ b/apps/marketing/src/content/docs/docs/using/plans-and-todos.md
@@ -1,13 +1,13 @@
 ---
-title: Plans & Todo Lists
-description: See how Frontman creates visible task plans and todo lists for complex edits, tracks progress step by step, and keeps one active item at a time.
+title: Use Frontman Plans & Todo Lists
+description: Follow, redirect, and understand the task plan Frontman maintains while completing multi-step work.
 ---
 
-For complex tasks, Frontman creates a structured plan — a visible todo list that tracks each step of the work. This gives you real-time insight into what the agent is doing, what's done, and what's next.
+For complex tasks, Frontman can create a visible todo list that tracks completed, active, and pending work. The list is an execution aid maintained by the agent, not a promise that every initial step will remain unchanged.
 
 ## When plans are created
 
-The agent creates a plan when a task has **three or more distinct steps**. Simple, single-step tasks (like fixing a typo or answering a question) don't need one.
+Frontman's `todo_write` tool instructs the agent to create a plan for tasks with **three or more distinct steps that benefit from tracking**. Simple, single-step tasks such as fixing a typo do not need one. The selected model still decides when to call the tool.
 
 Examples of tasks that trigger a plan:
 
@@ -24,20 +24,61 @@ Plans are rendered directly in the chat UI as a checklist. Each item shows:
 - **Status** — `pending`, `in_progress`, or `completed`
 - **Priority** — `high`, `medium` (default), or `low`
 
-Only one item is `in_progress` at a time. As the agent finishes each step, it marks it `completed` and moves to the next.
+The agent's tool instructions say to keep exactly one item `in_progress` while work is underway. The chat renders status icons and completed-item progress; you can expand or collapse a plan without changing its contents.
+
+## Complete example
+
+Suppose you ask:
+
+```text
+Add an empty state to the orders page, update its test, and verify the page in the browser.
+```
+
+Frontman can create this initial plan:
+
+| Item                                      | Status        | Priority |
+| ----------------------------------------- | ------------- | -------- |
+| Inspect the orders page and existing test | `in_progress` | `high`   |
+| Implement the empty state                 | `pending`     | `high`   |
+| Update the page test                      | `pending`     | `medium` |
+| Verify the result in the browser          | `pending`     | `medium` |
+
+After inspection, it rewrites the complete list rather than sending a one-item status patch:
+
+| Item                                      | Status        |
+| ----------------------------------------- | ------------- |
+| Inspect the orders page and existing test | `completed`   |
+| Implement the empty state                 | `in_progress` |
+| Update the page test                      | `pending`     |
+| Verify the result in the browser          | `pending`     |
+
+If inspection reveals that fixture data also needs an update, the agent can add that item. In this example, the final list retains the completed items and has no active item after work finishes.
 
 ## How the agent manages plans
 
-1. **Upfront planning** — The agent analyzes your request and creates the full list of steps before starting work.
-2. **Progressive updates** — As it works, it rewrites the list to update statuses. Each call replaces the entire list (completed items are preserved in the new list).
-3. **Discovery** — If the agent discovers new subtasks while working (e.g., an unexpected test failure), it adds them to the plan.
+1. **Initial plan** — The agent turns distinct work outcomes into todo items before or early in execution.
+2. **Atomic updates** — Every `todo_write` call replaces the entire list. An omitted item is removed, so the agent carries completed and pending items forward when updating status.
+3. **Discovery** — The agent can add newly discovered work, such as fixing a test failure caused by the requested change.
+4. **Completion** — Items should move to `completed` only after their outcome is finished and relevant checks pass.
+
+## Your control over a plan
+
+Plans are not directly editable checklists. Control the work through chat and task controls:
+
+- Click **Stop** if the active step is wrong or the task should not continue.
+- Send a follow-up that names the outcome to skip, add, or change. The agent can rewrite the plan on its next turn.
+- Narrow a large request into separate prompts when you want explicit approval between stages.
+- Treat status as the agent's report. Verify important changes in files, tests, and the live preview before accepting the result.
+
+Stopping a task stops execution; it does not itself rewrite todo statuses. A later turn can revise the plan based on your new instruction.
 
 ## Tips for working with plans
 
 - **Check progress** — Glance at the plan to see how far along the agent is without reading every message.
-- **Interrupt early** — If you see a step that looks wrong, you can stop the agent before it gets further.
-- **Reference steps** — You can mention specific plan items when giving follow-up instructions (e.g., "skip the test step" or "do the migration step differently").
+- **Interrupt early** — If the active item looks wrong, stop the agent before it proceeds.
+- **Reference outcomes** — In a follow-up, quote the item text and state what should change.
+- **Keep verification visible** — Ask for tests or browser checks as explicit items when they matter to task completion.
 
 ## Technical details
 
-Plans use the `todo_write` tool. See [Tool Capabilities](/docs/using/tool-capabilities/) for the full parameter reference.
+Plans use the `todo_write` tool. [Frontman Agent Tool Capabilities](/docs/using/tool-capabilities/#todo_write) owns its parameter and status reference. [Prompt Strategies](/docs/using/prompt-strategies/) covers how to split or sequence larger requests.

--- a/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
+++ b/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
@@ -1,15 +1,17 @@
 ---
-title: Tool Capabilities
-description: Reference for every tool the Frontman agent can use — screenshots, DOM inspection, file editing, navigation, and more.
+title: Frontman Agent Tool Capabilities
+description: Reference the browser, framework, and backend tools available to Frontman's agent and where each tool executes.
 ---
+
+This page owns tool names, parameters, execution locations, and framework availability. Use [Frontman Limitations & Workarounds](/docs/using/limitations/) for operational boundaries, [Annotate UI Elements for Frontman](/docs/using/annotations/) for element-selection workflow, and [Use Frontman Plans & Todo Lists](/docs/using/plans-and-todos/) for plan lifecycle.
 
 Frontman's agent has access to three categories of tools that run in different environments. Understanding what each tool does helps you write better prompts and predict what the agent will do.
 
-| Category | Where it runs | Purpose |
-|----------|---------------|---------|
-| [**Browser tools**](#browser-tools) | In your browser, against the live preview | See the page, interact with elements, inspect the DOM |
-| [**Framework tools**](#framework-tools) | On your machine, via the dev server plugin | Read/write files, discover routes, check build logs |
-| [**Backend tools**](#backend-tools) | On the Frontman server | Fetch web pages, manage todo lists |
+| Category                                | Where it runs                              | Purpose                                               |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| [**Browser tools**](#browser-tools)     | In your browser, against the live preview  | See the page, interact with elements, inspect the DOM |
+| [**Framework tools**](#framework-tools) | On your machine, via the dev server plugin | Read/write files, discover routes, check build logs   |
+| [**Backend tools**](#backend-tools)     | On the Frontman server                     | Fetch web pages, manage todo lists                    |
 
 ## Browser tools
 
@@ -19,9 +21,9 @@ Browser tools execute inside your browser tab, operating on the live preview ifr
 
 Captures a screenshot of the current web preview page. Returns a base64-encoded JPEG image.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `selector` | string? | CSS selector to screenshot a specific element instead of the full page |
+| Parameter  | Type     | Description                                                                               |
+| ---------- | -------- | ----------------------------------------------------------------------------------------- |
+| `selector` | string?  | CSS selector to screenshot a specific element instead of the full page                    |
 | `fullPage` | boolean? | Capture the entire scrollable page instead of just the visible viewport. Default: `false` |
 
 The agent uses screenshots before and after edits to verify visual changes. This is the core of Frontman's perception-action loop — it's how the agent "sees" your running app.
@@ -30,10 +32,10 @@ The agent uses screenshots before and after edits to verify visual changes. This
 
 Evaluates arbitrary JavaScript inside the web preview iframe and returns the result.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `expression` | string | JavaScript code to evaluate |
-| `timeout` | number? | Maximum execution time in milliseconds. Default: 5000 |
+| Parameter    | Type    | Description                                           |
+| ------------ | ------- | ----------------------------------------------------- |
+| `expression` | string  | JavaScript code to evaluate                           |
+| `timeout`    | number? | Maximum execution time in milliseconds. Default: 5000 |
 
 Use cases include querying DOM properties, measuring layout, reading computed styles, and navigating pages. The expression runs via `new Function` in the iframe's window context. Promises are automatically awaited. DOM nodes, NodeLists, Maps, Sets, and circular references are serialized to readable JSON. Console output during execution is captured.
 
@@ -43,15 +45,15 @@ Output is capped at 30 KB.
 
 Inspects a specific section of the DOM in the web preview.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `selector` | string | CSS selector or XPath expression targeting a DOM subtree |
-| `mode` | string? | `"simplified"` (default) or `"full"` |
-| `maxDepth` | number? | Maximum tree depth in simplified mode. Default: 5 |
-| `maxNodes` | number? | Maximum element nodes to include. Default: 200 |
-| `pierceShadowDom` | boolean? | Traverse into shadow DOM roots. Default: `false` |
+| Parameter         | Type     | Description                                              |
+| ----------------- | -------- | -------------------------------------------------------- |
+| `selector`        | string   | CSS selector or XPath expression targeting a DOM subtree |
+| `mode`            | string?  | `"simplified"` (default) or `"full"`                     |
+| `maxDepth`        | number?  | Maximum tree depth in simplified mode. Default: 5        |
+| `maxNodes`        | number?  | Maximum element nodes to include. Default: 200           |
+| `pierceShadowDom` | boolean? | Traverse into shadow DOM roots. Default: `false`         |
 
-**Simplified mode** returns a pruned indented representation with tag names, key attributes (id, class, role, aria-*, href, src), framework component names, and short text snippets. Script, style, and SVG elements are stripped. Capped at 200 nodes.
+**Simplified mode** returns a pruned indented representation with tag names, key attributes (id, class, role, aria-\*, href, src), framework component names, and short text snippets. Script, style, and SVG elements are stripped. Capped at 200 nodes.
 
 **Full mode** returns raw `outerHTML`. Capped at 15 KB. Use only when you need exact markup for a small, specific component.
 
@@ -61,10 +63,10 @@ If a subtree is too large, the tool rejects the request and returns a list of th
 
 Discovers clickable and interactive elements on the current page.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `role` | string? | Filter by ARIA role (e.g. `"button"`, `"link"`) |
-| `name` | string? | Filter by accessible name substring (case-insensitive) |
+| Parameter | Type    | Description                                            |
+| --------- | ------- | ------------------------------------------------------ |
+| `role`    | string? | Filter by ARIA role (e.g. `"button"`, `"link"`)        |
+| `name`    | string? | Filter by accessible name substring (case-insensitive) |
 
 Returns elements with their ARIA roles, accessible names, CSS selectors, detection method, and visible text. Detection methods include:
 
@@ -78,16 +80,17 @@ Results are capped at 50 elements.
 
 Performs actions on elements in the web preview.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `selector` | string? | CSS selector (preferred) |
-| `role` | string? | ARIA role — must be used with `name` |
-| `name` | string? | Accessible name — must be used with `role` |
-| `text` | string? | Visible text content to match |
-| `action` | string? | `"click"` (default), `"hover"`, or `"focus"` |
-| `index` | number? | 0-based index when multiple elements match |
+| Parameter  | Type    | Description                                  |
+| ---------- | ------- | -------------------------------------------- |
+| `selector` | string? | CSS selector (preferred)                     |
+| `role`     | string? | ARIA role — must be used with `name`         |
+| `name`     | string? | Accessible name — must be used with `role`   |
+| `text`     | string? | Visible text content to match                |
+| `action`   | string? | `"click"` (default), `"hover"`, or `"focus"` |
+| `index`    | number? | 0-based index when multiple elements match   |
 
 Supports three targeting strategies:
+
 1. **CSS selector** — most precise, use selectors from `get_interactive_elements`
 2. **Role + name** — ARIA-based targeting (e.g. role=`"button"`, name=`"Submit"`)
 3. **Text** — matches the innermost element containing the text
@@ -96,12 +99,12 @@ Supports three targeting strategies:
 
 Searches for visible text on the current page, like Ctrl+F.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `query` | string | Text to search for (case-insensitive) |
-| `selector` | string? | Scope search to a CSS selector or XPath subtree |
-| `maxResults` | number? | Maximum results. Default: 25 |
-| `contextChars` | number? | Characters of surrounding context. Default: 80 |
+| Parameter      | Type    | Description                                     |
+| -------------- | ------- | ----------------------------------------------- |
+| `query`        | string  | Text to search for (case-insensitive)           |
+| `selector`     | string? | Scope search to a CSS selector or XPath subtree |
+| `maxResults`   | number? | Maximum results. Default: 25                    |
+| `contextChars` | number? | Characters of surrounding context. Default: 80  |
 
 Returns matching elements with surrounding text context, CSS selectors, tags, and accessibility metadata. Matches are wrapped in `>>` and `<<` markers within the context text.
 
@@ -109,13 +112,13 @@ Returns matching elements with surrounding text context, CSS selectors, tags, an
 
 Controls the device emulation mode for responsive design testing.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `action` | string | `"set_preset"`, `"set_custom"`, `"set_responsive"`, `"set_orientation"`, `"get_current"`, or `"list_presets"` |
-| `device` | string? | Device preset name (for `set_preset`) |
-| `width` | number? | Viewport width in CSS pixels (for `set_custom`) |
-| `height` | number? | Viewport height in CSS pixels (for `set_custom`) |
-| `orientation` | string? | `"portrait"` or `"landscape"` (for `set_orientation`) |
+| Parameter     | Type    | Description                                                                                                   |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `action`      | string  | `"set_preset"`, `"set_custom"`, `"set_responsive"`, `"set_orientation"`, `"get_current"`, or `"list_presets"` |
+| `device`      | string? | Device preset name (for `set_preset`)                                                                         |
+| `width`       | number? | Viewport width in CSS pixels (for `set_custom`)                                                               |
+| `height`      | number? | Viewport height in CSS pixels (for `set_custom`)                                                              |
+| `orientation` | string? | `"portrait"` or `"landscape"` (for `set_orientation`)                                                         |
 
 **Available presets:** iPhone SE, iPhone 15 Pro, iPhone 15 Pro Max, Pixel 8, Samsung Galaxy S24, iPad Mini, iPad Air, iPad Pro 11", iPad Pro 12.9", Laptop, Laptop L, 4K.
 
@@ -123,8 +126,8 @@ Controls the device emulation mode for responsive design testing.
 
 Pauses the agent loop and asks you a question via an interactive drawer.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
+| Parameter   | Type  | Description                                                                                                |
+| ----------- | ----- | ---------------------------------------------------------------------------------------------------------- |
 | `questions` | array | Array of question objects, each with a `question`, `header`, `options` array, and optional `multiple` flag |
 
 The agent uses this when it needs clarification, wants to offer a choice between approaches, or needs approval for a destructive action. The agent loop literally pauses — no LLM calls happen until you respond.
@@ -135,21 +138,21 @@ See [The Question Flow](/docs/using/question-flow/) for more detail.
 
 ## Framework tools
 
-Framework tools run on your machine via the Frontman dev server plugin. They give the agent access to your project's files, route structure, and build output. There's a shared set of **core tools** available in every framework, plus **framework-specific tools** that vary by integration.
+Framework tools run on your machine via the Astro, Next.js, or Vite dev server integration. They give the agent access to your project's files, route structure, and build output. WordPress instead exposes site-management tools through its plugin; see [Install and Use Frontman for WordPress](/docs/integrations/wordpress/).
 
-### Core tools (all frameworks)
+### Core tools (code-first integrations)
 
-These tools are available in every Frontman integration — Astro, Next.js, and Vite.
+These tools are available in the Astro, Next.js, and Vite integrations. They are not WordPress plugin tools.
 
 #### `read_file`
 
 Reads a file from your project's filesystem.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Path to file — relative to source root or absolute |
-| `offset` | number? | Line number to start from (0-indexed). Default: 0 |
-| `limit` | number? | Maximum lines to read. Default: 500 |
+| Parameter | Type    | Description                                        |
+| --------- | ------- | -------------------------------------------------- |
+| `path`    | string  | Path to file — relative to source root or absolute |
+| `offset`  | number? | Line number to start from (0-indexed). Default: 0  |
+| `limit`   | number? | Maximum lines to read. Default: 500                |
 
 Returns the file content along with total line count and whether more content exists. For large files, the agent is instructed to use `grep` first to find relevant sections, then `read_file` with a targeted offset.
 
@@ -161,12 +164,12 @@ The agent tracks which files it has read. The `edit_file` and `write_file` tools
 
 Writes content to a file. Creates parent directories if they don't exist.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Path to file — relative to source root or absolute |
-| `content` | string? | Text content to write |
-| `image_ref` | string? | URI of a user-attached image to save to disk |
-| `encoding` | string? | Set to `"base64"` for binary data |
+| Parameter   | Type    | Description                                        |
+| ----------- | ------- | -------------------------------------------------- |
+| `path`      | string  | Path to file — relative to source root or absolute |
+| `content`   | string? | Text content to write                              |
+| `image_ref` | string? | URI of a user-attached image to save to disk       |
+| `encoding`  | string? | Set to `"base64"` for binary data                  |
 
 Provide either `content` or `image_ref`, not both. If the file already exists, the agent must read it first — the tool rejects writes to existing files that haven't been read.
 
@@ -176,12 +179,12 @@ Prefer `write_file` over `edit_file` when rewriting most of a file.
 
 Edits a file by finding text and replacing it, with fuzzy matching.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Path to file |
-| `oldText` | string | Text to find and replace. Empty string creates a new file. |
-| `newText` | string | Replacement text |
-| `replaceAll` | boolean? | Replace all occurrences. Default: `false` |
+| Parameter    | Type     | Description                                                |
+| ------------ | -------- | ---------------------------------------------------------- |
+| `path`       | string   | Path to file                                               |
+| `oldText`    | string   | Text to find and replace. Empty string creates a new file. |
+| `newText`    | string   | Replacement text                                           |
+| `replaceAll` | boolean? | Replace all occurrences. Default: `false`                  |
 
 The tool uses multiple matching strategies — exact, line-trimmed, whitespace-normalized, indentation-flexible — to handle common formatting differences. This means the agent doesn't need to get whitespace exactly right.
 
@@ -195,9 +198,9 @@ Each framework enhances `edit_file` with **post-edit error detection**. After ap
 
 Lists the immediate contents of a single directory.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string? | Directory to list. Default: project root. If a file path is given, lists its parent directory. |
+| Parameter | Type    | Description                                                                                    |
+| --------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `path`    | string? | Directory to list. Default: project root. If a file path is given, lists its parent directory. |
 
 Returns entries with name, path, and file/directory type. Respects `.gitignore`.
 
@@ -205,10 +208,10 @@ Returns entries with name, path, and file/directory type. Respects `.gitignore`.
 
 Returns a recursive directory tree of the project structure.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string? | Subdirectory to root the tree at. Default: project root |
-| `depth` | number? | Maximum depth. Default: 3 |
+| Parameter | Type    | Description                                             |
+| --------- | ------- | ------------------------------------------------------- |
+| `path`    | string? | Subdirectory to root the tree at. Default: project root |
+| `depth`   | number? | Maximum depth. Default: 3                               |
 
 Includes monorepo workspace detection — workspace roots are annotated with `[workspace: name]`. Skips noisy directories like `node_modules`, `.git`, `dist`, and `build`. Respects `.gitignore`.
 
@@ -218,9 +221,9 @@ This tool also runs automatically during initialization to give the agent an ove
 
 Checks if a file or directory exists.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `path` | string | Path to check |
+| Parameter | Type   | Description   |
+| --------- | ------ | ------------- |
+| `path`    | string | Path to check |
 
 Returns `true` or `false`.
 
@@ -228,15 +231,15 @@ Returns `true` or `false`.
 
 Searches file contents for text or regex patterns using ripgrep (with git grep and plain grep as fallbacks).
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pattern` | string | Text or regex to search for |
-| `path` | string? | Directory or file to search in. Default: source root |
-| `type` | string? | File type filter (e.g. `"js"`, `"ts"`, `"py"`) |
-| `glob` | string? | Glob pattern (e.g. `"*.tsx"`, `"*.{ts,tsx}"`) |
-| `case_insensitive` | boolean? | Default: `false` |
-| `literal` | boolean? | Treat pattern as literal text, not regex. Default: `false` |
-| `max_results` | number? | Maximum files to return. Default: 20 |
+| Parameter          | Type     | Description                                                |
+| ------------------ | -------- | ---------------------------------------------------------- |
+| `pattern`          | string   | Text or regex to search for                                |
+| `path`             | string?  | Directory or file to search in. Default: source root       |
+| `type`             | string?  | File type filter (e.g. `"js"`, `"ts"`, `"py"`)             |
+| `glob`             | string?  | Glob pattern (e.g. `"*.tsx"`, `"*.{ts,tsx}"`)              |
+| `case_insensitive` | boolean? | Default: `false`                                           |
+| `literal`          | boolean? | Treat pattern as literal text, not regex. Default: `false` |
+| `max_results`      | number?  | Maximum files to return. Default: 20                       |
 
 Returns matching lines grouped by file, with line numbers. Results are sorted by file modification time (newest first). Binary and hidden files are skipped.
 
@@ -244,26 +247,26 @@ Returns matching lines grouped by file, with line numbers. Results are sorted by
 
 Searches for files by name across the project.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pattern` | string | Filename pattern (supports glob-like: `"*.test.ts"`, `"Button*"`) |
-| `path` | string? | Directory to search in. Default: source root |
-| `max_results` | number? | Maximum results. Default: 20 |
+| Parameter     | Type    | Description                                                       |
+| ------------- | ------- | ----------------------------------------------------------------- |
+| `pattern`     | string  | Filename pattern (supports glob-like: `"*.test.ts"`, `"Button*"`) |
+| `path`        | string? | Directory to search in. Default: source root                      |
+| `max_results` | number? | Maximum results. Default: 20                                      |
 
 Uses ripgrep `--files` with a git ls-files fallback. Matches file names only, not directory names. Hidden files (dotfiles) are included.
 
 #### `lighthouse`
 
-Runs a full Google Lighthouse audit on a URL.
+Runs Lighthouse for four selected categories: performance, accessibility, best practices, and SEO.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `url` | string | The URL to audit (e.g. `http://localhost:4321/`) |
-| `preset` | string? | `"desktop"` (default) or `"mobile"` |
+| Parameter | Type    | Description                                      |
+| --------- | ------- | ------------------------------------------------ |
+| `url`     | string  | The URL to audit (e.g. `http://localhost:4321/`) |
+| `preset`  | string? | `"desktop"` (default) or `"mobile"`              |
 
 Returns scores (0–100) for performance, accessibility, best practices, and SEO, plus the top 3 worst issues per category. Each issue includes descriptions, CSS selectors, HTML snippets, and source locations when available.
 
-Requires Chrome to be installed. Takes 15–30 seconds per run.
+Requires Chrome to be installed.
 
 :::tip
 Only the 3 worst issues per category are returned. After fixing those, re-run the audit to surface additional issues that were previously ranked lower.
@@ -285,18 +288,18 @@ This goes beyond simple filesystem scanning — it captures routes that don't ex
 
 Retrieves Astro dev server logs from a rotating 1024-entry buffer.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pattern` | string? | Regex pattern to filter messages (case-insensitive) |
-| `level` | string? | Filter by type: `"console"`, `"build"`, or `"error"` |
-| `since` | string? | ISO 8601 timestamp — only return logs after this time |
-| `tail` | number? | Limit to most recent N entries |
+| Parameter | Type    | Description                                           |
+| --------- | ------- | ----------------------------------------------------- |
+| `pattern` | string? | Regex pattern to filter messages (case-insensitive)   |
+| `level`   | string? | Filter by type: `"console"`, `"build"`, or `"error"`  |
+| `since`   | string? | ISO 8601 timestamp — only return logs after this time |
+| `tail`    | number? | Limit to most recent N entries                        |
 
 Captures console output, Astro build/HMR logs, and uncaught exceptions with stack traces.
 
 #### `get_astro_audit`
 
-*(Astro only, runs in browser)*
+_(Astro only, runs in browser)_
 
 Reads accessibility and performance audit results from Astro's dev toolbar. Traverses the toolbar's shadow DOM to extract the ~26 checks that Astro runs automatically.
 
@@ -342,21 +345,31 @@ Backend tools run on the Frontman server. They handle operations that don't need
 
 Fetches a web page and returns its content as markdown.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `url` | string | URL to fetch (must start with `http://` or `https://`) |
-| `offset` | number? | Line number to start from. Default: 0 |
-| `limit` | number? | Maximum lines to return (1–2000). Default: 500 |
+| Parameter | Type    | Description                                            |
+| --------- | ------- | ------------------------------------------------------ |
+| `url`     | string  | URL to fetch (must start with `http://` or `https://`) |
+| `offset`  | number? | Line number to start from. Default: 0                  |
+| `limit`   | number? | Maximum lines to return (1–2000). Default: 500         |
 
 HTML pages are automatically converted to markdown. Results are paginated by lines for large pages. Includes SSRF protection — requests to private/internal addresses (localhost, 10.x.x.x, 192.168.x.x, etc.) are blocked.
+
+### `get_tool_result`
+
+Retrieves a persisted result when an earlier tool result was replaced by an omitted-data placeholder.
+
+| Parameter      | Type   | Description                                                              |
+| -------------- | ------ | ------------------------------------------------------------------------ |
+| `tool_call_id` | string | Exact `tool_call_id` copied from the omitted-data placeholder. Required. |
+
+The ID must be passed unchanged; it identifies a tool result in the current task history. The tool returns the original MCP `ToolResult`. It returns an error when the ID is not a string, no matching result exists, or the stored result is not a valid MCP tool result.
 
 ### `todo_write`
 
 Writes the complete todo list for the current task. Every call replaces the entire list.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `todos` | array | Complete todo list. Each item has `content`, `active_form`, `status` (`"pending"`, `"in_progress"`, `"completed"`), and optional `priority` (`"high"`, `"medium"`, `"low"`) |
+| Parameter | Type  | Description                                                                                                                                                                 |
+| --------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `todos`   | array | Complete todo list. Each item has `content`, `active_form`, `status` (`"pending"`, `"in_progress"`, `"completed"`), and optional `priority` (`"high"`, `"medium"`, `"low"`) |
 
 The agent uses this for tasks with 3+ distinct steps. The todo list appears in the chat UI so you can track progress. See [Plans & Todo Lists](/docs/using/plans-and-todos/) for more detail.
 
@@ -364,34 +377,38 @@ The agent uses this for tasks with 3+ distinct steps. The todo list appears in t
 
 ## Tool summary by framework
 
-This table shows which tools are available for each framework integration.
+This table distinguishes shared browser/backend tools from code-first dev server tools. WordPress site mutations use dedicated plugin tools documented in the [WordPress guide](/docs/integrations/wordpress/), not the similarly scoped file tools below.
 
-| Tool | Astro | Next.js | Vite | Where | Access |
-|------|:-----:|:-------:|:----:|-------|--------|
-| `take_screenshot` | ✓ | ✓ | ✓ | Browser | read |
-| `execute_js` | ✓ | ✓ | ✓ | Browser | read-write |
-| `get_dom` | ✓ | ✓ | ✓ | Browser | read |
-| `get_interactive_elements` | ✓ | ✓ | ✓ | Browser | read |
-| `interact_with_element` | ✓ | ✓ | ✓ | Browser | read-write |
-| `search_text` | ✓ | ✓ | ✓ | Browser | read |
-| `set_device_mode` | ✓ | ✓ | ✓ | Browser | write |
-| `question` | ✓ | ✓ | ✓ | Browser | write |
-| `get_astro_audit` | ✓ | — | — | Browser | read |
-| `read_file` | ✓ | ✓ | ✓ | Dev server | read |
-| `write_file` | ✓ | ✓ | ✓ | Dev server | write |
-| `edit_file` | ✓ | ✓ | ✓ | Dev server | read-write |
-| `list_files` | ✓ | ✓ | ✓ | Dev server | read |
-| `list_tree` | ✓ | ✓ | ✓ | Dev server | read |
-| `file_exists` | ✓ | ✓ | ✓ | Dev server | read |
-| `grep` | ✓ | ✓ | ✓ | Dev server | read |
-| `search_files` | ✓ | ✓ | ✓ | Dev server | read |
-| `lighthouse` | ✓ | ✓ | ✓ | Dev server | read |
-| `get_client_pages` | ✓ | — | — | Dev server | read |
-| `get_routes` | — | ✓ | — | Dev server | read |
-| `get_logs` | ✓ | ✓ | ✓ | Dev server | read |
-| `web_fetch` | ✓ | ✓ | ✓ | Backend | read |
-| `get_tool_result` | ✓ | ✓ | ✓ | Backend | read |
-| `todo_write` | ✓ | ✓ | ✓ | Backend | write |
+Verified July 30, 2026 against `@frontman-ai/astro` 2.0.0, `@frontman-ai/nextjs` 1.0.3, `@frontman-ai/vite` 1.0.3, and Frontman WordPress plugin 2.0.0 source.
+
+| Tool                       | Astro | Next.js | Vite |  WordPress  | Where      | Access     |
+| -------------------------- | :---: | :-----: | :--: | :---------: | ---------- | ---------- |
+| `take_screenshot`          |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read       |
+| `execute_js`               |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read-write |
+| `get_dom`                  |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read       |
+| `get_interactive_elements` |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read       |
+| `interact_with_element`    |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read-write |
+| `search_text`              |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | read       |
+| `set_device_mode`          |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | write      |
+| `question`                 |   ✓   |    ✓    |  ✓   |      ✓      | Browser    | write      |
+| `get_astro_audit`          |   ✓   |    —    |  —   |      —      | Browser    | read       |
+| `read_file`                |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `write_file`               |   ✓   |    ✓    |  ✓   |      —      | Dev server | write      |
+| `edit_file`                |   ✓   |    ✓    |  ✓   |      —      | Dev server | read-write |
+| `list_files`               |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `list_tree`                |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `file_exists`              |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `grep`                     |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `search_files`             |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `lighthouse`               |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| `get_client_pages`         |   ✓   |    —    |  —   |      —      | Dev server | read       |
+| `get_routes`               |   —   |    ✓    |  —   |      —      | Dev server | read       |
+| `get_logs`                 |   ✓   |    ✓    |  ✓   |      —      | Dev server | read       |
+| WordPress `wp_*` tools     |   —   |    —    |  —   |      ✓      | WP plugin  | varies     |
+| WooCommerce `wc_*` tools   |   —   |    —    |  —   | conditional | WP plugin  | varies     |
+| `web_fetch`                |   ✓   |    ✓    |  ✓   |      ✓      | Backend    | read       |
+| `get_tool_result`          |   ✓   |    ✓    |  ✓   |      ✓      | Backend    | read       |
+| `todo_write`               |   ✓   |    ✓    |  ✓   |      ✓      | Backend    | write      |
 
 ---
 

--- a/apps/marketing/src/content/structuredData.test.mjs
+++ b/apps/marketing/src/content/structuredData.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createWebPageSchema } from '../utils/structuredData.mjs'
+
+describe('WebPage structured data', () => {
+	it('identifies each non-home page by its canonical URL and metadata', () => {
+		expect(
+			createWebPageSchema({
+				url: 'https://frontman.sh/features/',
+				title: 'Frontman Features',
+				description: 'Explore Frontman capabilities.'
+			})
+		).toEqual({
+			'@type': 'WebPage',
+			'@id': 'https://frontman.sh/features/#webpage',
+			url: 'https://frontman.sh/features/',
+			name: 'Frontman Features',
+			description: 'Explore Frontman capabilities.'
+		})
+	})
+
+	it('limits homepage speakable selectors to the homepage', () => {
+		const homepage = createWebPageSchema({
+			url: 'https://frontman.sh/',
+			title: 'Frontman',
+			description: 'AI website editor.'
+		})
+		const docs = createWebPageSchema({
+			url: 'https://frontman.sh/docs/',
+			title: 'Frontman Docs',
+			description: 'Frontman documentation.'
+		})
+
+		expect(homepage.speakable).toBeDefined()
+		expect(docs.speakable).toBeUndefined()
+	})
+
+	it('uses page-specific WebPage schema in both marketing and docs heads', async () => {
+		const [marketingHead, docsHead] = await Promise.all([
+			readFile(
+				resolve(import.meta.dirname, '../components/blocks/head/partials/StructuredData.astro'),
+				'utf8'
+			),
+			readFile(resolve(import.meta.dirname, '../components/starlight/Head.astro'), 'utf8')
+		])
+
+		expect(marketingHead).toContain('createWebPageSchema({ url: pageUrl, title, description })')
+		expect(docsHead).toContain(
+			'createWebPageSchema({ url: pageUrl, title: pageTitle, description: pageDescription })'
+		)
+	})
+})

--- a/apps/marketing/src/content/structuredData.test.mjs
+++ b/apps/marketing/src/content/structuredData.test.mjs
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { createWebPageSchema } from '../utils/structuredData.mjs'
+import { createWebPageSchema, getWebPageId } from '../utils/structuredData.mjs'
 
 describe('WebPage structured data', () => {
 	it('identifies each non-home page by its canonical URL and metadata', () => {
@@ -34,6 +34,19 @@ describe('WebPage structured data', () => {
 
 		expect(homepage.speakable).toBeDefined()
 		expect(docs.speakable).toBeUndefined()
+	})
+
+	it('shares one WebPage identifier with article and release schemas', async () => {
+		const [postLayout, releaseLayout] = await Promise.all([
+			readFile(resolve(import.meta.dirname, '../layouts/PostLayout.astro'), 'utf8'),
+			readFile(resolve(import.meta.dirname, '../layouts/ReleasesLayout.astro'), 'utf8')
+		])
+
+		expect(getWebPageId('https://frontman.sh/blog/example/')).toBe(
+			'https://frontman.sh/blog/example/#webpage'
+		)
+		expect(postLayout).toContain('getWebPageId(Astro.url.href)')
+		expect(releaseLayout).toContain('getWebPageId(Astro.url.href)')
 	})
 
 	it('uses page-specific WebPage schema in both marketing and docs heads', async () => {

--- a/apps/marketing/src/content/tagIndexability.test.mjs
+++ b/apps/marketing/src/content/tagIndexability.test.mjs
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { countPostsByTag, isIndexableTagCount } from '../utils/tagIndexability.mjs'
+import {
+	countPostsByTag,
+	isIndexableTagCount,
+	parseFrontmatterTags
+} from '../utils/tagIndexability.mjs'
 
 describe('tag indexability', () => {
 	it('keeps archives with fewer than three posts out of search', () => {
@@ -25,6 +29,14 @@ describe('tag indexability', () => {
 		expect(counts.get('ai')).toBe(3)
 		expect(counts.get('tutorial')).toBe(1)
 		expect(counts.get('workflow')).toBe(1)
+	})
+
+	it('parses inline and block-list frontmatter tags identically', () => {
+		expect(parseFrontmatterTags("---\ntags: ['ai', 'tutorial']\n---")).toEqual(['ai', 'tutorial'])
+		expect(parseFrontmatterTags('---\ntags:\n  - ai\n  - tutorial\n---')).toEqual([
+			'ai',
+			'tutorial'
+		])
 	})
 
 	it('applies the policy to rendered robots directives and sitemap entries', async () => {

--- a/apps/marketing/src/content/tagIndexability.test.mjs
+++ b/apps/marketing/src/content/tagIndexability.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { countPostsByTag, isIndexableTagCount } from '../utils/tagIndexability.mjs'
+
+describe('tag indexability', () => {
+	it('keeps archives with fewer than three posts out of search', () => {
+		expect(isIndexableTagCount(0)).toBe(false)
+		expect(isIndexableTagCount(1)).toBe(false)
+		expect(isIndexableTagCount(2)).toBe(false)
+	})
+
+	it('allows archives with at least three posts to be indexed', () => {
+		expect(isIndexableTagCount(3)).toBe(true)
+		expect(isIndexableTagCount(10)).toBe(true)
+	})
+
+	it('counts each post once for every assigned tag', () => {
+		const counts = countPostsByTag([
+			{ data: { tags: ['ai', 'tutorial'] } },
+			{ data: { tags: ['ai'] } },
+			{ data: { tags: ['ai', 'workflow'] } }
+		])
+
+		expect(counts.get('ai')).toBe(3)
+		expect(counts.get('tutorial')).toBe(1)
+		expect(counts.get('workflow')).toBe(1)
+	})
+
+	it('applies the policy to rendered robots directives and sitemap entries', async () => {
+		const [tagPage, sitemapConfig] = await Promise.all([
+			readFile(resolve(import.meta.dirname, '../pages/blog/tags/[tag].astro'), 'utf8'),
+			readFile(resolve(import.meta.dirname, '../../astro.config.mjs'), 'utf8')
+		])
+
+		expect(tagPage).toContain('noindex={!shouldIndex}')
+		expect(sitemapConfig).toContain('!isIndexableTagCount(blogTagCounts.get(tagMatch[1]) ?? 0)')
+		expect(sitemapConfig).toContain('return undefined')
+	})
+})

--- a/apps/marketing/src/layouts/PostLayout.astro
+++ b/apps/marketing/src/layouts/PostLayout.astro
@@ -5,6 +5,7 @@ const { frontmatter, body } = Astro.props
 //Layout Components
 import Layout from './Layout.astro'
 import { getAuthor } from '../content/authors'
+import { getWebPageId } from '../utils/structuredData.mjs'
 
 // Section Components
 import BlogPostHero from '../components/blocks/blog/BlogPostHero.astro'
@@ -17,64 +18,72 @@ const SEO = {
 }
 
 // Dates
-const pubDateISO = frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate
-const updatedDateISO = frontmatter.updatedDate instanceof Date ? frontmatter.updatedDate.toISOString() : frontmatter.updatedDate
+const pubDateISO =
+	frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate
+const updatedDateISO =
+	frontmatter.updatedDate instanceof Date
+		? frontmatter.updatedDate.toISOString()
+		: frontmatter.updatedDate
 const author = getAuthor(frontmatter.author)
 const absoluteAuthorUrl = new URL(author.url, Astro.site).href
 
 // Word count from markdown body (strip markdown syntax, count words)
 const wordCount = body
-	? body.replace(/```[\s\S]*?```/g, '').replace(/[#*_\[\]()>|`~-]/g, '').split(/\s+/).filter(Boolean).length
+	? body
+			.replace(/```[\s\S]*?```/g, '')
+			.replace(/[#*_\[\]()>|`~-]/g, '')
+			.split(/\s+/)
+			.filter(Boolean).length
 	: undefined
 
 // BlogPosting JSON-LD
 const blogPostJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "BlogPosting",
-	"headline": frontmatter.title,
-	"description": frontmatter.description,
-	"datePublished": pubDateISO,
-	...(updatedDateISO ? { "dateModified": updatedDateISO } : { "dateModified": pubDateISO }),
-	"author": {
-		"@type": "Person",
-		"@id": `${absoluteAuthorUrl}#person`,
-		"name": frontmatter.author,
-		"jobTitle": author.role,
-		"url": absoluteAuthorUrl
+	'@context': 'https://schema.org',
+	'@type': 'BlogPosting',
+	headline: frontmatter.title,
+	description: frontmatter.description,
+	datePublished: pubDateISO,
+	...(updatedDateISO ? { dateModified: updatedDateISO } : { dateModified: pubDateISO }),
+	author: {
+		'@type': 'Person',
+		'@id': `${absoluteAuthorUrl}#person`,
+		name: frontmatter.author,
+		jobTitle: author.role,
+		url: absoluteAuthorUrl
 	},
-	...(frontmatter.image ? { "image": `https://frontman.sh${frontmatter.image}` } : {}),
-	...(wordCount ? { "wordCount": wordCount } : {}),
-	...(frontmatter.tags?.length ? { "keywords": frontmatter.tags.join(', ') } : {}),
-	"articleSection": frontmatter.articleSection,
-	"publisher": {
-		"@type": "Organization",
-		"name": "Frontman",
-		"logo": {
-			"@type": "ImageObject",
-			"url": "https://frontman.sh/logo.svg"
+	...(frontmatter.image ? { image: `https://frontman.sh${frontmatter.image}` } : {}),
+	...(wordCount ? { wordCount: wordCount } : {}),
+	...(frontmatter.tags?.length ? { keywords: frontmatter.tags.join(', ') } : {}),
+	articleSection: frontmatter.articleSection,
+	publisher: {
+		'@type': 'Organization',
+		name: 'Frontman',
+		logo: {
+			'@type': 'ImageObject',
+			url: 'https://frontman.sh/logo.svg'
 		}
 	},
-	"speakable": {
-		"@type": "SpeakableSpecification",
-		"cssSelector": [".post-header__title", ".post-body h2", ".post-body p:first-of-type"]
+	speakable: {
+		'@type': 'SpeakableSpecification',
+		cssSelector: ['.post-header__title', '.post-body h2', '.post-body p:first-of-type']
 	},
-	"mainEntityOfPage": {
-		"@type": "WebPage",
-		"@id": Astro.url.href
+	mainEntityOfPage: {
+		'@type': 'WebPage',
+		'@id': getWebPageId(Astro.url.href)
 	}
 }
 
 // FAQPage JSON-LD (optional, driven by frontmatter.faq)
 const faqJsonLd = frontmatter.faq?.length
 	? {
-			"@context": "https://schema.org",
-			"@type": "FAQPage",
-			"mainEntity": frontmatter.faq.map((item: { question: string; answer: string }) => ({
-				"@type": "Question",
-				"name": item.question,
-				"acceptedAnswer": {
-					"@type": "Answer",
-					"text": item.answer
+			'@context': 'https://schema.org',
+			'@type': 'FAQPage',
+			mainEntity: frontmatter.faq.map((item: { question: string; answer: string }) => ({
+				'@type': 'Question',
+				name: item.question,
+				acceptedAnswer: {
+					'@type': 'Answer',
+					text: item.answer
 				}
 			}))
 		}
@@ -83,18 +92,18 @@ const faqJsonLd = frontmatter.faq?.length
 // ItemList JSON-LD (optional, driven by frontmatter.comparisonItems)
 const itemListJsonLd = frontmatter.comparisonItems?.length
 	? {
-			"@context": "https://schema.org",
-			"@type": "ItemList",
-			"name": `${frontmatter.title} compared tools`,
-			"itemListElement": frontmatter.comparisonItems.map(
+			'@context': 'https://schema.org',
+			'@type': 'ItemList',
+			name: `${frontmatter.title} compared tools`,
+			itemListElement: frontmatter.comparisonItems.map(
 				(item: { name: string; url: string; description?: string }, index: number) => ({
-					"@type": "ListItem",
-					"position": index + 1,
-					"item": {
-						"@type": "Thing",
-						"name": item.name,
-						"url": item.url,
-						...(item.description ? { "description": item.description } : {})
+					'@type': 'ListItem',
+					position: index + 1,
+					item: {
+						'@type': 'Thing',
+						name: item.name,
+						url: item.url,
+						...(item.description ? { description: item.description } : {})
 					}
 				})
 			)
@@ -104,17 +113,20 @@ const itemListJsonLd = frontmatter.comparisonItems?.length
 // VideoObject JSON-LD (optional, driven by frontmatter.video)
 const videoJsonLd = frontmatter.video
 	? {
-			"@context": "https://schema.org",
-			"@type": "VideoObject",
-			"name": frontmatter.video.name,
-			"description": frontmatter.video.description,
-			"thumbnailUrl": frontmatter.video.thumbnailUrl
+			'@context': 'https://schema.org',
+			'@type': 'VideoObject',
+			name: frontmatter.video.name,
+			description: frontmatter.video.description,
+			thumbnailUrl: frontmatter.video.thumbnailUrl
 				? `https://frontman.sh${frontmatter.video.thumbnailUrl}`
 				: `https://img.youtube.com/vi/${frontmatter.video.youtubeId}/maxresdefault.jpg`,
-			"uploadDate": frontmatter.video.uploadDate
-				?? (frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate),
-			"contentUrl": `https://www.youtube.com/watch?v=${frontmatter.video.youtubeId}`,
-			"embedUrl": `https://www.youtube-nocookie.com/embed/${frontmatter.video.youtubeId}`
+			uploadDate:
+				frontmatter.video.uploadDate ??
+				(frontmatter.pubDate instanceof Date
+					? frontmatter.pubDate.toISOString()
+					: frontmatter.pubDate),
+			contentUrl: `https://www.youtube.com/watch?v=${frontmatter.video.youtubeId}`,
+			embedUrl: `https://www.youtube-nocookie.com/embed/${frontmatter.video.youtubeId}`
 		}
 	: null
 ---
@@ -133,9 +145,21 @@ const videoJsonLd = frontmatter.video
 	}}
 >
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(blogPostJsonLd)} />
-	{faqJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
-	{itemListJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(itemListJsonLd)} />}
-	{videoJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} />}
+	{
+		faqJsonLd && (
+			<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+		)
+	}
+	{
+		itemListJsonLd && (
+			<script is:inline type="application/ld+json" set:html={JSON.stringify(itemListJsonLd)} />
+		)
+	}
+	{
+		videoJsonLd && (
+			<script is:inline type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} />
+		)
+	}
 	<BlogPostHero
 		tags={frontmatter.tags}
 		title={frontmatter.title}
@@ -150,26 +174,28 @@ const videoJsonLd = frontmatter.video
 		<slot />
 	</div>
 
-	{frontmatter.faq?.length && (
-		<section class="post-faq">
-			<div class="post-faq__container">
-				<h2 class="post-faq__title">FAQ</h2>
-				<div class="post-faq__list">
-					{frontmatter.faq.map((item: { question: string; answer: string }) => (
-						<details class="post-faq__item group">
-							<summary class="post-faq__question">
-								<span>{item.question}</span>
-								<span class="post-faq__icon">+</span>
-							</summary>
-							<div class="post-faq__answer">
-								<p>{item.answer}</p>
-							</div>
-						</details>
-					))}
+	{
+		frontmatter.faq?.length && (
+			<section class="post-faq">
+				<div class="post-faq__container">
+					<h2 class="post-faq__title">FAQ</h2>
+					<div class="post-faq__list">
+						{frontmatter.faq.map((item: { question: string; answer: string }) => (
+							<details class="post-faq__item group">
+								<summary class="post-faq__question">
+									<span>{item.question}</span>
+									<span class="post-faq__icon">+</span>
+								</summary>
+								<div class="post-faq__answer">
+									<p>{item.answer}</p>
+								</div>
+							</details>
+						))}
+					</div>
 				</div>
-			</div>
-		</section>
-	)}
+			</section>
+		)
+	}
 </Layout>
 
 <style>
@@ -294,7 +320,7 @@ const videoJsonLd = frontmatter.video
 		gap: 12px;
 	}
 	.post-body :global(.metric-comparison__agent::before) {
-		content: "";
+		content: '';
 		position: absolute;
 		inset: 0 auto 0 0;
 		z-index: -1;
@@ -359,9 +385,15 @@ const videoJsonLd = frontmatter.video
 		list-style: none;
 		transition: color 0.2s;
 	}
-	.post-faq__question::-webkit-details-marker { display: none; }
-	.post-faq__question:hover { color: #fff; }
-	.post-faq__question span:first-child { padding-right: 24px; }
+	.post-faq__question::-webkit-details-marker {
+		display: none;
+	}
+	.post-faq__question:hover {
+		color: #fff;
+	}
+	.post-faq__question span:first-child {
+		padding-right: 24px;
+	}
 	.post-faq__icon {
 		flex-shrink: 0;
 		width: 28px;
@@ -407,61 +439,89 @@ const videoJsonLd = frontmatter.video
 		.post-body :global(.metric-comparison__agent-value) {
 			font-size: 17px;
 		}
-		.post-faq { padding: 40px 20px; }
-		.post-faq__title { font-size: 24px; }
+		.post-faq {
+			padding: 40px 20px;
+		}
+		.post-faq__title {
+			font-size: 24px;
+		}
 	}
 </style>
 
 <script>
 	function initScrollableTables() {
 		document.querySelectorAll<HTMLTableElement>('.post-body table').forEach((table) => {
-			if (table.parentElement?.classList.contains('table-scroll')) return;
+			if (table.parentElement?.classList.contains('table-scroll')) return
 
-			const wrapper = document.createElement('div');
-			wrapper.className = 'table-scroll';
-			wrapper.setAttribute('role', 'region');
-			wrapper.setAttribute('aria-label', 'Scrollable table');
-			wrapper.setAttribute('tabindex', '0');
-			table.before(wrapper);
-			wrapper.appendChild(table);
-		});
+			const wrapper = document.createElement('div')
+			wrapper.className = 'table-scroll'
+			wrapper.setAttribute('role', 'region')
+			wrapper.setAttribute('aria-label', 'Scrollable table')
+			wrapper.setAttribute('tabindex', '0')
+			table.before(wrapper)
+			wrapper.appendChild(table)
+		})
 	}
 
 	function initMetricComparisons() {
 		document.querySelectorAll<HTMLUListElement>('.post-body ul').forEach((list) => {
-			const items = Array.from(list.querySelectorAll<HTMLLIElement>(':scope > li'));
-			const isMetricSummaryList = items.length > 0 && items.every((item) => {
-				const text = item.textContent ?? '';
-				return /^\s*\d+%/.test(text) && /\b(fewer|lower)\b/i.test(text);
-			});
-			if (!isMetricSummaryList || list.dataset.metricComparisonRendered === 'true') return;
+			const items = Array.from(list.querySelectorAll<HTMLLIElement>(':scope > li'))
+			const isMetricSummaryList =
+				items.length > 0 &&
+				items.every((item) => {
+					const text = item.textContent ?? ''
+					return /^\s*\d+%/.test(text) && /\b(fewer|lower)\b/i.test(text)
+				})
+			if (!isMetricSummaryList || list.dataset.metricComparisonRendered === 'true') return
 
 			const table = list.previousElementSibling?.matches('table')
-				? list.previousElementSibling as HTMLTableElement
-				: list.parentElement?.querySelector<HTMLTableElement>('table');
-			if (!table) return;
+				? (list.previousElementSibling as HTMLTableElement)
+				: list.parentElement?.querySelector<HTMLTableElement>('table')
+			if (!table) return
 
-			const rows = Array.from(table.querySelectorAll<HTMLTableRowElement>('tbody tr')).map((row) => {
-				const cells = Array.from(row.querySelectorAll<HTMLTableCellElement>('td')).map((cell) => cell.textContent?.trim() ?? '');
-				return {
-					agent: cells[0],
-					requests: Number(cells[1]?.replace(/,/g, '')),
-					totalTokens: Number(cells[5]?.replace(/,/g, '')),
-					cost: Number(cells[8]?.replace(/[$,]/g, '')),
-					costLabel: cells[8],
-				};
-			}).filter((row) => row.agent && Number.isFinite(row.requests) && Number.isFinite(row.totalTokens) && Number.isFinite(row.cost));
-			if (rows.length === 0) return;
+			const rows = Array.from(table.querySelectorAll<HTMLTableRowElement>('tbody tr'))
+				.map((row) => {
+					const cells = Array.from(row.querySelectorAll<HTMLTableCellElement>('td')).map(
+						(cell) => cell.textContent?.trim() ?? ''
+					)
+					return {
+						agent: cells[0],
+						requests: Number(cells[1]?.replace(/,/g, '')),
+						totalTokens: Number(cells[5]?.replace(/,/g, '')),
+						cost: Number(cells[8]?.replace(/[$,]/g, '')),
+						costLabel: cells[8]
+					}
+				})
+				.filter(
+					(row) =>
+						row.agent &&
+						Number.isFinite(row.requests) &&
+						Number.isFinite(row.totalTokens) &&
+						Number.isFinite(row.cost)
+				)
+			if (rows.length === 0) return
 
 			const categories = [
-				{ title: 'Number of requests', key: 'requests', format: (value: number) => value.toLocaleString() },
-				{ title: 'Total tokens', key: 'totalTokens', format: (value: number) => value.toLocaleString() },
-				{ title: 'Cost', key: 'cost', format: (_value: number, row: typeof rows[number]) => row.costLabel },
-			] as const;
+				{
+					title: 'Number of requests',
+					key: 'requests',
+					format: (value: number) => value.toLocaleString()
+				},
+				{
+					title: 'Total tokens',
+					key: 'totalTokens',
+					format: (value: number) => value.toLocaleString()
+				},
+				{
+					title: 'Cost',
+					key: 'cost',
+					format: (_value: number, row: (typeof rows)[number]) => row.costLabel
+				}
+			] as const
 
-			const card = document.createElement('section');
-			card.className = 'metric-comparison';
-			card.setAttribute('aria-label', 'Agent efficiency comparison');
+			const card = document.createElement('section')
+			card.className = 'metric-comparison'
+			card.setAttribute('aria-label', 'Agent efficiency comparison')
 			card.innerHTML = `
 				<div class="metric-comparison__header">
 					<div>
@@ -471,76 +531,76 @@ const videoJsonLd = frontmatter.video
 					<span class="metric-comparison__winner-key">Winner highlighted</span>
 				</div>
 				<div class="metric-comparison__grid"></div>
-			`;
+			`
 
-			const grid = card.querySelector<HTMLDivElement>('.metric-comparison__grid');
-			if (!grid) return;
+			const grid = card.querySelector<HTMLDivElement>('.metric-comparison__grid')
+			if (!grid) return
 
 			categories.forEach((category) => {
-				const values = rows.map((row) => row[category.key]);
-				const minValue = Math.min(...values);
-				const maxValue = Math.max(...values);
-				const section = document.createElement('section');
-				section.className = 'metric-comparison__category';
-				section.innerHTML = `<h4 class="metric-comparison__category-title">${category.title}</h4>`;
+				const values = rows.map((row) => row[category.key])
+				const minValue = Math.min(...values)
+				const maxValue = Math.max(...values)
+				const section = document.createElement('section')
+				section.className = 'metric-comparison__category'
+				section.innerHTML = `<h4 class="metric-comparison__category-title">${category.title}</h4>`
 
-				const agents = document.createElement('div');
-				agents.className = 'metric-comparison__agents';
+				const agents = document.createElement('div')
+				agents.className = 'metric-comparison__agents'
 				rows.forEach((row) => {
-					const value = row[category.key];
-					const barWidth = maxValue > 0 ? Math.max(8, (value / maxValue) * 100) : 0;
-					const isWinner = value === minValue;
-					const agent = document.createElement('div');
-					agent.className = `metric-comparison__agent${isWinner ? ' metric-comparison__agent--winner' : ''}`;
-					agent.style.setProperty('--bar-width', `${barWidth}%`);
+					const value = row[category.key]
+					const barWidth = maxValue > 0 ? Math.max(8, (value / maxValue) * 100) : 0
+					const isWinner = value === minValue
+					const agent = document.createElement('div')
+					agent.className = `metric-comparison__agent${isWinner ? ' metric-comparison__agent--winner' : ''}`
+					agent.style.setProperty('--bar-width', `${barWidth}%`)
 					agent.innerHTML = `
 						<span class="metric-comparison__agent-name">${row.agent}</span>
 						<span class="metric-comparison__agent-value">${category.format(value, row)}</span>
-					`;
-					agents.appendChild(agent);
-				});
+					`
+					agents.appendChild(agent)
+				})
 
-				section.appendChild(agents);
-				grid.appendChild(section);
-			});
+				section.appendChild(agents)
+				grid.appendChild(section)
+			})
 
-			list.dataset.metricComparisonRendered = 'true';
-			list.replaceWith(card);
-		});
+			list.dataset.metricComparisonRendered = 'true'
+			list.replaceWith(card)
+		})
 	}
 
 	function initCodeCopyButtons() {
 		document.querySelectorAll<HTMLPreElement>('pre.astro-code').forEach((pre) => {
-			if (pre.querySelector('.code-copy-btn')) return;
+			if (pre.querySelector('.code-copy-btn')) return
 
-			const btn = document.createElement('button');
-			btn.className = 'code-copy-btn';
-			btn.setAttribute('aria-label', 'Copy code');
-			btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+			const btn = document.createElement('button')
+			btn.className = 'code-copy-btn'
+			btn.setAttribute('aria-label', 'Copy code')
+			btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`
 
 			btn.addEventListener('click', async () => {
-				const code = pre.querySelector('code');
-				if (!code) return;
-				await navigator.clipboard.writeText(code.textContent || '');
-				btn.classList.add('copied');
-				btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+				const code = pre.querySelector('code')
+				if (!code) return
+				await navigator.clipboard.writeText(code.textContent || '')
+				btn.classList.add('copied')
+				btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`
 				setTimeout(() => {
-					btn.classList.remove('copied');
-					btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
-				}, 2000);
-			});
+					btn.classList.remove('copied')
+					btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`
+				}, 2000)
+			})
 
-			pre.style.position = 'relative';
-			pre.appendChild(btn);
-		});
+			pre.style.position = 'relative'
+			pre.appendChild(btn)
+		})
 	}
 
-	initScrollableTables();
-	initMetricComparisons();
-	initCodeCopyButtons();
+	initScrollableTables()
+	initMetricComparisons()
+	initCodeCopyButtons()
 	document.addEventListener('astro:after-swap', () => {
-		initScrollableTables();
-		initMetricComparisons();
-		initCodeCopyButtons();
-	});
+		initScrollableTables()
+		initMetricComparisons()
+		initCodeCopyButtons()
+	})
 </script>

--- a/apps/marketing/src/layouts/ReleasesLayout.astro
+++ b/apps/marketing/src/layouts/ReleasesLayout.astro
@@ -3,54 +3,64 @@ const { frontmatter, body, relatedReleases = [] } = Astro.props
 
 import Layout from './Layout.astro'
 import BlogPostHero from '../components/blocks/blog/BlogPostHero.astro'
+import { getWebPageId } from '../utils/structuredData.mjs'
 
 const SEO = {
 	title: `${frontmatter.title} | Frontman`,
 	description: frontmatter.description
 }
 
-const pubDateISO = frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate
-const updatedDateISO = frontmatter.updatedDate instanceof Date ? frontmatter.updatedDate.toISOString() : frontmatter.updatedDate
+const pubDateISO =
+	frontmatter.pubDate instanceof Date ? frontmatter.pubDate.toISOString() : frontmatter.pubDate
+const updatedDateISO =
+	frontmatter.updatedDate instanceof Date
+		? frontmatter.updatedDate.toISOString()
+		: frontmatter.updatedDate
 
 const wordCount = body
-	? body.replace(/```[\s\S]*?```/g, '').replace(/[#*_\[\]()>|`~-]/g, '').split(/\s+/).filter(Boolean).length
+	? body
+			.replace(/```[\s\S]*?```/g, '')
+			.replace(/[#*_\[\]()>|`~-]/g, '')
+			.split(/\s+/)
+			.filter(Boolean).length
 	: undefined
 
 // WebPage JSON-LD with dateModified for freshness signals
 const webPageJsonLd = {
-	"@context": "https://schema.org",
-	"@type": "WebPage",
-	"name": frontmatter.title,
-	"description": frontmatter.description,
-	"url": Astro.url.href,
-	"datePublished": pubDateISO,
-	...(updatedDateISO ? { "dateModified": updatedDateISO } : { "dateModified": pubDateISO }),
-	...(wordCount ? { "wordCount": wordCount } : {}),
-	"publisher": {
-		"@type": "Organization",
-		"name": "Frontman",
-		"logo": {
-			"@type": "ImageObject",
-			"url": "https://frontman.sh/logo.svg"
+	'@context': 'https://schema.org',
+	'@type': 'WebPage',
+	'@id': getWebPageId(Astro.url.href),
+	name: frontmatter.title,
+	description: frontmatter.description,
+	url: Astro.url.href,
+	datePublished: pubDateISO,
+	...(updatedDateISO ? { dateModified: updatedDateISO } : { dateModified: pubDateISO }),
+	...(wordCount ? { wordCount: wordCount } : {}),
+	publisher: {
+		'@type': 'Organization',
+		name: 'Frontman',
+		logo: {
+			'@type': 'ImageObject',
+			url: 'https://frontman.sh/logo.svg'
 		}
 	},
-	"mainEntityOfPage": {
-		"@type": "WebPage",
-		"@id": Astro.url.href
+	mainEntityOfPage: {
+		'@type': 'WebPage',
+		'@id': getWebPageId(Astro.url.href)
 	}
 }
 
 // FAQPage JSON-LD (optional)
 const faqJsonLd = frontmatter.faq?.length
 	? {
-			"@context": "https://schema.org",
-			"@type": "FAQPage",
-			"mainEntity": frontmatter.faq.map((item: { question: string; answer: string }) => ({
-				"@type": "Question",
-				"name": item.question,
-				"acceptedAnswer": {
-					"@type": "Answer",
-					"text": item.answer
+			'@context': 'https://schema.org',
+			'@type': 'FAQPage',
+			mainEntity: frontmatter.faq.map((item: { question: string; answer: string }) => ({
+				'@type': 'Question',
+				name: item.question,
+				acceptedAnswer: {
+					'@type': 'Answer',
+					text: item.answer
 				}
 			}))
 		}
@@ -63,11 +73,15 @@ const faqJsonLd = frontmatter.faq?.length
 	ogImage={frontmatter.image}
 	article={{
 		publishedTime: pubDateISO,
-		modifiedTime: updatedDateISO || pubDateISO,
+		modifiedTime: updatedDateISO || pubDateISO
 	}}
 >
 	<script is:inline type="application/ld+json" set:html={JSON.stringify(webPageJsonLd)} />
-	{faqJsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
+	{
+		faqJsonLd && (
+			<script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+		)
+	}
 	<BlogPostHero
 		title={frontmatter.title}
 		pubDate={frontmatter.pubDate}
@@ -80,31 +94,35 @@ const faqJsonLd = frontmatter.faq?.length
 
 	<nav class="release-navigation" aria-label="Release archive navigation">
 		<a href="/open-source-ai-releases/">All open-source AI releases</a>
-		{relatedReleases.map((release: { id: string; title: string }) => (
-			<a href={`/open-source-ai-releases/${release.id}/`}>{release.title}</a>
-		))}
+		{
+			relatedReleases.map((release: { id: string; title: string }) => (
+				<a href={`/open-source-ai-releases/${release.id}/`}>{release.title}</a>
+			))
+		}
 	</nav>
 
-	{frontmatter.faq?.length && (
-		<section class="post-faq">
-			<div class="post-faq__container">
-				<h2 class="post-faq__title">Frequently Asked Questions</h2>
-				<div class="post-faq__list">
-					{frontmatter.faq.map((item: { question: string; answer: string }) => (
-						<details class="post-faq__item group">
-							<summary class="post-faq__question">
-								<span>{item.question}</span>
-								<span class="post-faq__icon">+</span>
-							</summary>
-							<div class="post-faq__answer">
-								<p>{item.answer}</p>
-							</div>
-						</details>
-					))}
+	{
+		frontmatter.faq?.length && (
+			<section class="post-faq">
+				<div class="post-faq__container">
+					<h2 class="post-faq__title">Frequently Asked Questions</h2>
+					<div class="post-faq__list">
+						{frontmatter.faq.map((item: { question: string; answer: string }) => (
+							<details class="post-faq__item group">
+								<summary class="post-faq__question">
+									<span>{item.question}</span>
+									<span class="post-faq__icon">+</span>
+								</summary>
+								<div class="post-faq__answer">
+									<p>{item.answer}</p>
+								</div>
+							</details>
+						))}
+					</div>
 				</div>
-			</div>
-		</section>
-	)}
+			</section>
+		)
+	}
 </Layout>
 
 <style>
@@ -113,10 +131,10 @@ const faqJsonLd = frontmatter.faq?.length
 		@apply mx-auto max-w-3xl px-6 py-12 lg:py-24;
 	}
 	.release-navigation {
-		@apply mx-auto flex max-w-3xl flex-col gap-3 border-t border-neutral-800 px-6 pb-12 pt-8 text-sm lg:pb-20;
+		@apply mx-auto flex max-w-3xl flex-col gap-3 border-t border-neutral-800 px-6 pt-8 pb-12 text-sm lg:pb-20;
 	}
 	.release-navigation a {
-		@apply text-primary-400 underline underline-offset-4 hover:text-primary-300;
+		@apply text-primary-400 hover:text-primary-300 underline underline-offset-4;
 	}
 
 	.post-faq {
@@ -157,9 +175,15 @@ const faqJsonLd = frontmatter.faq?.length
 		list-style: none;
 		transition: color 0.2s;
 	}
-	.post-faq__question::-webkit-details-marker { display: none; }
-	.post-faq__question:hover { color: #fff; }
-	.post-faq__question span:first-child { padding-right: 24px; }
+	.post-faq__question::-webkit-details-marker {
+		display: none;
+	}
+	.post-faq__question:hover {
+		color: #fff;
+	}
+	.post-faq__question span:first-child {
+		padding-right: 24px;
+	}
 	.post-faq__icon {
 		flex-shrink: 0;
 		width: 28px;
@@ -188,7 +212,11 @@ const faqJsonLd = frontmatter.faq?.length
 	}
 
 	@media (max-width: 768px) {
-		.post-faq { padding: 40px 20px; }
-		.post-faq__title { font-size: 24px; }
+		.post-faq {
+			padding: 40px 20px;
+		}
+		.post-faq__title {
+			font-size: 24px;
+		}
 	}
 </style>

--- a/apps/marketing/src/pages/blog/tags/[tag].astro
+++ b/apps/marketing/src/pages/blog/tags/[tag].astro
@@ -15,6 +15,7 @@ import Col from '../../../components/ui/Col.astro'
 
 // Data
 import { getCollection } from 'astro:content'
+import { isIndexableTagCount } from '../../../utils/tagIndexability.mjs'
 export async function getStaticPaths() {
 	const allPosts = await getCollection('blog')
 	const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())]
@@ -29,6 +30,7 @@ export async function getStaticPaths() {
 }
 const { tag } = Astro.params
 const { posts } = Astro.props
+const shouldIndex = isIndexableTagCount(posts.length)
 
 const tagDisplayNames: Record<string, string> = {
 	ai: 'AI',
@@ -44,33 +46,54 @@ const tagDisplayNames: Record<string, string> = {
 	wordpress: 'WordPress'
 }
 
-const displayTag = tagDisplayNames[tag ?? ''] ?? (tag ?? '')
-	.split('-')
-	.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-	.join(' ')
+const displayTag =
+	tagDisplayNames[tag ?? ''] ??
+	(tag ?? '')
+		.split('-')
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ')
 
 const tagDescriptions: Record<string, string> = {
-	announcement: 'Product launches, feature releases, and important updates from the Frontman team. Stay up to date with what we are shipping and where the project is headed.',
-	collaboration: 'How Frontman enables designers, PMs, and developers to work together on frontend code — directly inside the running application, without context switching.',
-	security: 'How Frontman keeps your code and data safe. Learn about our security model, local-first architecture, and the principles behind our approach to trust and access control.',
-	tutorial: 'Step-by-step guides and walkthroughs for getting the most out of Frontman. From first setup to advanced workflows, these posts help you hit the ground running.',
-	comparison: 'Side-by-side comparisons of Frontman with other AI coding tools like Cursor, Copilot, v0, and Stagewise. Understand the tradeoffs and find the right tool for your workflow.',
-	ai: 'How artificial intelligence powers Frontman and the broader landscape of AI-assisted frontend development. From prompt-driven editing to runtime-aware code generation, explore the AI techniques behind modern developer tooling.',
-	'developer-tools': 'Posts about the developer tools ecosystem and how Frontman fits alongside your existing workflow. Browser DevTools, build systems, and the tools that make frontend development faster.',
-	'getting-started': 'Everything you need to get up and running with Frontman. Installation guides, first steps, and tips for making the most of Frontman from day one.',
-	workflow: 'Practical advice on integrating Frontman into your daily development workflow. Learn how browser-based AI editing can streamline code reviews, design handoffs, and rapid prototyping.',
-	'open-source': 'Frontman is source-available. Its browser client and JavaScript framework integrations are open source under Apache-2.0, its WordPress plugin is GPL-2.0-or-later, and Frontman Server is AGPL-3.0-only with AI Supplementary Terms. Read about transparency, community contributions, and building in the open.',
-	performance: 'How Frontman helps you build faster websites. From built-in Lighthouse audits to runtime performance insights, learn how to catch and fix performance issues without leaving your browser.',
+	announcement:
+		'Product launches, feature releases, and important updates from the Frontman team. Stay up to date with what we are shipping and where the project is headed.',
+	'ai-agents':
+		'Technical analysis of coding-agent loops, tool access, protocol boundaries, and verification. Use this collection to understand how agents gather context and where human review still matters.',
+	collaboration:
+		'Governance patterns for designers, PMs, and developers making reviewable frontend changes together, with less browser-to-source translation and explicit engineering escalation paths.',
+	'design-systems':
+		'Practical guidance for maintaining tokens, reusable components, responsive rules, and review standards while AI tools edit frontend source in development environments.',
+	frontend:
+		'Analysis of browser context, responsive UI work, component structure, and the verification practices that help teams review agent-generated frontend changes.',
+	security:
+		'Due-diligence guidance for Frontman deployments, including browser, filesystem, server, provider, credential, and WordPress mutation boundaries.',
+	tutorial:
+		'Step-by-step guides and walkthroughs for getting the most out of Frontman. From first setup to advanced workflows, these posts help you hit the ground running.',
+	comparison:
+		'Side-by-side comparisons of Frontman with other AI coding tools like Cursor, Copilot, v0, and Stagewise. Understand the tradeoffs and find the right tool for your workflow.',
+	ai: 'Analysis of AI-assisted frontend workflows, coding-agent limitations, model choices, and the evidence teams need when evaluating browser-aware development tools.',
+	'developer-tools':
+		'Posts about the developer tools ecosystem and how Frontman fits alongside your existing workflow. Browser DevTools, build systems, and the tools that make frontend development faster.',
+	'getting-started':
+		'Everything you need to get up and running with Frontman. Installation guides, first steps, and tips for making the most of Frontman from day one.',
+	workflow:
+		'Practical advice on integrating Frontman into your daily development workflow. Learn how browser-based AI editing can streamline code reviews, design handoffs, and rapid prototyping.',
+	wordpress:
+		'Frontman WordPress plugin setup, release notes, compatibility analysis, and practical editing workflows for teams evaluating AI-assisted WordPress maintenance.',
+	'open-source':
+		'Frontman is source-available. Its browser client and JavaScript framework integrations are open source under Apache-2.0, its WordPress plugin is GPL-2.0-or-later, and Frontman Server is AGPL-3.0-only with AI Supplementary Terms. Read about transparency, community contributions, and building in the open.',
+	performance:
+		'Guides to Frontman’s Lighthouse summary, framework logs, and reproducible browser checks for investigating frontend performance issues.'
 }
 
-const tagDescription = tagDescriptions[tag ?? ''] ??
+const tagDescription =
+	tagDescriptions[tag ?? ''] ??
 	`Articles and insights about ${displayTag} in the context of AI-powered frontend development. Explore how Frontman and browser-based tooling are changing the way teams build and iterate on user interfaces.`
 
 // Content
 // - SEO
 const SEO = {
 	title: `${displayTag} | Frontman Blog`,
-	description: `Browse all Frontman blog posts tagged as "${displayTag}". Read articles about ${displayTag} covering AI coding tools, browser-based development, and frontend workflows.`
+	description: tagDescription
 }
 
 // - Page Header
@@ -80,18 +103,18 @@ const header = {
 }
 ---
 
-<Layout title={SEO.title} description={SEO.description}>
+<Layout title={SEO.title} description={SEO.description} noindex={!shouldIndex}>
 	<Hero title={header.title} text={header.text} />
 	<Section id="tag-intro">
 		<Row>
 			<Col span="8" align="center">
 				<p class="tag-intro__text">{tagDescription}</p>
 				<p class="tag-intro__count">
-					{posts.length === 1
-						? `There is currently 1 article tagged "${displayTag}".`
-						: `There are currently ${posts.length} articles tagged "${displayTag}".`
+					{
+						posts.length === 1
+							? `There is currently 1 article tagged "${displayTag}".`
+							: `There are currently ${posts.length} articles tagged "${displayTag}".`
 					}
-					Check back regularly — we publish new content every week.
 				</p>
 			</Col>
 		</Row>
@@ -102,7 +125,7 @@ const header = {
 <style>
 	@reference "../../../styles/global.css";
 	.tag-intro__text {
-		@apply text-lg leading-relaxed text-neutral-600 dark:text-neutral-300 mb-4;
+		@apply mb-4 text-lg leading-relaxed text-neutral-600 dark:text-neutral-300;
 	}
 	.tag-intro__count {
 		@apply text-base text-neutral-500 dark:text-neutral-400;

--- a/apps/marketing/src/utils/structuredData.mjs
+++ b/apps/marketing/src/utils/structuredData.mjs
@@ -1,7 +1,9 @@
+export const getWebPageId = (url) => `${url}#webpage`
+
 export const createWebPageSchema = ({ url, title, description }) => {
 	const schema = {
 		'@type': 'WebPage',
-		'@id': `${url}#webpage`,
+		'@id': getWebPageId(url),
 		url,
 		name: title,
 		description

--- a/apps/marketing/src/utils/structuredData.mjs
+++ b/apps/marketing/src/utils/structuredData.mjs
@@ -1,0 +1,18 @@
+export const createWebPageSchema = ({ url, title, description }) => {
+	const schema = {
+		'@type': 'WebPage',
+		'@id': `${url}#webpage`,
+		url,
+		name: title,
+		description
+	}
+
+	if (url === 'https://frontman.sh/') {
+		schema.speakable = {
+			'@type': 'SpeakableSpecification',
+			cssSelector: ['#intro .hero-section__subtitle', '#intro .hero-section__geo-lead']
+		}
+	}
+
+	return schema
+}

--- a/apps/marketing/src/utils/tagIndexability.mjs
+++ b/apps/marketing/src/utils/tagIndexability.mjs
@@ -1,0 +1,15 @@
+export const minimumIndexableTagPosts = 3
+
+export const isIndexableTagCount = (count) => count >= minimumIndexableTagPosts
+
+export const countPostsByTag = (posts) => {
+	const counts = new Map()
+
+	for (const post of posts) {
+		for (const tag of post.data.tags) {
+			counts.set(tag, (counts.get(tag) ?? 0) + 1)
+		}
+	}
+
+	return counts
+}

--- a/apps/marketing/src/utils/tagIndexability.mjs
+++ b/apps/marketing/src/utils/tagIndexability.mjs
@@ -2,6 +2,32 @@ export const minimumIndexableTagPosts = 3
 
 export const isIndexableTagCount = (count) => count >= minimumIndexableTagPosts
 
+const parseTag = (value) => value.trim().replace(/^['"]|['"]$/g, '')
+
+export const parseFrontmatterTags = (source) => {
+	const frontmatter = source.match(/^---\s*\n([\s\S]*?)\n---/)?.[1] ?? source
+	const lines = frontmatter.split('\n')
+	const tagsLineIndex = lines.findIndex((line) => /^tags:\s*/.test(line))
+	if (tagsLineIndex === -1) return []
+
+	const inlineValue = lines[tagsLineIndex].replace(/^tags:\s*/, '').trim()
+	if (inlineValue.length > 0) {
+		if (!inlineValue.startsWith('[') || !inlineValue.endsWith(']')) {
+			throw new Error('Blog tags must use a YAML array')
+		}
+
+		return inlineValue.slice(1, -1).split(',').map(parseTag).filter(Boolean)
+	}
+
+	const tags = []
+	for (const line of lines.slice(tagsLineIndex + 1)) {
+		const item = line.match(/^\s+-\s+(.+)$/)?.[1]
+		if (!item) break
+		tags.push(parseTag(item))
+	}
+	return tags
+}
+
 export const countPostsByTag = (posts) => {
 	const counts = new Map()
 

--- a/docs/plans/google-index-content-recovery.md
+++ b/docs/plans/google-index-content-recovery.md
@@ -1,0 +1,257 @@
+# Implementation Plan: Google Index Content Recovery
+
+## Overview
+
+Implement the approved indexing-recovery specification in risk-first slices. Behavioral SEO changes receive tests first. Content rewrites are grouped by search-intent cluster so each increment remains reviewable and the site builds between checkpoints.
+
+## Architecture Decisions
+
+- Derive tag indexability from post count at build time. Routes remain available; thin archives become `noindex,follow` and disappear from sitemap output.
+- Keep taxonomy policy near existing tag and sitemap code rather than introducing a general SEO subsystem.
+- Pass canonical page identity into shared structured-data rendering so non-home routes stop declaring themselves as homepage.
+- Prefer real content dates. Omit `lastmod` where no trustworthy source date exists.
+- Preserve all published article URLs and differentiate content rather than redirecting it.
+
+## Task List
+
+### Phase 1: Indexing Policy
+
+#### Task 1: Test tag indexability policy
+
+**Acceptance criteria:**
+
+- A failing test requires archives with fewer than three posts to be noindexed and omitted from sitemap policy.
+- A failing test requires populated retained archives to remain indexable.
+
+**Verification:** `make test`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `apps/marketing/src/content/tagIndexability.test.mjs`
+
+#### Task 2: Implement tag indexability and navigation policy
+
+**Acceptance criteria:**
+
+- Thin tag routes render `noindex,follow`.
+- Thin tags are excluded from generated sitemap output.
+- Global tag navigation does not promote thin tags.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** Task 1
+
+**Files likely touched:**
+
+- `apps/marketing/src/pages/blog/tags/[tag].astro`
+- `apps/marketing/src/components/ui/blog/TagNavigation.astro`
+- `apps/marketing/astro.config.mjs`
+- `apps/marketing/src/content/tagIndexability.test.mjs`
+
+### Checkpoint: Taxonomy
+
+- Tests pass.
+- Production build contains expected tag robots directives and sitemap membership.
+
+### Phase 2: Semantic Signals
+
+#### Task 3: Test and implement page-specific structured data
+
+**Acceptance criteria:**
+
+- A test fails against homepage-only `WebPage` identity.
+- Shared structured data uses current canonical URL, page title, and description.
+- Homepage organization/software/service entities remain intact.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `apps/marketing/src/content/structuredData.test.mjs`
+- `apps/marketing/src/components/blocks/head/partials/StructuredData.astro`
+- `apps/marketing/src/components/blocks/head/Header.astro`
+- `apps/marketing/src/layouts/Layout.astro`
+
+#### Task 4: Correct sitemap freshness signals
+
+**Acceptance criteria:**
+
+- Blog and release entries retain real content dates.
+- Unrelated static pages do not share a fabricated global modification date.
+- Known current comparison dates can be represented without lying about other pages.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `apps/marketing/astro.config.mjs`
+- relevant metadata test file if required
+
+### Checkpoint: Technical SEO
+
+- Tests pass.
+- Production sitemap and JSON-LD checks pass.
+
+### Phase 3: Documentation Value
+
+#### Task 5: Expand thin task documentation
+
+**Acceptance criteria:**
+
+- API Keys explains setup, verification, replacement/removal, common failures, and security boundaries using verified behavior.
+- Installation explains prerequisites, integration choice, success verification, updates, and removal paths where supported.
+- Plans and Todos contains a complete example and clarifies user control and lifecycle.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `apps/marketing/src/content/docs/docs/api-keys.md`
+- `apps/marketing/src/content/docs/docs/installation.md`
+- `apps/marketing/src/content/docs/docs/using/plans-and-todos.md`
+
+#### Task 6: Clarify substantial documentation intent
+
+**Acceptance criteria:**
+
+- Ambiguous titles identify Frontman and the user task.
+- Large pages remove stale or contradictory claims discovered during review.
+- Cross-links establish one reference owner per repeated topic.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** Task 5
+
+**Files likely touched:**
+
+- Up to five reviewed docs files per increment, split if needed
+
+### Checkpoint: Documentation
+
+- Metadata tests and broken-link build pass.
+- New procedures match repository behavior.
+
+### Phase 4: Article Differentiation
+
+#### Task 7: Differentiate runtime-context articles
+
+**Acceptance criteria:**
+
+- `runtime-context-gap` owns technical architecture intent.
+- `ai-coding-agents-blind-to-ui` owns UI-agent problem diagnosis.
+- `introducing-frontman` owns product origin/category introduction.
+- Each article uses distinct examples and links to sibling intent instead of repeating it.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- Three article Markdown files
+- Metadata test if titles or required fields change
+
+#### Task 8: Differentiate collaboration articles
+
+**Acceptance criteria:**
+
+- `edit-website-without-developer` owns governed self-service editing intent.
+- `team-collaboration` owns role and review-process design.
+- `multi-select` owns batch-selection product workflow with concrete constraints and output.
+- Hypothetical timing claims are removed or labeled illustrative.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- Three article Markdown files
+
+#### Task 9: Differentiate tutorials and announcements
+
+**Acceptance criteria:**
+
+- Next.js tutorial provides a reproducible, technically valid walkthrough distinct from integration docs.
+- GPT model announcement becomes sourced release content with durable links to model reference.
+- Lighthouse page removes placeholders and unsupported measurements; examples are reproducible or labeled illustrative.
+- Security article uses verifiable architecture and policy references.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** Task 5
+
+**Files likely touched:**
+
+- Split into increments of at most four article files
+
+#### Task 10: Clarify comparison ownership
+
+**Acceptance criteria:**
+
+- Three-way blog article targets workflow selection across tool classes.
+- `/vs/claude-code/` remains exact two-product comparison owner.
+- Comparison methodology, dates, and sources are explicit.
+- Unresolved table placeholder is removed.
+
+**Verification:** `make test && make build`
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `apps/marketing/src/content/blog/frontman-vs-cursor-vs-claude-code.md`
+- `apps/marketing/src/pages/vs/claude-code.astro`
+- comparison metadata test if needed
+
+### Checkpoint: Content
+
+- Every article URL remains present.
+- Metadata tests and broken-link build pass.
+- Repository search finds no unresolved placeholders in rewritten pages.
+
+### Phase 5: Delivery
+
+#### Task 11: Add changeset and final verification
+
+**Acceptance criteria:**
+
+- Changeset describes indexing, taxonomy, and content-quality improvements.
+- Changed files are formatted.
+- Full marketing test suite and production build pass.
+- Diff review finds no unsupported claims or unrelated changes.
+
+**Verification:**
+
+- `make test`
+- `make build`
+- `yarn prettier --check <changed-files>`
+
+**Dependencies:** Tasks 1-10
+
+**Files likely touched:**
+
+- `.changeset/<generated-name>.md`
+
+## Risks and Mitigations
+
+| Risk                                          | Impact | Mitigation                                                                  |
+| --------------------------------------------- | ------ | --------------------------------------------------------------------------- |
+| Tag thresholds hide useful niche archives     | Medium | Keep routes available and use post-count threshold only for search exposure |
+| Rewrites introduce unsupported claims         | High   | Verify behavior in source; label examples; prefer primary-source links      |
+| Large content diff becomes unreviewable       | High   | Implement by intent cluster and build after each cluster                    |
+| Structured-data change regresses rich results | Medium | Preserve global entities and add current-page identity tests                |
+| Sitemap dates become incomplete               | Low    | Missing truthful dates are preferable to fabricated dates                   |
+| Existing unrelated worktree changes conflict  | Medium | Inspect each touched file and preserve concurrent changes                   |
+
+## Open Questions
+
+None.

--- a/docs/specs/google-index-content-recovery.md
+++ b/docs/specs/google-index-content-recovery.md
@@ -1,0 +1,148 @@
+# Spec: Google Index Content Recovery
+
+## Objective
+
+Improve the independent search value and indexing signals of Frontman's marketing and documentation pages after Google classified 33 sitemap URLs as `Crawled - currently not indexed`.
+
+The work must retain every published article URL and rewrite overlapping articles around distinct search intents. It must reduce low-value taxonomy exposure, strengthen genuinely thin documentation, clarify which page owns each topic, and correct semantic and sitemap signals without adding filler.
+
+## Scope
+
+### Blog taxonomy
+
+- Keep tag routes available for site navigation.
+- Mark tag archives with fewer than three posts as `noindex,follow` and exclude them from sitemap output.
+- Keep only coherent, sufficiently populated tag archives indexable.
+- Stop exposing every thin tag archive through global tag navigation.
+- Give retained indexable archives distinct editorial purpose rather than generic archive copy.
+
+### Overlapping articles
+
+- Retain every published article and URL.
+- Rewrite each overlapping article around a distinct audience, intent, evidence set, and outcome.
+- Remove repeated ticket-delay, click-and-describe, runtime-context, and PR-review passages where they do not serve that page's intent.
+- Replace placeholders and hypothetical performance claims with verifiable examples, source citations, reproducible steps, or explicitly labeled illustrative examples.
+- Establish internal-link hierarchy between conceptual hubs, tutorials, product announcements, and comparison pages.
+
+### Documentation
+
+- Expand genuinely thin pages: API Keys, Installation, and Plans and Todos.
+- Improve task-specific titles and descriptions for ambiguous documentation pages.
+- Keep substantial pages concise and focused; do not add prose solely to increase word count.
+- Verify new procedures and claims against implementation or existing authoritative documentation.
+
+### Commercial and static pages
+
+- Make `/vs/claude-code/` the owner of exact two-product comparison intent while retaining the three-way article for multi-tool workflow selection.
+- Preserve `/features/` content depth and improve its capability-page differentiation.
+- Accept `/terms/` as non-acquisition content; do not pad it for indexing.
+
+### Technical SEO
+
+- Emit page-specific `WebPage` structured data instead of homepage identity on every route.
+- Preserve organization, software, and service entities globally.
+- Emit accurate sitemap `lastmod` values where source dates exist; do not assign one synthetic date to unrelated pages.
+- Add automated tests for tag indexability/sitemap policy and page-specific structured data.
+- Add a changeset describing public marketing and documentation improvements.
+
+## Tech Stack
+
+- Astro 7
+- TypeScript and JavaScript
+- Astro Content Collections and Starlight
+- `@astrojs/sitemap`
+- Vitest
+- Markdown and MDX content
+
+## Commands
+
+- Marketing tests: `make test` from `apps/marketing`
+- Marketing build and Astro checks: `make build` from `apps/marketing`
+- Formatting check for changed files: `yarn prettier --check <changed-files>` from repository root
+- Production-output checks: inspect generated files under `apps/marketing/dist` after build
+
+## Project Structure
+
+- `apps/marketing/src/content/blog/`: published blog articles
+- `apps/marketing/src/content/docs/docs/`: Starlight documentation
+- `apps/marketing/src/pages/blog/tags/`: tag archive routes
+- `apps/marketing/src/components/ui/blog/`: blog taxonomy navigation
+- `apps/marketing/src/components/blocks/head/`: metadata and structured data
+- `apps/marketing/astro.config.mjs`: sitemap and Starlight configuration
+- `apps/marketing/src/content/*.test.mjs`: metadata and content policy tests
+- `.changeset/`: changelog fragments
+
+## Code Style
+
+Follow existing Astro and content conventions. Keep policy logic explicit and local rather than introducing a general SEO framework.
+
+```astro
+---
+const shouldIndex = posts.length >= 3
+---
+
+<Layout noindex={!shouldIndex}>
+  <!-- Existing archive rendering -->
+</Layout>
+```
+
+Content must use concrete, attributable language. Claims based on examples rather than measured production data must be labeled as examples.
+
+## Testing Strategy
+
+- Add a failing content-policy test before changing tag indexability and sitemap behavior.
+- Add a failing structured-data test before changing global `WebPage` output.
+- Extend metadata tests for rewritten article titles, descriptions, and unique intent where practical.
+- Run all existing marketing tests after each behavioral slice.
+- Build production marketing output and verify:
+  - thin tags contain `noindex,follow`;
+  - thin tags are absent from generated sitemaps;
+  - retained tag hubs remain indexable;
+  - non-home pages identify their own canonical URL in structured data;
+  - internal links are valid.
+
+Static Markdown rewrites do not require unit tests individually, but must pass metadata tests, broken-link build checks, and formatting checks.
+
+## Boundaries
+
+### Always
+
+- Preserve all currently published article URLs.
+- Preserve factual product behavior and licensing language.
+- Label illustrative data as illustrative.
+- Keep canonical URLs self-referencing unless a separate redirect decision is approved.
+- Use existing Makefile targets for tests and builds.
+
+### Ask first
+
+- Delete or redirect any published article.
+- Add dependencies.
+- Change product behavior, pricing, licensing, or security policy.
+- Make all tag archives indexable regardless of corpus size.
+
+### Never
+
+- Invent customer results, benchmark outcomes, citations, or product capabilities.
+- Add generic text solely to meet a word-count target.
+- Submit ordinary marketing URLs through Google's restricted Indexing API.
+- Modify unrelated application code.
+
+## Success Criteria
+
+- Every published article URL remains available.
+- Each overlapping article has a distinct primary intent documented by title, opening, structure, and internal-link destination.
+- No unresolved content placeholders remain on rewritten pages.
+- Performance and comparison claims are sourced, reproducible, or explicitly illustrative.
+- Tag archives with fewer than three posts render `noindex,follow` and do not appear in generated sitemap files.
+- Retained tag hubs include meaningful unique editorial organization and do not duplicate another retained hub's purpose.
+- API Keys, Installation, and Plans and Todos provide complete task outcomes, verification, and next steps.
+- Ambiguous documentation titles identify Frontman and user task.
+- `/vs/claude-code/` owns exact Frontman-versus-Claude-Code intent; three-way article owns multi-tool workflow selection.
+- Every rendered page emits correct page-specific `WebPage` URL and identity.
+- Sitemap dates reflect source modification dates where known and omit fabricated dates where unknown.
+- Marketing tests and production build pass.
+- Changeset exists.
+
+## Open Questions
+
+None. User selected rewriting every published page instead of redirects or search exclusion for overlapping articles.


### PR DESCRIPTION
## Summary

- exclude thin tag archives from search and sitemap while keeping useful taxonomy hubs indexable
- add page-specific structured data and truthful sitemap modification dates
- rewrite overlapping articles and expand weak documentation with verified product boundaries
- document security, telemetry, WordPress mutation, and self-hosting behavior accurately

## Verification

- `make test` in `apps/marketing` (26 tests)
- `make build` in `apps/marketing` (145 pages, zero Astro diagnostics, no broken internal links)
- Prettier check for changed files
- final adversarial review: no Critical or Required findings

## Follow-up

After deployment, resubmit `https://frontman.sh/sitemap-index.xml` and monitor Page Indexing for 2-4 weeks.