### PR TITLE
Parse provider OAuth responses with Sury

### DIFF
--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -699,10 +699,7 @@ let handleEffect = (effect, state: state, dispatch) => {
         if response.ok {
           let json = await response->WebAPI.Response.json
           let {connected, expiresAt} =
-            json->S.decodeOrThrow(
-              ~from=S.json,
-              ~to=Client__State__Types.anthropicOAuthStatusResponseSchema,
-            )
+            json->S.decodeOrThrow(~from=S.json, ~to=Client__State__Types.oauthStatusResponseSchema)
           dispatch(AnthropicOAuthStatusReceived({connected, expiresAt}))
         }
       } catch {
@@ -808,15 +805,8 @@ let handleEffect = (effect, state: state, dispatch) => {
         let response = await WebAPI.Global.fetch(url, ~init={credentials: Include})
         if response.ok {
           let json = await response->WebAPI.Response.json
-          let connected =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("connected")->Option.flatMap(JSON.Decode.bool))
-            ->Option.getOr(false)
-          let expiresAt =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string))
+          let {connected, expiresAt} =
+            json->S.decodeOrThrow(~from=S.json, ~to=Client__State__Types.oauthStatusResponseSchema)
           dispatch(OpenAIOAuthStatusReceived({connected, expiresAt}))
         }
       } catch {
@@ -843,23 +833,12 @@ let handleEffect = (effect, state: state, dispatch) => {
         )
         if response.ok {
           let json = await response->WebAPI.Response.json
-          let obj = json->JSON.Decode.object
-          let deviceAuthId =
-            obj->Option.flatMap(o =>
-              o->Dict.get("device_auth_id")->Option.flatMap(JSON.Decode.string)
+          let {deviceAuthId, userCode, verificationUrl} =
+            json->S.decodeOrThrow(
+              ~from=S.json,
+              ~to=Client__State__Types.openAIDeviceAuthResponseSchema,
             )
-          let userCode =
-            obj->Option.flatMap(o => o->Dict.get("user_code")->Option.flatMap(JSON.Decode.string))
-          let verificationUrl =
-            obj->Option.flatMap(o =>
-              o->Dict.get("verification_url")->Option.flatMap(JSON.Decode.string)
-            )
-          switch (deviceAuthId, userCode, verificationUrl) {
-          | (Some(deviceAuthId), Some(userCode), Some(verificationUrl)) =>
-            dispatch(OpenAIDeviceCodeReceived({deviceAuthId, userCode, verificationUrl}))
-          | _ =>
-            dispatch(OpenAIOAuthError({deviceAuthId: None, error: "Invalid response from server"}))
-          }
+          dispatch(OpenAIDeviceCodeReceived({deviceAuthId, userCode, verificationUrl}))
         } else {
           dispatch(
             OpenAIOAuthError({deviceAuthId: None, error: "Failed to initiate authentication"}),
@@ -904,22 +883,16 @@ let handleEffect = (effect, state: state, dispatch) => {
             )
             if response.ok {
               let json = await response->WebAPI.Response.json
-              let status =
-                json
-                ->JSON.Decode.object
-                ->Option.flatMap(obj => obj->Dict.get("status")->Option.flatMap(JSON.Decode.string))
-                ->Option.getOr("")
+              let {status, expiresAt} =
+                json->S.decodeOrThrow(
+                  ~from=S.json,
+                  ~to=Client__State__Types.openAIDeviceAuthPollResponseSchema,
+                )
               switch status {
-              | "connected" =>
-                let expiresAt =
-                  json
-                  ->JSON.Decode.object
-                  ->Option.flatMap(obj =>
-                    obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string)
-                  )
-                  ->Option.getOr("")
+              | Client__State__Types.DeviceAuthConnected =>
+                let expiresAt = expiresAt->Option.getOrThrow
                 dispatch(OpenAIOAuthConnected({deviceAuthId, expiresAt}))
-              | _ =>
+              | Client__State__Types.DeviceAuthPending =>
                 await Promise.make((resolve, _) => {
                   let _ = setTimeout(() => resolve(), intervalMs)
                 })
@@ -1343,15 +1316,12 @@ let next = (state: state, action) => {
     }
 
   | AnthropicOAuthStatusReceived({connected, expiresAt}) =>
-    let status = if connected {
-      switch expiresAt {
-      | Some(expiresAtStr) =>
-        let expiresAtMs = Date.fromString(expiresAtStr)->Date.getTime
-        Client__State__Types.Connected({expiresAt: expiresAtMs})
-      | None => Client__State__Types.Connected({expiresAt: 0.0})
-      }
-    } else {
-      Client__State__Types.NotConnected
+    let status = switch (connected, expiresAt) {
+    | (true, Some(expiresAtStr)) =>
+      let expiresAtMs = Date.fromString(expiresAtStr)->Date.getTime
+      Client__State__Types.Connected({expiresAt: expiresAtMs})
+    | (true, None) => failwith("Connected Anthropic OAuth status missing expires_at")
+    | (false, _) => Client__State__Types.NotConnected
     }
     {...state, anthropicOAuthStatus: status}->StateReducer.update
 
@@ -1439,15 +1409,12 @@ let next = (state: state, action) => {
     }
 
   | OpenAIOAuthStatusReceived({connected, expiresAt}) =>
-    let status = if connected {
-      switch expiresAt {
-      | Some(expiresAtStr) =>
-        let expiresAtMs = Date.fromString(expiresAtStr)->Date.getTime
-        Client__State__Types.OpenAIConnected({expiresAt: expiresAtMs})
-      | None => Client__State__Types.OpenAIConnected({expiresAt: 0.0})
-      }
-    } else {
-      Client__State__Types.OpenAINotConnected
+    let status = switch (connected, expiresAt) {
+    | (true, Some(expiresAtStr)) =>
+      let expiresAtMs = Date.fromString(expiresAtStr)->Date.getTime
+      Client__State__Types.OpenAIConnected({expiresAt: expiresAtMs})
+    | (true, None) => failwith("Connected OpenAI OAuth status missing expires_at")
+    | (false, _) => Client__State__Types.OpenAINotConnected
     }
     {...state, openaiOAuthStatus: status}->StateReducer.update
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -698,15 +698,11 @@ let handleEffect = (effect, state: state, dispatch) => {
         let response = await WebAPI.Global.fetch(url, ~init={credentials: Include})
         if response.ok {
           let json = await response->WebAPI.Response.json
-          let connected =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("connected")->Option.flatMap(JSON.Decode.bool))
-            ->Option.getOr(false)
-          let expiresAt =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string))
+          let {connected, expiresAt} =
+            json->S.decodeOrThrow(
+              ~from=S.json,
+              ~to=Client__State__Types.anthropicOAuthStatusResponseSchema,
+            )
           dispatch(AnthropicOAuthStatusReceived({connected, expiresAt}))
         }
       } catch {
@@ -723,21 +719,12 @@ let handleEffect = (effect, state: state, dispatch) => {
         let response = await WebAPI.Global.fetch(url, ~init={credentials: Include})
         if response.ok {
           let json = await response->WebAPI.Response.json
-          let authorizeUrl =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj =>
-              obj->Dict.get("authorize_url")->Option.flatMap(JSON.Decode.string)
+          let {authorizeUrl, verifier} =
+            json->S.decodeOrThrow(
+              ~from=S.json,
+              ~to=Client__State__Types.anthropicOAuthAuthorizeUrlResponseSchema,
             )
-          let verifier =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("verifier")->Option.flatMap(JSON.Decode.string))
-          switch (authorizeUrl, verifier) {
-          | (Some(authorizeUrl), Some(verifier)) =>
-            dispatch(AnthropicOAuthUrlReceived({authorizeUrl, verifier}))
-          | _ => dispatch(AnthropicOAuthError({error: "Invalid response from server"}))
-          }
+          dispatch(AnthropicOAuthUrlReceived({authorizeUrl, verifier}))
         } else {
           dispatch(AnthropicOAuthError({error: "Failed to get authorization URL"}))
         }
@@ -769,21 +756,19 @@ let handleEffect = (effect, state: state, dispatch) => {
         )
         if response.ok {
           let json = await response->WebAPI.Response.json
-          let expiresAt =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("expires_at")->Option.flatMap(JSON.Decode.string))
-          switch expiresAt {
-          | Some(expiresAt) => dispatch(AnthropicOAuthConnected({expiresAt: expiresAt}))
-          | None => dispatch(AnthropicOAuthError({error: "Invalid response from server"}))
-          }
+          let {expiresAt} =
+            json->S.decodeOrThrow(
+              ~from=S.json,
+              ~to=Client__State__Types.anthropicOAuthExchangeResponseSchema,
+            )
+          dispatch(AnthropicOAuthConnected({expiresAt: expiresAt}))
         } else {
           let json = await response->WebAPI.Response.json
-          let error =
-            json
-            ->JSON.Decode.object
-            ->Option.flatMap(obj => obj->Dict.get("error")->Option.flatMap(JSON.Decode.string))
-            ->Option.getOr("Failed to exchange code")
+          let {error} =
+            json->S.decodeOrThrow(
+              ~from=S.json,
+              ~to=Client__State__Types.anthropicOAuthErrorResponseSchema,
+            )
           dispatch(AnthropicOAuthError({error: error}))
         }
       } catch {

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -64,7 +64,7 @@ type apiKeySettings = {
 }
 
 @schema
-type anthropicOAuthStatusResponse = {
+type oauthStatusResponse = {
   connected: bool,
   @as("expires_at")
   expiresAt: option<string>,
@@ -86,6 +86,28 @@ type anthropicOAuthExchangeResponse = {
 @schema
 type anthropicOAuthErrorResponse = {
   error: string,
+}
+
+@schema
+type openAIDeviceAuthResponse = {
+  @as("device_auth_id")
+  deviceAuthId: string,
+  @as("user_code")
+  userCode: string,
+  @as("verification_url")
+  verificationUrl: string,
+}
+
+@schema
+type openAIDeviceAuthPollStatus =
+  | @as("connected") DeviceAuthConnected
+  | @as("pending") DeviceAuthPending
+
+@schema
+type openAIDeviceAuthPollResponse = {
+  status: openAIDeviceAuthPollStatus,
+  @as("expires_at")
+  expiresAt: option<string>,
 }
 
 module ACPConfig = {

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -63,6 +63,31 @@ type apiKeySettings = {
   saveStatus: apiKeySaveStatus,
 }
 
+@schema
+type anthropicOAuthStatusResponse = {
+  connected: bool,
+  @as("expires_at")
+  expiresAt: option<string>,
+}
+
+@schema
+type anthropicOAuthAuthorizeUrlResponse = {
+  @as("authorize_url")
+  authorizeUrl: string,
+  verifier: string,
+}
+
+@schema
+type anthropicOAuthExchangeResponse = {
+  @as("expires_at")
+  expiresAt: string,
+}
+
+@schema
+type anthropicOAuthErrorResponse = {
+  error: string,
+}
+
 module ACPConfig = {
   type sessionConfigOption = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionConfigOption
   type sessionConfigValueId = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP.sessionConfigValueId


### PR DESCRIPTION
## Summary
- add typed Sury schemas for Anthropic and OpenAI OAuth responses
- replace manual JSON decoding in Anthropic status, authorization URL, and code exchange effects
- replace manual JSON decoding in OpenAI status, device authorization, and polling effects
- reject unknown poll states and connected statuses missing expiration data

## Verification
- `make test` in `libs/client` (35 files, 341 tests)
- pre-push ReScript reanalyze (0 issues)
- ReScript formatting hook
- `git diff --check`

Closes #171