### PR TITLE
Add WordPress Playground demo

### DIFF
--- a/.changeset/add-wordpress-playground-demo.md
+++ b/.changeset/add-wordpress-playground-demo.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Add a disposable WordPress Playground demo that installs Frontman and opens a seeded editing task.

--- a/apps/marketing/public/wordpress-playground/blueprint.json
+++ b/apps/marketing/public/wordpress-playground/blueprint.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "Frontman WordPress Playground",
+    "description": "Try one real Frontman edit in a disposable WordPress site.",
+    "author": "frontman-ai"
+  },
+  "preferredVersions": {
+    "php": "8.4",
+    "wp": "7.0.2"
+  },
+  "features": {
+    "networking": true
+  },
+  "landingPage": "/demo/frontman",
+  "login": true,
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "frontman-agentic-ai-editor"
+      },
+      "options": {
+        "activate": true,
+        "onError": "throw"
+      }
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "blogname": "Frontman WordPress Playground",
+        "permalink_structure": "/%postname%/"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php\nrequire '/wordpress/wp-load.php';\n$page = get_page_by_path('demo', OBJECT, 'page');\n$data = [\n  'post_title' => 'Frontman WordPress Playground',\n  'post_name' => 'demo',\n  'post_status' => 'publish',\n  'post_type' => 'page',\n  'post_content' => '<!-- wp:group {\"layout\":{\"type\":\"constrained\"}} --><div class=\"wp-block-group\"><!-- wp:heading {\"level\":1} --><h1 class=\"wp-block-heading\">Frequently ask questions</h1><!-- /wp:heading --><!-- wp:paragraph --><p>This disposable site contains one intentional heading error. Ask Frontman to change it to “Frequently Asked Questions”.</p><!-- /wp:paragraph --></div><!-- /wp:group -->'\n];\nif ($page) {\n  $data['ID'] = $page->ID;\n  wp_update_post($data);\n} else {\n  wp_insert_post($data);\n}\nflush_rewrite_rules();"
+    }
+  ]
+}

--- a/apps/marketing/src/components/ui/Button.astro
+++ b/apps/marketing/src/components/ui/Button.astro
@@ -4,6 +4,7 @@ type Props = {
 	type?: 'link' | 'button' | 'submit' | 'reset'
 	size?: 'lg' | 'base' | 'sm'
 	link?: string
+	target?: '_blank' | '_self'
 	modal?: string
 	style?: 'primary' | 'secondary' | 'neutral' | 'white'
 	variation?: 'outline' | 'link'
@@ -17,6 +18,7 @@ const {
 	type = 'button',
 	size = 'base',
 	link,
+	target,
 	modal,
 	style = 'primary',
 	variation,
@@ -32,7 +34,7 @@ const {
 	type === 'link' || link ? (
 		<a
 			href={link}
-			target={link?.startsWith('http') ? '_blank' : '_self'}
+			target={target ?? (link?.startsWith('http') ? '_blank' : '_self')}
 			class:list={[
 				'button',
 				{ ['button--' + `${size}`]: size },

--- a/apps/marketing/src/pages/wordpress.astro
+++ b/apps/marketing/src/pages/wordpress.astro
@@ -7,6 +7,7 @@ import videoPlaceholder from '../assets/video-placeholder.png'
 
 const pluginUrl = 'https://wordpress.org/plugins/frontman-agentic-ai-editor/'
 const taskDemoUrl = '/blog/best-wordpress-ai-plugins-2026/#frontman-workflow-demo'
+const playgroundUrl = 'https://playground.wordpress.net/?networking=yes&blueprint-url=https%3A%2F%2Ffrontman.sh%2Fwordpress-playground%2Fblueprint.json'
 const youtubeVideoId = '-4GD1GYwH8Y'
 
 const SEO = {
@@ -151,6 +152,13 @@ const pageJsonLd = {
 				<div class="wp-step"><span>2</span><h3>Open the live workspace</h3><p>Visit https://yoursite.com/frontman, or append /frontman to a specific page URL.</p></div>
 				<div class="wp-step"><span>3</span><h3>Review what changed</h3><p>Ask for the update, watch the preview, and decide whether the result is ready.</p></div>
 			</div>
+			<div class="wp-playground">
+				<div>
+					<h3>Try one real edit in disposable WordPress.</h3>
+					<p>The demo installs Frontman and opens a seeded page automatically. Frontman sign-in and your own supported AI provider are still required.</p>
+				</div>
+				<Button size="lg" link={playgroundUrl} target="_self">Open WordPress Playground <span aria-hidden="true">→</span></Button>
+			</div>
 			<a href={taskDemoUrl} class="wp-demo-link">Watch one complete staging-safe WordPress task <span aria-hidden="true">→</span></a>
 		</div>
 	</section>
@@ -258,6 +266,9 @@ const pageJsonLd = {
 	.wp-section--light { background: #fafafa; color: #09090b; }
 	.wp-section h2 { @apply mb-5 text-3xl font-bold tracking-[-0.03em] md:text-5xl; line-height: 1.08; color: inherit; opacity: 1; }
 	.wp-section p { @apply text-lg leading-8; color: inherit; opacity: 0.78; }
+	.wp-playground { @apply mt-12 flex flex-col items-start justify-between gap-6 rounded-2xl border border-violet-200 bg-violet-50 p-6 md:flex-row md:items-center md:p-8; }
+	.wp-playground h3 { @apply mb-2 text-2xl font-bold tracking-[-0.02em] text-zinc-950; }
+	.wp-playground p { @apply max-w-2xl text-base leading-7 text-zinc-700; opacity: 1; }
 	.wp-section-header { max-width: 760px; margin-bottom: 36px; }
 	.wp-steps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
 	.wp-step { border: 2px solid #111827; border-radius: 20px; padding: 24px; background: white; box-shadow: 6px 6px 0 #111827; }

--- a/apps/marketing/src/pages/wordpress.astro
+++ b/apps/marketing/src/pages/wordpress.astro
@@ -99,9 +99,10 @@ const pageJsonLd = {
 				</p>
 				<div class="wp-actions wp-hero__cta">
 					<Button size="lg" style="white" link={pluginUrl} classes="wp-primary-cta">Install from WordPress.org <span class="wp-cta-arrow" aria-hidden="true">→</span></Button>
-					<a href="/docs/integrations/wordpress/" class="wp-secondary-link">Read setup guide</a>
+					<Button size="lg" style="white" variation="outline" link={playgroundUrl} target="_self">Open WordPress Playground <span class="wp-cta-arrow" aria-hidden="true">→</span></Button>
 				</div>
-				<p class="wp-note">WordPress 6.0+, PHP 7.4+, administrator access required. Beta: start on staging and keep backups.</p>
+				<a href="/docs/integrations/wordpress/" class="wp-secondary-link wp-hero__setup-link">Read setup guide</a>
+				<p class="wp-note">Try a real edit in disposable WordPress with Frontman installed and a seeded page. Frontman sign-in and your own supported AI provider are still required. WordPress 6.0+, PHP 7.4+, administrator access required. Beta: start on staging and keep backups.</p>
 			</div>
 			<div class="wp-video-wrapper">
 				<button
@@ -151,13 +152,6 @@ const pageJsonLd = {
 				<div class="wp-step"><span>1</span><h3>Install from wp-admin</h3><p>Go to Plugins > Add New Plugin, search for Frontman Agentic AI Editor, install, and activate.</p></div>
 				<div class="wp-step"><span>2</span><h3>Open the live workspace</h3><p>Visit https://yoursite.com/frontman, or append /frontman to a specific page URL.</p></div>
 				<div class="wp-step"><span>3</span><h3>Review what changed</h3><p>Ask for the update, watch the preview, and decide whether the result is ready.</p></div>
-			</div>
-			<div class="wp-playground">
-				<div>
-					<h3>Try one real edit in disposable WordPress.</h3>
-					<p>The demo installs Frontman and opens a seeded page automatically. Frontman sign-in and your own supported AI provider are still required.</p>
-				</div>
-				<Button size="lg" link={playgroundUrl} target="_self">Open WordPress Playground <span aria-hidden="true">→</span></Button>
 			</div>
 			<a href={taskDemoUrl} class="wp-demo-link">Watch one complete staging-safe WordPress task <span aria-hidden="true">→</span></a>
 		</div>
@@ -245,9 +239,10 @@ const pageJsonLd = {
 	h1 { font-family: 'SF Pro Display', system-ui, helvetica, sans-serif; font-size: 48px; line-height: 54px; font-weight: 700; letter-spacing: -0.035em; color: white; text-wrap: balance; }
 	.wp-lead { @apply mt-6 text-lg text-white/85; line-height: 1.55; max-width: 620px; text-wrap: pretty; }
 	.wp-actions { @apply mt-8 flex flex-wrap items-center gap-4; }
-	.wp-hero__cta { gap: 20px; }
+	.wp-hero__cta { justify-content: center; gap: 20px; }
 	.wp-hero__cta .button { justify-content: center; }
 	.wp-primary-cta { min-width: 268px; }
+	.wp-hero__setup-link { display: inline-flex; margin-top: 20px; }
 	.wp-cta-arrow { margin-left: 8px; }
 	.wp-actions--center { justify-content: center; }
 	.wp-secondary-link { @apply font-semibold text-white underline underline-offset-4 hover:text-primary-100; }
@@ -266,9 +261,6 @@ const pageJsonLd = {
 	.wp-section--light { background: #fafafa; color: #09090b; }
 	.wp-section h2 { @apply mb-5 text-3xl font-bold tracking-[-0.03em] md:text-5xl; line-height: 1.08; color: inherit; opacity: 1; }
 	.wp-section p { @apply text-lg leading-8; color: inherit; opacity: 0.78; }
-	.wp-playground { @apply mt-12 flex flex-col items-start justify-between gap-6 rounded-2xl border border-violet-200 bg-violet-50 p-6 md:flex-row md:items-center md:p-8; }
-	.wp-playground h3 { @apply mb-2 text-2xl font-bold tracking-[-0.02em] text-zinc-950; }
-	.wp-playground p { @apply max-w-2xl text-base leading-7 text-zinc-700; opacity: 1; }
 	.wp-section-header { max-width: 760px; margin-bottom: 36px; }
 	.wp-steps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
 	.wp-step { border: 2px solid #111827; border-radius: 20px; padding: 24px; background: white; box-shadow: 6px 6px 0 #111827; }


### PR DESCRIPTION
## Summary
- add a public WordPress Playground Blueprint that installs Frontman 3.0.0 and seeds one Gutenberg heading task
- add an honest same-tab Playground launch CTA to the WordPress product page
- allow Button callers to override external-link target behavior

## Verification
- validated Blueprint against the official WordPress Playground schema
- completed a real hosted Frontman edit locally and on `playground.wordpress.net` with a scoped relay URL
- confirmed `wp_update_block` changed the seeded heading and refreshed the preview
- Astro check: 0 errors, warnings, or hints
- marketing build: 148 pages, no broken links
- Vitest: 22 files, 88 tests passed
- pre-commit and pre-push hooks passed

## Launch
After deployment, verify `https://frontman.sh/wordpress-playground/blueprint.json` returns JSON with CORS enabled, then run the production CTA in a fresh browser session.