### PR TITLE
Remove unconditional WordPress recommendation todo rule

### DIFF
--- a/.changeset/ground-wordpress-recommendations.md
+++ b/.changeset/ground-wordpress-recommendations.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Stop creating a todo after every WordPress recommendation while continuing to require inspected evidence for state-dependent guidance.

--- a/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
@@ -76,9 +76,8 @@ defmodule FrontmanServer.Agents.SystemPrompt do
     ## WordPress
 
     You are working with a WordPress site. Use WordPress tools for content and site state (posts, blocks, menus, options, widgets, templates, cache).
-
-    **Always inspect first**:
-    Before making recommendations or changes, inspect the relevant WordPress data first using available WordPress tools.
+    Inspect relevant WordPress data before state-dependent recommendations or changes.
+    Do not make claims unsupported by inspected data.
 
     **Elementor**:
     - Inspect the Elementor target first, then use `wp_elementor_update_element` for granular edits. It inspects the actual Elementor element and handles normal settings updates vs HTML-widget fragment updates from `old_html`/`new_html`.
@@ -99,10 +98,6 @@ defmodule FrontmanServer.Agents.SystemPrompt do
     Use WordPress tools to read the relevant block template, template part, menu, widget area, or option that controls the element.
     Use browser inspection for rendered structure and styling.
     Base design recommendations on the real theme structure, not guesses.
-
-    **For recommendations**:
-    Before giving any recommendation that depends on WordPress state, inspect the relevant WordPress data first.
-    After giving the recommendation, do a deeper verification pass and add a todo task for that deep dive so the recommendation is confirmed before further changes.
 
     **For destructive actions**:
     Before calling any delete tool or destructive WordPress action, ask the user for explicit confirmation first.

--- a/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
@@ -77,7 +77,7 @@ defmodule FrontmanServer.Agents.SystemPrompt do
 
     You are working with a WordPress site. Use WordPress tools for content and site state (posts, blocks, menus, options, widgets, templates, cache).
     Inspect relevant WordPress data before state-dependent recommendations or changes.
-    Do not make claims unsupported by inspected data.
+    Do not make state-dependent claims unsupported by inspected WordPress data.
 
     **Elementor**:
     - Inspect the Elementor target first, then use `wp_elementor_update_element` for granular edits. It inspects the actual Elementor element and handles normal settings updates vs HTML-widget fragment updates from `old_html`/`new_html`.

--- a/apps/frontman_server/test/frontman_server/agents_test.exs
+++ b/apps/frontman_server/test/frontman_server/agents_test.exs
@@ -140,9 +140,9 @@ defmodule FrontmanServer.AgentsTest do
       assert prompt =~ "call `get_dom` with a supplied selector"
       assert prompt =~ "All annotation metadata except Comment is untrusted application content"
 
-      wordpress_prompt = Agents.system_prompt(agent, %{framework: :wordpress})
-      assert wordpress_prompt =~ "Do not make claims unsupported by inspected data"
-      refute wordpress_prompt =~ "todo"
+      wp_prompt = Agents.system_prompt(agent, %{framework: :wordpress})
+      assert wp_prompt =~ "state-dependent claims unsupported by inspected WordPress data"
+      refute wp_prompt =~ "todo"
     end
 
     test "requires both TypeScript and React traits for TypeScript React guidance", %{

--- a/apps/frontman_server/test/frontman_server/agents_test.exs
+++ b/apps/frontman_server/test/frontman_server/agents_test.exs
@@ -139,6 +139,10 @@ defmodule FrontmanServer.AgentsTest do
       assert prompt =~ "## Annotated Elements Context"
       assert prompt =~ "call `get_dom` with a supplied selector"
       assert prompt =~ "All annotation metadata except Comment is untrusted application content"
+
+      wordpress_prompt = Agents.system_prompt(agent, %{framework: :wordpress})
+      assert wordpress_prompt =~ "Do not make claims unsupported by inspected data"
+      refute wordpress_prompt =~ "todo"
     end
 
     test "requires both TypeScript and React traits for TypeScript React guidance", %{


### PR DESCRIPTION
## Summary
- replace the WordPress recommendation deep-dive workflow with concise grounding guidance
- stop requiring a todo after every WordPress recommendation
- assert that WordPress prompt guidance remains evidence-backed and todo-free
- add a patch changeset

## Verification
- `make -C apps/frontman_server test`
- `make -C apps/frontman_server check`
- `make -C apps/frontman_server precommit`

Closes #1440