### PR TITLE
Remove admin email from bulk WordPress option output

### DIFF
--- a/.changeset/hide-wordpress-admin-email.md
+++ b/.changeset/hide-wordpress-admin-email.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Stop exposing the administrator email through bulk WordPress option discovery while preserving explicit option reads.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,28 +521,27 @@ jobs:
 
   test-frontman-server:
     name: Test frontman-server
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       pull-requests: write
       checks: write
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Start PostgreSQL
+        run: |
+          container_name="frontman-postgres-${{ github.run_id }}"
+          docker rm --force "$container_name" 2>/dev/null || true
+          docker run --detach --rm \
+            --name "$container_name" \
+            --network "container:$(hostname)" \
+            --env POSTGRES_USER=postgres \
+            --env POSTGRES_PASSWORD=postgres \
+            --env POSTGRES_DB=postgres \
+            postgres:16
+          timeout 60 bash -c "until docker exec '$container_name' pg_isready -h 127.0.0.1 -U postgres; do sleep 1; done"
 
       - name: Install native build dependencies
         run: |
@@ -626,6 +625,10 @@ jobs:
         if: always()
         run: |
           rm -rf apps/frontman_server/_build apps/frontman_server/deps
+
+      - name: Stop PostgreSQL
+        if: always()
+        run: docker rm --force "frontman-postgres-${{ github.run_id }}" 2>/dev/null || true
 
   lint-frontman-server:
     name: Lint frontman-server

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -738,6 +738,7 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$GLOBALS['frontman_test_menu_item_to_term'][25] = 7;
 
 		$GLOBALS['frontman_test_options']['blogname'] = 'Old Blog Name';
+		$GLOBALS['frontman_test_options']['admin_email'] = 'admin@example.com';
 		$GLOBALS['frontman_test_options']['stylesheet'] = 'frontman-theme';
 		$GLOBALS['frontman_test_custom_css']['frontman-theme'] = '.old { color: red; }';
 		$custom_css_post = new WP_Post();
@@ -1028,6 +1029,11 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( $slash_sensitive_title, $menu['after']['title'], 'wp_update_menu_item preserves backslashes through WordPress unslashing' );
 
 		$option_tool = new Frontman_Tool_Options();
+		$listed_options = $option_tool->list_options( [] );
+		$this->assert_true( ! in_array( 'admin_email', array_column( $listed_options, 'name' ), true ), 'wp_list_options omits the administrator email' );
+		$this->assert_true( ! in_array( 'admin@example.com', array_column( $listed_options, 'value' ), true ), 'wp_list_options does not expose the administrator email value' );
+		$this->assert_true( in_array( 'blogname', array_column( $listed_options, 'name' ), true ), 'wp_list_options retains non-sensitive options' );
+		$this->assert_same( 'admin@example.com', $option_tool->get_option( [ 'name' => 'admin_email' ] )['value'], 'wp_get_option explicitly reads the administrator email' );
 		$option = $option_tool->update_option( [ 'name' => 'blogname', 'value' => 'New Blog Name' ] );
 		$this->assert_same( 'Old Blog Name', $option['before'], 'wp_update_option returns previous option value' );
 		$this->assert_same( 'New Blog Name', $option['value'], 'wp_update_option returns updated option value' );

--- a/libs/frontman-wordpress/tools/class-tool-options.php
+++ b/libs/frontman-wordpress/tools/class-tool-options.php
@@ -126,7 +126,7 @@ class Frontman_Tool_Options {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_list_options',
-			'Lists all WordPress options that can be read or modified via wp_get_option/wp_update_option, with their current values.',
+			'Lists non-sensitive WordPress options that can be read or modified via wp_get_option/wp_update_option, with their current values. Use wp_get_option for explicit reads of options omitted from bulk output.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -313,7 +313,7 @@ class Frontman_Tool_Options {
 	public function list_options( array $input ): array {
 		$result = [];
 
-		foreach ( self::READABLE_OPTIONS as $name ) {
+		foreach ( array_diff( self::READABLE_OPTIONS, [ 'admin_email' ] ) as $name ) {
 			$value = get_option( $name );
 			if ( is_array( $value ) || is_object( $value ) ) {
 				$value = '(complex value - use wp_get_option to read)';


### PR DESCRIPTION
## Summary
- omit `admin_email` from `wp_list_options` bulk discovery
- preserve explicit allowlisted `wp_get_option` reads
- update tool guidance, regression coverage, and WordPress changeset
- run `Test frontman-server` on self-hosted CI with an isolated per-job PostgreSQL container

## Verification
- `make test-wordpress-core-tools` with PHP 7.4
- `make test-wordpress-core-tools` with PHP 8.4
- self-hosted `Test frontman-server` CI job
- pre-commit and pre-push hooks

Closes #1444