### PR TITLE
Stop sending malformed tool arguments to Sentry

### DIFF
--- a/.changeset/calm-tools-redact.md
+++ b/.changeset/calm-tools-redact.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Keep malformed tool arguments out of diagnostic reports while retaining safe tool failure context.

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -23,8 +23,6 @@ defmodule FrontmanServer.Application do
     :user_name,
     :reason,
     :error_code,
-    :raw_arguments,
-    :decode_error,
     :loop_id
   ]
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -209,6 +209,17 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
       {:ok, _interaction} ->
         :ok
 
+      {:error, {:invalid_tool_arguments, _message}} ->
+        Logger.error("Tool argument parse failure", tool_parse_metadata(tool_call, task_id))
+
+        persist_error_tool_result(
+          scope,
+          task_id,
+          turn_number,
+          tool_call,
+          "Failed to parse arguments for tool"
+        )
+
       {:error, reason} ->
         Logger.error(
           "ToolExecutor: Failed to publish MCP tool call #{tool_call.id}: #{inspect(reason)}"
@@ -228,17 +239,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     }
 
     case SwarmAi.ToolCall.parse_arguments(tool_call) do
-      {:error, message} ->
-        metadata = [
-          error_type: "tool_parse_error",
-          tool_name: tool_call.name,
-          tool_call_id: tool_call.id,
-          task_id: task_id,
-          raw_arguments: String.slice(tool_call.arguments, 0, 500),
-          decode_error: message
-        ]
-
-        Logger.error("Tool argument parse failure", metadata)
+      {:error, _message} ->
+        Logger.error("Tool argument parse failure", tool_parse_metadata(tool_call, task_id))
 
         persist_error_tool_result(
           scope,
@@ -259,6 +261,15 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
           turn_number
         )
     end
+  end
+
+  defp tool_parse_metadata(tool_call, task_id) do
+    [
+      error_type: "tool_parse_error",
+      tool_name: tool_call.name,
+      tool_call_id: tool_call.id,
+      task_id: task_id
+    ]
   end
 
   defp do_run_backend_tool(scope, module, args, context, tool_call, task_id, turn_number) do

--- a/apps/frontman_server/lib/model_context_protocol.ex
+++ b/apps/frontman_server/lib/model_context_protocol.ex
@@ -113,7 +113,7 @@ defmodule ModelContextProtocol do
   tool call id remains in params.callId for agent/tool-result correlation.
   """
   def build_tool_execution(%ToolCallParams{} = params) do
-    Logger.info("MCP tool call: #{params.tool_name} arguments=#{inspect(params.arguments)}")
+    Logger.info("MCP tool call: #{params.tool_name}")
 
     JsonRpc.request(params.request_id, "tools/call", %{
       "name" => params.tool_name,

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -1,12 +1,5 @@
 defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
-  @moduledoc """
-  Integration tests verifying Sentry error reporting for tool execution failures.
-
-  Tests the following gaps identified in issue #474:
-  - Gap 2: Soft tool errors ({:error, reason}) reported to Sentry
-  - Gap 4: MCP tool timeouts reported to Sentry
-  - Gap 5: JSON argument parse failures reported to Sentry
-  """
+  @moduledoc false
 
   use SwarmAi.Testing, async: false
 
@@ -94,7 +87,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       scope: scope,
       turn_number: turn_number
     } do
-      tool_call = swarm_tool_call("todo_write", "{invalid json!!!}")
+      secret = "frontman-secret-1445"
+      tool_call = swarm_tool_call("todo_write", ~s({"secret":"#{secret}"))
 
       todo_write_module = Enum.find(Tools.backend_tool_modules(), &(&1.name() == "todo_write"))
 
@@ -125,8 +119,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       assert metadata[:tool_name] == "todo_write"
       assert metadata[:user_id] == scope.user.id
       assert metadata[:task_id] == task_id
-      assert metadata[:raw_arguments] == "{invalid json!!!}"
-      assert is_binary(metadata[:decode_error])
+      refute inspect(report) =~ secret
 
       soft_error_reports =
         Enum.filter(reports, fn event ->
@@ -166,38 +159,21 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
     end
 
     @tag :capture_log
-    test "truncates long raw arguments in Sentry report", %{
+    test "reports malformed MCP arguments without their content", %{
       task_id: task_id,
       scope: scope,
       turn_number: turn_number
     } do
-      long_invalid_json = String.duplicate("x", 1000)
+      secret = "frontman-mcp-secret-1445"
+      tool_call = swarm_tool_call("take_screenshot", ~s(["#{secret}"]))
 
-      tool_call = swarm_tool_call("todo_write", long_invalid_json)
+      assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tool_call)
+      assert_receive {:tool_result, _, [%{text: "Failed to parse arguments for tool"}], true}
 
-      todo_write_module = Enum.find(Tools.backend_tool_modules(), &(&1.name() == "todo_write"))
-
-      result =
-        ToolExecutor.run_backend_tool(
-          scope,
-          todo_write_module,
-          task_id,
-          turn_number,
-          tool_call
-        )
-
-      assert %SwarmAi.ToolResult{is_error: true} = result
-
-      reports = Sentry.Test.pop_sentry_reports()
-
-      parse_error_reports =
-        Enum.filter(reports, fn event ->
-          event.tags[:error_type] == "tool_parse_error"
-        end)
-
-      assert [report] = parse_error_reports
-
-      assert String.length(report.extra[:logger_metadata][:raw_arguments]) == 500
+      assert [report] = Sentry.Test.pop_sentry_reports()
+      assert report.tags[:error_type] == "tool_parse_error"
+      assert report.tags[:tool_name] == "take_screenshot"
+      refute inspect(report) =~ secret
     end
   end
 

--- a/apps/frontman_server/test/model_context_protocol_test.exs
+++ b/apps/frontman_server/test/model_context_protocol_test.exs
@@ -82,6 +82,7 @@ defmodule ModelContextProtocolTest do
       Logger.configure(level: prev_level)
 
       assert log =~ "MCP tool call: read_file"
+      refute log =~ "/tmp/test.txt"
     end
   end
 end

--- a/apps/swarm_ai/lib/swarm_ai/llm/response.ex
+++ b/apps/swarm_ai/lib/swarm_ai/llm/response.ex
@@ -203,7 +203,7 @@ defmodule SwarmAi.LLM.Response do
       MapSet.member?(malformed_indexes, index) ->
         raw = Map.fetch!(fragments_by_index, index)
 
-        Logger.warning("Tool call #{name} (#{id}) has invalid JSON arguments: #{inspect(raw)}")
+        Logger.warning("Tool call #{name} (#{id}) has invalid JSON arguments")
 
         raw
 

--- a/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
@@ -1,6 +1,8 @@
 defmodule SwarmAi.Loop.RunnerTest do
   use SwarmAi.Testing, async: true
 
+  import ExUnit.CaptureLog
+
   alias SwarmAi.{LLM, Loop, Message}
   alias SwarmAi.Loop.{Config, Runner, Step}
 
@@ -324,21 +326,25 @@ defmodule SwarmAi.Loop.RunnerTest do
 
     @tag :capture_log
     test "truncated stream preserves invalid JSON for debugging (no masking)" do
+      secret = "frontman-stream-secret-1445"
+
       stream = [
         StreamChunk.tool_call("read_file", %{}, %{id: "call_trunc", index: 0}),
         StreamChunk.meta(%{
-          tool_call_args: %{index: 0, fragment: ~s[{"path": "app/admin/products/page.tsx"]}
+          tool_call_args: %{index: 0, fragment: ~s[{"path": "#{secret}"]}
         }),
         StreamChunk.meta(%{finish_reason: :tool_calls})
       ]
 
-      response = LLM.Response.from_stream(stream)
+      log = capture_log(fn -> send(self(), {:response, LLM.Response.from_stream(stream)}) end)
+      assert_receive {:response, response}
 
       assert length(response.tool_calls) == 1
       [tool_call] = response.tool_calls
       assert tool_call.id == "call_trunc"
       assert tool_call.name == "read_file"
-      assert tool_call.arguments == ~s[{"path": "app/admin/products/page.tsx"]
+      assert tool_call.arguments == ~s[{"path": "#{secret}"]
+      refute log =~ secret
     end
 
     @tag :capture_log

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -82,12 +82,6 @@ let getToolByName = (server: t, name: string): option<module(Tool.Tool)> => {
   })
 }
 
-let argumentKeys = (arguments: option<Dict.t<JSON.t>>): string =>
-  switch arguments {
-  | None => "none"
-  | Some(args) => args->Dict.keysToArray->Array.join(",")
-  }
-
 let executeLocalTool = async (
   toolModule: module(Tool.Tool),
   ~arguments: option<Dict.t<JSON.t>>,
@@ -111,8 +105,6 @@ let executeLocalTool = async (
         "tool": T.name,
         "taskId": taskId,
         "toolCallId": toolCallId,
-        "schemaError": msg,
-        "argumentKeys": argumentKeys(arguments),
       },
       "Tool input schema validation failed",
     )


### PR DESCRIPTION
## Summary
- remove malformed tool payloads and parser errors from server and browser diagnostics
- retain tool name, call ID, task ID, and stable parse-error category
- return generic tool errors for malformed MCP arguments instead of crashing execution
- preserve raw arguments in task history and provider context

## Verification
- `make -C apps/frontman_server check` (724 tests)
- `make -C apps/swarm_ai check` (112 tests)
- `make -C libs/frontman-client check` (96 tests)
- pre-commit and pre-push hooks

52 additions, 63 deletions.

Closes #1445