### PR TITLE
ci(security): add scanning gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,6 @@
 name: CodeQL
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,14 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze JavaScript and TypeScript
+    name: Analyze ${{ matrix.language }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
@@ -24,9 +30,9 @@ jobs:
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3
         with:
           build-mode: none
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
 
       - name: Analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3
         with:
-          category: /language:javascript-typescript
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '23 4 * * 1'
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3
+        with:
+          build-mode: none
+          languages: javascript-typescript
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
+        with:
+          fail-on-scopes: runtime, development, unknown
+          fail-on-severity: moderate
+          license-check: false
+          show-patched-versions: true


### PR DESCRIPTION
## Summary
- run repository-owned CodeQL baselines for GitHub Actions and JavaScript/TypeScript on main pushes and weekly
- rely on the existing organization-managed CodeQL check for pull requests, avoiding duplicate scans
- review dependency diffs on every pull request
- block newly introduced moderate-or-higher vulnerabilities in runtime, development, and unknown scopes
- pin every action to an immutable commit SHA

## Coverage
- CodeQL supports GitHub Actions and JavaScript/TypeScript used in this repository
- CodeQL does not directly support Elixir, ReScript, or PHP source
- tracked ReScript-generated `.mjs` output remains visible to JavaScript analysis

## Verification
- parsed both workflow files with the installed YAML parser
- dependency review workflow passed on this pull request
- organization-managed CodeQL check passed on this pull request
- `make check-source-comments`
- `git diff --check`