### PR TITLE
clear banner when retry resumes

### DIFF
--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -283,9 +283,6 @@ defmodule FrontmanServerWeb.TaskChannel do
         _missing -> load_turn_context!(socket, turn_number)
       end
 
-    notification = ACP.build_state_update_notification(socket.assigns.task_id, "running")
-    push(socket, @acp_message, notification)
-
     {:noreply, assign(socket, :active_turn, context)}
   end
 
@@ -789,7 +786,8 @@ defmodule FrontmanServerWeb.TaskChannel do
            }
          ) do
       :ok ->
-        :ok
+        notification = ACP.build_state_update_notification(socket.assigns.task_id, "running")
+        push(socket, @acp_message, notification)
 
       {:error, reason} ->
         unless reason in [:not_found, :stale_turn] do

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -283,6 +283,9 @@ defmodule FrontmanServerWeb.TaskChannel do
         _missing -> load_turn_context!(socket, turn_number)
       end
 
+    notification = ACP.build_state_update_notification(socket.assigns.task_id, "running")
+    push(socket, @acp_message, notification)
+
     {:noreply, assign(socket, :active_turn, context)}
   end
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

An error banner (like overloaded api error) does not clear even after retry resumes.  Push the state update to clear the banner.


https://github.com/user-attachments/assets/7965164e-7ecd-4a82-8dde-25fbf32cc993

https://github.com/user-attachments/assets/3eb158da-7871-4ede-ae0d-e77945ca6b42




## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->




## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
