### PR TITLE
Establish lockstep Reworker preview protocol

### DIFF
--- a/.changeset/quiet-spoons-preview.md
+++ b/.changeset/quiet-spoons-preview.md
@@ -2,4 +2,4 @@
 "@frontman-ai/frontman-protocol": minor
 ---
 
-Add lockstep typed Reworker preview messages and structured errors.
+Establish lockstep Reworker preview protocol types and structured errors.

--- a/.changeset/quiet-spoons-preview.md
+++ b/.changeset/quiet-spoons-preview.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-protocol": minor
+---
+
+Add typed Reworker preview capability negotiation and protocol versioning.

--- a/.changeset/quiet-spoons-preview.md
+++ b/.changeset/quiet-spoons-preview.md
@@ -2,4 +2,4 @@
 "@frontman-ai/frontman-protocol": minor
 ---
 
-Add typed Reworker preview capability negotiation and protocol versioning.
+Add lockstep typed Reworker preview messages and structured errors.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
         if: steps.changes.outputs.protocol == 'true'
         run: make build
 
+      - name: Test preview protocol
+        if: steps.changes.outputs.protocol == 'true'
+        run: make -C libs/frontman-protocol test
+
       - name: Check schemas are up to date
         if: steps.changes.outputs.protocol == 'true'
         run: make -C libs/frontman-protocol check-schemas

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,6 @@
 approvedGitRepositories:
   - "https://github.com/frontman-ai/dom-element-to-component-source.git"
+  - "https://github.com/frontman-ai/reworker.git"
 
 catalog:
   "@rescript/webapi": "*"

--- a/libs/frontman-protocol/Makefile
+++ b/libs/frontman-protocol/Makefile
@@ -1,9 +1,10 @@
 .DEFAULT_GOAL := help
-.PHONY: help build clean export-schemas check-schemas
+.PHONY: help build test clean export-schemas check-schemas
 
-HELP_TARGETS := help build clean export-schemas check-schemas
+HELP_TARGETS := help build test clean export-schemas check-schemas
 HELP_help := Display this help message
 HELP_build := Build ReScript
+HELP_test := Run tests
 HELP_clean := Clean build artifacts
 HELP_export-schemas := Export Sury schemas to JSON Schema files
 HELP_check-schemas := Verify committed schemas are up to date
@@ -13,6 +14,9 @@ help:
 
 build:
 	yarn rescript build
+
+test: build
+	yarn vitest run
 
 clean:
 	yarn rescript clean

--- a/libs/frontman-protocol/package.json
+++ b/libs/frontman-protocol/package.json
@@ -34,7 +34,7 @@
 		"build": "rescript build"
 	},
 	"dependencies": {
-		"@bluehotdog/reworker": "https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz",
+		"@bluehotdog/reworker": "https://github.com/frontman-ai/reworker.git#head=main",
 		"sury": "11.0.0-alpha.10"
 	},
 	"devDependencies": {

--- a/libs/frontman-protocol/package.json
+++ b/libs/frontman-protocol/package.json
@@ -34,10 +34,14 @@
 		"build": "rescript build"
 	},
 	"dependencies": {
+		"@bluehotdog/reworker": "https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz",
 		"sury": "11.0.0-alpha.10"
 	},
 	"devDependencies": {
 		"@rescript/webapi": "*",
-		"rescript": "catalog:"
+		"rescript": "catalog:",
+		"rescript-vitest": "catalog:",
+		"vite": "catalog:",
+		"vitest": "catalog:"
 	}
 }

--- a/libs/frontman-protocol/rescript.json
+++ b/libs/frontman-protocol/rescript.json
@@ -15,6 +15,10 @@
 		{
 			"dir": "scripts",
 			"type": "dev"
+		},
+		{
+			"dir": "test",
+			"type": "dev"
 		}
 	],
 	"package-specs": [
@@ -25,6 +29,6 @@
 		}
 	],
 	"ppx-flags": ["sury-ppx/bin"],
-	"dependencies": ["@rescript/webapi", "sury"],
-	"dev-dependencies": ["@frontman/bindings"]
+	"dependencies": ["@bluehotdog/reworker", "@rescript/webapi", "sury"],
+	"dev-dependencies": ["@frontman/bindings", "rescript-vitest"]
 }

--- a/libs/frontman-protocol/src/FrontmanProtocol.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol.res
@@ -3,3 +3,4 @@ module Relay = FrontmanProtocol__Relay
 module Tool = FrontmanProtocol__Tool
 module ACP = FrontmanProtocol__ACP
 module JsonRpc = FrontmanProtocol__JsonRpc
+module Preview = FrontmanProtocol__Preview

--- a/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
@@ -4,6 +4,3 @@ type error = {
   code: errorCode,
   message: string,
 }
-
-type Types.message<_> +=
-  | Ready: Types.message<unit>

--- a/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
@@ -1,0 +1,52 @@
+let protocolMajor = 1
+
+type capability = string
+
+module Capability = {
+  let domSerialization: capability = "dom.serialization"
+  let elementIdentity: capability = "element.identity"
+  let selection: capability = "selection"
+  let click: capability = "click"
+  let navigation: capability = "navigation"
+  let geometry: capability = "geometry"
+  let screenshot: capability = "screenshot"
+  let scroll: capability = "scroll"
+  let mutationEvents: capability = "mutation-events"
+  let nestedFrames: capability = "nested-frames"
+}
+
+type errorCode = string
+
+module ErrorCode = {
+  let unsupportedProtocolMajor: errorCode = "unsupported_protocol_major"
+}
+
+type error = {
+  code: errorCode,
+  message: string,
+}
+
+type capabilityRequest = {protocolMajor: int}
+
+type capabilityResponse = {
+  protocolMajor: int,
+  capabilities: array<capability>,
+}
+
+type capabilityResult = result<capabilityResponse, error>
+
+type Types.message<_> +=
+  | GetCapabilities(capabilityRequest): Types.message<capabilityResult>
+
+let negotiateCapabilities = (
+  request: capabilityRequest,
+  ~capabilities: array<capability>,
+): capabilityResult =>
+  switch request.protocolMajor {
+  | requestedMajor if requestedMajor == protocolMajor => Ok({protocolMajor, capabilities})
+  | requestedMajor =>
+    Error({
+      code: ErrorCode.unsupportedProtocolMajor,
+      message: `Unsupported preview protocol major ${requestedMajor->Int.toString}; supported major is ${protocolMajor->Int.toString}`,
+    })
+  }

--- a/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Preview.res
@@ -1,52 +1,9 @@
-let protocolMajor = 1
-
-type capability = string
-
-module Capability = {
-  let domSerialization: capability = "dom.serialization"
-  let elementIdentity: capability = "element.identity"
-  let selection: capability = "selection"
-  let click: capability = "click"
-  let navigation: capability = "navigation"
-  let geometry: capability = "geometry"
-  let screenshot: capability = "screenshot"
-  let scroll: capability = "scroll"
-  let mutationEvents: capability = "mutation-events"
-  let nestedFrames: capability = "nested-frames"
-}
-
 type errorCode = string
-
-module ErrorCode = {
-  let unsupportedProtocolMajor: errorCode = "unsupported_protocol_major"
-}
 
 type error = {
   code: errorCode,
   message: string,
 }
 
-type capabilityRequest = {protocolMajor: int}
-
-type capabilityResponse = {
-  protocolMajor: int,
-  capabilities: array<capability>,
-}
-
-type capabilityResult = result<capabilityResponse, error>
-
 type Types.message<_> +=
-  | GetCapabilities(capabilityRequest): Types.message<capabilityResult>
-
-let negotiateCapabilities = (
-  request: capabilityRequest,
-  ~capabilities: array<capability>,
-): capabilityResult =>
-  switch request.protocolMajor {
-  | requestedMajor if requestedMajor == protocolMajor => Ok({protocolMajor, capabilities})
-  | requestedMajor =>
-    Error({
-      code: ErrorCode.unsupportedProtocolMajor,
-      message: `Unsupported preview protocol major ${requestedMajor->Int.toString}; supported major is ${protocolMajor->Int.toString}`,
-    })
-  }
+  | Ready: Types.message<unit>

--- a/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
@@ -2,17 +2,7 @@ open Vitest
 
 @val external structuredClone: 'a => 'a = "structuredClone"
 
-let handle = (request: Types.message<unit>) =>
-  switch request {
-  | FrontmanProtocol.Preview.Ready => ()
-  | _ => JsError.throwWithMessage("Unexpected preview message")
-  }
-
-describe("lockstep preview messages", _t => {
-  test("Ready proves the Frontman handler is installed", t => {
-    t->expect(handle(FrontmanProtocol.Preview.Ready))->Expect.toEqual()
-  })
-
+describe("lockstep preview protocol", _t => {
   test("error DTO survives structured clone", t => {
     let error: FrontmanProtocol.Preview.error = {
       code: "preview_unavailable",

--- a/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
@@ -1,0 +1,66 @@
+open Vitest
+
+@val external structuredClone: 'a => 'a = "structuredClone"
+
+let handle = (request: Types.message<FrontmanProtocol.Preview.capabilityResult>) =>
+  switch request {
+  | FrontmanProtocol.Preview.GetCapabilities(request) =>
+    FrontmanProtocol.Preview.negotiateCapabilities(
+      request,
+      ~capabilities=[FrontmanProtocol.Preview.Capability.domSerialization],
+    )
+  | _ => Error({code: "unexpected_message", message: "Unexpected preview message"})
+  }
+
+describe("preview capability negotiation", _t => {
+  test("returns protocol version and supported capabilities", t => {
+    let response = handle(
+      FrontmanProtocol.Preview.GetCapabilities({
+        protocolMajor: FrontmanProtocol.Preview.protocolMajor,
+      }),
+    )
+
+    t
+    ->expect(response)
+    ->Expect.toEqual(
+      Ok({
+        protocolMajor: FrontmanProtocol.Preview.protocolMajor,
+        capabilities: [FrontmanProtocol.Preview.Capability.domSerialization],
+      }),
+    )
+  })
+
+  test("returns typed error for unsupported protocol major", t => {
+    let response = handle(FrontmanProtocol.Preview.GetCapabilities({protocolMajor: 99}))
+
+    t
+    ->expect(response)
+    ->Expect.toEqual(
+      Error({
+        code: FrontmanProtocol.Preview.ErrorCode.unsupportedProtocolMajor,
+        message: "Unsupported preview protocol major 99; supported major is 1",
+      }),
+    )
+  })
+
+  test("response DTO survives structured clone", t => {
+    let response: FrontmanProtocol.Preview.capabilityResult = Ok({
+      protocolMajor: FrontmanProtocol.Preview.protocolMajor,
+      capabilities: [
+        FrontmanProtocol.Preview.Capability.domSerialization,
+        FrontmanProtocol.Preview.Capability.selection,
+      ],
+    })
+
+    t->expect(structuredClone(response))->Expect.toEqual(response)
+  })
+
+  test("error DTO survives structured clone", t => {
+    let error: FrontmanProtocol.Preview.error = {
+      code: FrontmanProtocol.Preview.ErrorCode.unsupportedProtocolMajor,
+      message: "unsupported",
+    }
+
+    t->expect(structuredClone(error))->Expect.toEqual(error)
+  })
+})

--- a/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__Preview.test.res
@@ -2,63 +2,21 @@ open Vitest
 
 @val external structuredClone: 'a => 'a = "structuredClone"
 
-let handle = (request: Types.message<FrontmanProtocol.Preview.capabilityResult>) =>
+let handle = (request: Types.message<unit>) =>
   switch request {
-  | FrontmanProtocol.Preview.GetCapabilities(request) =>
-    FrontmanProtocol.Preview.negotiateCapabilities(
-      request,
-      ~capabilities=[FrontmanProtocol.Preview.Capability.domSerialization],
-    )
-  | _ => Error({code: "unexpected_message", message: "Unexpected preview message"})
+  | FrontmanProtocol.Preview.Ready => ()
+  | _ => JsError.throwWithMessage("Unexpected preview message")
   }
 
-describe("preview capability negotiation", _t => {
-  test("returns protocol version and supported capabilities", t => {
-    let response = handle(
-      FrontmanProtocol.Preview.GetCapabilities({
-        protocolMajor: FrontmanProtocol.Preview.protocolMajor,
-      }),
-    )
-
-    t
-    ->expect(response)
-    ->Expect.toEqual(
-      Ok({
-        protocolMajor: FrontmanProtocol.Preview.protocolMajor,
-        capabilities: [FrontmanProtocol.Preview.Capability.domSerialization],
-      }),
-    )
-  })
-
-  test("returns typed error for unsupported protocol major", t => {
-    let response = handle(FrontmanProtocol.Preview.GetCapabilities({protocolMajor: 99}))
-
-    t
-    ->expect(response)
-    ->Expect.toEqual(
-      Error({
-        code: FrontmanProtocol.Preview.ErrorCode.unsupportedProtocolMajor,
-        message: "Unsupported preview protocol major 99; supported major is 1",
-      }),
-    )
-  })
-
-  test("response DTO survives structured clone", t => {
-    let response: FrontmanProtocol.Preview.capabilityResult = Ok({
-      protocolMajor: FrontmanProtocol.Preview.protocolMajor,
-      capabilities: [
-        FrontmanProtocol.Preview.Capability.domSerialization,
-        FrontmanProtocol.Preview.Capability.selection,
-      ],
-    })
-
-    t->expect(structuredClone(response))->Expect.toEqual(response)
+describe("lockstep preview messages", _t => {
+  test("Ready proves the Frontman handler is installed", t => {
+    t->expect(handle(FrontmanProtocol.Preview.Ready))->Expect.toEqual()
   })
 
   test("error DTO survives structured clone", t => {
     let error: FrontmanProtocol.Preview.error = {
-      code: FrontmanProtocol.Preview.ErrorCode.unsupportedProtocolMajor,
-      message: "unsupported",
+      code: "preview_unavailable",
+      message: "Preview bridge is unavailable",
     }
 
     t->expect(structuredClone(error))->Expect.toEqual(error)

--- a/libs/frontman-protocol/vitest.config.ts
+++ b/libs/frontman-protocol/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.res.mjs'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,6 +1341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bluehotdog/reworker@https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz":
+  version: 0.0.2
+  resolution: "@bluehotdog/reworker@https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz"
+  peerDependencies:
+    rescript: ^12.0.0
+  checksum: 10c0/71c0a133b2cdba218502a5d8a462a0e26871337ef56a47c189ac6684e2511077615b1c044fd6d4edcac8729f3b858a4eaf08c38c0cd9ff617d4340e21ace07af
+  languageName: node
+  linkType: hard
+
 "@braintree/sanitize-url@npm:^7.1.2":
   version: 7.1.2
   resolution: "@braintree/sanitize-url@npm:7.1.2"
@@ -2475,9 +2484,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontman-ai/frontman-protocol@workspace:libs/frontman-protocol"
   dependencies:
+    "@bluehotdog/reworker": "https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz"
     "@rescript/webapi": "npm:*"
     rescript: "catalog:"
+    rescript-vitest: "catalog:"
     sury: "npm:11.0.0-alpha.10"
+    vite: "catalog:"
+    vitest: "catalog:"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,12 +1341,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bluehotdog/reworker@https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz":
+"@bluehotdog/reworker@https://github.com/frontman-ai/reworker.git#head=main":
   version: 0.0.2
-  resolution: "@bluehotdog/reworker@https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz"
+  resolution: "@bluehotdog/reworker@https://github.com/frontman-ai/reworker.git#commit=29ad2c9b7a610dead396126609224eedbdb83772"
   peerDependencies:
     rescript: ^12.0.0
-  checksum: 10c0/71c0a133b2cdba218502a5d8a462a0e26871337ef56a47c189ac6684e2511077615b1c044fd6d4edcac8729f3b858a4eaf08c38c0cd9ff617d4340e21ace07af
+  checksum: 10c0/bfe753fc1ee0da0a1bcae409715e0f5b180179c68760dff30c749b0f49bea136b52b598bb4bbf3d03148198b8ed63df3c41c044240ceb3539ab02a2e70e12da8
   languageName: node
   linkType: hard
 
@@ -2484,7 +2484,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontman-ai/frontman-protocol@workspace:libs/frontman-protocol"
   dependencies:
-    "@bluehotdog/reworker": "https://github.com/frontman-ai/reworker/archive/12f1cbd08b768a8ed06826c23f05338ae3ac61ee.tar.gz"
+    "@bluehotdog/reworker": "https://github.com/frontman-ai/reworker.git#head=main"
     "@rescript/webapi": "npm:*"
     rescript: "catalog:"
     rescript-vitest: "catalog:"


### PR DESCRIPTION
## Summary
- establish shared preview protocol module and clone-safe structured errors
- rely on Reworker `Open` and `whenOpen` for startup readiness
- leave first real GADT operation to DOM serialization work in #1450
- bind protocol package to Reworker `main`
- run focused preview protocol tests in CI
- establish strict lockstep foundation for immutable parent/bridge capsules tracked by #1474

## Verification
- `make -C libs/frontman-protocol test`
- `make rescript-build`
- `make reanalyze`
- ReScript formatting and pre-commit/pre-push hooks

Closes #1449