### PR TITLE
Fix embedded auth rollout and popup logout

### DIFF
--- a/.changeset/unify-frontman-login.md
+++ b/.changeset/unify-frontman-login.md
@@ -1,5 +1,6 @@
 ---
 "@frontman-ai/client": patch
+"@frontman-ai/frontman-wordpress": patch
 ---
 
-Use one explicit new-tab sign-in flow in top-level and embedded Frontman clients.
+Use one explicit new-tab sign-in flow in top-level and embedded Frontman clients. Ensure WordPress installations receive the updated hosted client instead of a browser-cached bundle.

--- a/libs/client/public/_headers
+++ b/libs/client/public/_headers
@@ -1,0 +1,5 @@
+/frontman.es.js
+  Cache-Control: public, max-age=0, must-revalidate
+
+/frontman.css
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary
- force Cloudflare Pages to revalidate stable Frontman client assets and release a WordPress cache-key patch
- run embedded logout in a first-party popup without navigating WordPress Playground
- disconnect ACP immediately, confirm logout with bounded consecutive checks, and return client to sign-in state
- bind socket credentials to database sessions, use stable browser socket identities, revoke before disconnect, and revalidate on channel join
- add public popup completion route and CSRF-protected logout mode

## Verification
- `make -C libs/client test` (333 tests)
- `make -C libs/client build-standalone`
- `mix test` (740 tests)
- `mix format --check-formatted`
- `mix credo --strict`
- `mix compile --warnings-as-errors --all-warnings`
- fresh WordPress Playground load in isolated Chromium

## Notes
- `mix precommit` is documented in app guidance but no alias exists; equivalent server gates ran separately
- full authenticated production Playground logout still requires human OAuth credentials after deployment
