### PR TITLE
Link WordPress articles to product demos

### DIFF
--- a/apps/marketing/src/content/blog/ai-agent-wordpress-plugin-comparison.md
+++ b/apps/marketing/src/content/blog/ai-agent-wordpress-plugin-comparison.md
@@ -65,6 +65,8 @@ If you want a chatbot, use the chatbot plugin. If you want embeddings and knowle
 
 That last sentence is where [Frontman for WordPress](/wordpress/) lives.
 
+Before installing anything, [watch one complete existing-site edit](/blog/best-wordpress-ai-plugins-2026/#frontman-workflow-demo) or [try the workflow in a disposable WordPress Playground](https://playground.wordpress.net/?networking=yes&blueprint-url=https%3A%2F%2Ffrontman.sh%2Fwordpress-playground%2Fblueprint.json). The Playground loads a seeded page and the plugin automatically; Frontman sign-in and your own supported AI provider are still required.
+
 ### Why Frontman's WordPress plugin is different
 
 Frontman is not trying to be the largest AI plugin for WordPress. That race is already crowded, and honestly, AI Engine is very good at it.

--- a/apps/marketing/src/content/blog/best-wordpress-mcp-servers-and-plugins-2026.md
+++ b/apps/marketing/src/content/blog/best-wordpress-mcp-servers-and-plugins-2026.md
@@ -63,7 +63,7 @@ imageAlt: 'Best WordPress MCP Servers and Plugins in 2026 article cover.'
 
 There is no universal winner. Your decision turns on five things: the WordPress actions you need, how the server authenticates clients, whether writes require review, where the server runs, and how you recover from a bad tool call.
 
-Need Claude, ChatGPT, or Cursor to call WordPress tools? Choose an MCP server. Need a person to request a change and review the live page in one workflow? Evaluate [Frontman for WordPress](/wordpress/) instead.
+Need Claude, ChatGPT, or Cursor to call WordPress tools? Choose an MCP server. Need a person to request a change and review the live page in one workflow? Evaluate [Frontman for WordPress](/wordpress/) instead. You can [watch one complete request-to-review task](/blog/best-wordpress-ai-plugins-2026/#frontman-workflow-demo) before deciding which workflow fits.
 
 If you cannot explain who approves a write and how you recover it, the server is not ready for production.
 

--- a/apps/marketing/src/content/blog/wordpress-7-breaking-changes.md
+++ b/apps/marketing/src/content/blog/wordpress-7-breaking-changes.md
@@ -46,6 +46,8 @@ Before getting into the individual breaking changes, here's the scope. WordPress
 
 Each of these affects a different audience. If you maintain custom blocks, the iframed editor is your biggest concern. If you run WooCommerce, plugin compatibility matters more than any single API change. If you manage client sites on shared hosting, the real-time collaboration overhead is worth understanding before it surprises you.
 
+Once the compatibility audit passes, keep the first post-upgrade change bounded and visible. [Watch one complete WordPress edit from request through reviewed result](/blog/best-wordpress-ai-plugins-2026/#frontman-workflow-demo), or [open the disposable WordPress Playground](https://playground.wordpress.net/?networking=yes&blueprint-url=https%3A%2F%2Ffrontman.sh%2Fwordpress-playground%2Fblueprint.json) to inspect Frontman's live-preview workflow without touching your site. The Playground is a seeded test environment, not proof that your production theme and plugin stack are compatible.
+
 ## Breaking change #1: The iframed editor and Block API Version 3
 
 WordPress 7 [loads the post editor inside an iframe](https://make.wordpress.org/core/2026/02/24/iframed-editor-changes-in-wordpress-7-0/). This is the change that breaks the most plugins.

--- a/apps/marketing/src/content/blog/wordpress-integration.md
+++ b/apps/marketing/src/content/blog/wordpress-integration.md
@@ -84,4 +84,6 @@ That said, this is experimental software. If you choose to use it in production,
 
 Frontman is now available in the [WordPress Plugin Directory](https://wordpress.org/plugins/frontman-agentic-ai-editor/). Install it from **Plugins > Add New Plugin** in wp-admin.
 
+To evaluate the workflow before installing it on your site, [open the disposable WordPress Playground](https://playground.wordpress.net/?networking=yes&blueprint-url=https%3A%2F%2Ffrontman.sh%2Fwordpress-playground%2Fblueprint.json). It loads Frontman and a seeded page automatically; Frontman sign-in and your own supported AI provider are still required. You can also [watch one complete staging-safe task](/blog/best-wordpress-ai-plugins-2026/#frontman-workflow-demo) from request through reviewed result.
+
 We're excited to bring Frontman to the WordPress ecosystem. This is just the beginning, and with your help, it'll get a lot better.


### PR DESCRIPTION
## Summary

- link four existing WordPress articles to deployed task proof
- route relevant readers to WordPress Playground where appropriate
- preserve staging, provider, and compatibility limits

## Evidence

The WordPress 7 article received 2,623 impressions and 64 clicks in the latest 30-day Search Console window, while the WordPress product page received 139 impressions and one click. These links reuse existing organic reach instead of adding another acquisition page.

## Verification

- `npx --yes @yarnpkg/cli-dist@4.10.3 workspace marketing build`
- Astro check: 0 errors, warnings, or hints
- broken-link checker: no broken links
- pre-commit source-comment checks passed
- pre-push hooks passed