### PR TITLE
Animate idle chat composer border

### DIFF
--- a/.changeset/animate-chat-composer-border.md
+++ b/.changeset/animate-chat-composer-border.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": minor
+---
+
+Add an animated border beam to the idle chat composer.

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -81,7 +81,8 @@
 		"@tiptap/extension-text": "3.30.1",
 		"@tiptap/extensions": "3.30.1",
 		"@tiptap/pm": "3.30.1",
-		"@tiptap/react": "3.30.1"
+		"@tiptap/react": "3.30.1",
+		"border-beam": "^1.3.0"
 	},
 	"peerDependencies": {
 		"react": "^19.2.7",

--- a/libs/client/src/components/frontman/Client__BorderBeam.res
+++ b/libs/client/src/components/frontman/Client__BorderBeam.res
@@ -1,0 +1,18 @@
+type animationType = [#sm | #md | #line | #"pulse-outside" | #"pulse-inner"]
+type colorVariant = [#colorful | #mono | #ocean | #sunset]
+type theme = [#dark | #light | #auto]
+
+@module("border-beam") @react.component
+external make: (
+  ~children: React.element,
+  ~size: animationType=?,
+  ~colorVariant: colorVariant=?,
+  ~theme: theme=?,
+  ~duration: float=?,
+  ~active: bool=?,
+  ~borderRadius: float=?,
+  ~strength: float=?,
+  ~className: string=?,
+  ~onFocus: ReactEvent.Focus.t => unit=?,
+  ~onBlur: ReactEvent.Focus.t => unit=?,
+) => React.element = "BorderBeam"

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -7,13 +7,10 @@
  */
 module Icons = Client__ToolIcons
 module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
-module Node = WebAPI.Node
 
 type inputItem = FileAttachment({id: string, name: string, mediaType: string, dataUrl: string})
 
 let isComposerBeamActive = (~hasFocus, ~isInputDisabled) => !hasFocus && !isInputDisabled
-
-external asNode: {..} => WebAPI.DomTypes.node = "%identity"
 
 module ModelSelector = {
   module Select = Client__UI__Select
@@ -465,7 +462,10 @@ let make = (
       onBlur={event =>
         switch ReactEvent.Focus.relatedTarget(event) {
         | Some(target)
-          if Node.contains(event->ReactEvent.Focus.currentTarget->asNode, target->asNode) => ()
+          if WebAPI.Node.contains(
+            ReactEvent.Focus.currentTarget(event)->Obj.magic->WebAPI.Element.asNode,
+            target->Obj.magic->WebAPI.Element.asNode,
+          ) => ()
         | _ => setHasComposerFocus(_ => false)
         }}
     >

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -7,6 +7,7 @@
  */
 module Icons = Client__ToolIcons
 module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
+module Node = WebAPI.Node
 
 type inputItem = FileAttachment({id: string, name: string, mediaType: string, dataUrl: string})
 
@@ -464,10 +465,7 @@ let make = (
       onBlur={event =>
         switch ReactEvent.Focus.relatedTarget(event) {
         | Some(target)
-          if WebAPI.Node.contains(
-            asNode(ReactEvent.Focus.currentTarget(event)),
-            asNode(target),
-          ) => ()
+          if Node.contains(event->ReactEvent.Focus.currentTarget->asNode, target->asNode) => ()
         | _ => setHasComposerFocus(_ => false)
         }}
     >

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -12,11 +12,7 @@ type inputItem = FileAttachment({id: string, name: string, mediaType: string, da
 
 let isComposerBeamActive = (~hasFocus, ~isInputDisabled) => !hasFocus && !isInputDisabled
 
-let focusMovedInsideComposer: ReactEvent.Focus.t => bool = %raw(`
-  function(event) {
-    return event.relatedTarget !== null && event.currentTarget.contains(event.relatedTarget);
-  }
-`)
+@send external contains: ({..}, {..}) => bool = "contains"
 
 module ModelSelector = {
   module Select = Client__UI__Select
@@ -466,9 +462,9 @@ let make = (
       className="frontman-composer-beam mx-3 mb-2"
       onFocus={_ => setHasComposerFocus(_ => true)}
       onBlur={event =>
-        switch focusMovedInsideComposer(event) {
-        | true => ()
-        | false => setHasComposerFocus(_ => false)
+        switch ReactEvent.Focus.relatedTarget(event) {
+        | Some(target) if ReactEvent.Focus.currentTarget(event)->contains(target) => ()
+        | _ => setHasComposerFocus(_ => false)
         }}
     >
       <div

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -10,6 +10,14 @@ module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 
 type inputItem = FileAttachment({id: string, name: string, mediaType: string, dataUrl: string})
 
+let isComposerBeamActive = (~hasFocus, ~isInputDisabled) => !hasFocus && !isInputDisabled
+
+let focusMovedInsideComposer: ReactEvent.Focus.t => bool = %raw(`
+  function(event) {
+    return event.relatedTarget !== null && event.currentTarget.contains(event.relatedTarget);
+  }
+`)
+
 module ModelSelector = {
   module Select = Client__UI__Select
   module ACP = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
@@ -320,6 +328,7 @@ let make = (
   ~isEnrichingAnnotations: bool=false,
 ) => {
   let (hasContent, setHasContent) = React.useState(() => false)
+  let (hasComposerFocus, setHasComposerFocus) = React.useState(() => false)
   let (submitSignal, setSubmitSignal) = React.useState(() => 0)
   let (attachSignal, setAttachSignal) = React.useState(() => 0)
   let (dropFilesSignal, setDropFilesSignal) = React.useState(() => 0)
@@ -446,95 +455,114 @@ let make = (
     | None => React.null
     }}
 
-    <div
-      className="mx-3 mb-2 overflow-hidden rounded-xl border bg-white/[0.025] transition-colors
-                 focus-within:ring-1 focus-within:ring-white/20"
-      style={{borderColor: composerBorderColor}}
+    <Client__BorderBeam
+      size=#"pulse-outside"
+      colorVariant=#ocean
+      theme=#dark
+      duration=2.8
+      strength=0.85
+      borderRadius=15.0
+      active={isComposerBeamActive(~hasFocus=hasComposerFocus, ~isInputDisabled)}
+      className="frontman-composer-beam mx-3 mb-2"
+      onFocus={_ => setHasComposerFocus(_ => true)}
+      onBlur={event =>
+        switch focusMovedInsideComposer(event) {
+        | true => ()
+        | false => setHasComposerFocus(_ => false)
+        }}
     >
-      <div className="flex items-center px-2 py-1">
-        <div className="flex flex-1 items-center gap-1 min-w-0 overflow-hidden transition-opacity">
-          <AttachButton
-            onClick={openAttachPicker}
-            disabled={isInputDisabled || isEnrichingAnnotations}
-            showLabel={showToolbarLabels}
-          />
-
-          {switch onSelectElement {
-          | Some(handler) =>
-            <SelectElementButton
-              onClick={handler}
-              isSelecting={isSelecting}
-              hasAnnotations={hasAnnotations}
+      <div
+        className="overflow-hidden rounded-xl border bg-white/[0.025] transition-colors
+                   focus-within:ring-1 focus-within:ring-white/20"
+        style={{borderColor: composerBorderColor}}
+      >
+        <div className="flex items-center px-2 py-1">
+          <div
+            className="flex flex-1 items-center gap-1 min-w-0 overflow-hidden transition-opacity"
+          >
+            <AttachButton
+              onClick={openAttachPicker}
+              disabled={isInputDisabled || isEnrichingAnnotations}
               showLabel={showToolbarLabels}
             />
-          | None => React.null
-          }}
-        </div>
-      </div>
 
-      <div className="border-t border-white/8">
-        <Client__PromptEditor
-          disabled={isInputDisabled}
-          placeholder={currentPlaceholder}
-          isEnrichingAnnotations
-          hasAnnotations
-          submitSignal
-          attachSignal
-          dropFilesSignal
-          droppedFiles
-          onHasContentChange={value => setHasContent(_ => value)}
-          onSubmit={handleEditorSubmit}
-          onPreviewImage={src => setPreviewSrc(_ => Some(src))}
-          onFileSizeError={message => setFileSizeError(_ => Some(message))}
-        />
-      </div>
-
-      <div className="flex min-w-0 items-center gap-2 border-t border-white/8 px-2 py-1">
-        <div
-          className={`grid min-w-0 flex-1 ${hasAgentSelector
-              ? "grid-cols-2"
-              : "grid-cols-1"} gap-2`}
-        >
-          {switch (agentCatalog, selectedAgentId) {
-          | (Some(agents), Some(agentId)) if agents->Array.length > 0 =>
-            <AgentSelector agents selectedAgentId={agentId} onAgentChange />
-          | _ => React.null
-          }}
-
-          {switch (isModelsConfigLoading, modelConfigOption) {
-          | (true, _) =>
-            <div className="inline-flex h-9 min-w-0 items-center gap-1 px-2 text-xs">
-              <span className="shrink-0 text-zinc-500"> {React.string("Model")} </span>
-              <span className="shrink-0 text-zinc-600"> {React.string("\u{B7}")} </span>
-              <span className="truncate text-zinc-500"> {React.string("Loading...")} </span>
-            </div>
-          | (false, Some(configOption)) if !modelConfigOptionHasModels(configOption) =>
-            <button
-              type_="button"
-              onClick={_ => onConfigureProvider()}
-              className="inline-flex h-9 min-w-0 items-center gap-1 rounded-md px-2 text-xs
-                         text-violet-300 bg-violet-600/15 hover:bg-violet-600/25
-                         transition-colors cursor-pointer"
-            >
-              <span className="shrink-0 text-zinc-500"> {React.string("Model")} </span>
-              <span className="shrink-0 text-zinc-600"> {React.string("\u{B7}")} </span>
-              <span className="truncate"> {React.string("Configure provider")} </span>
-            </button>
-          | (false, Some(configOption)) =>
-            <div className="min-w-0 overflow-hidden">
-              <ModelSelector
-                configOption selectedValue={selectedModelValue->Option.getOr("")} onModelChange
+            {switch onSelectElement {
+            | Some(handler) =>
+              <SelectElementButton
+                onClick={handler}
+                isSelecting={isSelecting}
+                hasAnnotations={hasAnnotations}
+                showLabel={showToolbarLabels}
               />
-            </div>
-          | (false, None) => React.null
-          }}
+            | None => React.null
+            }}
+          </div>
         </div>
 
-        <SubmitButton
-          disabled={isSubmitDisabled} showStop={showStopButton} onClick={doSubmit} onCancel
-        />
+        <div className="border-t border-white/8">
+          <Client__PromptEditor
+            disabled={isInputDisabled}
+            placeholder={currentPlaceholder}
+            isEnrichingAnnotations
+            hasAnnotations
+            submitSignal
+            attachSignal
+            dropFilesSignal
+            droppedFiles
+            onHasContentChange={value => setHasContent(_ => value)}
+            onSubmit={handleEditorSubmit}
+            onPreviewImage={src => setPreviewSrc(_ => Some(src))}
+            onFileSizeError={message => setFileSizeError(_ => Some(message))}
+          />
+        </div>
+
+        <div className="flex min-w-0 items-center gap-2 border-t border-white/8 px-2 py-1">
+          <div
+            className={`grid min-w-0 flex-1 ${hasAgentSelector
+                ? "grid-cols-2"
+                : "grid-cols-1"} gap-2`}
+          >
+            {switch (agentCatalog, selectedAgentId) {
+            | (Some(agents), Some(agentId)) if agents->Array.length > 0 =>
+              <AgentSelector agents selectedAgentId={agentId} onAgentChange />
+            | _ => React.null
+            }}
+
+            {switch (isModelsConfigLoading, modelConfigOption) {
+            | (true, _) =>
+              <div className="inline-flex h-9 min-w-0 items-center gap-1 px-2 text-xs">
+                <span className="shrink-0 text-zinc-500"> {React.string("Model")} </span>
+                <span className="shrink-0 text-zinc-600"> {React.string("\u{B7}")} </span>
+                <span className="truncate text-zinc-500"> {React.string("Loading...")} </span>
+              </div>
+            | (false, Some(configOption)) if !modelConfigOptionHasModels(configOption) =>
+              <button
+                type_="button"
+                onClick={_ => onConfigureProvider()}
+                className="inline-flex h-9 min-w-0 items-center gap-1 rounded-md px-2 text-xs
+                           text-violet-300 bg-violet-600/15 hover:bg-violet-600/25
+                           transition-colors cursor-pointer"
+              >
+                <span className="shrink-0 text-zinc-500"> {React.string("Model")} </span>
+                <span className="shrink-0 text-zinc-600"> {React.string("\u{B7}")} </span>
+                <span className="truncate"> {React.string("Configure provider")} </span>
+              </button>
+            | (false, Some(configOption)) =>
+              <div className="min-w-0 overflow-hidden">
+                <ModelSelector
+                  configOption selectedValue={selectedModelValue->Option.getOr("")} onModelChange
+                />
+              </div>
+            | (false, None) => React.null
+            }}
+          </div>
+
+          <SubmitButton
+            disabled={isSubmitDisabled} showStop={showStopButton} onClick={doSubmit} onCancel
+          />
+        </div>
       </div>
-    </div>
+    </Client__BorderBeam>
 
     {switch previewSrc {
     | Some(src) => <Client__ImagePreview src onClose={() => setPreviewSrc(_ => None)} />

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -12,7 +12,7 @@ type inputItem = FileAttachment({id: string, name: string, mediaType: string, da
 
 let isComposerBeamActive = (~hasFocus, ~isInputDisabled) => !hasFocus && !isInputDisabled
 
-@send external contains: ({..}, {..}) => bool = "contains"
+external asNode: {..} => WebAPI.DomTypes.node = "%identity"
 
 module ModelSelector = {
   module Select = Client__UI__Select
@@ -463,7 +463,11 @@ let make = (
       onFocus={_ => setHasComposerFocus(_ => true)}
       onBlur={event =>
         switch ReactEvent.Focus.relatedTarget(event) {
-        | Some(target) if ReactEvent.Focus.currentTarget(event)->contains(target) => ()
+        | Some(target)
+          if WebAPI.Node.contains(
+            asNode(ReactEvent.Focus.currentTarget(event)),
+            asNode(target),
+          ) => ()
         | _ => setHasComposerFocus(_ => false)
         }}
     >

--- a/libs/client/src/index.css
+++ b/libs/client/src/index.css
@@ -90,6 +90,20 @@
 	background: rgb(255 255 255 / 0.02);
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.frontman-composer-beam.frontman-composer-beam[data-active],
+	.frontman-composer-beam.frontman-composer-beam[data-fading],
+	.frontman-composer-beam.frontman-composer-beam[data-active]::before,
+	.frontman-composer-beam.frontman-composer-beam[data-fading]::before,
+	.frontman-composer-beam.frontman-composer-beam[data-active]::after,
+	.frontman-composer-beam.frontman-composer-beam[data-fading]::after,
+	.frontman-composer-beam.frontman-composer-beam[data-active] [data-beam-bloom],
+	.frontman-composer-beam.frontman-composer-beam[data-fading]
+		[data-beam-bloom] {
+		animation: none;
+	}
+}
+
 .frontman-prompt-editor-content {
 	width: 100%;
 	color: rgb(244 244 245);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,6 +2407,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@zumer/snapdom": "npm:^2.12.9"
     babel-plugin-react-compiler: "npm:^1.0.0"
+    border-beam: "npm:^1.3.0"
     dom-accessibility-api: "npm:^0.7.1"
     dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
     lucide-react: "npm:^1.25.0"
@@ -8304,6 +8305,16 @@ __metadata:
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
+  languageName: node
+  linkType: hard
+
+"border-beam@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "border-beam@npm:1.3.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/4c252d7ced08f989e42f3ca614d23632223149a48bc8f479656b74d275c766cfa1bf3c270480dd34a7a873f1adc4d6a5a0dea67fe274edff0c612f515b06e99b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- wrap the chat composer in a pulse-outside Border Beam while it is idle
- expose typed ReScript variants for animation, color, and theme options
- preserve the existing agent border and disable motion for reduced-motion users
- add a client changeset

## Verification

- `make test` in `libs/client`: 341 tests passed
- `make build-lib` in `libs/client`: production library bundle passed
- pre-push ReScript reanalysis: 0 issues across all packages
- `make lint` remains blocked by pre-existing formatting in unchanged `libs/client/src/styles/frontman-theme.css`