### PR TITLE
fix get help button appearance

### DIFF
--- a/libs/client/src/components/frontman/Client__ErrorBanner.res
+++ b/libs/client/src/components/frontman/Client__ErrorBanner.res
@@ -43,7 +43,7 @@ let make = (
         href="https://frontman.sh/docs"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-xs text-red-400/40 hover:text-red-300 px-3 py-1 transition-colors"
+        className="text-xs text-red-300 underline underline-offset-2 decoration-red-500/50 hover:text-red-200 hover:decoration-red-400 px-3 py-1 transition-colors"
       >
         {React.string("Get help")}
       </a>


### PR DESCRIPTION
## Description

Earlier it looked like it was disabled. So changed the text red color and added underline

**before**

<img width="904" height="240" alt="image" src="https://github.com/user-attachments/assets/537a25ac-64dc-4d44-999a-5a172706f180" />

**after**

<img width="507" height="130" alt="image" src="https://github.com/user-attachments/assets/384e67c5-dd17-45ad-b0e4-7c9941b11f76" />


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
