### PR TITLE
add vertical spacing between tool call blocks

### DIFF
--- a/libs/client/src/components/frontman/Client__ToolCallBlock.res
+++ b/libs/client/src/components/frontman/Client__ToolCallBlock.res
@@ -109,7 +109,7 @@ let make = (
       [
         "group overflow-hidden",
         "animate-in fade-in duration-100",
-        compact ? "rounded-lg" : "rounded-xl",
+        compact ? "rounded-lg" : "my-1.5 rounded-xl",
         compact ? "bg-[#8051CD]/15" : "bg-[#8051CD]/20",
         compact ? "border border-[#8051CD]/30" : "border border-[#8051CD]/40",
         compact ? "px-3 py-2" : "px-4 py-3",


### PR DESCRIPTION
## Description

Adds vertical spacing between tool call blocks.

| before | after |
|--------|--------|
| <img width="389" height="253" alt="image" src="https://github.com/user-attachments/assets/df4f7a1f-7450-4500-998e-fdba997da3ef" /> | <img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/caa85825-3a3b-46b6-97cc-1d18a26a769b" /> | 

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
not needed for this change
- [ ] Ran `yarn changeset` (if user-facing change)
not a major change
- [x] Tested locally with `make dev`
