### PR TITLE
test(nextjs): patch version 16 fixtures

### DIFF
--- a/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
+++ b/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
@@ -20,7 +20,7 @@ let nextVersionForFixture = (fixtureName: string): option<string> => {
   if fixtureName->String.startsWith("nextjs15") {
     Some("15.0.0")
   } else if fixtureName->String.startsWith("nextjs16") {
-    Some("16.2.11")
+    Some("16.0.0")
   } else {
     None
   }
@@ -139,7 +139,7 @@ describe("Project Detection", _t => {
         switch result {
         | Ok(info) =>
           t->expect(info.nextVersion.major)->Expect.toBe(16)
-          t->expect(info.nextVersion.raw)->Expect.toBe("16.2.11")
+          t->expect(info.nextVersion.raw)->Expect.toBe("16.0.0")
         | Error(msg) => t->expect(msg)->Expect.toBe("should not fail")
         }
       },

--- a/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
+++ b/libs/frontman-nextjs/test/cli/FrontmanNextjs__Cli__Install.test.res
@@ -20,7 +20,7 @@ let nextVersionForFixture = (fixtureName: string): option<string> => {
   if fixtureName->String.startsWith("nextjs15") {
     Some("15.0.0")
   } else if fixtureName->String.startsWith("nextjs16") {
-    Some("16.0.0")
+    Some("16.2.11")
   } else {
     None
   }
@@ -139,7 +139,7 @@ describe("Project Detection", _t => {
         switch result {
         | Ok(info) =>
           t->expect(info.nextVersion.major)->Expect.toBe(16)
-          t->expect(info.nextVersion.raw)->Expect.toBe("16.0.0")
+          t->expect(info.nextVersion.raw)->Expect.toBe("16.2.11")
         | Error(msg) => t->expect(msg)->Expect.toBe("should not fail")
         }
       },

--- a/libs/frontman-nextjs/test/cli/fixtures/nextjs16-clean/package.json
+++ b/libs/frontman-nextjs/test/cli/fixtures/nextjs16-clean/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs16-clean",
   "version": "1.0.0",
   "dependencies": {
-    "next": "^16.0.0",
+    "next": "^16.2.11",
     "react": "^19.0.0"
   }
 }

--- a/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-frontman/package.json
+++ b/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-frontman/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs16-with-frontman",
   "version": "1.0.0",
   "dependencies": {
-    "next": "^16.0.0",
+    "next": "^16.2.11",
     "react": "^19.0.0",
     "@frontman-ai/nextjs": "^0.1.0"
   }

--- a/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-proxy/package.json
+++ b/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs16-with-proxy",
   "version": "1.0.0",
   "dependencies": {
-    "next": "^16.0.0",
+    "next": "^16.2.11",
     "react": "^19.0.0"
   }
 }

--- a/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-src/package.json
+++ b/libs/frontman-nextjs/test/cli/fixtures/nextjs16-with-src/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs16-with-src",
   "version": "1.0.0",
   "dependencies": {
-    "next": "16.0.0",
+    "next": "16.2.11",
     "react": "19.0.0",
     "react-dom": "19.0.0"
   }


### PR DESCRIPTION
## Summary
- update Next.js 16 fixture manifests to patched 16.2.11
- preserve installer detection coverage for the earliest supported 16.0 release
- clear test-only Dependabot findings without changing production installer behavior

## Verification
- `make -C libs/frontman-nextjs test` (182 tests)