### PR TITLE
run provider specific tests conditionally on forks

### DIFF
--- a/test/e2e/tests/astro.test.ts
+++ b/test/e2e/tests/astro.test.ts
@@ -5,6 +5,9 @@ import { openFrontmanUI, sendPrompt } from "../helpers/frontman-ui.js";
 import { installAstro } from "../helpers/installer.js";
 
 const PORT = 3011;
+const providerIt = it.skipIf(
+  !process.env.E2E_OPENAI_ACCESS_TOKEN || !process.env.E2E_OPENAI_REFRESH_TOKEN,
+);
 
 describe("Astro E2E", () => {
   let browser: Browser;
@@ -62,7 +65,7 @@ describe("Astro E2E", () => {
     expect(indexRoute.file).toContain("index.astro");
   });
 
-  it("should sync the preview URL after client-side navigation", async () => {
+  providerIt("should sync the preview URL after client-side navigation", async () => {
     page = await context.newPage();
     await openFrontmanUI(page, PORT);
 
@@ -78,7 +81,7 @@ describe("Astro E2E", () => {
     await page.close();
   });
 
-  it("should make a text change via AI prompt", async () => {
+  providerIt("should make a text change via AI prompt", async () => {
     page = await context.newPage();
 
     await openFrontmanUI(page, PORT);

--- a/test/e2e/tests/nextjs.test.ts
+++ b/test/e2e/tests/nextjs.test.ts
@@ -15,6 +15,10 @@ import { openFrontmanUI, sendPrompt } from "../helpers/frontman-ui.js";
 import { installNextjs } from "../helpers/installer.js";
 
 const PORT = 3010;
+const providerIt = it.skipIf(
+	!process.env.E2E_OPENAI_ACCESS_TOKEN ||
+		!process.env.E2E_OPENAI_REFRESH_TOKEN,
+);
 
 describe("Next.js E2E", () => {
 	let browser: Browser;
@@ -44,7 +48,7 @@ describe("Next.js E2E", () => {
 		expect(html).toContain("Hello World");
 	});
 
-	it("selects agents accessibly without overflowing chat widths", async () => {
+	providerIt("selects agents accessibly without overflowing chat widths", async () => {
 		const selectorPage = await context.newPage();
 		await openFrontmanUI(selectorPage, PORT, {
 			assertHealthy: server.assertHealthy,
@@ -111,7 +115,7 @@ describe("Next.js E2E", () => {
 		await selectorPage.close();
 	});
 
-	it("should make a text change via AI prompt", async () => {
+	providerIt("should make a text change via AI prompt", async () => {
 		page = await context.newPage();
 
 		await openFrontmanUI(page, PORT, { assertHealthy: server.assertHealthy });

--- a/test/e2e/tests/vite.test.ts
+++ b/test/e2e/tests/vite.test.ts
@@ -5,6 +5,9 @@ import { openFrontmanUI, sendPrompt } from "../helpers/frontman-ui.js";
 import { installVite } from "../helpers/installer.js";
 
 const PORT = 3012;
+const providerIt = it.skipIf(
+  !process.env.E2E_OPENAI_ACCESS_TOKEN || !process.env.E2E_OPENAI_REFRESH_TOKEN,
+);
 
 describe("Vite E2E", () => {
   let browser: Browser;
@@ -39,7 +42,7 @@ describe("Vite E2E", () => {
       .waitFor({ state: "visible" });
   });
 
-  it("should make a text change via AI prompt", async () => {
+  providerIt("should make a text change via AI prompt", async () => {
     page = await context.newPage();
 
     await openFrontmanUI(page, PORT);

--- a/test/e2e/tests/vue-vite.test.ts
+++ b/test/e2e/tests/vue-vite.test.ts
@@ -5,6 +5,9 @@ import { openFrontmanUI, sendPrompt } from "../helpers/frontman-ui.js";
 import { installVueVite } from "../helpers/installer.js";
 
 const PORT = 3013;
+const providerIt = it.skipIf(
+  !process.env.E2E_OPENAI_ACCESS_TOKEN || !process.env.E2E_OPENAI_REFRESH_TOKEN,
+);
 
 describe("Vue + Vite E2E", () => {
   let browser: Browser;
@@ -39,7 +42,7 @@ describe("Vue + Vite E2E", () => {
       .waitFor({ state: "visible" });
   });
 
-  it("should make a text change via AI prompt", async () => {
+  providerIt("should make a text change via AI prompt", async () => {
     page = await context.newPage();
 
     await openFrontmanUI(page, PORT);


### PR DESCRIPTION
## Description

Openai access and refresh token can run only in the source repo and not forks. So added conditional testing to skip those tests when the tokens are missing.

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [x] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
