### PR TITLE
Fix packaged ripgrep runtime loading

### DIFF
--- a/.changeset/quiet-pandas-search.md
+++ b/.changeset/quiet-pandas-search.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/nextjs": patch
+"@frontman-ai/vite": patch
+"@frontman-ai/astro": patch
+---
+
+Load packaged ripgrep binaries at runtime so grep and file search work from bundled integrations.

--- a/.github/workflows/ripgrep-runtime.yml
+++ b/.github/workflows/ripgrep-runtime.yml
@@ -1,0 +1,62 @@
+name: Packed Ripgrep Runtime
+
+on:
+  pull_request:
+    paths:
+      - "libs/bindings/**"
+      - "libs/frontman-core/**"
+      - "libs/frontman-nextjs/**"
+      - "libs/frontman-vite/**"
+      - "test/ripgrep-runtime/**"
+      - "yarn.lock"
+      - ".github/workflows/ripgrep-runtime.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/bindings/**"
+      - "libs/frontman-core/**"
+      - "libs/frontman-nextjs/**"
+      - "libs/frontman-vite/**"
+      - "test/ripgrep-runtime/**"
+      - "yarn.lock"
+      - ".github/workflows/ripgrep-runtime.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  packed-consumer:
+    name: ${{ matrix.integration }} / Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        integration: [nextjs, vite]
+        node: [18.0.0]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Setup build Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.4.1"
+
+      - name: Enable Corepack
+        run: corepack enable && corepack install
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Pack integration
+        run: make -C test/ripgrep-runtime pack PACKAGE=${{ matrix.integration }}
+
+      - name: Setup consumer Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Test packed runtime
+        run: |
+          TARBALL=$(node -e 'const p=require("./test/ripgrep-runtime/.artifacts/${{ matrix.integration }}-pack.json")[0]; process.stdout.write(require("node:path").resolve("test/ripgrep-runtime/.artifacts", p.filename))')
+          node test/ripgrep-runtime/run-consumer.mjs "${{ matrix.integration }}" "$TARBALL"

--- a/libs/bindings/src/Ripgrep.res
+++ b/libs/bindings/src/Ripgrep.res
@@ -1,0 +1,6 @@
+@module("./RipgrepRuntime.mjs")
+external getRipgrepPathRaw: unit => promise<Nullable.t<string>> = "getRipgrepPath"
+
+let getRipgrepPath = async (): option<string> => {
+  (await getRipgrepPathRaw())->Nullable.toOption
+}

--- a/libs/bindings/src/RipgrepRuntime.mjs
+++ b/libs/bindings/src/RipgrepRuntime.mjs
@@ -1,0 +1,12 @@
+import {importRuntimeModule} from "./RuntimeImport.mjs"
+
+const ripgrepModule = "@vscode/ripgrep"
+
+export async function getRipgrepPath() {
+  try {
+    const {rgPath} = await importRuntimeModule(ripgrepModule)
+    return rgPath
+  } catch {
+    return undefined
+  }
+}

--- a/libs/bindings/src/RuntimeImport.mjs
+++ b/libs/bindings/src/RuntimeImport.mjs
@@ -1,0 +1,18 @@
+import {createRequire} from "node:module"
+import {pathToFileURL} from "node:url"
+
+const runtimeRequire = createRequire(import.meta.url)
+const runtimeResolve = new Function("loader", "specifier", "return loader.resolve(specifier)")
+const runtimeLoad = new Function("specifier", "return import(specifier)")
+
+export const importRuntimeModule = async specifier => {
+  const resolvedUrl = pathToFileURL(runtimeResolve(runtimeRequire, specifier)).href
+  try {
+    return await runtimeLoad(resolvedUrl)
+  } catch (error) {
+    if (error?.code !== "ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING") {
+      throw error
+    }
+    return import(resolvedUrl)
+  }
+}

--- a/libs/frontman-astro/package.json
+++ b/libs/frontman-astro/package.json
@@ -57,6 +57,9 @@
 		"lighthouse": "^13.4.0",
 		"magic-string": "^0.30.21"
 	},
+	"optionalDependencies": {
+		"@vscode/ripgrep": "^1.18.0"
+	},
 	"peerDependencies": {
 		"astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
 	},

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
@@ -64,15 +64,6 @@ type output = {
 
 let (visibleToAgent, outputJsonSchema) = (true, Some(outputSchema->S.toJSONSchema))
 
-let getRipgrepPath = (): option<string> => {
-  try {
-    let vsCodeRipgrep = %raw(`require('@vscode/ripgrep')`)
-    Some(vsCodeRipgrep["rgPath"])
-  } catch {
-  | _ => None
-  }
-}
-
 let buildRipgrepArgs = (
   ~pattern: string,
   ~searchPath: string,
@@ -419,7 +410,7 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.C
     }
   }
 
-  let result = switch getRipgrepPath() {
+  let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
   | Some(rgPath) =>
     let result = await executeRipgrep(
       ~rgPath,

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -56,15 +56,6 @@ type backendError = {
   targetPath: string,
 }
 
-let getRipgrepPath = (): option<string> => {
-  try {
-    let vsCodeRipgrep = %raw(`require('@vscode/ripgrep')`)
-    Some(vsCodeRipgrep["rgPath"])
-  } catch {
-  | _ => None
-  }
-}
-
 let buildRipgrepArgs = (~searchPath: string): array<string> => {
   let args = []
 
@@ -232,7 +223,7 @@ let executeOutput = async (ctx: Tool.serverExecutionContext, input: input): resu
 
   let maxResults = input.maxResults->Option.getOr(20)
 
-  let result = switch getRipgrepPath() {
+  let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
   | Some(rgPath) =>
     let ripgrepResult = await executeRipgrep(
       ~rgPath,

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -60,6 +60,9 @@
 		"chrome-launcher": "^1.1.2",
 		"lighthouse": "^13.4.0"
 	},
+	"optionalDependencies": {
+		"@vscode/ripgrep": "^1.18.0"
+	},
 	"peerDependencies": {
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/sdk-logs": ">=0.52.0 <1.0.0",

--- a/libs/frontman-nextjs/test/FrontmanNextjs__Bundle.test.res
+++ b/libs/frontman-nextjs/test/FrontmanNextjs__Bundle.test.res
@@ -1,0 +1,15 @@
+open Vitest
+
+module Fs = FrontmanBindings.Fs
+module Path = FrontmanBindings.Path
+module Process = FrontmanBindings.Process
+
+describe("server bundle runtime dependencies", _ => {
+  let bundle = Fs.readFileSync(Path.join([Process.cwd(), "dist", "index.js"]))
+
+  test("does not bundle ripgrep platform resolution", t => {
+    t->expect(bundle->String.includes("platformPkg = `@vscode/ripgrep-"))->Expect.toBe(false)
+    t->expect(bundle->String.includes("import(ripgrepModule)"))->Expect.toBe(false)
+    t->expect(bundle->String.includes("runtimeRequire(specifier)"))->Expect.toBe(false)
+  })
+})

--- a/libs/frontman-vite/package.json
+++ b/libs/frontman-vite/package.json
@@ -57,6 +57,9 @@
 		"chrome-launcher": "^1.1.2",
 		"lighthouse": "^13.4.0"
 	},
+	"optionalDependencies": {
+		"@vscode/ripgrep": "^1.18.0"
+	},
 	"peerDependencies": {
 		"vite": ">=5.0.0"
 	},

--- a/test/astro-compat/fixture/tests/dev-server.test.mjs
+++ b/test/astro-compat/fixture/tests/dev-server.test.mjs
@@ -77,4 +77,13 @@ test("packed integration works in Astro dev server", {timeout: 120_000}, async t
   assert.match(body, /index\.astro/)
   assert.match(body, /\[slug\]\.astro/)
   assert.match(body, /health\.json\.ts/)
+
+  const searchResponse = await fetch(`${origin}${toolPath}`, {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({name: "search_files", arguments: {pattern: "package.json"}}),
+  })
+  const searchBody = await searchResponse.text()
+  assert.equal(searchResponse.status, 200)
+  assert.match(searchBody, /package\.json/)
 })

--- a/test/ripgrep-runtime/Makefile
+++ b/test/ripgrep-runtime/Makefile
@@ -1,0 +1,21 @@
+.DEFAULT_GOAL := test
+.PHONY: build pack test clean
+
+PACKAGE ?= nextjs
+PACKAGE_DIR := ../../libs/frontman-$(PACKAGE)
+ARTIFACT_DIR := $(CURDIR)/.artifacts
+PACK_JSON := $(ARTIFACT_DIR)/$(PACKAGE)-pack.json
+
+build:
+	@$(MAKE) -C "$(PACKAGE_DIR)" build
+
+pack: build
+	@mkdir -p "$(ARTIFACT_DIR)"
+	@npm pack --json --pack-destination "$(ARTIFACT_DIR)" "$(PACKAGE_DIR)" > "$(PACK_JSON)"
+
+test: pack
+	@TARBALL=$$(node -e 'const p=require("$(PACK_JSON)")[0]; process.stdout.write(require("node:path").resolve("$(ARTIFACT_DIR)", p.filename))'); \
+	node run-consumer.mjs "$(PACKAGE)" "$$TARBALL"
+
+clean:
+	@rm -rf "$(ARTIFACT_DIR)"

--- a/test/ripgrep-runtime/run-consumer.mjs
+++ b/test/ripgrep-runtime/run-consumer.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import {mkdtemp, readFile, rm, writeFile} from "node:fs/promises"
+import {tmpdir} from "node:os"
+import {resolve} from "node:path"
+import {spawnSync} from "node:child_process"
+import {createRequire} from "node:module"
+import {pathToFileURL} from "node:url"
+
+const [integration, tarball] = process.argv.slice(2)
+assert.ok(integration && tarball, "Usage: node run-consumer.mjs <nextjs|vite> <tarball>")
+
+const packageConfig = {
+  nextjs: {
+    packageName: "@frontman-ai/nextjs",
+    peers: {next: "13.2.0", react: "18.2.0", "react-dom": "18.2.0"},
+  },
+  vite: {packageName: "@frontman-ai/vite", peers: {vite: "5.0.0"}},
+}[integration]
+assert.ok(packageConfig, `Unsupported integration: ${integration}`)
+
+const consumer = await mkdtemp(resolve(tmpdir(), `frontman-${integration}-ripgrep-`))
+
+function run(command, args) {
+  const result = spawnSync(command, args, {cwd: consumer, encoding: "utf8", stdio: "inherit"})
+  assert.equal(result.status, 0, `${command} ${args.join(" ")} failed`)
+}
+
+try {
+  const packageJson = {
+    name: "frontman-ripgrep-consumer",
+    private: true,
+    type: "module",
+    dependencies: {...packageConfig.peers, [packageConfig.packageName]: resolve(tarball)},
+  }
+  await writeFile(resolve(consumer, "package.json"), JSON.stringify(packageJson, null, 2) + "\n")
+  await writeFile(resolve(consumer, "search-target.txt"), "packed ripgrep runtime\n")
+  run("npm", ["install", "--strict-peer-deps", "--save-exact"])
+
+  const packageRoot = resolve(consumer, "node_modules", packageConfig.packageName)
+  const packageRequire = createRequire(resolve(packageRoot, "package.json"))
+  const ripgrepUrl = pathToFileURL(packageRequire.resolve("@vscode/ripgrep"))
+  const {rgPath} = await import(ripgrepUrl)
+  assert.equal(typeof rgPath, "string")
+  const frontman = await import(pathToFileURL(resolve(packageRoot, "dist", "index.js")))
+  const configInput = {projectRoot: consumer, sourceRoot: consumer, basePath: "frontman"}
+  const middleware = integration === "nextjs"
+    ? frontman.createMiddleware(configInput)
+    : frontman.createMiddleware(frontman.makeConfig(configInput))
+  const request = new Request("http://localhost/frontman/tools/call", {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({name: "search_files", arguments: {pattern: "search-target.txt"}}),
+  })
+  const response = await middleware(request)
+  assert.equal(response?.status, 200)
+  assert.match(await response.text(), /search-target\.txt/)
+
+  const installedPackage = JSON.parse(
+    await readFile(resolve(packageRoot, "package.json"), "utf8"),
+  )
+  assert.equal(installedPackage.optionalDependencies["@vscode/ripgrep"], "^1.18.0")
+} finally {
+  await rm(consumer, {recursive: true, force: true})
+}

--- a/test/ripgrep-runtime/run-consumer.mjs
+++ b/test/ripgrep-runtime/run-consumer.mjs
@@ -1,9 +1,8 @@
 import assert from "node:assert/strict"
-import {mkdtemp, readFile, rm, writeFile} from "node:fs/promises"
+import {mkdtemp, rm, writeFile} from "node:fs/promises"
 import {tmpdir} from "node:os"
 import {resolve} from "node:path"
 import {spawnSync} from "node:child_process"
-import {createRequire} from "node:module"
 import {pathToFileURL} from "node:url"
 
 const [integration, tarball] = process.argv.slice(2)
@@ -21,7 +20,7 @@ assert.ok(packageConfig, `Unsupported integration: ${integration}`)
 const consumer = await mkdtemp(resolve(tmpdir(), `frontman-${integration}-ripgrep-`))
 
 function run(command, args) {
-  const result = spawnSync(command, args, {cwd: consumer, encoding: "utf8", stdio: "inherit"})
+  const result = spawnSync(command, args, {cwd: consumer, stdio: "inherit"})
   assert.equal(result.status, 0, `${command} ${args.join(" ")} failed`)
 }
 
@@ -37,10 +36,6 @@ try {
   run("npm", ["install", "--strict-peer-deps", "--save-exact"])
 
   const packageRoot = resolve(consumer, "node_modules", packageConfig.packageName)
-  const packageRequire = createRequire(resolve(packageRoot, "package.json"))
-  const ripgrepUrl = pathToFileURL(packageRequire.resolve("@vscode/ripgrep"))
-  const {rgPath} = await import(ripgrepUrl)
-  assert.equal(typeof rgPath, "string")
   const frontman = await import(pathToFileURL(resolve(packageRoot, "dist", "index.js")))
   const configInput = {projectRoot: consumer, sourceRoot: consumer, basePath: "frontman"}
   const middleware = integration === "nextjs"
@@ -54,11 +49,6 @@ try {
   const response = await middleware(request)
   assert.equal(response?.status, 200)
   assert.match(await response.text(), /search-target\.txt/)
-
-  const installedPackage = JSON.parse(
-    await readFile(resolve(packageRoot, "package.json"), "utf8"),
-  )
-  assert.equal(installedPackage.optionalDependencies["@vscode/ripgrep"], "^1.18.0")
 } finally {
   await rm(consumer, {recursive: true, force: true})
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,6 +2336,7 @@ __metadata:
     "@frontman/bindings": "npm:*"
     "@rescript/runtime": "npm:12.3.0"
     "@rescript/webapi": "npm:*"
+    "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
     dom-element-to-component-source: "npm:0.5.0"
     lighthouse: "npm:^13.4.0"
@@ -2348,6 +2349,9 @@ __metadata:
     vitest: "catalog:"
   peerDependencies:
     astro: ^5.0.0 || ^6.0.0 || ^7.0.0
+  dependenciesMeta:
+    "@vscode/ripgrep":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2470,6 +2474,7 @@ __metadata:
     "@rescript/runtime": "npm:12.3.0"
     "@rescript/webapi": "npm:*"
     "@sentry/nextjs": "npm:^10.66.0"
+    "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
     dom-element-to-component-source: "npm:0.5.0"
     lighthouse: "npm:^13.4.0"
@@ -2489,6 +2494,9 @@ __metadata:
     next: ^13.2.0 || ^14.0 || ^15.0 || ^16.0
     react: ^18.2.0 || ^19.0.0
     react-dom: ^18.2.0 || ^19.0.0
+  dependenciesMeta:
+    "@vscode/ripgrep":
+      optional: true
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
@@ -2532,6 +2540,7 @@ __metadata:
     "@frontman-ai/frontman-protocol": "npm:*"
     "@rescript/runtime": "npm:12.3.0"
     "@rescript/webapi": "npm:*"
+    "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
     dom-element-to-component-source: "npm:0.5.0"
     lighthouse: "npm:^13.4.0"
@@ -2543,6 +2552,9 @@ __metadata:
     vitest: "catalog:"
   peerDependencies:
     vite: ">=5.0.0"
+  dependenciesMeta:
+    "@vscode/ripgrep":
+      optional: true
   bin:
     frontman-vite: ./dist/cli.js
   languageName: unknown


### PR DESCRIPTION
## Summary
- resolve ESM ripgrep binaries at runtime instead of bundling platform resolution
- declare ripgrep as optional dependency of Next.js, Vite, and Astro integrations
- add packed-consumer checks on documented Node.js floors

## Verification
- `make -C libs/frontman-core test`
- `make -C libs/frontman-nextjs test`
- `make -C libs/frontman-vite build`
- `make -C libs/frontman-astro build`
- packed Next.js consumer on Node.js 18.0.0
- packed Vite consumer on Node.js 18.0.0
- packed Astro 6 consumer on Node.js 22.19.0

Prerequisite for #1415.