### PR TITLE
use paste command twice to expand pasted text

### DIFF
--- a/.changeset/expand-repeated-pastes.md
+++ b/.changeset/expand-repeated-pastes.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Allow a second paste within five seconds to expand a pasted-text chip in place.

--- a/libs/bindings/src/Bindings__Tiptap__Core.res
+++ b/libs/bindings/src/Bindings__Tiptap__Core.res
@@ -43,6 +43,7 @@ external mergeAttributes: (htmlAttributes, Dict.t<string>) => htmlAttributes = "
 @send external focus: chain => chain = "focus"
 @send external insertContentAtPos: (chain, int, nodeSpec) => chain = "insertContentAt"
 @send external insertContentAtRange: (chain, insertRange, nodeSpec) => chain = "insertContentAt"
+@send external insertTextAtRange: (chain, insertRange, string) => chain = "insertContentAt"
 @send external setTextSelection: (chain, int) => chain = "setTextSelection"
 @send external run: chain => bool = "run"
 
@@ -53,5 +54,6 @@ module Commands = {
 
   @get external commands: editor => t = "commands"
   @send external clearContent: t => unit = "clearContent"
+  @send external setTextSelection: (t, int) => bool = "setTextSelection"
   @send external splitBlock: t => bool = "splitBlock"
 }

--- a/libs/bindings/src/Bindings__Tiptap__Core.res
+++ b/libs/bindings/src/Bindings__Tiptap__Core.res
@@ -4,7 +4,9 @@ type nodeExtension = extension
 type nodeConstructor
 type chain
 type selection = {from: int, to_: int}
-type editorState = {selection: selection}
+type proseMirrorNodeType
+type proseMirrorNode
+type editorState = {selection: selection, doc: proseMirrorNode}
 
 type insertRange = {from: int, to_: int}
 type htmlAttributes
@@ -38,6 +40,13 @@ external mergeAttributes: (htmlAttributes, Dict.t<string>) => htmlAttributes = "
 @send external setEditable: (editor, bool) => unit = "setEditable"
 @get external isEmpty: editor => bool = "isEmpty"
 @get external state: editor => editorState = "state"
+
+@get external nodeType: proseMirrorNode => proseMirrorNodeType = "type"
+@get external nodeTypeName: proseMirrorNodeType => string = "name"
+@get external nodeAttrs: proseMirrorNode => Dict.t<unknown> = "attrs"
+@get external nodeSize: proseMirrorNode => int = "nodeSize"
+@send
+external descendants: (proseMirrorNode, (proseMirrorNode, int) => bool) => unit = "descendants"
 
 @send external chain: editor => chain = "chain"
 @send external focus: chain => chain = "focus"

--- a/libs/bindings/src/Bindings__Tiptap__Core.res
+++ b/libs/bindings/src/Bindings__Tiptap__Core.res
@@ -11,9 +11,25 @@ type editorState = {selection: selection, doc: proseMirrorNode}
 type insertRange = {from: int, to_: int}
 type htmlAttributes
 type htmlRenderContext = {"HTMLAttributes": htmlAttributes}
-type nodeSpec
 type attributeSpec = {default: string}
 type parseRule = {tag: string}
+
+module Content: {
+  type t
+
+  let text: string => t
+  let node: (~type_: string, ~attrs: Dict.t<JSON.t>) => t
+} = {
+  type t = {
+    @as("type")
+    type_: string,
+    text?: string,
+    attrs?: Dict.t<JSON.t>,
+  }
+
+  let text = text => {type_: "text", text}
+  let node = (~type_, ~attrs) => {type_, attrs}
+}
 
 type nodeOptions<'options> = {
   name: string,
@@ -50,9 +66,8 @@ external descendants: (proseMirrorNode, (proseMirrorNode, int) => bool) => unit 
 
 @send external chain: editor => chain = "chain"
 @send external focus: chain => chain = "focus"
-@send external insertContentAtPos: (chain, int, nodeSpec) => chain = "insertContentAt"
-@send external insertContentAtRange: (chain, insertRange, nodeSpec) => chain = "insertContentAt"
-@send external insertTextAtRange: (chain, insertRange, string) => chain = "insertContentAt"
+@send external insertContentAtPos: (chain, int, Content.t) => chain = "insertContentAt"
+@send external insertContentAtRange: (chain, insertRange, Content.t) => chain = "insertContentAt"
 @send external setTextSelection: (chain, int) => chain = "setTextSelection"
 @send external run: chain => bool = "run"
 
@@ -63,6 +78,5 @@ module Commands = {
 
   @get external commands: editor => t = "commands"
   @send external clearContent: t => unit = "clearContent"
-  @send external setTextSelection: (t, int) => bool = "setTextSelection"
   @send external splitBlock: t => bool = "splitBlock"
 }

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -40,7 +40,7 @@ module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
 type fileAttachmentNodeOptions = {onPreviewImage: string => unit}
 type fileAttachmentAttrs = editorFileAttachment
 type pastedTextAttrs = {id: string, text: string, label: string}
-type expandablePaste = {text: string, from: int, to_: int, expiresAt: float}
+type expandablePaste = {chipId: string, text: string, expiresAt: float}
 type insertTarget =
   | Cursor(int)
   | Range(TiptapCore.insertRange)
@@ -372,16 +372,9 @@ let insertFileAttachment = (editor, fileAttachment, insertTarget) => {
 
 let insertPastedText = (editor, text) => {
   let insertTarget = getSelectionInsertTarget(editor)
-  let insertedAtomStart = switch insertTarget {
-  | Cursor(position) => position
-  | Range({from}) => from
-  }
   let insertedAtomEnd = getInsertedAtomEnd(insertTarget)
-  let attrs = stringAttrs([
-    ("id", generateId()),
-    ("text", text),
-    ("label", getPastedTextLabel(text)),
-  ])
+  let chipId = generateId()
+  let attrs = stringAttrs([("id", chipId), ("text", text), ("label", getPastedTextLabel(text))])
   let content = nodeSpec(~type_="pastedText", ~attrs)
   let chain = editor->TiptapCore.chain->TiptapCore.focus
 
@@ -393,15 +386,37 @@ let insertPastedText = (editor, text) => {
   ->TiptapCore.run
   ->ignore
 
-  {text, from: insertedAtomStart, to_: insertedAtomEnd, expiresAt: Date.now() +. 5000.0}
+  {chipId, text, expiresAt: Date.now() +. 5000.0}
 }
 
-let expandPastedText = (editor, paste) => {
+/* get the live range by chip id instead of using the insert-time position*/
+let findPastedTextChipRange = (editor, chipId): option<TiptapCore.insertRange> => {
+  let state: TiptapCore.editorState = editor->TiptapCore.state
+  let found = ref(None)
+
+  state.doc->TiptapCore.descendants((node, position) => {
+    switch found.contents {
+    | Some(_) => false
+    | None =>
+      switch node->TiptapCore.nodeType->TiptapCore.nodeTypeName == "pastedText" &&
+        node->TiptapCore.nodeAttrs->attrString("id") == chipId {
+      | true =>
+        found := Some({TiptapCore.from: position, to_: position + node->TiptapCore.nodeSize})
+        false
+      | false => true
+      }
+    }
+  })
+
+  found.contents
+}
+
+let expandPastedText = (editor, paste, range: TiptapCore.insertRange) => {
   editor
   ->TiptapCore.chain
   ->TiptapCore.focus
-  ->TiptapCore.insertTextAtRange({from: paste.from, to_: paste.to_}, paste.text)
-  ->TiptapCore.setTextSelection(paste.from + paste.text->String.length)
+  ->TiptapCore.insertTextAtRange(range, paste.text)
+  ->TiptapCore.setTextSelection(range.from + paste.text->String.length)
   ->TiptapCore.run
   ->ignore
 }
@@ -586,13 +601,7 @@ let make = (
           event->WebAPI.ClipboardEvent.preventDefault
           true
         | Some(currentEditor) =>
-          switch expandablePasteRef.current {
-          | Some(paste) if Date.now() <= paste.expiresAt =>
-            event->WebAPI.ClipboardEvent.preventDefault
-            cancelExpandablePaste()
-            expandPastedText(currentEditor, paste)
-            true
-          | _ =>
+          let insertNewPaste = () => {
             cancelExpandablePaste()
             let dataTransfer = event.clipboardData->Null.toOption
             let acceptedFiles = dataTransfer->getClipboardFiles->Array.filter(isAcceptedPromptFile)
@@ -612,6 +621,20 @@ let make = (
               expandablePasteRef.current = Some(insertPastedText(currentEditor, text))
               true
             }
+          }
+
+          switch expandablePasteRef.current {
+          | Some(paste) if Date.now() <= paste.expiresAt =>
+            /* expand only when it is still in the doc*/
+            switch findPastedTextChipRange(currentEditor, paste.chipId) {
+            | Some(range) =>
+              event->WebAPI.ClipboardEvent.preventDefault
+              cancelExpandablePaste()
+              expandPastedText(currentEditor, paste, range)
+              true
+            | None => insertNewPaste()
+            }
+          | _ => insertNewPaste()
           }
         }
       },

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -32,6 +32,7 @@ type rec jsonContentNode = {
 @send external clickElement: Dom.element => unit = "click"
 @get external inputFiles: Dom.element => Null.t<WebAPI.DomTypes.fileList> = "files"
 @set external setInputValue: (Dom.element, string) => unit = "value"
+@get external navigatorUserAgent: WebAPI.Global.navigator => string = "userAgent"
 module TiptapReact = FrontmanBindings.Bindings__Tiptap__React
 module TiptapCore = FrontmanBindings.Bindings__Tiptap__Core
 module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
@@ -39,6 +40,7 @@ module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
 type fileAttachmentNodeOptions = {onPreviewImage: string => unit}
 type fileAttachmentAttrs = editorFileAttachment
 type pastedTextAttrs = {id: string, text: string, label: string}
+type expandablePaste = {text: string, from: int, to_: int, expiresAt: float}
 type insertTarget =
   | Cursor(int)
   | Range(TiptapCore.insertRange)
@@ -92,6 +94,17 @@ let lineCount = text => text->String.split("\n")->Array.length
 let isLongPromptPasteText = text => text->lineCount >= 3 || text->String.length > 150
 
 let getPastedTextLabel = text => `Pasted ~${text->lineCount->Int.toString} lines`
+
+let getPasteExpandShortcut = userAgent => userAgent->String.includes("Mac") ? "Cmd+V" : "Ctrl+V"
+
+let isPasteShortcut = (event: WebAPI.UiEventsTypes.keyboardEvent) =>
+  event.key->String.toLowerCase == "v" && (event.metaKey || event.ctrlKey)
+
+let isModifierKey = key =>
+  switch key {
+  | "Meta" | "Control" | "Alt" | "Shift" => true
+  | _ => false
+  }
 
 let truncateChipLabel = label => {
   switch label->String.length > 20 {
@@ -186,7 +199,14 @@ module PastedTextView = {
     <TiptapReact.NodeViewWrapper
       as_="span" className="frontman-prompt-pill" dataChipId={attrs.id} dataChipType="paste"
     >
-      <span> {React.string(label)} </span>
+      <span className="frontman-prompt-paste-label">
+        <span> {React.string(label)} </span>
+        <span className="frontman-prompt-paste-hint">
+          {React.string(
+            `${WebAPI.Global.navigator->navigatorUserAgent->getPasteExpandShortcut} to expand`,
+          )}
+        </span>
+      </span>
       <button
         ariaLabel="Remove pasted text"
         className="frontman-prompt-pill-remove"
@@ -352,6 +372,10 @@ let insertFileAttachment = (editor, fileAttachment, insertTarget) => {
 
 let insertPastedText = (editor, text) => {
   let insertTarget = getSelectionInsertTarget(editor)
+  let insertedAtomStart = switch insertTarget {
+  | Cursor(position) => position
+  | Range({from}) => from
+  }
   let insertedAtomEnd = getInsertedAtomEnd(insertTarget)
   let attrs = stringAttrs([
     ("id", generateId()),
@@ -366,6 +390,18 @@ let insertPastedText = (editor, text) => {
   | Range(range) => chain->TiptapCore.insertContentAtRange(range, content)
   }
   ->TiptapCore.setTextSelection(insertedAtomEnd)
+  ->TiptapCore.run
+  ->ignore
+
+  {text, from: insertedAtomStart, to_: insertedAtomEnd, expiresAt: Date.now() +. 5000.0}
+}
+
+let expandPastedText = (editor, paste) => {
+  editor
+  ->TiptapCore.chain
+  ->TiptapCore.focus
+  ->TiptapCore.insertTextAtRange({from: paste.from, to_: paste.to_}, paste.text)
+  ->TiptapCore.setTextSelection(paste.from + paste.text->String.length)
   ->TiptapCore.run
   ->ignore
 }
@@ -448,6 +484,7 @@ let make = (
   let lastSubmitSignalRef = React.useRef(submitSignal)
   let lastAttachSignalRef = React.useRef(attachSignal)
   let lastDropFilesSignalRef = React.useRef(dropFilesSignal)
+  let expandablePasteRef: React.ref<option<expandablePaste>> = React.useRef(None)
 
   placeholderRef.current = placeholder
   disabledRef.current = disabled
@@ -459,6 +496,7 @@ let make = (
   onFileSizeErrorRef.current = onFileSizeError
 
   let isInputBlocked = () => disabledRef.current || isEnrichingAnnotationsRef.current
+  let cancelExpandablePaste = () => expandablePasteRef.current = None
 
   let submitEditor = editor => {
     let serialized = editor->TiptapCore.getJSON->Obj.magic->serializePromptEditorContent
@@ -522,6 +560,10 @@ let make = (
     editorProps: {
       attributes: Dict.fromArray([("aria-label", placeholder), ("role", "textbox")]),
       handleKeyDown: (_view, event) => {
+        switch event->isPasteShortcut || event.key->isModifierKey {
+        | true => ()
+        | false => cancelExpandablePaste()
+        }
         switch event.key {
         | "Enter" =>
           switch editorRef.current->Null.toOption {
@@ -544,21 +586,32 @@ let make = (
           event->WebAPI.ClipboardEvent.preventDefault
           true
         | Some(currentEditor) =>
-          let dataTransfer = event.clipboardData->Null.toOption
-          let acceptedFiles = dataTransfer->getClipboardFiles->Array.filter(isAcceptedPromptFile)
-          let text =
-            dataTransfer->Option.map(WebAPI.DataTransfer.getData(_, "text/plain"))->Option.getOr("")
+          switch expandablePasteRef.current {
+          | Some(paste) if Date.now() <= paste.expiresAt =>
+            event->WebAPI.ClipboardEvent.preventDefault
+            cancelExpandablePaste()
+            expandPastedText(currentEditor, paste)
+            true
+          | _ =>
+            cancelExpandablePaste()
+            let dataTransfer = event.clipboardData->Null.toOption
+            let acceptedFiles = dataTransfer->getClipboardFiles->Array.filter(isAcceptedPromptFile)
+            let text =
+              dataTransfer
+              ->Option.map(WebAPI.DataTransfer.getData(_, "text/plain"))
+              ->Option.getOr("")
 
-          switch (acceptedFiles->Array.length > 0, text == "" || !isLongPromptPasteText(text)) {
-          | (true, _) =>
-            event->WebAPI.ClipboardEvent.preventDefault
-            addFiles(currentEditor, acceptedFiles)->ignore
-            true
-          | (false, true) => false
-          | (false, false) =>
-            event->WebAPI.ClipboardEvent.preventDefault
-            insertPastedText(currentEditor, text)
-            true
+            switch (acceptedFiles->Array.length > 0, text == "" || !isLongPromptPasteText(text)) {
+            | (true, _) =>
+              event->WebAPI.ClipboardEvent.preventDefault
+              addFiles(currentEditor, acceptedFiles)->ignore
+              true
+            | (false, true) => false
+            | (false, false) =>
+              event->WebAPI.ClipboardEvent.preventDefault
+              expandablePasteRef.current = Some(insertPastedText(currentEditor, text))
+              true
+            }
           }
         }
       },

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -40,7 +40,7 @@ module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
 type fileAttachmentNodeOptions = {onPreviewImage: string => unit}
 type fileAttachmentAttrs = editorFileAttachment
 type pastedTextAttrs = {id: string, text: string, label: string}
-type expandablePaste = {chipId: string, text: string, expiresAt: float}
+type expandablePaste = {chipId: string, text: string}
 type insertTarget =
   | Cursor(int)
   | Range(TiptapCore.insertRange)
@@ -95,6 +95,8 @@ let isLongPromptPasteText = text => text->lineCount >= 3 || text->String.length 
 
 let getPastedTextLabel = text => `Pasted ~${text->lineCount->Int.toString} lines`
 
+let expandablePasteWindowMs = 5000
+
 let getPasteExpandShortcut = userAgent => userAgent->String.includes("Mac") ? "Cmd+V" : "Ctrl+V"
 
 let isPasteShortcut = (event: WebAPI.UiEventsTypes.keyboardEvent) =>
@@ -105,6 +107,13 @@ let isModifierKey = key =>
   | "Meta" | "Control" | "Alt" | "Shift" => true
   | _ => false
   }
+
+/* rechecks if the chip content is same as the clipboard content before expanding */
+let expandablePasteContext: React.Context.t<option<string>> = React.createContext(None)
+
+module ExpandablePasteProvider = {
+  let make = React.Context.provider(expandablePasteContext)
+}
 
 let truncateChipLabel = label => {
   switch label->String.length > 20 {
@@ -191,6 +200,7 @@ module FileAttachmentView = {
 module PastedTextView = {
   let make = (props: TiptapReact.nodeViewProps<unit>) => {
     let attrs = pastedTextAttrsFromNode(props.node)
+    let expandableChipId = React.useContext(expandablePasteContext)
     let label = switch attrs.label {
     | "" => getPastedTextLabel(attrs.text)
     | label => label
@@ -201,11 +211,15 @@ module PastedTextView = {
     >
       <span className="frontman-prompt-paste-label">
         <span> {React.string(label)} </span>
-        <span className="frontman-prompt-paste-hint">
-          {React.string(
-            `${WebAPI.Global.navigator->navigatorUserAgent->getPasteExpandShortcut} to expand`,
-          )}
-        </span>
+        {switch expandableChipId == Some(attrs.id) {
+        | false => React.null
+        | true =>
+          <span className="frontman-prompt-paste-hint">
+            {React.string(
+              `${WebAPI.Global.navigator->navigatorUserAgent->getPasteExpandShortcut} to expand`,
+            )}
+          </span>
+        }}
       </span>
       <button
         ariaLabel="Remove pasted text"
@@ -386,7 +400,7 @@ let insertPastedText = (editor, text) => {
   ->TiptapCore.run
   ->ignore
 
-  {chipId, text, expiresAt: Date.now() +. 5000.0}
+  {chipId, text}
 }
 
 /* get the live range by chip id instead of using the insert-time position*/
@@ -499,8 +513,11 @@ let make = (
   let lastSubmitSignalRef = React.useRef(submitSignal)
   let lastAttachSignalRef = React.useRef(attachSignal)
   let lastDropFilesSignalRef = React.useRef(dropFilesSignal)
+  let (expandablePaste, setExpandablePaste) = React.useState((): option<expandablePaste> => None)
   let expandablePasteRef: React.ref<option<expandablePaste>> = React.useRef(None)
+  let expandablePasteTimerRef: React.ref<option<int>> = React.useRef(None)
 
+  expandablePasteRef.current = expandablePaste
   placeholderRef.current = placeholder
   disabledRef.current = disabled
   isEnrichingAnnotationsRef.current = isEnrichingAnnotations
@@ -511,7 +528,32 @@ let make = (
   onFileSizeErrorRef.current = onFileSizeError
 
   let isInputBlocked = () => disabledRef.current || isEnrichingAnnotationsRef.current
-  let cancelExpandablePaste = () => expandablePasteRef.current = None
+
+  let clearExpandablePasteTimer = () => {
+    expandablePasteTimerRef.current->Option.forEach(WebAPI.Global.clearTimeout)
+    expandablePasteTimerRef.current = None
+  }
+
+  let cancelExpandablePaste = () => {
+    switch expandablePasteRef.current {
+    | None => ()
+    | Some(_) =>
+      clearExpandablePasteTimer()
+      expandablePasteRef.current = None
+      setExpandablePaste(_ => None)
+    }
+  }
+
+  let startExpandablePaste = paste => {
+    clearExpandablePasteTimer()
+    expandablePasteRef.current = Some(paste)
+    setExpandablePaste(_ => Some(paste))
+    expandablePasteTimerRef.current = Some(
+      WebAPI.Global.setTimeout(~handler=cancelExpandablePaste, ~timeout=expandablePasteWindowMs),
+    )
+  }
+
+  React.useEffect0(() => Some(clearExpandablePasteTimer))
 
   let submitEditor = editor => {
     let serialized = editor->TiptapCore.getJSON->Obj.magic->serializePromptEditorContent
@@ -601,15 +643,13 @@ let make = (
           event->WebAPI.ClipboardEvent.preventDefault
           true
         | Some(currentEditor) =>
+          let dataTransfer = event.clipboardData->Null.toOption
+          let acceptedFiles = dataTransfer->getClipboardFiles->Array.filter(isAcceptedPromptFile)
+          let text =
+            dataTransfer->Option.map(WebAPI.DataTransfer.getData(_, "text/plain"))->Option.getOr("")
+
           let insertNewPaste = () => {
             cancelExpandablePaste()
-            let dataTransfer = event.clipboardData->Null.toOption
-            let acceptedFiles = dataTransfer->getClipboardFiles->Array.filter(isAcceptedPromptFile)
-            let text =
-              dataTransfer
-              ->Option.map(WebAPI.DataTransfer.getData(_, "text/plain"))
-              ->Option.getOr("")
-
             switch (acceptedFiles->Array.length > 0, text == "" || !isLongPromptPasteText(text)) {
             | (true, _) =>
               event->WebAPI.ClipboardEvent.preventDefault
@@ -618,13 +658,13 @@ let make = (
             | (false, true) => false
             | (false, false) =>
               event->WebAPI.ClipboardEvent.preventDefault
-              expandablePasteRef.current = Some(insertPastedText(currentEditor, text))
+              startExpandablePaste(insertPastedText(currentEditor, text))
               true
             }
           }
 
           switch expandablePasteRef.current {
-          | Some(paste) if Date.now() <= paste.expiresAt =>
+          | Some(paste) if text != "" && text == paste.text =>
             /* expand only when it is still in the doc*/
             switch findPastedTextChipRange(currentEditor, paste.chipId) {
             | Some(range) =>
@@ -748,11 +788,13 @@ let make = (
       ref={ReactDOM.Ref.domRef(fileInputRef)}
       type_="file"
     />
-    <TiptapReact.EditorContent
-      editor
-      className={`frontman-prompt-editor-content ${disabled || isEnrichingAnnotations
-          ? "frontman-prompt-editor-content-disabled"
-          : ""}`}
-    />
+    <ExpandablePasteProvider value={expandablePaste->Option.map(paste => paste.chipId)}>
+      <TiptapReact.EditorContent
+        editor
+        className={`frontman-prompt-editor-content ${disabled || isEnrichingAnnotations
+            ? "frontman-prompt-editor-content-disabled"
+            : ""}`}
+      />
+    </ExpandablePasteProvider>
   </div>
 }

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -108,7 +108,6 @@ let isModifierKey = key =>
   | _ => false
   }
 
-/* rechecks if the chip content is same as the clipboard content before expanding */
 let expandablePasteContext: React.Context.t<option<string>> = React.createContext(None)
 
 module ExpandablePasteProvider = {
@@ -299,13 +298,6 @@ let stringAttrs = pairs => {
   attrs
 }
 
-let nodeSpec = (~type_, ~attrs): TiptapCore.nodeSpec => {
-  let spec = Dict.make()
-  spec->Dict.set("type", JSON.Encode.string(type_))
-  spec->Dict.set("attrs", JSON.Encode.object(attrs))
-  spec->Obj.magic
-}
-
 let fileAttachmentToAttrs = (fileAttachment: editorFileAttachment) => {
   stringAttrs([
     ("id", fileAttachment.id),
@@ -371,7 +363,10 @@ let getInsertedAtomEnd = target => {
 let insertFileAttachment = (editor, fileAttachment, insertTarget) => {
   let insertedAtomEnd = getInsertedAtomEnd(insertTarget)
   let chain = editor->TiptapCore.chain->TiptapCore.focus
-  let content = nodeSpec(~type_="fileAttachment", ~attrs=fileAttachment->fileAttachmentToAttrs)
+  let content = TiptapCore.Content.node(
+    ~type_="fileAttachment",
+    ~attrs=fileAttachment->fileAttachmentToAttrs,
+  )
 
   switch insertTarget {
   | Cursor(position) => chain->TiptapCore.insertContentAtPos(position, content)
@@ -389,7 +384,7 @@ let insertPastedText = (editor, text) => {
   let insertedAtomEnd = getInsertedAtomEnd(insertTarget)
   let chipId = generateId()
   let attrs = stringAttrs([("id", chipId), ("text", text), ("label", getPastedTextLabel(text))])
-  let content = nodeSpec(~type_="pastedText", ~attrs)
+  let content = TiptapCore.Content.node(~type_="pastedText", ~attrs)
   let chain = editor->TiptapCore.chain->TiptapCore.focus
 
   switch insertTarget {
@@ -403,7 +398,6 @@ let insertPastedText = (editor, text) => {
   {chipId, text}
 }
 
-/* get the live range by chip id instead of using the insert-time position*/
 let findPastedTextChipRange = (editor, chipId): option<TiptapCore.insertRange> => {
   let state: TiptapCore.editorState = editor->TiptapCore.state
   let found = ref(None)
@@ -429,7 +423,7 @@ let expandPastedText = (editor, paste, range: TiptapCore.insertRange) => {
   editor
   ->TiptapCore.chain
   ->TiptapCore.focus
-  ->TiptapCore.insertTextAtRange(range, paste.text)
+  ->TiptapCore.insertContentAtRange(range, TiptapCore.Content.text(paste.text))
   ->TiptapCore.setTextSelection(range.from + paste.text->String.length)
   ->TiptapCore.run
   ->ignore
@@ -665,7 +659,6 @@ let make = (
 
           switch expandablePasteRef.current {
           | Some(paste) if text != "" && text == paste.text =>
-            /* expand only when it is still in the doc*/
             switch findPastedTextChipRange(currentEditor, paste.chipId) {
             | Some(range) =>
               event->WebAPI.ClipboardEvent.preventDefault

--- a/libs/client/src/index.css
+++ b/libs/client/src/index.css
@@ -159,14 +159,6 @@
 	overflow: hidden;
 	white-space: nowrap;
 	color: rgb(196 181 253);
-	animation: frontman-hide-paste-hint 1ms 5s forwards;
-}
-
-@keyframes frontman-hide-paste-hint {
-	to {
-		max-width: 0;
-		opacity: 0;
-	}
 }
 
 .frontman-prompt-pill-remove {

--- a/libs/client/src/index.css
+++ b/libs/client/src/index.css
@@ -148,6 +148,27 @@
 	flex-shrink: 0;
 }
 
+.frontman-prompt-paste-label {
+	display: inline-flex;
+	flex-wrap: wrap;
+	column-gap: 0.25rem;
+}
+
+.frontman-prompt-paste-hint {
+	max-width: 10rem;
+	overflow: hidden;
+	white-space: nowrap;
+	color: rgb(196 181 253);
+	animation: frontman-hide-paste-hint 1ms 5s forwards;
+}
+
+@keyframes frontman-hide-paste-hint {
+	to {
+		max-width: 0;
+		opacity: 0;
+	}
+}
+
 .frontman-prompt-pill-remove {
 	margin-left: 0.125rem;
 	color: rgb(167 139 250);

--- a/libs/client/test/Bindings__Tiptap__Core.test.res
+++ b/libs/client/test/Bindings__Tiptap__Core.test.res
@@ -1,0 +1,27 @@
+open Vitest
+
+module TiptapCore = FrontmanBindings.Bindings__Tiptap__Core
+
+@get external contentType: TiptapCore.Content.t => string = "type"
+@get external contentText: TiptapCore.Content.t => string = "text"
+@get external contentAttrs: TiptapCore.Content.t => Dict.t<JSON.t> = "attrs"
+
+describe("Tiptap content", () => {
+  test("keeps HTML-like text literal", t => {
+    let text = `<button data-action="save">Save & close</button>`
+    let content = TiptapCore.Content.text(text)
+
+    t->expect(content->contentType)->Expect.toBe("text")
+    t->expect(content->contentText)->Expect.toBe(text)
+  })
+
+  test("constructs custom nodes with attributes", t => {
+    let attrs = Dict.fromArray([("id", JSON.Encode.string("paste-1"))])
+    let content = TiptapCore.Content.node(~type_="pastedText", ~attrs)
+
+    t->expect(content->contentType)->Expect.toBe("pastedText")
+    t
+    ->expect(content->contentAttrs->Dict.get("id")->Option.flatMap(JSON.Decode.string))
+    ->Expect.toEqual(Some("paste-1"))
+  })
+})


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Use cmd+v twice to expand the pasted text

https://github.com/user-attachments/assets/996974f2-2f6e-46d1-b2a6-26ed9ccc39fd

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist



- [ ] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
