### PR TITLE
Add safe Custom CSS revision recovery

### DIFF
--- a/.changeset/add-wordpress-custom-css-recovery.md
+++ b/.changeset/add-wordpress-custom-css-recovery.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Add theme-scoped WordPress Additional CSS revision listing, inspection, and confirmed restoration with current-state conflict detection and observed before/after fingerprints.

--- a/apps/marketing/src/content/docs/docs/integrations/wordpress.md
+++ b/apps/marketing/src/content/docs/docs/integrations/wordpress.md
@@ -49,7 +49,7 @@ This inventory reflects Frontman WordPress plugin 2.0.0 source, verified July 30
 - **Elementor, when active:** inspect page data and widgets; add, update, duplicate, move, remove, or generate elements; replace complete page data; flush generated CSS; list and restore Frontman rollback snapshots.
 - **Navigation, templates, and widgets:** manage classic menus, menu items, menu locations, block-theme navigation menus, block templates, template parts, widget areas, and supported widget types.
 - **Site settings:** read and update allowlisted core options such as title, tagline, front-page selection, permalink structure, and comment settings. Arbitrary option access is not available.
-- **Additional CSS:** read active-theme Additional CSS and replace its complete contents with `wp_update_custom_css`. This site-wide write requires explicit confirmation and returns before/after CSS.
+- **Additional CSS:** read and replace active-theme Additional CSS. Frontman can also list, inspect, and restore WordPress Custom CSS revisions for plain CSS.
 - **Theme settings:** list active-theme Customizer/theme mods or read one mod. Plugin 2.0.0 does not expose a generic theme-mod write tool.
 - **Media:** upload a user-attached image into Media Library with optional title, alt text, caption, description, and parent post. Maximum decoded upload size is 20 MB. Plugin does not expose general media browsing, editing, or deletion tools.
 - **WooCommerce, when active:** `wc_*` tools cover products, categories, tags, attributes and terms, variations, reviews, orders, notes, refunds, customers, shipping, taxes, coupons, payment gateways, reports, settings, system status, store data, and product/order/customer metadata.
@@ -57,11 +57,32 @@ This inventory reflects Frontman WordPress plugin 2.0.0 source, verified July 30
 
 ## Confirmation and Rollback
 
-- Frontman must ask for approval before calling plugin tools whose schema requires `confirm=true`. This includes WordPress delete tools, complete Elementor page replacement, Elementor element removal and rollback restoration, Additional CSS replacement, and WooCommerce `PUT`/`DELETE` mutations plus metadata updates/deletes.
+- Frontman must ask for approval before calling plugin tools whose schema requires `confirm=true`. This includes WordPress delete tools, Elementor restoration, Additional CSS writes, and WooCommerce mutations.
 - Post and page deletion moves content to trash by default; `force=true` permanently deletes it. Other delete tools do not promise trash or automatic restoration.
 - Many mutation results include before/after state for review, but those snapshots are not a general undo system.
 - Elementor content mutation tools save private rollback snapshots and return rollback IDs. `wp_elementor_list_rollbacks` finds them; `wp_elementor_restore_rollback` restores one after separate confirmation.
-- No plugin-wide one-click rollback exists for Gutenberg, menus, templates, widgets, options, Additional CSS, media, or WooCommerce. Use WordPress revisions/trash where applicable and maintain site backups.
+- No plugin-wide one-click rollback exists for Gutenberg, menus, templates, widgets, options, media, or WooCommerce. Use revisions or trash where applicable, and maintain site backups.
+
+### Restore an Additional CSS revision
+
+Frontman uses this sequence for Additional CSS recovery:
+
+1. Read current CSS with `wp_get_custom_css`.
+2. List revision metadata with `wp_list_custom_css_revisions`.
+3. Inspect one revision with `wp_get_custom_css_revision`.
+4. Ask for approval to restore that revision.
+5. Restore it with `wp_restore_custom_css_revision` and `confirm=true`.
+6. Read current CSS again and compare the observed fingerprint.
+
+The restore tool requires the active stylesheet, current parent post ID, selected revision ID, and current SHA-256 fingerprint. These values prevent known stale writes. The fingerprint check is not an atomic lock. Another writer can change CSS after the check.
+
+Restoration supports plain CSS only. Frontman rejects restoration when WordPress stores preprocessor source in `post_content_filtered`. WordPress revisions do not contain this source by default.
+
+WordPress settings control revision creation and retention. A restore can create a revision, but Frontman does not promise this result. WordPress save filters can also transform restored CSS. Frontman returns the content metadata that it observes after the write.
+
+Do not retry a restore after a lost response. Read current CSS, compare it with the known prior and target fingerprints, inspect content if necessary, and ask the user what to do.
+
+This recovery flow has runtime coverage on WordPress 6.0.9 with PHP 7.4, WordPress 7.0.2 with PHP 7.4, and WordPress 7.0.2 with PHP 8.4. This matrix does not claim coverage for every intermediate version.
 
 ## Security
 

--- a/docs/specs/custom-css-revision-recovery.md
+++ b/docs/specs/custom-css-revision-recovery.md
@@ -4,8 +4,7 @@
 
 Expose safe, theme-scoped recovery for WordPress Additional CSS without claiming
 atomicity, byte identity, revision creation, or retry behavior that WordPress does
-not provide. Public tools are deferred until real WordPress evidence establishes
-the restoration contract.
+not provide. Real WordPress evidence defines the public restoration contract.
 
 ## Commands
 
@@ -58,7 +57,7 @@ post-save filters can transform content.
 
 ## Public Tool Contract
 
-Phase 2 will preserve current `wp_get_custom_css` fields and add parent ID, byte
+Public tools preserve current `wp_get_custom_css` fields and add parent ID, byte
 count, SHA-256 fingerprint, modified timestamp, and preprocessor-source presence.
 The fingerprint describes captured `post_content`; it is not a revision ID or lock.
 
@@ -96,9 +95,9 @@ and ask the user to decide. Never retry restoration automatically.
 
 - Real WordPress tests cover plain CSS, preprocessor filters, save transformations, revision availability, scope, stale state, and concurrent writes.
 - CI runs exactly WordPress 6.0.9/PHP 7.4, WordPress 7.0.2/PHP 7.4, and WordPress 7.0.2/PHP 8.4.
-- Phase 2 tools implement the contract above without changing existing Additional CSS response fields.
+- Public tools implement the contract above without changing existing Additional CSS response fields.
 - User documentation explains workflow, compatibility, concurrency limits, preprocessor rejection, conditional revision behavior, and lost-response recovery.
 
 ## Open Questions
 
-None for Phase 1. Public tools remain gated on review of this evidence and strategy.
+None. The evidence gate is complete, and the public tools implement this strategy.

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -249,12 +249,20 @@ class Frontman_Tools {
 				);
 
 			case 'integer':
+				if ( $preserve_input_strings && ! is_int( $value ) ) {
+					return $value;
+				}
+
 				return (int) $value;
 
 			case 'number':
 				return (float) $value;
 
 			case 'boolean':
+				if ( $preserve_input_strings && ! is_bool( $value ) ) {
+					return $value;
+				}
+
 				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 
 			case 'string':

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -259,7 +259,7 @@ class Frontman_Tools {
 				return (float) $value;
 
 			case 'boolean':
-				if ( $preserve_input_strings && ! is_bool( $value ) ) {
+				if ( $preserve_input_strings && 'confirm' === $field_name && ! is_bool( $value ) ) {
 					return $value;
 				}
 

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -6,6 +6,11 @@ $GLOBALS['frontman_test_posts'] = [];
 $GLOBALS['frontman_test_meta'] = [];
 $GLOBALS['frontman_test_options'] = [];
 $GLOBALS['frontman_test_custom_css'] = [];
+$GLOBALS['frontman_test_custom_css_posts'] = [];
+$GLOBALS['frontman_test_custom_css_revisions'] = [];
+$GLOBALS['frontman_test_revisions_enabled'] = [];
+$GLOBALS['frontman_test_custom_css_restore_count'] = 0;
+$GLOBALS['frontman_test_custom_css_restore_transform'] = null;
 $GLOBALS['frontman_test_theme_mods'] = [];
 $GLOBALS['frontman_test_menu_terms'] = [];
 $GLOBALS['frontman_test_menu_item_to_term'] = [];
@@ -117,7 +122,16 @@ if ( ! function_exists( 'get_permalink' ) ) {
 
 if ( ! function_exists( 'get_post' ) ) {
 	function get_post( int $id ) {
-		return $GLOBALS['frontman_test_posts'][ $id ] ?? null;
+		if ( isset( $GLOBALS['frontman_test_posts'][ $id ] ) ) {
+			return $GLOBALS['frontman_test_posts'][ $id ];
+		}
+		foreach ( $GLOBALS['frontman_test_custom_css_posts'] as $post ) {
+			if ( $id === (int) $post->ID ) {
+				return $post;
+			}
+		}
+
+		return null;
 	}
 }
 
@@ -320,6 +334,13 @@ if ( ! function_exists( 'wp_get_custom_css' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_get_custom_css_post' ) ) {
+	function wp_get_custom_css_post( string $stylesheet = '' ) {
+		$stylesheet = '' === $stylesheet ? get_stylesheet() : $stylesheet;
+		return $GLOBALS['frontman_test_custom_css_posts'][ $stylesheet ] ?? null;
+	}
+}
+
 if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
 	function wp_update_custom_css_post( string $css, array $args = [] ) {
 		$stylesheet = $args['stylesheet'] ?? get_stylesheet();
@@ -327,8 +348,65 @@ if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
 		$post = new WP_Post();
 		$post->ID = 9001;
 		$post->post_type = 'custom_css';
+		$post->post_name = $stylesheet;
 		$post->post_content = $css;
+		$post->post_content_filtered = '';
+		$post->post_modified_gmt = '2026-03-24 12:00:00';
+		$GLOBALS['frontman_test_custom_css_posts'][ $stylesheet ] = $post;
 		return $post;
+	}
+}
+
+if ( ! function_exists( 'wp_revisions_enabled' ) ) {
+	function wp_revisions_enabled( WP_Post $post ): bool {
+		return $GLOBALS['frontman_test_revisions_enabled'][ $post->ID ] ?? true;
+	}
+}
+
+if ( ! function_exists( 'wp_get_post_revisions' ) ) {
+	function wp_get_post_revisions( int $parent_id ): array {
+		return array_values( array_filter( $GLOBALS['frontman_test_custom_css_revisions'], static function( WP_Post $revision ) use ( $parent_id ): bool {
+			return $parent_id === $revision->post_parent;
+		} ) );
+	}
+}
+
+if ( ! function_exists( 'wp_get_post_revision' ) ) {
+	function wp_get_post_revision( int $revision_id ) {
+		return $GLOBALS['frontman_test_custom_css_revisions'][ $revision_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'wp_is_post_revision' ) ) {
+	function wp_is_post_revision( $revision ) {
+		return $revision instanceof WP_Post && 'revision' === $revision->post_type ? $revision->post_parent : false;
+	}
+}
+
+if ( ! function_exists( 'clean_post_cache' ) ) {
+	function clean_post_cache( int $post_id ): void {}
+}
+
+if ( ! function_exists( 'wp_restore_post_revision' ) ) {
+	function wp_restore_post_revision( WP_Post $revision, ?array $fields = null ) {
+		$GLOBALS['frontman_test_custom_css_restore_count']++;
+		$parent_id = (int) $revision->post_parent;
+		foreach ( $GLOBALS['frontman_test_custom_css_posts'] as $stylesheet => $post ) {
+			if ( $parent_id !== (int) $post->ID ) {
+				continue;
+			}
+
+			$content = (string) $revision->post_content;
+			if ( is_callable( $GLOBALS['frontman_test_custom_css_restore_transform'] ) ) {
+				$content = ( $GLOBALS['frontman_test_custom_css_restore_transform'] )( $content );
+			}
+			$post->post_content = $content;
+			$post->post_modified_gmt = '2026-03-24 13:00:00';
+			$GLOBALS['frontman_test_custom_css'][ $stylesheet ] = $content;
+			return $parent_id;
+		}
+
+		return false;
 	}
 }
 
@@ -662,6 +740,22 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$GLOBALS['frontman_test_options']['blogname'] = 'Old Blog Name';
 		$GLOBALS['frontman_test_options']['stylesheet'] = 'frontman-theme';
 		$GLOBALS['frontman_test_custom_css']['frontman-theme'] = '.old { color: red; }';
+		$custom_css_post = new WP_Post();
+		$custom_css_post->ID = 9001;
+		$custom_css_post->post_type = 'custom_css';
+		$custom_css_post->post_name = 'frontman-theme';
+		$custom_css_post->post_content = '.old { color: red; }';
+		$custom_css_post->post_content_filtered = '$old-color: red;';
+		$custom_css_post->post_modified_gmt = '2026-03-24 10:30:00';
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme'] = $custom_css_post;
+		$custom_css_revision = new WP_Post();
+		$custom_css_revision->ID = 9101;
+		$custom_css_revision->post_parent = 9001;
+		$custom_css_revision->post_type = 'revision';
+		$custom_css_revision->post_content = '.old { color: blue; }';
+		$custom_css_revision->post_date = '2026-03-23 11:00:00';
+		$custom_css_revision->post_date_gmt = '2026-03-23 15:00:00';
+		$GLOBALS['frontman_test_custom_css_revisions'][9101] = $custom_css_revision;
 		$GLOBALS['frontman_test_theme_mods'] = [
 			'header_image' => 'https://example.com/header.jpg',
 			'page_title_enabled' => true,
@@ -973,6 +1067,182 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$current_css = $tool->get_custom_css( [] );
 		$this->assert_same( 'frontman-theme', $current_css['stylesheet'], 'wp_get_custom_css returns active stylesheet' );
 		$this->assert_same( '.old { color: red; }', $current_css['css'], 'wp_get_custom_css reads Additional CSS' );
+		$this->assert_same( 9001, $current_css['parent_post_id'], 'wp_get_custom_css returns active Custom CSS post ID' );
+		$this->assert_same( strlen( '.old { color: red; }' ), $current_css['persisted_css_bytes'], 'wp_get_custom_css counts exact persisted CSS bytes' );
+		$this->assert_same( hash( 'sha256', '.old { color: red; }' ), $current_css['persisted_css_sha256'], 'wp_get_custom_css fingerprints exact persisted CSS' );
+		$this->assert_same( '2026-03-24 10:30:00', $current_css['post_modified_gmt'], 'wp_get_custom_css returns observed Custom CSS modification time' );
+		$this->assert_same( true, $current_css['preprocessor_source_present'], 'wp_get_custom_css reports preprocessor source without returning it' );
+		$this->assert_true( ! array_key_exists( 'preprocessor_source', $current_css ), 'wp_get_custom_css does not expose preprocessor source' );
+
+		$missing_css = $tool->get_custom_css( [ 'stylesheet' => 'theme-without-custom-css' ] );
+		$this->assert_same( '', $missing_css['css'], 'wp_get_custom_css preserves empty CSS for a missing Custom CSS post' );
+		$this->assert_same( null, $missing_css['parent_post_id'], 'wp_get_custom_css explicitly reports a missing Custom CSS post' );
+		$this->assert_same( 0, $missing_css['persisted_css_bytes'], 'wp_get_custom_css reports zero persisted bytes for a missing post' );
+		$this->assert_same( hash( 'sha256', '' ), $missing_css['persisted_css_sha256'], 'wp_get_custom_css fingerprints captured empty content for a missing post' );
+		$this->assert_same( null, $missing_css['post_modified_gmt'], 'wp_get_custom_css reports no modification time for a missing post' );
+		$this->assert_same( false, $missing_css['preprocessor_source_present'], 'wp_get_custom_css reports no preprocessor source for a missing post' );
+
+		$revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
+		$this->assert_same( 'available', $revisions['status'], 'wp_list_custom_css_revisions reports available history' );
+		$this->assert_same( true, $revisions['revisions_enabled'], 'wp_list_custom_css_revisions reports revision support' );
+		$this->assert_same( 9101, $revisions['revisions'][0]['revision_id'], 'wp_list_custom_css_revisions returns revision ID' );
+		$this->assert_same( 9001, $revisions['revisions'][0]['parent_post_id'], 'wp_list_custom_css_revisions returns revision parent' );
+		$this->assert_same( '2026-03-23 11:00:00', $revisions['revisions'][0]['post_date'], 'wp_list_custom_css_revisions returns revision date' );
+		$this->assert_same( strlen( '.old { color: blue; }' ), $revisions['revisions'][0]['css_bytes'], 'wp_list_custom_css_revisions counts revision CSS bytes' );
+		$this->assert_same( hash( 'sha256', '.old { color: blue; }' ), $revisions['revisions'][0]['css_sha256'], 'wp_list_custom_css_revisions fingerprints revision CSS' );
+		$this->assert_true( ! array_key_exists( 'css', $revisions['revisions'][0] ), 'wp_list_custom_css_revisions omits full CSS' );
+
+		$revision = $tool->get_custom_css_revision( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001, 'revision_id' => 9101 ] );
+		$this->assert_same( '.old { color: blue; }', $revision['css'], 'wp_get_custom_css_revision returns selected revision CSS' );
+		$this->assert_same( hash( 'sha256', '.old { color: blue; }' ), $revision['css_sha256'], 'wp_get_custom_css_revision fingerprints selected revision CSS' );
+		$custom_css_revision = $GLOBALS['frontman_test_custom_css_revisions'][9101];
+
+		$GLOBALS['frontman_test_custom_css_revisions'] = [];
+		$no_revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
+		$this->assert_same( 'no_revisions', $no_revisions['status'], 'wp_list_custom_css_revisions distinguishes enabled empty history' );
+		$GLOBALS['frontman_test_revisions_enabled'][9001] = false;
+		$disabled_revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
+		$this->assert_same( 'revisions_disabled', $disabled_revisions['status'], 'wp_list_custom_css_revisions distinguishes disabled revisions' );
+		$GLOBALS['frontman_test_revisions_enabled'][9001] = true;
+		$GLOBALS['frontman_test_custom_css_revisions'][9101] = $custom_css_revision;
+
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->list_custom_css_revisions( [ 'stylesheet' => 'inactive-theme', 'parent_post_id' => 9001 ] );
+			},
+			'active stylesheet',
+			'wp_list_custom_css_revisions rejects inactive stylesheets'
+		);
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9999 ] );
+			},
+			'parent post',
+			'wp_list_custom_css_revisions rejects stale parent IDs'
+		);
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->get_custom_css_revision( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001, 'revision_id' => 9999 ] );
+			},
+			'not found',
+			'wp_get_custom_css_revision rejects missing revisions'
+		);
+		$cross_parent_revision = clone $custom_css_revision;
+		$cross_parent_revision->ID = 9102;
+		$cross_parent_revision->post_parent = 9999;
+		$GLOBALS['frontman_test_custom_css_revisions'][9102] = $cross_parent_revision;
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->get_custom_css_revision( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001, 'revision_id' => 9102 ] );
+			},
+			'does not belong',
+			'wp_get_custom_css_revision rejects cross-parent revisions'
+		);
+
+		$revision_registry = new Frontman_Tools();
+		( new Frontman_Tool_Options() )->register( $revision_registry );
+		$this->assert_same( 'read', $revision_registry->get( 'wp_list_custom_css_revisions' )->access, 'wp_list_custom_css_revisions infers read access' );
+		$this->assert_same( 'read', $revision_registry->get( 'wp_get_custom_css_revision' )->access, 'wp_get_custom_css_revision infers read access' );
+		$this->assert_same( [ 'stylesheet', 'parent_post_id' ], $revision_registry->get( 'wp_list_custom_css_revisions' )->input_schema['required'], 'wp_list_custom_css_revisions requires scope inputs' );
+		$this->assert_same( [ 'stylesheet', 'parent_post_id', 'revision_id' ], $revision_registry->get( 'wp_get_custom_css_revision' )->input_schema['required'], 'wp_get_custom_css_revision requires scope and revision inputs' );
+		$this->assert_same( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ], $revision_registry->sanitize_input( 'wp_list_custom_css_revisions', [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001, 'unexpected' => 'drop-me' ] ), 'wp_list_custom_css_revisions rejects extra properties' );
+		$this->assert_tool_error_result_contains(
+			$revision_registry->call( 'wp_list_custom_css_revisions', $revision_registry->sanitize_input( 'wp_list_custom_css_revisions', [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => '9001junk' ] ) ),
+			'positive integer',
+			'wp_list_custom_css_revisions rejects malformed parent IDs through registry sanitization'
+		);
+		$this->assert_tool_error_result_contains(
+			$revision_registry->call( 'wp_get_custom_css_revision', $revision_registry->sanitize_input( 'wp_get_custom_css_revision', [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001, 'revision_id' => '9101junk' ] ) ),
+			'positive integer',
+			'wp_get_custom_css_revision rejects malformed revision IDs through registry sanitization'
+		);
+
+		$restore_input = [
+			'stylesheet' => 'frontman-theme',
+			'parent_post_id' => 9001,
+			'revision_id' => 9101,
+			'expected_current_sha256' => hash( 'sha256', '.old { color: red; }' ),
+			'confirm' => true,
+		];
+		$this->assert_error_contains(
+			static function() use ( $tool, $restore_input ) {
+				$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'confirm' => false ] ) );
+			},
+			'confirm=true',
+			'wp_restore_custom_css_revision requires confirmation'
+		);
+		$this->assert_error_contains(
+			static function() use ( $tool, $restore_input ) {
+				$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'expected_current_sha256' => hash( 'sha256', 'stale' ) ] ) );
+			},
+			'changed',
+			'wp_restore_custom_css_revision rejects stale current CSS'
+		);
+		$this->assert_error_contains(
+			static function() use ( $tool, $restore_input ) {
+				$tool->restore_custom_css_revision( $restore_input );
+			},
+			'preprocessor',
+			'wp_restore_custom_css_revision rejects preprocessor-backed CSS'
+		);
+		$this->assert_same( 0, $GLOBALS['frontman_test_custom_css_restore_count'], 'Failed restore preconditions do not call WordPress restore API' );
+
+		$valid_custom_css_post = $GLOBALS['frontman_test_custom_css_posts']['frontman-theme'];
+		$poisoned_post = clone $valid_custom_css_post;
+		$poisoned_post->ID = 42;
+		$poisoned_post->post_type = 'page';
+		$poisoned_post->post_name = 'unrelated-page';
+		$poisoned_post->post_content = 'private page content';
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme'] = $poisoned_post;
+		$this->assert_error_contains(
+			static function() use ( $tool ) {
+				$tool->get_custom_css( [ 'stylesheet' => 'frontman-theme' ] );
+			},
+			'invalid post',
+			'wp_get_custom_css rejects a poisoned Custom CSS post pointer'
+		);
+		$this->assert_error_contains(
+			static function() use ( $tool, $restore_input ) {
+				$tool->restore_custom_css_revision( $restore_input );
+			},
+			'invalid post',
+			'wp_restore_custom_css_revision rejects a poisoned Custom CSS post pointer'
+		);
+		$this->assert_same( 0, $GLOBALS['frontman_test_custom_css_restore_count'], 'Poisoned scope does not call WordPress restore API' );
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme'] = $valid_custom_css_post;
+
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme']->post_content_filtered = '';
+		$string_confirmation = $revision_registry->call(
+			'wp_restore_custom_css_revision',
+			$revision_registry->sanitize_input( 'wp_restore_custom_css_revision', array_merge( $restore_input, [ 'confirm' => 'true' ] ) )
+		);
+		$this->assert_tool_error_result_contains( $string_confirmation, 'confirm=true', 'wp_restore_custom_css_revision rejects string confirmation through registry sanitization' );
+		$this->assert_same( 0, $GLOBALS['frontman_test_custom_css_restore_count'], 'String confirmation does not call WordPress restore API' );
+
+		$restored = $tool->restore_custom_css_revision( $restore_input );
+		$this->assert_same( [ 'selected_revision_id', 'before', 'after' ], array_keys( $restored ), 'wp_restore_custom_css_revision limits its receipt to observed metadata' );
+		$this->assert_same( 9101, $restored['selected_revision_id'], 'wp_restore_custom_css_revision reports selected revision ID' );
+		$this->assert_same( hash( 'sha256', '.old { color: red; }' ), $restored['before']['persisted_css_sha256'], 'wp_restore_custom_css_revision reports observed prior fingerprint' );
+		$this->assert_same( hash( 'sha256', '.old { color: blue; }' ), $restored['after']['persisted_css_sha256'], 'wp_restore_custom_css_revision reports observed restored fingerprint' );
+		$this->assert_same( 1, $GLOBALS['frontman_test_custom_css_restore_count'], 'Successful restore calls WordPress restore API once' );
+
+		wp_update_custom_css_post( '.current { color: green; }', [ 'stylesheet' => 'frontman-theme' ] );
+		$GLOBALS['frontman_test_custom_css_restore_transform'] = static function( string $css ): string {
+			return $css . ' /* transformed */';
+		};
+		$transformed = $tool->restore_custom_css_revision( array_merge( $restore_input, [ 'expected_current_sha256' => hash( 'sha256', '.current { color: green; }' ) ] ) );
+		$this->assert_same( hash( 'sha256', '.old { color: blue; } /* transformed */' ), $transformed['after']['persisted_css_sha256'], 'wp_restore_custom_css_revision reports transformed persisted output' );
+		$GLOBALS['frontman_test_custom_css_restore_transform'] = null;
+		wp_update_custom_css_post( '.old { color: red; }', [ 'stylesheet' => 'frontman-theme' ] );
+
+		$this->assert_same( 'read-write', $revision_registry->get( 'wp_restore_custom_css_revision' )->access, 'wp_restore_custom_css_revision infers mutation access' );
+		$this->assert_same( [ 'stylesheet', 'parent_post_id', 'revision_id', 'expected_current_sha256', 'confirm' ], $revision_registry->get( 'wp_restore_custom_css_revision' )->input_schema['required'], 'wp_restore_custom_css_revision requires every safety input' );
+		$this->assert_same( $restore_input, $revision_registry->sanitize_input( 'wp_restore_custom_css_revision', array_merge( $restore_input, [ 'unexpected' => 'drop-me' ] ) ), 'wp_restore_custom_css_revision rejects extra properties' );
+		$this->assert_tool_error_result_contains(
+			$revision_registry->call( 'wp_restore_custom_css_revision', $revision_registry->sanitize_input( 'wp_restore_custom_css_revision', array_merge( $restore_input, [ 'revision_id' => '9101junk' ] ) ) ),
+			'positive integer',
+			'wp_restore_custom_css_revision rejects malformed revision IDs through registry sanitization'
+		);
 
 		$this->assert_error_contains(
 			static function() use ( $tool ) {

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -364,7 +364,7 @@ if ( ! function_exists( 'wp_revisions_enabled' ) ) {
 }
 
 if ( ! function_exists( 'wp_get_post_revisions' ) ) {
-	function wp_get_post_revisions( int $parent_id ): array {
+	function wp_get_post_revisions( int $parent_id, ?array $args = null ): array {
 		return array_values( array_filter( $GLOBALS['frontman_test_custom_css_revisions'], static function( WP_Post $revision ) use ( $parent_id ): bool {
 			return $parent_id === $revision->post_parent;
 		} ) );
@@ -1097,13 +1097,14 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( hash( 'sha256', '.old { color: blue; }' ), $revision['css_sha256'], 'wp_get_custom_css_revision fingerprints selected revision CSS' );
 		$custom_css_revision = $GLOBALS['frontman_test_custom_css_revisions'][9101];
 
-		$GLOBALS['frontman_test_custom_css_revisions'] = [];
-		$no_revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
-		$this->assert_same( 'no_revisions', $no_revisions['status'], 'wp_list_custom_css_revisions distinguishes enabled empty history' );
 		$GLOBALS['frontman_test_revisions_enabled'][9001] = false;
 		$disabled_revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
 		$this->assert_same( 'revisions_disabled', $disabled_revisions['status'], 'wp_list_custom_css_revisions distinguishes disabled revisions' );
+		$this->assert_same( 9101, $disabled_revisions['revisions'][0]['revision_id'], 'wp_list_custom_css_revisions includes retained history when revision creation is disabled' );
 		$GLOBALS['frontman_test_revisions_enabled'][9001] = true;
+		$GLOBALS['frontman_test_custom_css_revisions'] = [];
+		$no_revisions = $tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-theme', 'parent_post_id' => 9001 ] );
+		$this->assert_same( 'no_revisions', $no_revisions['status'], 'wp_list_custom_css_revisions distinguishes enabled empty history' );
 		$GLOBALS['frontman_test_custom_css_revisions'][9101] = $custom_css_revision;
 
 		$this->assert_error_contains(

--- a/libs/frontman-wordpress/tests/WooCommerceToolsTest.php
+++ b/libs/frontman-wordpress/tests/WooCommerceToolsTest.php
@@ -196,6 +196,7 @@ class Frontman_WooCommerce_Tools_Test_Runner {
 		$this->test_string_path_ids_are_allowed();
 		$this->test_product_reviews_use_global_reviews_endpoint();
 		$this->test_delete_product_requires_confirmation();
+		$this->test_delete_product_string_false_is_not_forced();
 		$this->test_product_meta_upsert_uses_meta_data_array();
 		$this->test_product_meta_delete_uses_woocommerce_crud();
 
@@ -466,6 +467,14 @@ class Frontman_WooCommerce_Tools_Test_Runner {
 
 		$error = $this->call_error( 'wc_delete_product', [ 'productId' => 10, 'force' => true, 'confirm' => false ] );
 		$this->assert_true( false !== strpos( $error, 'explicit confirmation' ), 'wc_delete_product requires confirm=true' );
+	}
+
+	private function test_delete_product_string_false_is_not_forced(): void {
+		$this->reset_rest();
+		$input = $this->tools->sanitize_input( 'wc_delete_product', [ 'productId' => 10, 'force' => 'false', 'confirm' => true ] );
+		$this->call_success( 'wc_delete_product', $input );
+
+		$this->assert_same( false, $GLOBALS['frontman_wc_rest_requests'][1]->params['force'], 'wc_delete_product does not convert string false into forced deletion' );
 	}
 
 	private function test_product_meta_upsert_uses_meta_data_array(): void {

--- a/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
@@ -36,6 +36,15 @@ function frontman_custom_css_persisted_post( int $post_id ): WP_Post {
 	return $post;
 }
 
+function frontman_custom_css_assert_tool_error( callable $call, string $expected_message ): void {
+	try {
+		$call();
+		throw new RuntimeException( 'Expected Custom CSS tool error was not thrown.' );
+	} catch ( Frontman_Tool_Error $error ) {
+		frontman_runtime_assert( false !== strpos( $error->getMessage(), $expected_message ), 'Unexpected Custom CSS tool error: ' . $error->getMessage() );
+	}
+}
+
 function frontman_characterize_custom_css_revision_history(): void {
 	$stylesheet = 'frontman-runtime-history';
 	$first = frontman_custom_css_update( $stylesheet, '.history { color: red; }' );
@@ -205,6 +214,217 @@ function frontman_characterize_custom_css_conflicts(): void {
 	frontman_runtime_assert( '.conflict { color: red; }' === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Generic restore did not overwrite simulated concurrent write.' );
 }
 
+function frontman_test_custom_css_read_tools(): void {
+	$stylesheet = get_stylesheet();
+	$target_css = '.tool-read { color: red; }';
+	$current_css = '.tool-read { color: blue; }';
+	$post = frontman_custom_css_update( $stylesheet, $target_css );
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, $target_css );
+	$tool = new Frontman_Tool_Options();
+
+	$current = $tool->get_custom_css( [ 'stylesheet' => $stylesheet ] );
+	frontman_runtime_assert( $post->ID === $current['parent_post_id'], 'Current CSS metadata returned wrong parent.' );
+	frontman_runtime_assert( strlen( $current_css ) === $current['persisted_css_bytes'], 'Current CSS metadata returned wrong byte count.' );
+	frontman_runtime_assert( hash( 'sha256', $current_css ) === $current['persisted_css_sha256'], 'Current CSS metadata returned wrong fingerprint.' );
+	frontman_runtime_assert( false === $current['preprocessor_source_present'], 'Plain current CSS unexpectedly reported preprocessor source.' );
+
+	$listed = $tool->list_custom_css_revisions( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID ] );
+	frontman_runtime_assert( 'available' === $listed['status'], 'Revision listing did not report available history.' );
+	$listed_by_id = array_column( $listed['revisions'], null, 'revision_id' );
+	frontman_runtime_assert( isset( $listed_by_id[ $revision->ID ] ), 'Revision listing omitted selected revision.' );
+	frontman_runtime_assert( ! array_key_exists( 'css', $listed_by_id[ $revision->ID ] ), 'Revision listing exposed full CSS.' );
+	frontman_runtime_assert( hash( 'sha256', $target_css ) === $listed_by_id[ $revision->ID ]['css_sha256'], 'Revision listing returned wrong fingerprint.' );
+
+	$inspected = $tool->get_custom_css_revision( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID, 'revision_id' => $revision->ID ] );
+	frontman_runtime_assert( $target_css === $inspected['css'], 'Revision inspection returned wrong CSS.' );
+
+	$disable_revisions = static function( int $revisions, WP_Post $candidate ) use ( $post ): int {
+		return $post->ID === $candidate->ID ? 0 : $revisions;
+	};
+	add_filter( 'wp_revisions_to_keep', $disable_revisions, 10, 2 );
+	$disabled = $tool->list_custom_css_revisions( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID ] );
+	frontman_runtime_assert( 'revisions_disabled' === $disabled['status'], 'Revision listing did not report disabled revisions.' );
+	remove_filter( 'wp_revisions_to_keep', $disable_revisions, 10 );
+
+	foreach ( wp_get_post_revisions( $post->ID ) as $existing_revision ) {
+		wp_delete_post_revision( $existing_revision->ID );
+	}
+	$empty_list = $tool->list_custom_css_revisions( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID ] );
+	frontman_runtime_assert( 'no_revisions' === $empty_list['status'], 'Revision listing did not report enabled empty history.' );
+
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $stylesheet, $post ): void {
+			$tool->list_custom_css_revisions( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID + 1 ] );
+		},
+		'parent post'
+	);
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $stylesheet, $post ): void {
+			$tool->get_custom_css_revision( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID, 'revision_id' => PHP_INT_MAX ] );
+		},
+		'not found'
+	);
+	$cross_parent = frontman_custom_css_update( 'frontman-runtime-cross-parent-tool', '.cross-parent { color: red; }' );
+	$cross_revision = frontman_custom_css_revision_with_content( $cross_parent->ID, '.cross-parent { color: red; }' );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $stylesheet, $post, $cross_revision ): void {
+			$tool->get_custom_css_revision( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID, 'revision_id' => $cross_revision->ID ] );
+		},
+		'does not belong'
+	);
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $post ): void {
+			$tool->list_custom_css_revisions( [ 'stylesheet' => 'frontman-runtime-inactive', 'parent_post_id' => $post->ID ] );
+		},
+		'active stylesheet'
+	);
+}
+
+function frontman_test_custom_css_restore_tool(): void {
+	$stylesheet = get_stylesheet();
+	$target_css = '.tool-restore { color: red; }';
+	$current_css = '.tool-restore { color: blue; }';
+	$post = frontman_custom_css_update( $stylesheet, $target_css );
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$revision = frontman_custom_css_revision_with_content( $post->ID, $target_css );
+	$tool = new Frontman_Tool_Options();
+	$restore_input = [
+		'stylesheet'              => $stylesheet,
+		'parent_post_id'          => $post->ID,
+		'revision_id'             => $revision->ID,
+		'expected_current_sha256' => hash( 'sha256', $current_css ),
+		'confirm'                 => true,
+	];
+	$unrelated_post_id = wp_insert_post(
+		wp_slash(
+			[
+				'post_title'   => 'Unrelated scope fixture',
+				'post_content' => 'private unrelated content',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+			]
+		),
+		true
+	);
+	frontman_runtime_assert( ! is_wp_error( $unrelated_post_id ), 'Could not create poisoned scope fixture.' );
+	set_theme_mod( 'custom_css_post_id', $unrelated_post_id );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $stylesheet ): void {
+			$tool->get_custom_css( [ 'stylesheet' => $stylesheet ] );
+		},
+		'invalid post'
+	);
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( $restore_input );
+		},
+		'invalid post'
+	);
+	frontman_runtime_assert( 'private unrelated content' === get_post( $unrelated_post_id )->post_content, 'Poisoned scope restore changed unrelated post content.' );
+	set_theme_mod( 'custom_css_post_id', $post->ID );
+
+	$registry = new Frontman_Tools();
+	$tool->register( $registry );
+	$string_confirmation = $registry->call(
+		'wp_restore_custom_css_revision',
+		$registry->sanitize_input( 'wp_restore_custom_css_revision', array_merge( $restore_input, [ 'confirm' => 'true' ] ) )
+	);
+	frontman_runtime_assert( true === $string_confirmation['isError'], 'String restore confirmation was accepted.' );
+	frontman_runtime_assert( false !== strpos( $string_confirmation['content'][0]['text'], 'confirm=true' ), 'String confirmation returned unexpected restore error.' );
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'String confirmation changed current CSS.' );
+	$malformed_revision = $registry->call(
+		'wp_restore_custom_css_revision',
+		$registry->sanitize_input( 'wp_restore_custom_css_revision', array_merge( $restore_input, [ 'revision_id' => $revision->ID . 'junk' ] ) )
+	);
+	frontman_runtime_assert( true === $malformed_revision['isError'], 'Malformed restore revision ID was accepted.' );
+	frontman_runtime_assert( false !== strpos( $malformed_revision['content'][0]['text'], 'positive integer' ), 'Malformed revision ID returned unexpected restore error.' );
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Malformed revision ID changed current CSS.' );
+
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'confirm' => false ] ) );
+		},
+		'confirm=true'
+	);
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Confirmation failure changed current CSS.' );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'expected_current_sha256' => hash( 'sha256', 'stale' ) ] ) );
+		},
+		'changed'
+	);
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Stale-state failure changed current CSS.' );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'parent_post_id' => $restore_input['parent_post_id'] + 1 ] ) );
+		},
+		'parent post'
+	);
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Parent mismatch changed current CSS.' );
+
+	$cross_parent = frontman_custom_css_update( 'frontman-runtime-cross-parent-restore', '.cross-restore { color: red; }' );
+	$cross_revision = frontman_custom_css_revision_with_content( $cross_parent->ID, '.cross-restore { color: red; }' );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input, $cross_revision ): void {
+			$tool->restore_custom_css_revision( array_merge( $restore_input, [ 'revision_id' => $cross_revision->ID ] ) );
+		},
+		'does not belong'
+	);
+	frontman_runtime_assert( $current_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Cross-parent revision failure changed current CSS.' );
+
+	frontman_custom_css_update( $stylesheet, $current_css, 'source-v2' );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( $restore_input );
+		},
+		'preprocessor'
+	);
+	$preprocessor_post = frontman_custom_css_persisted_post( $post->ID );
+	frontman_runtime_assert( $current_css === $preprocessor_post->post_content, 'Preprocessor rejection changed compiled CSS.' );
+	frontman_runtime_assert( 'source-v2' === $preprocessor_post->post_content_filtered, 'Preprocessor rejection changed source CSS.' );
+
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$restored = $tool->restore_custom_css_revision( $restore_input );
+	frontman_runtime_assert( [ 'selected_revision_id', 'before', 'after' ] === array_keys( $restored ), 'Restore receipt exposed unsupported fields.' );
+	frontman_runtime_assert( $revision->ID === $restored['selected_revision_id'], 'Restore receipt returned wrong selected revision.' );
+	frontman_runtime_assert( hash( 'sha256', $current_css ) === $restored['before']['persisted_css_sha256'], 'Restore receipt returned wrong before fingerprint.' );
+	frontman_runtime_assert( hash( 'sha256', $target_css ) === $restored['after']['persisted_css_sha256'], 'Restore receipt returned wrong after fingerprint.' );
+	frontman_runtime_assert( $target_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Restore tool did not persist selected plain CSS revision.' );
+
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$transform = static function( array $data ) use ( $target_css ): array {
+		if ( 'custom_css' === $data['post_type'] && $target_css === $data['post_content'] ) {
+			$data['post_content'] .= ' /* transformed */';
+		}
+
+		return $data;
+	};
+	add_filter( 'wp_insert_post_data', $transform );
+	$transformed = $tool->restore_custom_css_revision( $restore_input );
+	remove_filter( 'wp_insert_post_data', $transform );
+	$transformed_css = $target_css . ' /* transformed */';
+	frontman_runtime_assert( hash( 'sha256', $transformed_css ) === $transformed['after']['persisted_css_sha256'], 'Restore receipt did not report transformed persisted CSS.' );
+	frontman_runtime_assert( $transformed_css === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Restore tool persisted unexpected transformed output.' );
+
+	frontman_custom_css_update( $stylesheet, $current_css );
+	$change_scope = static function( array $data ) use ( $target_css ): array {
+		if ( 'custom_css' === $data['post_type'] && $target_css === $data['post_content'] ) {
+			$data['post_name'] = 'changed-custom-css-scope';
+		}
+
+		return $data;
+	};
+	add_filter( 'wp_insert_post_data', $change_scope );
+	frontman_custom_css_assert_tool_error(
+		static function() use ( $tool, $restore_input ): void {
+			$tool->restore_custom_css_revision( $restore_input );
+		},
+		'ambiguous'
+	);
+	remove_filter( 'wp_insert_post_data', $change_scope );
+}
+
 frontman_characterize_custom_css_revision_history();
 frontman_characterize_custom_css_revision_availability();
 frontman_characterize_custom_css_revision_scope();
@@ -212,3 +432,5 @@ frontman_characterize_plain_custom_css_restore();
 frontman_characterize_preprocessor_custom_css_restore();
 frontman_characterize_custom_css_save_transformation();
 frontman_characterize_custom_css_conflicts();
+frontman_test_custom_css_read_tools();
+frontman_test_custom_css_restore_tool();

--- a/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
@@ -245,6 +245,8 @@ function frontman_test_custom_css_read_tools(): void {
 	add_filter( 'wp_revisions_to_keep', $disable_revisions, 10, 2 );
 	$disabled = $tool->list_custom_css_revisions( [ 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID ] );
 	frontman_runtime_assert( 'revisions_disabled' === $disabled['status'], 'Revision listing did not report disabled revisions.' );
+	$disabled_by_id = array_column( $disabled['revisions'], null, 'revision_id' );
+	frontman_runtime_assert( isset( $disabled_by_id[ $revision->ID ] ), 'Revision listing hid retained history after revision creation was disabled.' );
 	remove_filter( 'wp_revisions_to_keep', $disable_revisions, 10 );
 
 	foreach ( wp_get_post_revisions( $post->ID ) as $existing_revision ) {

--- a/libs/frontman-wordpress/tools/class-tool-options.php
+++ b/libs/frontman-wordpress/tools/class-tool-options.php
@@ -3,7 +3,9 @@
  * WordPress Options tools — read and modify site options.
  *
  * Tools: wp_get_option, wp_update_option, wp_list_options,
- * wp_get_custom_css, wp_update_custom_css, wp_list_theme_mods, wp_get_theme_mod
+ * wp_get_custom_css, wp_list_custom_css_revisions, wp_get_custom_css_revision,
+ * wp_restore_custom_css_revision, wp_update_custom_css, wp_list_theme_mods,
+ * wp_get_theme_mod
  *
  * Handlers return plain data arrays on success, throw Frontman_Tool_Error on failure.
  *
@@ -147,6 +149,64 @@ class Frontman_Tool_Options {
 		) );
 
 		$tools->add( new Frontman_Tool_Definition(
+			'wp_list_custom_css_revisions',
+			'Lists revision metadata for the active theme Additional CSS post without returning full revision CSS.',
+			[
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'stylesheet'     => [ 'type' => 'string', 'description' => 'Expected active theme stylesheet slug from wp_get_custom_css.' ],
+					'parent_post_id' => [ 'type' => 'integer', 'description' => 'Expected current Custom CSS post ID from wp_get_custom_css.' ],
+				],
+				'required'             => [ 'stylesheet', 'parent_post_id' ],
+			],
+			[ $this, 'list_custom_css_revisions' ],
+			null,
+			true,
+			true
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_get_custom_css_revision',
+			'Reads one Additional CSS revision after validating the active stylesheet and current Custom CSS parent post.',
+			[
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'stylesheet'     => [ 'type' => 'string', 'description' => 'Expected active theme stylesheet slug from wp_get_custom_css.' ],
+					'parent_post_id' => [ 'type' => 'integer', 'description' => 'Expected current Custom CSS post ID from wp_get_custom_css.' ],
+					'revision_id'    => [ 'type' => 'integer', 'description' => 'Selected revision ID from wp_list_custom_css_revisions.' ],
+				],
+				'required'             => [ 'stylesheet', 'parent_post_id', 'revision_id' ],
+			],
+			[ $this, 'get_custom_css_revision' ],
+			null,
+			true,
+			true
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_restore_custom_css_revision',
+			'Restores one plain Additional CSS revision after confirmation and best-effort current-state conflict detection. Never retry automatically after a lost response.',
+			[
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'stylesheet'              => [ 'type' => 'string', 'description' => 'Expected active theme stylesheet slug from wp_get_custom_css.' ],
+					'parent_post_id'          => [ 'type' => 'integer', 'description' => 'Expected current Custom CSS post ID from wp_get_custom_css.' ],
+					'revision_id'             => [ 'type' => 'integer', 'description' => 'Selected revision ID from wp_list_custom_css_revisions.' ],
+					'expected_current_sha256' => [ 'type' => 'string', 'pattern' => '^[a-f0-9]{64}$', 'description' => 'Current persisted_css_sha256 from wp_get_custom_css. This is best-effort conflict detection, not an atomic lock.' ],
+					'confirm'                 => [ 'type' => 'boolean', 'description' => 'Must be true after the user approves restoring persistent site CSS.' ],
+				],
+				'required'             => [ 'stylesheet', 'parent_post_id', 'revision_id', 'expected_current_sha256', 'confirm' ],
+			],
+			[ $this, 'restore_custom_css_revision' ],
+			null,
+			true,
+			true
+		) );
+
+		$tools->add( new Frontman_Tool_Definition(
 			'wp_update_custom_css',
 			'Updates WordPress Additional CSS for the active theme and returns before/after CSS. Use only after inspecting the current CSS; requires confirm=true because it changes site-wide persistent styling.',
 			[
@@ -271,15 +331,113 @@ class Frontman_Tool_Options {
 	 * wp_get_custom_css handler.
 	 */
 	public function get_custom_css( array $input ): array {
-		if ( ! function_exists( 'wp_get_custom_css' ) ) {
+		if ( ! function_exists( 'wp_get_custom_css' ) || ! function_exists( 'wp_get_custom_css_post' ) ) {
 			throw new Frontman_Tool_Error( 'WordPress custom CSS API is unavailable.' );
 		}
 
-		$stylesheet = $this->stylesheet_from_input( $input, false );
+		$stylesheet   = $this->stylesheet_from_input( $input, false );
+		$post         = wp_get_custom_css_post( $stylesheet );
+		if ( null !== $post ) {
+			$this->assert_custom_css_post_scope( $post, $stylesheet );
+		}
+		$persisted_css = null === $post ? '' : (string) $post->post_content;
 
 		return [
-			'stylesheet' => $stylesheet,
-			'css'        => wp_get_custom_css( $stylesheet ),
+			'stylesheet'                  => $stylesheet,
+			'css'                         => wp_get_custom_css( $stylesheet ),
+			'parent_post_id'              => null === $post ? null : (int) $post->ID,
+			'persisted_css_bytes'         => strlen( $persisted_css ),
+			'persisted_css_sha256'        => hash( 'sha256', $persisted_css ),
+			'post_modified_gmt'           => null === $post ? null : (string) $post->post_modified_gmt,
+			'preprocessor_source_present' => null !== $post && '' !== (string) $post->post_content_filtered,
+		];
+	}
+
+	/**
+	 * wp_list_custom_css_revisions handler.
+	 */
+	public function list_custom_css_revisions( array $input ): array {
+		if ( ! function_exists( 'wp_revisions_enabled' ) || ! function_exists( 'wp_get_post_revisions' ) ) {
+			throw new Frontman_Tool_Error( 'WordPress revision API is unavailable.' );
+		}
+
+		[ $stylesheet, $post ] = $this->custom_css_post_from_expected_scope( $input, 'wp_list_custom_css_revisions' );
+		$revisions_enabled = wp_revisions_enabled( $post );
+		$revisions = $revisions_enabled ? wp_get_post_revisions( $post->ID ) : [];
+
+		return [
+			'stylesheet'        => $stylesheet,
+			'parent_post_id'    => (int) $post->ID,
+			'status'            => ! $revisions_enabled ? 'revisions_disabled' : ( [] === $revisions ? 'no_revisions' : 'available' ),
+			'revisions_enabled' => $revisions_enabled,
+			'revisions'         => array_values( array_map( [ $this, 'custom_css_revision_metadata' ], $revisions ) ),
+		];
+	}
+
+	/**
+	 * wp_get_custom_css_revision handler.
+	 */
+	public function get_custom_css_revision( array $input ): array {
+		[ $stylesheet, $post ] = $this->custom_css_post_from_expected_scope( $input, 'wp_get_custom_css_revision' );
+		$revision = $this->custom_css_revision_from_input( $input, (int) $post->ID );
+		$metadata = $this->custom_css_revision_metadata( $revision );
+
+		return array_merge(
+			[
+				'stylesheet' => $stylesheet,
+				'css'        => (string) $revision->post_content,
+			],
+			$metadata
+		);
+	}
+
+	/**
+	 * wp_restore_custom_css_revision handler.
+	 */
+	public function restore_custom_css_revision( array $input ): array {
+		if ( true !== ( $input['confirm'] ?? false ) ) {
+			throw new Frontman_Tool_Error( 'Additional CSS revision restore requires confirm=true after user approval.' );
+		}
+		if ( ! function_exists( 'wp_restore_post_revision' ) || ! function_exists( 'clean_post_cache' ) || ! function_exists( 'get_post' ) ) {
+			throw new Frontman_Tool_Error( 'WordPress revision restore API is unavailable.' );
+		}
+
+		[ $stylesheet, $post ] = $this->custom_css_post_from_expected_scope( $input, 'wp_restore_custom_css_revision' );
+		$revision = $this->custom_css_revision_from_input( $input, (int) $post->ID );
+		$before = $this->custom_css_post_metadata( $post );
+		$expected_hash = $input['expected_current_sha256'] ?? null;
+		if ( ! is_string( $expected_hash ) || 1 !== preg_match( '/\A[a-f0-9]{64}\z/', $expected_hash ) ) {
+			throw new Frontman_Tool_Error( 'expected_current_sha256 must be a lowercase SHA-256 fingerprint.' );
+		}
+		if ( $expected_hash !== $before['persisted_css_sha256'] ) {
+			throw new Frontman_Tool_Error( 'Current Additional CSS changed after inspection. Read current state again before restoring.' );
+		}
+		if ( $before['preprocessor_source_present'] ) {
+			throw new Frontman_Tool_Error( 'Custom CSS revision restore does not support preprocessor-backed CSS.' );
+		}
+
+		$restored_parent_id = wp_restore_post_revision( $revision, [ 'post_content' ] );
+		if ( (int) $post->ID !== $restored_parent_id ) {
+			throw new Frontman_Tool_Error( 'Custom CSS restoration outcome is ambiguous. Read current state and do not retry automatically.' );
+		}
+
+		clean_post_cache( $post->ID );
+		$observed_post = get_post( $post->ID );
+		if ( null === $observed_post || (int) $post->ID !== (int) $observed_post->ID ) {
+			throw new Frontman_Tool_Error( 'Custom CSS restoration could not be verified. Read current state and do not retry automatically.' );
+		}
+		if ( ! $this->is_custom_css_post_in_scope( $observed_post, $stylesheet ) ) {
+			throw new Frontman_Tool_Error( 'Custom CSS restoration scope is ambiguous. Read current state and do not retry automatically.' );
+		}
+		$after = $this->custom_css_post_metadata( $observed_post );
+		if ( $after['preprocessor_source_present'] ) {
+			throw new Frontman_Tool_Error( 'Custom CSS restoration produced unsupported preprocessor state. Read current state and do not retry automatically.' );
+		}
+
+		return [
+			'selected_revision_id' => (int) $revision->ID,
+			'before'               => $before,
+			'after'                => $after,
 		];
 	}
 
@@ -357,7 +515,7 @@ class Frontman_Tool_Options {
 		];
 	}
 
-	private function stylesheet_from_input( array $input, bool $active_only ): string {
+	private function stylesheet_from_input( array $input, bool $active_only, string $tool_name = 'wp_update_custom_css' ): string {
 		$stylesheet = array_key_exists( 'stylesheet', $input ) ? $input['stylesheet'] : $this->active_stylesheet();
 		if ( ! is_string( $stylesheet ) ) {
 			throw new Frontman_Tool_Error( 'stylesheet must be a string.' );
@@ -371,7 +529,7 @@ class Frontman_Tool_Options {
 
 		$active_stylesheet = $this->active_stylesheet();
 		if ( $active_only && $stylesheet !== $active_stylesheet ) {
-			throw new Frontman_Tool_Error( 'wp_update_custom_css only updates Additional CSS for the active stylesheet.' );
+			throw new Frontman_Tool_Error( "{$tool_name} only accesses Additional CSS for the active stylesheet." );
 		}
 		if ( function_exists( 'wp_get_theme' ) ) {
 			$theme = wp_get_theme( $stylesheet );
@@ -381,6 +539,84 @@ class Frontman_Tool_Options {
 		}
 
 		return $stylesheet;
+	}
+
+	private function custom_css_post_from_expected_scope( array $input, string $tool_name ): array {
+		if ( ! function_exists( 'wp_get_custom_css_post' ) ) {
+			throw new Frontman_Tool_Error( 'WordPress custom CSS API is unavailable.' );
+		}
+		if ( ! array_key_exists( 'stylesheet', $input ) ) {
+			throw new Frontman_Tool_Error( 'stylesheet is required.' );
+		}
+
+		$stylesheet = $this->stylesheet_from_input( $input, true, $tool_name );
+		if ( ! array_key_exists( 'parent_post_id', $input ) || ! is_int( $input['parent_post_id'] ) || 1 > $input['parent_post_id'] ) {
+			throw new Frontman_Tool_Error( 'parent_post_id is required and must be a positive integer.' );
+		}
+
+		$post = wp_get_custom_css_post( $stylesheet );
+		if ( null === $post ) {
+			throw new Frontman_Tool_Error( 'Current Custom CSS parent post was not found.' );
+		}
+		$this->assert_custom_css_post_scope( $post, $stylesheet );
+		if ( $input['parent_post_id'] !== (int) $post->ID ) {
+			throw new Frontman_Tool_Error( 'Current Custom CSS parent post does not match parent_post_id.' );
+		}
+
+		return [ $stylesheet, $post ];
+	}
+
+	private function assert_custom_css_post_scope( $post, string $stylesheet ): void {
+		if ( ! $this->is_custom_css_post_in_scope( $post, $stylesheet ) ) {
+			throw new Frontman_Tool_Error( 'Custom CSS lookup returned an invalid post for the expected stylesheet.' );
+		}
+	}
+
+	private function is_custom_css_post_in_scope( $post, string $stylesheet ): bool {
+		return 'custom_css' === (string) $post->post_type && sanitize_title( $stylesheet ) === (string) $post->post_name;
+	}
+
+	private function custom_css_revision_from_input( array $input, int $parent_post_id ) {
+		if ( ! function_exists( 'wp_get_post_revision' ) || ! function_exists( 'wp_is_post_revision' ) ) {
+			throw new Frontman_Tool_Error( 'WordPress revision API is unavailable.' );
+		}
+		if ( ! array_key_exists( 'revision_id', $input ) || ! is_int( $input['revision_id'] ) || 1 > $input['revision_id'] ) {
+			throw new Frontman_Tool_Error( 'revision_id is required and must be a positive integer.' );
+		}
+
+		$revision = wp_get_post_revision( $input['revision_id'] );
+		if ( null === $revision ) {
+			throw new Frontman_Tool_Error( 'Custom CSS revision not found.' );
+		}
+		if ( $parent_post_id !== (int) wp_is_post_revision( $revision ) ) {
+			throw new Frontman_Tool_Error( 'Selected revision does not belong to the expected Custom CSS parent post.' );
+		}
+
+		return $revision;
+	}
+
+	private function custom_css_revision_metadata( $revision ): array {
+		$css = (string) $revision->post_content;
+
+		return [
+			'revision_id'   => (int) $revision->ID,
+			'parent_post_id' => (int) $revision->post_parent,
+			'post_date'      => (string) $revision->post_date,
+			'post_date_gmt'  => (string) $revision->post_date_gmt,
+			'css_bytes'      => strlen( $css ),
+			'css_sha256'     => hash( 'sha256', $css ),
+		];
+	}
+
+	private function custom_css_post_metadata( $post ): array {
+		$css = (string) $post->post_content;
+
+		return [
+			'persisted_css_bytes'         => strlen( $css ),
+			'persisted_css_sha256'        => hash( 'sha256', $css ),
+			'post_modified_gmt'           => (string) $post->post_modified_gmt,
+			'preprocessor_source_present' => '' !== (string) $post->post_content_filtered,
+		];
 	}
 
 	private function active_stylesheet(): string {

--- a/libs/frontman-wordpress/tools/class-tool-options.php
+++ b/libs/frontman-wordpress/tools/class-tool-options.php
@@ -363,7 +363,7 @@ class Frontman_Tool_Options {
 
 		[ $stylesheet, $post ] = $this->custom_css_post_from_expected_scope( $input, 'wp_list_custom_css_revisions' );
 		$revisions_enabled = wp_revisions_enabled( $post );
-		$revisions = $revisions_enabled ? wp_get_post_revisions( $post->ID ) : [];
+		$revisions = wp_get_post_revisions( $post->ID, [ 'check_enabled' => false ] );
 
 		return [
 			'stylesheet'        => $stylesheet,


### PR DESCRIPTION
## Summary

- extend `wp_get_custom_css` with exact persisted-state metadata
- add scoped revision listing and selected-revision inspection
- add confirmed plain-CSS restoration with stale-state and ambiguity detection
- reject inactive themes, cross-parent revisions, poisoned post pointers, malformed inputs, and preprocessor-backed state
- document compatibility, concurrency limits, and lost-response recovery

## Verification

- isolated WordPress tool tests on PHP 7.4 and PHP 8.4
- `WORDPRESS_VERSION=6.0.9 PHP_VERSION=7.4 make test-wordpress-runtime`
- `WORDPRESS_VERSION=7.0.2 PHP_VERSION=7.4 make test-wordpress-runtime`
- `WORDPRESS_VERSION=7.0.2 PHP_VERSION=8.4 make test-wordpress-runtime`
- `make package-wordpress-plugin VERSION=2.0.0`
- `git diff --check`

Closes #1360