### PR TITLE
fix(release): keep internal packages private

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,13 +133,13 @@ npm publishing is done manually after the release PR merges:
 ```bash
 git checkout main && git pull
 
-# Publish @frontman-ai/astro
-make publish-astro
+# Publish all public npm packages
+make publish
 ```
 
-This builds the package from scratch (ReScript + tsup bundle) and runs `npm publish`. The version in `package.json` was already bumped by changesets in step 2.
+This builds and publishes `@frontman-ai/astro`, `@frontman-ai/vite`, `@frontman-ai/nextjs`, and `@frontman-ai/react-statestore`. Packages whose versions already exist on npm are skipped, so the command can be retried safely. Package versions were already bumped by Changesets in step 2.
 
-> **Note:** Only `@frontman-ai/astro` has a publish target currently. To add more, create a `publish` target in the package's Makefile and a corresponding `publish-<name>` target in the root Makefile.
+The core, protocol, browser client, and UI workspaces are internal build inputs. Their code is bundled into the public framework packages or deployed browser assets, so they are not published separately.
 
 ## License
 

--- a/libs/client/Makefile
+++ b/libs/client/Makefile
@@ -70,8 +70,4 @@ serve:
 preview:
 	yarn vite preview
 
-publish:
-	$(MAKE) build-lib
-	npm publish
-
 check: lint

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@frontman-ai/client",
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"version": "1.0.4",
 	"description": "React UI component library for Frontman",
 	"license": "Apache-2.0",

--- a/libs/frontman-client/package.json
+++ b/libs/frontman-client/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@frontman-ai/frontman-client",
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"version": "2.0.0",
 	"description": "Browser-side client for Frontman",
 	"license": "Apache-2.0",
@@ -28,8 +26,7 @@
 		"src"
 	],
 	"scripts": {
-		"build": "rescript build",
-		"prepublishOnly": "yarn build"
+		"build": "rescript build"
 	},
 	"dependencies": {
 		"@frontman/logs": "workspace:*",

--- a/libs/frontman-core/package.json
+++ b/libs/frontman-core/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@frontman-ai/frontman-core",
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"version": "1.0.3",
 	"description": "Core server-side tools for Frontman",
 	"license": "Apache-2.0",
@@ -32,8 +30,7 @@
 		"src"
 	],
 	"scripts": {
-		"build": "rescript build",
-		"prepublishOnly": "yarn build"
+		"build": "rescript build"
 	},
 	"dependencies": {
 		"@frontman-ai/frontman-protocol": "2.0.0",

--- a/libs/frontman-protocol/package.json
+++ b/libs/frontman-protocol/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@frontman-ai/frontman-protocol",
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"version": "2.0.0",
 	"description": "Protocol definitions for Frontman",
 	"license": "Apache-2.0",
@@ -33,8 +31,7 @@
 		"schemas"
 	],
 	"scripts": {
-		"build": "rescript build",
-		"prepublishOnly": "yarn build"
+		"build": "rescript build"
 	},
 	"dependencies": {
 		"sury": "11.0.0-alpha.10"


### PR DESCRIPTION
## Summary
- mark bundled core, protocol, browser client, and UI workspaces private
- remove stale npm publication hooks from internal packages
- document actual public package publish flow

## Verification
- ➤ YN0000: · Yarn 4.10.3
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Post-resolution validation
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 1s 83ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 226ms
➤ YN0000: · Done with warnings in 1s 531ms
- 🦋  info NO packages to be bumped at patch
🦋  ---
🦋  info NO packages to be bumped at minor
🦋  ---
🦋  info NO packages to be bumped at major
- cd libs/frontman-astro && make publish OTP=
make[1]: Entering directory '/home/bluehotdog/dev/frontman/libs/frontman-astro'
yarn build
PKG=$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
if npm view "$PKG" version >/dev/null 2>&1; then \
	echo "Skipping $PKG — already published"; \
	exit 0; \
fi; \
npm publish 
make[1]: Leaving directory '/home/bluehotdog/dev/frontman/libs/frontman-astro'
cd libs/frontman-vite && make publish OTP=
make[1]: Entering directory '/home/bluehotdog/dev/frontman/libs/frontman-vite'
yarn build
PKG=$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
if npm view "$PKG" version >/dev/null 2>&1; then \
	echo "Skipping $PKG — already published"; \
	exit 0; \
fi; \
npm publish 
make[1]: Leaving directory '/home/bluehotdog/dev/frontman/libs/frontman-vite'
cd libs/frontman-nextjs && make publish OTP=
make[1]: Entering directory '/home/bluehotdog/dev/frontman/libs/frontman-nextjs'
yarn build
PKG=$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
if npm view "$PKG" version >/dev/null 2>&1; then \
	echo "Skipping $PKG — already published"; \
	exit 0; \
fi; \
npm publish 
make[1]: Leaving directory '/home/bluehotdog/dev/frontman/libs/frontman-nextjs'
cd libs/react-statestore && make publish OTP=
make[1]: Entering directory '/home/bluehotdog/dev/frontman/libs/react-statestore'
yarn rescript clean
yarn rescript build
PKG=$(node -e "const p=require('./package.json'); console.log(p.name+'@'+p.version)"); \
if npm view "$PKG" version >/dev/null 2>&1; then \
	echo "Skipping $PKG — already published"; \
	exit 0; \
fi; \
npm publish 
make[1]: Leaving directory '/home/bluehotdog/dev/frontman/libs/react-statestore'
- pre-commit and pre-push hooks