### PR TITLE
focus editor input after clicking on new task button

### DIFF
--- a/.changeset/focus-new-task-editor.md
+++ b/.changeset/focus-new-task-editor.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Focus the prompt editor after starting a new task.

--- a/libs/client/src/Client__TopBar.res
+++ b/libs/client/src/Client__TopBar.res
@@ -5,6 +5,7 @@ module FrontmanLogo = Client__FrontmanLogo
 
 @send external locationAssign: ('a, string) => unit = "assign"
 @send external blur: Dom.element => unit = "blur"
+@send external focus: WebAPI.DomTypes.element => unit = "focus"
 
 let renderToolbarButton = (~label, ~onClick, ~children, ~className="") =>
   <Tooltip>
@@ -94,6 +95,11 @@ let make = (
       clearSession()
       Client__State.Actions.clearCurrentTask()
     }
+    WebAPI.Window.current
+    ->WebAPI.Window.document
+    ->WebAPI.Document.querySelector(".frontman-prompt-editor .ProseMirror")
+    ->Null.toOption
+    ->Option.forEach(focus)
   }
 
   let deviceModeActive = Client__DeviceMode.isActive(deviceMode)

--- a/libs/client/src/Client__TopBar.res
+++ b/libs/client/src/Client__TopBar.res
@@ -3,10 +3,6 @@ module Button = Client__UI__Button
 module Tooltip = Client__UI__Tooltip
 module FrontmanLogo = Client__FrontmanLogo
 
-@send external locationAssign: ('a, string) => unit = "assign"
-@send external blur: Dom.element => unit = "blur"
-@send external focus: WebAPI.DomTypes.element => unit = "focus"
-
 let renderToolbarButton = (~label, ~onClick, ~children, ~className="") =>
   <Tooltip>
     <Tooltip.Trigger
@@ -58,18 +54,15 @@ let make = (
         | false => ()
         | true =>
           previewFrame.contentWindow->Option.forEach(contentWindow => {
-            contentWindow->WebAPI.Window.location->locationAssign(resolvedUrl)
+            contentWindow->WebAPI.Window.location->WebAPI.Location.assign(resolvedUrl)
           })
           Client__State.Actions.setPreviewUrl(~url=resolvedUrl)
           Client__State.Actions.clearAnnotations()
           Client__BrowserUrl.syncBrowserUrl(~previewUrl=resolvedUrl)
         }
       }
-      let target: Dom.element = ReactEvent.Keyboard.target(e)->Obj.magic
-      target->blur
-    | "Escape" =>
-      let target: Dom.element = ReactEvent.Keyboard.target(e)->Obj.magic
-      target->blur
+      ReactEvent.Keyboard.currentTarget(e)["blur"]()
+    | "Escape" => ReactEvent.Keyboard.currentTarget(e)["blur"]()
     | _ => ()
     }
   }
@@ -95,11 +88,7 @@ let make = (
       clearSession()
       Client__State.Actions.clearCurrentTask()
     }
-    WebAPI.Window.current
-    ->WebAPI.Window.document
-    ->WebAPI.Document.querySelector(".frontman-prompt-editor .ProseMirror")
-    ->Null.toOption
-    ->Option.forEach(focus)
+    Client__PromptEditor.focus()
   }
 
   let deviceModeActive = Client__DeviceMode.isActive(deviceMode)

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -28,12 +28,6 @@ type rec jsonContentNode = {
   content?: array<jsonContentNode>,
 }
 
-@new external makeError: string => JsExn.t = "Error"
-@send external clickElement: Dom.element => unit = "click"
-@get external inputFiles: Dom.element => Null.t<WebAPI.DomTypes.fileList> = "files"
-@set external setInputValue: (Dom.element, string) => unit = "value"
-@get external navigatorUserAgent: WebAPI.DomTypes.navigator => string = "userAgent"
-
 module TiptapReact = FrontmanBindings.Bindings__Tiptap__React
 module TiptapCore = FrontmanBindings.Bindings__Tiptap__Core
 module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
@@ -226,7 +220,7 @@ module PastedTextView = {
             {React.string(
               `${WebAPI.Window.current
                 ->WebAPI.Window.navigator
-                ->navigatorUserAgent
+                ->WebAPI.Navigator.userAgent
                 ->getPasteExpandShortcut} to expand`,
             )}
           </span>
@@ -300,7 +294,7 @@ let readFileAsDataUrl = (file: browserFile): promise<string> => {
       ->Option.getOrThrow(~message="FileReader result missing after load")
       ->resolve
     })
-    reader->WebAPI.FileReader.setOnerror(_ => reject(makeError("Failed to read file")))
+    reader->WebAPI.FileReader.setOnerror(_ => reject(JsError.make("Failed to read file")))
     reader->WebAPI.FileReader.readAsDataURL((file :> WebAPI.FileTypes.blob))
   })
 }
@@ -760,7 +754,10 @@ let make = (
       lastAttachSignalRef.current = attachSignal
       switch disabledRef.current || isEnrichingAnnotationsRef.current {
       | true => ()
-      | false => fileInputRef.current->Nullable.toOption->Option.forEach(clickElement)
+      | false =>
+        fileInputRef.current
+        ->Nullable.toOption
+        ->Option.forEach(element => (element->ReactDOM.domElementToObj)["click"]())
       }
     }
     None
@@ -783,16 +780,16 @@ let make = (
     None
   }, (dropFilesSignal, editor, droppedFiles))
 
-  let handleFileInputChange = _ => {
-    switch (editorRef.current->Null.toOption, fileInputRef.current->Nullable.toOption) {
-    | (Some(currentEditor), Some(input)) =>
-      input
-      ->inputFiles
+  let handleFileInputChange = (event: ReactEvent.Form.t) => {
+    let input = ReactEvent.Form.currentTarget(event)
+    switch editorRef.current->Null.toOption {
+    | Some(currentEditor) =>
+      input["files"]
       ->Null.toOption
       ->Option.map(filesFromFileList)
       ->Option.forEach(files => addFiles(currentEditor, files)->ignore)
-      input->setInputValue("")
-    | _ => ()
+      input["value"] = ""
+    | None => ()
     }
   }
 

--- a/libs/client/src/components/frontman/Client__PromptEditor.res
+++ b/libs/client/src/components/frontman/Client__PromptEditor.res
@@ -33,9 +33,18 @@ type rec jsonContentNode = {
 @get external inputFiles: Dom.element => Null.t<WebAPI.DomTypes.fileList> = "files"
 @set external setInputValue: (Dom.element, string) => unit = "value"
 @get external navigatorUserAgent: WebAPI.DomTypes.navigator => string = "userAgent"
+
 module TiptapReact = FrontmanBindings.Bindings__Tiptap__React
 module TiptapCore = FrontmanBindings.Bindings__Tiptap__Core
 module TiptapExtensions = FrontmanBindings.Bindings__Tiptap__Extensions
+
+let activeEditorRef: ref<Null.t<TiptapCore.editor>> = ref(Null.null)
+
+let focus = () => {
+  activeEditorRef.contents
+  ->Null.toOption
+  ->Option.forEach(editor => editor->TiptapCore.chain->TiptapCore.focus->TiptapCore.run->ignore)
+}
 
 type fileAttachmentNodeOptions = {onPreviewImage: string => unit}
 type fileAttachmentAttrs = editorFileAttachment
@@ -710,10 +719,15 @@ let make = (
 
   React.useEffect1(() => {
     editorRef.current = editor
+    activeEditorRef.contents = editor
     Some(
       () => {
         switch editorRef.current == editor {
         | true => editorRef.current = Null.null
+        | false => ()
+        }
+        switch activeEditorRef.contents == editor {
+        | true => activeEditorRef.contents = Null.null
         | false => ()
         }
       },


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Focus on the editor input after clicking on the new task button.

https://github.com/user-attachments/assets/61d054eb-510f-4f1b-bf89-946750cd3eca


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
