### PR TITLE
show existing loader when streaming

### DIFF
--- a/.changeset/thinking-indicator-whole-turn.md
+++ b/.changeset/thinking-indicator-whole-turn.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Keep the thinking indicator visible for the whole AI turn, including while text is streaming.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -98,7 +98,6 @@ let make = (~onConfigureProvider: unit => unit) => {
   let {session, createSession} = Client__FrontmanProvider.useFrontman()
 
   let messages = Client__State.useSelector(Client__State.Selectors.messages)
-  let isStreaming = Client__State.useSelector(Client__State.Selectors.isStreaming)
   let isAgentRunning = Client__State.useSelector(Client__State.Selectors.isAgentRunning)
   let hasActiveACPSession = Client__State.useSelector(Client__State.Selectors.hasActiveACPSession)
   let sessionInitialized = Client__State.useSelector(Client__State.Selectors.sessionInitialized)
@@ -127,7 +126,6 @@ let make = (~onConfigureProvider: unit => unit) => {
 
   let (thinkingState, thinkingMessageId) = UseThinkingState.useWithMessageId(
     ~messages,
-    ~isStreaming,
     ~isAgentRunning,
     ~hasActiveACPSession,
     ~sessionInitialized,

--- a/libs/client/src/hooks/Client__UseThinkingState.res
+++ b/libs/client/src/hooks/Client__UseThinkingState.res
@@ -39,34 +39,10 @@ let isTurnEnded = (lastMessage: option<Message.t>): bool => {
 }
 
 /**
- * Check if the last message is currently streaming
- */
-let isLastMessageStreaming = (lastMessage: option<Message.t>): bool => {
-  switch lastMessage {
-  | Some(Message.Assistant(Streaming(_))) => true
-  | Some(Message.ToolCall({state: InputStreaming, _})) => true
-  | _ => false
-  }
-}
-
-/**
- * Check if the last message is a completed tool call that might need a response
- */
-let isAwaitingResponse = (lastMessage: option<Message.t>): bool => {
-  switch lastMessage {
-  | Some(Message.User(_)) => true
-  | Some(Message.ToolCall({state: OutputAvailable, _})) => true
-  | Some(Message.ToolCall({state: OutputError, _})) => false
-  | _ => false
-  }
-}
-
-/**
  * Main hook - determines thinking state based on all relevant factors
  */
 let use = (
   ~messages: array<Message.t>,
-  ~isStreaming as _: bool,
   ~isAgentRunning: bool,
   ~hasActiveACPSession: bool,
   ~sessionInitialized: bool,
@@ -93,14 +69,12 @@ let use = (
  */
 let useWithMessageId = (
   ~messages: array<Message.t>,
-  ~isStreaming: bool,
   ~isAgentRunning: bool,
   ~hasActiveACPSession: bool,
   ~sessionInitialized: bool,
 ): (thinkingState, string) => {
   let state = use(
     ~messages,
-    ~isStreaming,
     ~isAgentRunning,
     ~hasActiveACPSession,
     ~sessionInitialized,

--- a/libs/client/src/hooks/Client__UseThinkingState.res
+++ b/libs/client/src/hooks/Client__UseThinkingState.res
@@ -66,7 +66,7 @@ let isAwaitingResponse = (lastMessage: option<Message.t>): bool => {
  */
 let use = (
   ~messages: array<Message.t>,
-  ~isStreaming: bool,
+  ~isStreaming as _: bool,
   ~isAgentRunning: bool,
   ~hasActiveACPSession: bool,
   ~sessionInitialized: bool,
@@ -77,10 +77,7 @@ let use = (
     hasActiveACPSession &&
     sessionInitialized &&
     isAgentRunning &&
-    !isStreaming &&
-    !isTurnEnded(lastMessage) &&
-    !isLastMessageStreaming(lastMessage) &&
-    isAwaitingResponse(lastMessage)
+    !isTurnEnded(lastMessage)
 
   let thinkingContext = if showThinking {
     getThinkingContext(lastMessage)


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Show the existing loader until the whole AI turn is complete.

https://github.com/user-attachments/assets/c2fb7624-0432-4e8e-8d85-fd0d6961826e



## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
