### PR TITLE
feat(client): establish Reworker parent runtime

### DIFF
--- a/.changeset/brave-cats-connect.md
+++ b/.changeset/brave-cats-connect.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": minor
+---
+
+Establish the typed Reworker parent runtime for preview iframes.

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -38,6 +38,7 @@
 		"@babel/core": "^8.0.1",
 		"@base-ui/react": "^1.4.1",
 		"@biomejs/biome": "^2.5.3",
+		"@bluehotdog/reworker": "https://github.com/frontman-ai/reworker.git#head=main",
 		"@frontman-ai/astro-browser": "workspace:*",
 		"@frontman-ai/frontman-client": "workspace:*",
 		"@frontman-ai/frontman-protocol": "workspace:*",

--- a/libs/client/rescript.json
+++ b/libs/client/rescript.json
@@ -27,6 +27,7 @@
 	},
 	"ppx-flags": ["sury-ppx/bin"],
 	"dependencies": [
+		"@bluehotdog/reworker",
 		"@frontman/bindings",
 		"@frontman/logs",
 		"@rescript/react",

--- a/libs/client/src/webpreview/Client__PreviewRuntime.res
+++ b/libs/client/src/webpreview/Client__PreviewRuntime.res
@@ -10,21 +10,19 @@ let handler:
   type response. (Types.message<response>, unit, Runtime.context) => Response.t<response> =
   (_message, _sender, _context) => Response.none
 
-let make = (~iframe: WebAPI.DomTypes.element, ~targetOrigin, ~channel) => {
-  let iframeElement: WebAPI.DomTypes.htmliFrameElement = Obj.magic(iframe)
+let make = (~iframe: WebAPI.DomTypes.htmliFrameElement, ~targetOrigin, ~channel) => {
   let targetWindow =
-    iframeElement
+    iframe
     ->WebAPI.HTMLIFrameElement.contentWindow
     ->Option.getOrThrow(~message="Preview iframe requires a contentWindow")
-  let iframeTarget: WebAPI.DomTypes.eventTarget = Obj.magic(iframe)
   let transport = WindowTransport.Parent.make({
     targetWindow,
     targetOrigin,
     channel,
     subscribeLoad: listener => {
       let onLoad = _event => listener()
-      iframeTarget->WebAPI.EventTarget.addEventListener(WebAPI.EventTypes.Load, onLoad)
-      () => iframeTarget->WebAPI.EventTarget.removeEventListener(WebAPI.EventTypes.Load, onLoad)
+      iframe->WebAPI.HTMLIFrameElement.addEventListener(WebAPI.EventTypes.Load, onLoad)
+      () => iframe->WebAPI.HTMLIFrameElement.removeEventListener(WebAPI.EventTypes.Load, onLoad)
     },
     connectionTimeoutMs: 5000,
     maxChunkBytes: 1_000_000,

--- a/libs/client/src/webpreview/Client__PreviewRuntime.res
+++ b/libs/client/src/webpreview/Client__PreviewRuntime.res
@@ -1,0 +1,39 @@
+type t = Runtime.t<unit>
+
+let limits: Runtime.limits = {
+  requestTimeoutMs: 5000,
+  maxMessageBytes: 32_000_000,
+  maxPendingRequests: 100,
+}
+
+let handler:
+  type response. (Types.message<response>, unit, Runtime.context) => Response.t<response> =
+  (_message, _sender, _context) => Response.none
+
+let make = (~iframe: WebAPI.DomTypes.element, ~targetOrigin, ~channel) => {
+  let iframeElement: WebAPI.DomTypes.htmliFrameElement = Obj.magic(iframe)
+  let targetWindow =
+    iframeElement
+    ->WebAPI.HTMLIFrameElement.contentWindow
+    ->Option.getOrThrow(~message="Preview iframe requires a contentWindow")
+  let iframeTarget: WebAPI.DomTypes.eventTarget = Obj.magic(iframe)
+  let transport = WindowTransport.Parent.make({
+    targetWindow,
+    targetOrigin,
+    channel,
+    subscribeLoad: listener => {
+      let onLoad = _event => listener()
+      iframeTarget->WebAPI.EventTarget.addEventListener(WebAPI.EventTypes.Load, onLoad)
+      () => iframeTarget->WebAPI.EventTarget.removeEventListener(WebAPI.EventTypes.Load, onLoad)
+    },
+    connectionTimeoutMs: 5000,
+    maxChunkBytes: 1_000_000,
+  })
+
+  Runtime.make(transport, ~limits, ~handler)
+}
+
+let status = Runtime.status
+let onStatus = Runtime.onStatus
+let whenOpen = Runtime.whenOpen
+let close = Runtime.close

--- a/libs/client/src/webpreview/Client__PreviewRuntime.resi
+++ b/libs/client/src/webpreview/Client__PreviewRuntime.resi
@@ -1,6 +1,6 @@
 type t
 
-let make: (~iframe: WebAPI.DomTypes.element, ~targetOrigin: string, ~channel: string) => t
+let make: (~iframe: WebAPI.DomTypes.htmliFrameElement, ~targetOrigin: string, ~channel: string) => t
 let status: t => Runtime.status
 let onStatus: (t, Runtime.status => unit) => unit => unit
 let whenOpen: t => Promise.t<unit>

--- a/libs/client/src/webpreview/Client__PreviewRuntime.resi
+++ b/libs/client/src/webpreview/Client__PreviewRuntime.resi
@@ -1,0 +1,7 @@
+type t
+
+let make: (~iframe: WebAPI.DomTypes.element, ~targetOrigin: string, ~channel: string) => t
+let status: t => Runtime.status
+let onStatus: (t, Runtime.status => unit) => unit => unit
+let whenOpen: t => Promise.t<unit>
+let close: t => unit

--- a/libs/client/test/Client__PreviewRuntime.test.res
+++ b/libs/client/test/Client__PreviewRuntime.test.res
@@ -1,50 +1,35 @@
 open Vitest
 
-type bootstrapMessage = {
-  marker: string,
-  kind: string,
-  channel: string,
-}
+@send
+external createIframeElement: (
+  WebAPI.DomTypes.document,
+  @as(json`"iframe"`) _,
+) => WebAPI.DomTypes.htmliFrameElement = "createElement"
 
 afterEach(() => {
   Vi.useRealTimers()->ignore
 })
 
-let makeIframe = (~onPostMessage) => {
-  let targetWindow: Dict.t<Obj.t> = Dict.make()
-  targetWindow->Dict.set("postMessage", Obj.magic(onPostMessage))
-
-  let iframe = WebAPI.EventTarget.make()
-  (Obj.magic(iframe): Dict.t<Obj.t>)->Dict.set("contentWindow", Obj.magic(targetWindow))
-  (Obj.magic(iframe): WebAPI.DomTypes.element)
+let makeIframe = () => {
+  let document = WebAPI.Window.current->WebAPI.Window.document
+  let iframe = document->createIframeElement
+  document
+  ->WebAPI.Document.body
+  ->Null.toOption
+  ->Option.getOrThrow(~message="Test document requires a body")
+  ->WebAPI.HTMLElement.appendChild(iframe->WebAPI.HTMLIFrameElement.asNode)
+  ->ignore
+  iframe
 }
 
+let removeIframe = iframe => iframe->WebAPI.HTMLIFrameElement.remove
+
 describe("preview parent runtime", _t => {
-  testAsync("opens only with the expected origin and channel", async t => {
-    let iframe = makeIframe(
-      ~onPostMessage=(
-        message: bootstrapMessage,
-        targetOrigin: string,
-        ports: array<MessagePort.t>,
-      ) => {
-        switch (message.marker, message.kind, message.channel, targetOrigin, ports->Array.get(0)) {
-        | (
-            "@bluehotdog/reworker/window/v2",
-            "connect",
-            "preview-task-id",
-            "https://preview.example.com",
-            Some(port),
-          ) =>
-          let ready: Dict.t<string> = Dict.make()
-          ready->Dict.set("kind", "ready")
-          MessagePort.postMessage(port, ready)
-        | _ => ()
-        }
-      },
-    )
+  testAsync("close rejects readiness, notifies status, and prevents reconnecting", async t => {
+    let iframe = makeIframe()
     let runtime = Client__PreviewRuntime.make(
       ~iframe,
-      ~targetOrigin="https://preview.example.com",
+      ~targetOrigin="http://localhost:3000",
       ~channel="preview-task-id",
     )
     let statuses = ref([])
@@ -52,45 +37,30 @@ describe("preview parent runtime", _t => {
       runtime,
       status => statuses := statuses.contents->Array.concat([status]),
     )
+    let readiness = Client__PreviewRuntime.whenOpen(runtime)
 
-    t->expect(Client__PreviewRuntime.status(runtime))->Expect.toEqual(Runtime.Connecting)
-    await Client__PreviewRuntime.whenOpen(runtime)
-    t->expect(Client__PreviewRuntime.status(runtime))->Expect.toEqual(Runtime.Open)
-    t->expect(statuses.contents)->Expect.toContain(Runtime.Open)
-
-    removeStatusListener()
     Client__PreviewRuntime.close(runtime)
-  })
-
-  test("close removes the iframe load subscription", t => {
-    let postCount = ref(0)
-    let iframe = makeIframe(
-      ~onPostMessage=(_message, _targetOrigin, _ports) => postCount := postCount.contents + 1,
-    )
-    let runtime = Client__PreviewRuntime.make(
-      ~iframe,
-      ~targetOrigin="https://preview.example.com",
-      ~channel="preview-task-id",
-    )
-
-    t->expect(postCount.contents)->Expect.toBe(1)
-    Client__PreviewRuntime.close(runtime)
+    let readinessOutcome = await readiness
+    ->Promise.then(_ => Promise.resolve("opened"))
+    ->Promise.catch(_ => Promise.resolve("closed"))
     iframe
-    ->Obj.magic
-    ->WebAPI.EventTarget.dispatchEvent(WebAPI.Event.make(~type_="load"))
+    ->WebAPI.HTMLIFrameElement.dispatchEvent(WebAPI.Event.make(~type_="load"))
     ->ignore
-    t->expect(postCount.contents)->Expect.toBe(1)
+    t
+    ->expect(Client__PreviewRuntime.status(runtime))
+    ->Expect.toEqual(Runtime.Closed("Runtime closed"))
+    t->expect(readinessOutcome)->Expect.toBe("closed")
+    t->expect(statuses.contents)->Expect.toEqual([Runtime.Closed("Runtime closed")])
+    removeStatusListener()
+    removeIframe(iframe)
   })
 
-  testAsync("timeout disconnects and close removes the load subscription", async t => {
+  testAsync("timeout disconnects before deterministic close", async t => {
     Vi.useFakeTimers()->ignore
-    let postCount = ref(0)
-    let iframe = makeIframe(
-      ~onPostMessage=(_message, _targetOrigin, _ports) => postCount := postCount.contents + 1,
-    )
+    let iframe = makeIframe()
     let runtime = Client__PreviewRuntime.make(
       ~iframe,
-      ~targetOrigin="https://preview.example.com",
+      ~targetOrigin="http://localhost:3000",
       ~channel="preview-task-id",
     )
 
@@ -100,15 +70,11 @@ describe("preview parent runtime", _t => {
     ->Expect.toEqual(Runtime.Disconnected("Window transport readiness timed out"))
 
     Client__PreviewRuntime.close(runtime)
-    iframe
-    ->Obj.magic
-    ->WebAPI.EventTarget.dispatchEvent(WebAPI.Event.make(~type_="load"))
-    ->ignore
-    t->expect(postCount.contents)->Expect.toBe(1)
+    removeIframe(iframe)
   })
 
   test("rejects wildcard origins and empty channels", t => {
-    let iframe = makeIframe(~onPostMessage=(_message, _targetOrigin, _ports) => ())
+    let iframe = makeIframe()
 
     t
     ->expect(
@@ -121,10 +87,11 @@ describe("preview parent runtime", _t => {
       () =>
         Client__PreviewRuntime.make(
           ~iframe,
-          ~targetOrigin="https://preview.example.com",
+          ~targetOrigin="http://localhost:3000",
           ~channel="",
         )->ignore,
     )
     ->Expect.toThrow
+    removeIframe(iframe)
   })
 })

--- a/libs/client/test/Client__PreviewRuntime.test.res
+++ b/libs/client/test/Client__PreviewRuntime.test.res
@@ -6,8 +6,6 @@ type bootstrapMessage = {
   channel: string,
 }
 
-type readyMessage = {kind: string}
-
 afterEach(() => {
   Vi.useRealTimers()->ignore
 })
@@ -37,7 +35,9 @@ describe("preview parent runtime", _t => {
             "https://preview.example.com",
             Some(port),
           ) =>
-          MessagePort.postMessage(port, ({kind: "ready"}: readyMessage))
+          let ready: Dict.t<string> = Dict.make()
+          ready->Dict.set("kind", "ready")
+          MessagePort.postMessage(port, ready)
         | _ => ()
         }
       },

--- a/libs/client/test/Client__PreviewRuntime.test.res
+++ b/libs/client/test/Client__PreviewRuntime.test.res
@@ -1,0 +1,130 @@
+open Vitest
+
+type bootstrapMessage = {
+  marker: string,
+  kind: string,
+  channel: string,
+}
+
+type readyMessage = {kind: string}
+
+afterEach(() => {
+  Vi.useRealTimers()->ignore
+})
+
+let makeIframe = (~onPostMessage) => {
+  let targetWindow: Dict.t<Obj.t> = Dict.make()
+  targetWindow->Dict.set("postMessage", Obj.magic(onPostMessage))
+
+  let iframe = WebAPI.EventTarget.make()
+  (Obj.magic(iframe): Dict.t<Obj.t>)->Dict.set("contentWindow", Obj.magic(targetWindow))
+  (Obj.magic(iframe): WebAPI.DomTypes.element)
+}
+
+describe("preview parent runtime", _t => {
+  testAsync("opens only with the expected origin and channel", async t => {
+    let iframe = makeIframe(
+      ~onPostMessage=(
+        message: bootstrapMessage,
+        targetOrigin: string,
+        ports: array<MessagePort.t>,
+      ) => {
+        switch (message.marker, message.kind, message.channel, targetOrigin, ports->Array.get(0)) {
+        | (
+            "@bluehotdog/reworker/window/v2",
+            "connect",
+            "preview-task-id",
+            "https://preview.example.com",
+            Some(port),
+          ) =>
+          MessagePort.postMessage(port, ({kind: "ready"}: readyMessage))
+        | _ => ()
+        }
+      },
+    )
+    let runtime = Client__PreviewRuntime.make(
+      ~iframe,
+      ~targetOrigin="https://preview.example.com",
+      ~channel="preview-task-id",
+    )
+    let statuses = ref([])
+    let removeStatusListener = Client__PreviewRuntime.onStatus(
+      runtime,
+      status => statuses := statuses.contents->Array.concat([status]),
+    )
+
+    t->expect(Client__PreviewRuntime.status(runtime))->Expect.toEqual(Runtime.Connecting)
+    await Client__PreviewRuntime.whenOpen(runtime)
+    t->expect(Client__PreviewRuntime.status(runtime))->Expect.toEqual(Runtime.Open)
+    t->expect(statuses.contents)->Expect.toContain(Runtime.Open)
+
+    removeStatusListener()
+    Client__PreviewRuntime.close(runtime)
+  })
+
+  test("close removes the iframe load subscription", t => {
+    let postCount = ref(0)
+    let iframe = makeIframe(
+      ~onPostMessage=(_message, _targetOrigin, _ports) => postCount := postCount.contents + 1,
+    )
+    let runtime = Client__PreviewRuntime.make(
+      ~iframe,
+      ~targetOrigin="https://preview.example.com",
+      ~channel="preview-task-id",
+    )
+
+    t->expect(postCount.contents)->Expect.toBe(1)
+    Client__PreviewRuntime.close(runtime)
+    iframe
+    ->Obj.magic
+    ->WebAPI.EventTarget.dispatchEvent(WebAPI.Event.make(~type_="load"))
+    ->ignore
+    t->expect(postCount.contents)->Expect.toBe(1)
+  })
+
+  testAsync("timeout disconnects and close removes the load subscription", async t => {
+    Vi.useFakeTimers()->ignore
+    let postCount = ref(0)
+    let iframe = makeIframe(
+      ~onPostMessage=(_message, _targetOrigin, _ports) => postCount := postCount.contents + 1,
+    )
+    let runtime = Client__PreviewRuntime.make(
+      ~iframe,
+      ~targetOrigin="https://preview.example.com",
+      ~channel="preview-task-id",
+    )
+
+    let _ = await Vi.advanceTimersByTimeAsync(5000)
+    t
+    ->expect(Client__PreviewRuntime.status(runtime))
+    ->Expect.toEqual(Runtime.Disconnected("Window transport readiness timed out"))
+
+    Client__PreviewRuntime.close(runtime)
+    iframe
+    ->Obj.magic
+    ->WebAPI.EventTarget.dispatchEvent(WebAPI.Event.make(~type_="load"))
+    ->ignore
+    t->expect(postCount.contents)->Expect.toBe(1)
+  })
+
+  test("rejects wildcard origins and empty channels", t => {
+    let iframe = makeIframe(~onPostMessage=(_message, _targetOrigin, _ports) => ())
+
+    t
+    ->expect(
+      () =>
+        Client__PreviewRuntime.make(~iframe, ~targetOrigin="*", ~channel="preview-task-id")->ignore,
+    )
+    ->Expect.toThrow
+    t
+    ->expect(
+      () =>
+        Client__PreviewRuntime.make(
+          ~iframe,
+          ~targetOrigin="https://preview.example.com",
+          ~channel="",
+        )->ignore,
+    )
+    ->Expect.toThrow
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,6 +2362,7 @@ __metadata:
     "@babel/core": "npm:^8.0.1"
     "@base-ui/react": "npm:^1.4.1"
     "@biomejs/biome": "npm:^2.5.3"
+    "@bluehotdog/reworker": "https://github.com/frontman-ai/reworker.git#head=main"
     "@floating-ui/dom": "npm:^1.8.0"
     "@frontman-ai/astro-browser": "workspace:*"
     "@frontman-ai/frontman-client": "workspace:*"


### PR DESCRIPTION
## Summary
- add typed Reworker parent runtime for preview iframe bootstrap
- require `HTMLIFrameElement` at the API boundary with no casts or type escape hatches
- expose status, status subscription, readiness, and deterministic close lifecycle
- match child runtime limits, chunk size, exact origin, and channel requirements
- cover timeout, readiness rejection, status notification, invalid config, and close lifecycle with real jsdom iframe objects

## Verification
- `make -C libs/client test`
- `make rescript-build`
- `make reanalyze`
- pre-commit ReScript format and source-comment checks
- pre-push workspace reanalyze

## Scope
Cross-origin `Open` proof remains in #1458 because jsdom does not transfer `MessagePort`s through iframe `postMessage`. Production task-scoped runtime integration remains in #1469.

Closes #1448