### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ See [Self-Hosting and License](#self-hosting-and-license) above, plus the respec
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=frontman-ai%2Ffrontman&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#frontman-ai/frontman&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=frontman-ai/frontman&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=frontman-ai/frontman&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=frontman-ai/frontman&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=frontman-ai/frontman&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=frontman-ai/frontman&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=frontman-ai/frontman&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the original service relies on GitHub's stargazer API, which is now restricted. This switches the chart to an alternative that uses a different data source and requires no API token, so the chart works again.