### PR TITLE
Characterize safe Custom CSS revision recovery

### DIFF
--- a/.github/workflows/wordpress-compatibility.yml
+++ b/.github/workflows/wordpress-compatibility.yml
@@ -24,15 +24,19 @@ permissions:
   contents: read
 
 jobs:
-  wordpress-7:
-    name: WordPress 7.0.2 / PHP ${{ matrix.php }}
+  wordpress-runtime:
+    name: WordPress ${{ matrix.wordpress }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php:
-          - "7.4"
-          - "8.4"
+        include:
+          - wordpress: "6.0.9"
+            php: "7.4"
+          - wordpress: "7.0.2"
+            php: "7.4"
+          - wordpress: "7.0.2"
+            php: "8.4"
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -47,6 +51,6 @@ jobs:
 
       - name: Run WordPress runtime tests
         env:
-          WORDPRESS_VERSION: "7.0.2"
+          WORDPRESS_VERSION: ${{ matrix.wordpress }}
           PHP_VERSION: ${{ matrix.php }}
         run: bash scripts/test-wordpress-plugin-runtime.sh

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ HELP_release := Create a release PR from pending changesets
 HELP_package-wordpress-plugin := Build WordPress ZIP and WordPress.org bundle
 HELP_publish-wordpress-plugin-svn := Publish WordPress.org bundle to SVN (requires WORDPRESS_ORG_* env vars)
 HELP_test-wordpress-core-tools := Run PHP tests for WordPress tool implementations
-HELP_test-wordpress-runtime := Run plugin integration tests in WordPress 7.0.2 containers
+HELP_test-wordpress-runtime := Run plugin integration tests in WordPress containers
 
 HELP_E2E_TITLE := E2E Tests
 HELP_E2E_TARGETS := e2e e2e-nextjs e2e-astro e2e-vite e2e-vue-vite

--- a/docs/specs/custom-css-revision-recovery.md
+++ b/docs/specs/custom-css-revision-recovery.md
@@ -1,0 +1,104 @@
+# Spec: Custom CSS Revision Recovery
+
+## Objective
+
+Expose safe, theme-scoped recovery for WordPress Additional CSS without claiming
+atomicity, byte identity, revision creation, or retry behavior that WordPress does
+not provide. Public tools are deferred until real WordPress evidence establishes
+the restoration contract.
+
+## Commands
+
+- Isolated tests: `make test-wordpress-core-tools`
+- Minimum runtime: `WORDPRESS_VERSION=6.0.9 PHP_VERSION=7.4 make test-wordpress-runtime`
+- Current runtime: `WORDPRESS_VERSION=7.0.2 PHP_VERSION=7.4 make test-wordpress-runtime`
+- Current PHP runtime: `WORDPRESS_VERSION=7.0.2 PHP_VERSION=8.4 make test-wordpress-runtime`
+- Package: `make package-wordpress-plugin VERSION=2.0.0`
+
+## Project Structure
+
+- `libs/frontman-wordpress/tools/class-tool-options.php`: Additional CSS tools
+- `libs/frontman-wordpress/tests/MutationSnapshotsTest.php`: isolated tool tests
+- `libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php`: real WordPress characterization and contract tests
+- `scripts/test-wordpress-plugin-runtime.sh`: versioned WordPress runtime harness
+- `.github/workflows/wordpress-compatibility.yml`: tested compatibility matrix
+
+## Evidence
+
+The runtime suite establishes these behaviors on WordPress 6.0.9 with PHP 7.4
+and WordPress 7.0.2 with PHP 7.4 and 8.4:
+
+- Initial and changed Custom CSS saves create enumerable revisions when enabled.
+- Enabled-but-empty history and disabled revisions are distinguishable.
+- Revision objects identify their parent; missing and cross-parent revisions can be rejected.
+- A changed active stylesheet resolves a different Custom CSS parent.
+- Generic restore and Custom CSS replay both restore plain `post_content` in the tested default configuration.
+- Both paths created a revision in the tested cases, but creation and retention remain conditional WordPress behavior.
+- Generic restore leaves `post_content_filtered` unchanged and bypasses `update_custom_css_data`.
+- Replaying revision `post_content` invokes `update_custom_css_data`; a test preprocessor double-processes compiled CSS and replaces source with compiled CSS.
+- Generic restore of preprocessor-backed CSS combines historical compiled output with current source.
+- Generic post-save filters can transform persisted `post_content` for both strategies.
+- A SHA-256 mismatch detects a stale state before writing, but another writer can update after that check and be overwritten.
+
+## Restore Strategy
+
+Use `wp_restore_post_revision( $validated_revision, [ 'post_content' ] )` for plain
+CSS. Validate the loaded revision type and parent before passing that revision
+object forward. Restore and verify only `post_content`.
+
+Reject restoration when current `post_content_filtered` is non-empty. WordPress
+revisions do not capture that field by default, so neither candidate can recover
+coherent preprocessor source and compiled output. Do not replay stored compiled CSS
+through `wp_update_custom_css_post()`.
+
+After restoration, clean relevant post cache state and observe the persisted post
+through documented WordPress APIs. Report observed values. Do not call this a
+cache-bypassing database reread or promise that persisted bytes equal revision bytes;
+post-save filters can transform content.
+
+## Public Tool Contract
+
+Phase 2 will preserve current `wp_get_custom_css` fields and add parent ID, byte
+count, SHA-256 fingerprint, modified timestamp, and preprocessor-source presence.
+The fingerprint describes captured `post_content`; it is not a revision ID or lock.
+
+Revision listing requires expected active stylesheet and parent ID. It returns
+revision IDs, parent IDs, dates, byte counts, and SHA-256 fingerprints without full
+CSS. Selected revision inspection returns full content only after stylesheet,
+current parent, revision type, and revision parent validation.
+
+Restore requires `confirm=true`, expected active stylesheet, expected parent ID,
+selected revision ID, and expected current SHA-256. Every precondition runs before
+the write. Hash comparison is best-effort point-in-time conflict detection, not an
+atomic compare-and-swap.
+
+Receipt fields are limited to selected revision ID and observed before/after content
+metadata. No generated revision ID, byte-identity, atomicity, or retry-safety promise
+is allowed. Verification mismatch returns conflict or ambiguity, not success.
+
+## Lost Responses
+
+No durable operation record or idempotency protocol exists in Phase 2. A lost
+mutation response remains ambiguous. Recovery is to read current state, compare
+observed metadata with known before and target states, inspect content when needed,
+and ask the user to decide. Never retry restoration automatically.
+
+## Boundaries
+
+- Always require active stylesheet and current parent checks before revision data is returned.
+- Always require confirmation and expected current state before restoration.
+- Always verify and report observed persisted fields after restoration.
+- Never restore preprocessor-backed CSS while revisions omit source.
+- Never return full stylesheets in revision lists.
+- Never claim atomic conflict detection, unconditional revision creation, idempotency, or safe blind retry.
+
+## Success Criteria
+
+- Real WordPress tests cover plain CSS, preprocessor filters, save transformations, revision availability, scope, stale state, and concurrent writes.
+- CI runs exactly WordPress 6.0.9/PHP 7.4, WordPress 7.0.2/PHP 7.4, and WordPress 7.0.2/PHP 8.4.
+- Phase 2 tools implement the contract above without changing existing Additional CSS response fields.
+- User documentation explains workflow, compatibility, concurrency limits, preprocessor rejection, conditional revision behavior, and lost-response recovery.
+
+## Open Questions
+
+None for Phase 1. Public tools remain gated on review of this evidence and strategy.

--- a/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
@@ -1,0 +1,214 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	throw new RuntimeException( 'WordPress must be loaded before the Custom CSS runtime test.' );
+}
+
+function frontman_custom_css_update( string $stylesheet, string $css, string $preprocessed = '' ): WP_Post {
+	$post = wp_update_custom_css_post(
+		$css,
+		[
+			'stylesheet'   => $stylesheet,
+			'preprocessed' => $preprocessed,
+		]
+	);
+	frontman_runtime_assert( $post instanceof WP_Post, 'Could not update Custom CSS fixture.' );
+	clean_post_cache( $post->ID );
+
+	return get_post( $post->ID, OBJECT, 'raw' );
+}
+
+function frontman_custom_css_revision_with_content( int $parent_id, string $content ): WP_Post {
+	foreach ( wp_get_post_revisions( $parent_id ) as $revision ) {
+		if ( $content === $revision->post_content ) {
+			return $revision;
+		}
+	}
+
+	throw new RuntimeException( 'Expected Custom CSS revision content was not found.' );
+}
+
+function frontman_custom_css_persisted_post( int $post_id ): WP_Post {
+	clean_post_cache( $post_id );
+	$post = get_post( $post_id, OBJECT, 'raw' );
+	frontman_runtime_assert( $post instanceof WP_Post, 'Custom CSS post disappeared.' );
+
+	return $post;
+}
+
+function frontman_characterize_custom_css_revision_history(): void {
+	$stylesheet = 'frontman-runtime-history';
+	$first = frontman_custom_css_update( $stylesheet, '.history { color: red; }' );
+	$first_revisions = wp_get_post_revisions( $first->ID );
+	frontman_runtime_assert( 1 <= count( $first_revisions ), 'Initial Custom CSS save did not create a revision.' );
+
+	frontman_custom_css_update( $stylesheet, '.history { color: blue; }' );
+	$second_revisions = wp_get_post_revisions( $first->ID );
+	frontman_runtime_assert( count( $first_revisions ) < count( $second_revisions ), 'Changed Custom CSS save did not create another revision.' );
+	frontman_custom_css_revision_with_content( $first->ID, '.history { color: red; }' );
+	frontman_custom_css_revision_with_content( $first->ID, '.history { color: blue; }' );
+}
+
+function frontman_characterize_custom_css_revision_availability(): void {
+	$disable_revisions = static function( int $revisions, WP_Post $post ): int {
+		return 'custom_css' === $post->post_type ? 0 : $revisions;
+	};
+	add_filter( 'wp_revisions_to_keep', $disable_revisions, 10, 2 );
+	$disabled = frontman_custom_css_update( 'frontman-runtime-disabled', '.disabled { color: red; }' );
+	frontman_runtime_assert( ! wp_revisions_enabled( $disabled ), 'Custom CSS revisions should be disabled by the test filter.' );
+	frontman_runtime_assert( [] === wp_get_post_revisions( $disabled->ID ), 'Disabled Custom CSS revisions should have no history.' );
+	remove_filter( 'wp_revisions_to_keep', $disable_revisions, 10 );
+
+	$empty_id = wp_insert_post(
+		wp_slash(
+			[
+				'post_title'   => 'frontman-runtime-empty',
+				'post_name'    => 'frontman-runtime-empty',
+				'post_type'    => 'custom_css',
+				'post_status'  => 'publish',
+				'post_content' => '.empty { color: red; }',
+			]
+		),
+		true
+	);
+	frontman_runtime_assert( ! is_wp_error( $empty_id ), 'Could not create empty-history Custom CSS fixture.' );
+	$empty = get_post( $empty_id );
+	frontman_runtime_assert( wp_revisions_enabled( $empty ), 'Custom CSS revisions should be enabled for the empty-history fixture.' );
+	frontman_runtime_assert( [] === wp_get_post_revisions( $empty_id ), 'Directly inserted Custom CSS unexpectedly has revision history.' );
+}
+
+function frontman_characterize_custom_css_revision_scope(): void {
+	$first = frontman_custom_css_update( 'frontman-runtime-parent-one', '.parent-one { color: red; }' );
+	$second = frontman_custom_css_update( 'frontman-runtime-parent-two', '.parent-two { color: blue; }' );
+	$revision = frontman_custom_css_revision_with_content( $first->ID, '.parent-one { color: red; }' );
+	$missing_revision_id = PHP_INT_MAX;
+
+	frontman_runtime_assert( null === wp_get_post_revision( $missing_revision_id ), 'Missing revision lookup should return null.' );
+	frontman_runtime_assert( $first->ID === wp_is_post_revision( $revision ), 'Revision should resolve to its actual Custom CSS parent.' );
+	frontman_runtime_assert( $second->ID !== $revision->post_parent, 'Cross-parent revision fixture unexpectedly matched.' );
+
+	$active_stylesheet = get_stylesheet();
+	$active = frontman_custom_css_update( $active_stylesheet, '.active { color: red; }' );
+	$replacement = frontman_custom_css_update( 'frontman-runtime-replacement-theme', '.replacement { color: blue; }' );
+	$replace_stylesheet = static function(): string {
+		return 'frontman-runtime-replacement-theme';
+	};
+	add_filter( 'pre_option_stylesheet', $replace_stylesheet );
+	frontman_runtime_assert( 'frontman-runtime-replacement-theme' === get_stylesheet(), 'Active stylesheet change simulation failed.' );
+	frontman_runtime_assert( $replacement->ID === wp_get_custom_css_post()->ID, 'Default Custom CSS lookup did not follow changed active stylesheet.' );
+	frontman_runtime_assert( $active->ID !== wp_get_custom_css_post()->ID, 'Stale expected Custom CSS parent still matched after stylesheet change.' );
+	remove_filter( 'pre_option_stylesheet', $replace_stylesheet );
+}
+
+function frontman_characterize_plain_custom_css_restore(): void {
+	$stylesheet = 'frontman-runtime-plain-restore';
+	$target_css = '.plain { color: red; }';
+	$current_css = '.plain { color: blue; }';
+	$post = frontman_custom_css_update( $stylesheet, $target_css );
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, $target_css );
+
+	$before_revision_count = count( wp_get_post_revisions( $post->ID ) );
+	$restored_id = wp_restore_post_revision( $revision, [ 'post_content' ] );
+	frontman_runtime_assert( $post->ID === $restored_id, 'Generic Custom CSS revision restore did not return parent ID.' );
+	$generic = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( $target_css === $generic->post_content, 'Generic restore did not persist plain revision CSS.' );
+	frontman_runtime_assert( '' === $generic->post_content_filtered, 'Generic plain CSS restore changed preprocessor source.' );
+	$generic_created_revision = $before_revision_count < count( wp_get_post_revisions( $post->ID ) );
+
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$before_revision_count = count( wp_get_post_revisions( $post->ID ) );
+	frontman_custom_css_update( $stylesheet, $revision->post_content );
+	$replayed = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( $target_css === $replayed->post_content, 'Custom CSS replay did not persist plain revision CSS.' );
+	frontman_runtime_assert( '' === $replayed->post_content_filtered, 'Plain Custom CSS replay changed preprocessor source.' );
+	$replay_created_revision = $before_revision_count < count( wp_get_post_revisions( $post->ID ) );
+	frontman_runtime_assert( $generic_created_revision, 'Generic restore did not create the observed default-configuration revision.' );
+	frontman_runtime_assert( $replay_created_revision, 'Custom CSS replay did not create the observed default-configuration revision.' );
+
+	fwrite( STDOUT, 'Custom CSS plain restore revision observations: generic=' . ( $generic_created_revision ? 'created' : 'not-created' ) . ', replay=' . ( $replay_created_revision ? 'created' : 'not-created' ) . "\n" );
+}
+
+function frontman_characterize_preprocessor_custom_css_restore(): void {
+	$stylesheet = 'frontman-runtime-preprocessor';
+	$compile = static function( array $data, array $args ) use ( $stylesheet ): array {
+		if ( $stylesheet === $args['stylesheet'] ) {
+			$data['css'] = 'compiled{' . $args['css'] . '}';
+			$data['preprocessed'] = $args['css'];
+		}
+
+		return $data;
+	};
+	add_filter( 'update_custom_css_data', $compile, 10, 2 );
+
+	$post = frontman_custom_css_update( $stylesheet, 'source-v1' );
+	frontman_custom_css_update( $stylesheet, 'source-v2' );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, 'compiled{source-v1}' );
+	frontman_runtime_assert( '' === $revision->post_content_filtered, 'Default revision unexpectedly captured preprocessor source.' );
+
+	wp_restore_post_revision( $revision, [ 'post_content' ] );
+	$generic = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( 'compiled{source-v1}' === $generic->post_content, 'Generic preprocessor restore changed compiled target CSS.' );
+	frontman_runtime_assert( 'source-v2' === $generic->post_content_filtered, 'Generic restore should leave current preprocessor source unchanged.' );
+
+	frontman_custom_css_update( $stylesheet, 'source-v2' );
+	frontman_custom_css_update( $stylesheet, $revision->post_content );
+	$replayed = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( 'compiled{compiled{source-v1}}' === $replayed->post_content, 'Replay did not pass revision CSS through preprocessor filter.' );
+	frontman_runtime_assert( 'compiled{source-v1}' === $replayed->post_content_filtered, 'Replay did not replace preprocessor source with revision CSS.' );
+	remove_filter( 'update_custom_css_data', $compile, 10 );
+}
+
+function frontman_characterize_custom_css_save_transformation(): void {
+	$stylesheet = 'frontman-runtime-save-filter';
+	$target_css = '.filtered { color: red; }';
+	$current_css = '.filtered { color: blue; }';
+	$post = frontman_custom_css_update( $stylesheet, $target_css );
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, $target_css );
+	$transform = static function( array $data ): array {
+		if ( 'custom_css' === $data['post_type'] && '.filtered { color: red; }' === $data['post_content'] ) {
+			$data['post_content'] .= ' /* transformed */';
+		}
+
+		return $data;
+	};
+	add_filter( 'wp_insert_post_data', $transform );
+
+	wp_restore_post_revision( $revision, [ 'post_content' ] );
+	$observed = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( $target_css !== $observed->post_content, 'Save filter did not transform generic restore target.' );
+	frontman_runtime_assert( $target_css . ' /* transformed */' === $observed->post_content, 'Generic restore persisted unexpected transformed CSS.' );
+
+	frontman_custom_css_update( $stylesheet, $current_css );
+	frontman_custom_css_update( $stylesheet, $revision->post_content );
+	$observed = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( $target_css . ' /* transformed */' === $observed->post_content, 'Replay persisted unexpected transformed CSS.' );
+	remove_filter( 'wp_insert_post_data', $transform );
+}
+
+function frontman_characterize_custom_css_conflicts(): void {
+	$stylesheet = 'frontman-runtime-conflict';
+	$post = frontman_custom_css_update( $stylesheet, '.conflict { color: red; }' );
+	frontman_custom_css_update( $stylesheet, '.conflict { color: blue; }' );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, '.conflict { color: red; }' );
+	$expected_hash = hash( 'sha256', frontman_custom_css_persisted_post( $post->ID )->post_content );
+
+	frontman_custom_css_update( $stylesheet, '.conflict { color: green; }' );
+	$current_hash = hash( 'sha256', frontman_custom_css_persisted_post( $post->ID )->post_content );
+	frontman_runtime_assert( $expected_hash !== $current_hash, 'Stale expected Custom CSS state was not detectable.' );
+
+	$checked_hash = $current_hash;
+	frontman_custom_css_update( $stylesheet, '.conflict { color: purple; }' );
+	frontman_runtime_assert( $checked_hash !== hash( 'sha256', frontman_custom_css_persisted_post( $post->ID )->post_content ), 'Concurrent Custom CSS write simulation failed.' );
+	wp_restore_post_revision( $revision, [ 'post_content' ] );
+	frontman_runtime_assert( '.conflict { color: red; }' === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Generic restore did not overwrite simulated concurrent write.' );
+}
+
+frontman_characterize_custom_css_revision_history();
+frontman_characterize_custom_css_revision_availability();
+frontman_characterize_custom_css_revision_scope();
+frontman_characterize_plain_custom_css_restore();
+frontman_characterize_preprocessor_custom_css_restore();
+frontman_characterize_custom_css_save_transformation();
+frontman_characterize_custom_css_conflicts();

--- a/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
@@ -11,4 +11,7 @@ set_error_handler(
 
 require '/var/www/html/wp-load.php';
 require '/tmp/WordPressRuntimeTest.php';
+require '/tmp/CustomCssRuntimeTest.php';
 restore_error_handler();
+
+fwrite( STDOUT, 'OK (WordPress ' . get_bloginfo( 'version' ) . ', PHP ' . PHP_VERSION . ")\n" );

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -10,7 +10,9 @@ function frontman_runtime_assert( bool $condition, string $message ): void {
 	}
 }
 
-frontman_runtime_assert( '7.0.2' === get_bloginfo( 'version' ), 'Runtime must use WordPress 7.0.2.' );
+$expected_wordpress_version = getenv( 'EXPECTED_WORDPRESS_VERSION' );
+frontman_runtime_assert( false !== $expected_wordpress_version, 'Expected WordPress version was not provided.' );
+frontman_runtime_assert( $expected_wordpress_version === get_bloginfo( 'version' ), 'Runtime WordPress version does not match the requested version.' );
 frontman_runtime_assert( defined( 'FRONTMAN_VERSION' ), 'Frontman plugin was not activated.' );
 frontman_runtime_assert( null !== Frontman_Tools::instance()->get( 'wp_list_navigation_menus' ), 'Plugin bootstrap did not register navigation tools during init.' );
 
@@ -20,7 +22,7 @@ $post_id = wp_insert_post(
 	[
 		'post_type' => 'page',
 		'post_status' => 'publish',
-		'post_title' => 'Frontman WordPress 7 Runtime',
+		'post_title' => 'Frontman WordPress Runtime',
 		'post_content' => $content,
 	],
 	true
@@ -93,5 +95,3 @@ frontman_runtime_assert( 1 <= count( $menu_tool->list_navigation_menus( [] ) ), 
 $deleted = $menu_tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => true ] );
 frontman_runtime_assert( 'Updated Runtime Navigation' === $deleted['before']['title'], 'Navigation deletion did not preserve its snapshot.' );
 frontman_runtime_assert( null === get_post( $created['id'] ), 'Navigation tool did not permanently delete the post.' );
-
-fwrite( STDOUT, "OK (WordPress 7.0.2, PHP " . PHP_VERSION . ")\n" );

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -57,9 +57,19 @@ done
 "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/plugins/frontman-agentic-ai-editor
 "$RUNTIME" cp "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/." "$WORDPRESS:/var/www/html/wp-content/plugins/frontman-agentic-ai-editor/"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php" "$WORDPRESS:/tmp/WordPressRuntimeTest.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php" "$WORDPRESS:/tmp/CustomCssRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php" "$WORDPRESS:/tmp/RunWordPressRuntimeTest.php"
 
-"$RUNTIME" exec "$WORDPRESS" php -r 'define("WP_INSTALLING", true); require "/var/www/html/wp-load.php"; require_once ABSPATH . "wp-admin/includes/upgrade.php"; if (!is_blog_installed()) { wp_install("Frontman Runtime", "admin", "admin@example.test", true, "", "frontman-runtime-password"); }'
+"$RUNTIME" exec "$WORDPRESS" php -r 'define("WP_INSTALLING", true); define("WP_SITEURL", "http://frontman-runtime.example.test"); require "/var/www/html/wp-load.php"; require_once ABSPATH . "wp-admin/includes/upgrade.php"; if (!is_blog_installed()) { wp_install("Frontman Runtime", "admin", "admin@example.test", true, "", "frontman-runtime-password"); }'
+"$RUNTIME" exec "$WORDPRESS" php -r '$db = new mysqli(getenv("WORDPRESS_DB_HOST"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_NAME")); $result = $db->query("SELECT option_value FROM wp_options WHERE option_name = '\''siteurl'\''"); $row = $result ? $result->fetch_row() : false; if (!$row || !$row[0]) { throw new RuntimeException("WordPress installation did not persist a site URL."); }'
 "$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/ActivateWordPressPlugin.php
-"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/RunWordPressRuntimeTest.php
+TEST_OUTPUT="$("$RUNTIME" exec \
+  -e EXPECTED_WORDPRESS_VERSION="$WORDPRESS_VERSION" \
+  "$WORDPRESS" \
+  php -d display_errors=1 -d error_reporting=E_ALL /tmp/RunWordPressRuntimeTest.php)"
+printf '%s\n' "$TEST_OUTPUT"
+if [[ "$TEST_OUTPUT" != *"OK (WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
+  printf 'WordPress runtime tests did not report successful completion.\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- parameterize real WordPress runtime tests across the bounded compatibility matrix
- characterize Custom CSS revision history, scoping, plain restoration, preprocessors, save filters, stale state, and concurrent writes
- select generic `post_content` restoration for plain CSS and document preprocessor rejection and recovery limits

This is PR 1 of the issue plan. It establishes and records the contract; public recovery tools remain gated for PR 2.

## Evidence

- `wp_restore_post_revision($revision, ["post_content"])` restores plain CSS on every tested runtime
- replay through `wp_update_custom_css_post()` can double-process compiled CSS
- generic restoration leaves current preprocessor source paired with historical compiled output
- expected SHA-256 checks detect stale state but are not atomic
- revision creation was observed on the tested defaults but remains conditional behavior

## Verification

- `make test-wordpress-core-tools` in PHP 7.4 container
- `WORDPRESS_VERSION=6.0.9 PHP_VERSION=7.4 make test-wordpress-runtime`
- `WORDPRESS_VERSION=7.0.2 PHP_VERSION=7.4 make test-wordpress-runtime`
- `WORDPRESS_VERSION=7.0.2 PHP_VERSION=8.4 make test-wordpress-runtime`
- `make package-wordpress-plugin VERSION=2.0.0`
- `git diff --check`

Refs #1360