### PR TITLE
Preserve JSON-RPC identifiers without truncation

### DIFF
--- a/.changeset/safe-json-rpc-identifiers.md
+++ b/.changeset/safe-json-rpc-identifiers.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-protocol": patch
+---
+
+Support string and JavaScript-safe integer JSON-RPC identifiers without truncating large values.

--- a/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
@@ -13,22 +13,29 @@ module ErrorCode = {
 module Id: {
   type t
 
+  let fromInt: int => t
+  let fromString: string => t
   let toJson: t => JSON.t
   let schema: S.t<t>
 } = {
-  type t = IntId(int) | StringId(string)
+  type t = NumberId(float) | StringId(string)
+
+  @scope("Number") @val
+  external isSafeInteger: float => bool = "isSafeInteger"
+
+  let fromInt = value => NumberId(Int.toFloat(value))
+  let fromString = value => StringId(value)
 
   let fromJson = id =>
     switch (id->JSON.Decode.string, id->JSON.Decode.float) {
     | (Some(value), _) => Some(StringId(value))
-    | (_, Some(value)) if Float.fromInt(Float.toInt(value)) == value =>
-      Some(IntId(Float.toInt(value)))
+    | (_, Some(value)) if isSafeInteger(value) => Some(NumberId(value))
     | _ => None
     }
 
   let toJson = id =>
     switch id {
-    | IntId(value) => JSON.Encode.int(value)
+    | NumberId(value) => JSON.Encode.float(value)
     | StringId(value) => JSON.Encode.string(value)
     }
 
@@ -36,7 +43,7 @@ module Id: {
     parser: value =>
       switch value->fromJson {
       | Some(id) => id
-      | None => s.fail("JSON-RPC id must be a string or number")
+      | None => s.fail("JSON-RPC id must be a string or safe integral number")
       },
     serializer: id => id->toJson,
   })

--- a/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
@@ -1,0 +1,27 @@
+open Vitest
+
+module Id = FrontmanProtocol__JsonRpc.Id
+
+describe("JSON-RPC identifiers", _t => {
+  test("constructs numeric and string identifiers", t => {
+    t->expect(Id.fromInt(42)->Id.toJson)->Expect.toEqual(JSON.Encode.int(42))
+    t
+    ->expect(Id.fromString("request-42")->Id.toJson)
+    ->Expect.toEqual(JSON.Encode.string("request-42"))
+  })
+
+  test("accepts the JavaScript safe integer boundaries", t => {
+    let minimum = JSON.Encode.float(-9007199254740991.)
+    let maximum = JSON.Encode.float(9007199254740991.)
+
+    t->expect(minimum->S.parseOrThrow(~to=Id.schema)->Id.toJson)->Expect.toEqual(minimum)
+    t->expect(maximum->S.parseOrThrow(~to=Id.schema)->Id.toJson)->Expect.toEqual(maximum)
+  })
+
+  test("rejects unsafe and fractional numeric identifiers", t => {
+    t
+    ->expect(() => JSON.Encode.float(9007199254740992.)->S.parseOrThrow(~to=Id.schema)->ignore)
+    ->Expect.toThrow
+    t->expect(() => JSON.Encode.float(1.5)->S.parseOrThrow(~to=Id.schema)->ignore)->Expect.toThrow
+  })
+})


### PR DESCRIPTION
## Summary
- expose constructors for outbound numeric and string JSON-RPC identifiers
- preserve JavaScript-safe integer IDs instead of coercing them through ReScript `int`
- reject fractional and unsafe numeric IDs

## Verification
- `make test` in `libs/frontman-protocol` (4 tests)
- `make test` in `libs/frontman-client` (96 tests)
- ReScript formatting and pre-commit hooks