### PR TITLE
Preserve blog cover image aspect ratio

### DIFF
--- a/test/sites/blog-starter/src/app/_components/cover-image.tsx
+++ b/test/sites/blog-starter/src/app/_components/cover-image.tsx
@@ -15,7 +15,7 @@ const CoverImage = ({ title, src, slug, priority = false }: Props) => {
     <Image
       src={src}
       alt={`Cover Image for ${title}`}
-      className={cn("shadow-sm w-full", {
+      className={cn("shadow-sm h-auto w-full", {
         "hover:shadow-lg transition-shadow duration-200": slug,
       })}
       width={1300}


### PR DESCRIPTION
## Summary
- add `h-auto` to responsive blog cover images
- preserve intrinsic aspect ratio when `w-full` changes rendered width

## Verification
- `corepack yarn install --immutable`
- `make build` in `test/sites/blog-starter` (run twice successfully)
- pre-commit checks passed