### PR TITLE
show the first message optimistically as soon as sent

### DIFF
--- a/.changeset/plain-weeks-march.md
+++ b/.changeset/plain-weeks-march.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": minor
+---
+
+Render user messages optimistically as soon as they are submitted. Messages are inserted with a client-generated `optimistic-` id and swapped in place when the server echo arrives, so the text no longer disappears between pressing enter and the round trip completing.

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -8,7 +8,7 @@ module AssistantContentPart = Client__State__Types.AssistantContentPart
 
 module Actions = {
   let addUserMessage = (~sessionId, ~content, ~annotations=[], ~agentId) => {
-    let id = `user-${Date.now()->Float.toString}`
+    let id = `optimistic-${Date.now()->Float.toString}`
     Client__State__Store.dispatch(AddUserMessage({id, sessionId, content, annotations, agentId}))
   }
 
@@ -114,7 +114,7 @@ module Actions = {
   let cancelTurn = () => Client__State__Store.dispatch(CancelTurn)
 
   let executePendingPlan = () => {
-    let id = `user-${Date.now()->Float.toString}`
+    let id = `optimistic-${Date.now()->Float.toString}`
     Client__State__Store.dispatch(ExecutePendingPlan({id: id}))
   }
 

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -66,6 +66,27 @@ module Lens = {
     updateMessages(task, store => MessageStore.insert(store, message))
   }
 
+  /** Client-generated user messages are inserted optimistically and later replaced
+      by the server echo, which carries a different id. Returns `None` when the
+      array holds no optimistic message. */
+  let swapFirstOptimistic = (messages: array<Message.t>, replacement: Message.t): option<
+    array<Message.t>,
+  > => {
+    let isOptimistic = message => Message.getId(message)->String.startsWith("optimistic-")
+    switch messages->Array.findIndex(isOptimistic) {
+    | -1 => None
+    | index =>
+      Some(
+        messages->Array.mapWithIndex((message, i) =>
+          switch i == index {
+          | true => replacement
+          | false => message
+          }
+        ),
+      )
+    }
+  }
+
   let drainQueuedUserMessages = (task: Task.t): Task.t =>
     switch task {
     | Task.Loaded({queuedUserMessages: []}) => task
@@ -886,17 +907,24 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
         (Lens.updateMessage(task, id, _ => updated), [])
       | None =>
         let userMessage = Message.User({id, content, annotations, agentId})
-        (
-          Task.Loaded({
-            ...data,
-            queuedUserMessages: Array.concat(data.queuedUserMessages, [userMessage]),
-          }),
-          [],
-        )
+        switch data.queuedUserMessages->Lens.swapFirstOptimistic(userMessage) {
+        | Some(queuedUserMessages) => (Task.Loaded({...data, queuedUserMessages}), [])
+        | None =>
+          switch Task.getMessages(task)->Lens.swapFirstOptimistic(userMessage) {
+          | Some(messages) => (Lens.updateMessages(task, _ => MessageStore.fromArray(messages)), [])
+          | None => (
+              Task.Loaded({
+                ...data,
+                queuedUserMessages: Array.concat(data.queuedUserMessages, [userMessage]),
+              }),
+              [],
+            )
+          }
+        }
       }
     }
 
-  | (Task.Loaded(data), AddUserMessage({id: _, content, annotations, agentId})) =>
+  | (Task.Loaded(data), AddUserMessage({id, content, annotations, agentId})) =>
     let text = extractTextFromUserContent(content)
     let attachments = extractAttachmentsFromUserContent(content)
 
@@ -906,18 +934,28 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
       updatedImageAttachments->Dict.set(uri, att)
     })
 
-    (
-      Task.Loaded({
-        ...data,
-        turnError: None,
-        retryStatus: None,
-        imageAttachments: updatedImageAttachments,
-        annotations: [],
-        annotationMode: Annotation.Off,
-        activePopupAnnotationId: None,
-      }),
-      [SendMessage({text, attachments, annotations, agentId})],
-    )
+    let optimisticMessage = Message.User({id, content, annotations, agentId})
+
+    let sent = Task.Loaded({
+      ...data,
+      turnError: None,
+      retryStatus: None,
+      imageAttachments: updatedImageAttachments,
+      annotations: [],
+      annotationMode: Annotation.Off,
+      activePopupAnnotationId: None,
+    })
+
+    let withOptimisticMessage = switch data.isAgentRunning {
+    | true =>
+      sent->Task.updateLoadedData(d => {
+        ...d,
+        queuedUserMessages: Array.concat(d.queuedUserMessages, [optimisticMessage]),
+      })
+    | false => sent->Lens.completeStreamingMessage->Lens.insertMessage(optimisticMessage)
+    }
+
+    (withOptimisticMessage, [SendMessage({text, attachments, annotations, agentId})])
 
   | (Task.Loaded(data), PlanReceived({entries})) => (
       Task.Loaded({...data, planEntries: entries}),

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -270,10 +270,10 @@ describe("Client State Reducer", () => {
     t->expect(state.selectedAgentId)->Expect.toEqual(Some("planner-id"))
   })
 
-  test("AddUserMessage creates task and sends without optimistic message", t => {
+  test("AddUserMessage creates task and renders the message optimistically", t => {
     let state = Reducer.defaultState
     let action = Reducer.AddUserMessage({
-      id: "user-1",
+      id: "optimistic-1",
       sessionId: "session-1",
       content: [UserContentPart.text("Hello")],
       annotations: [],
@@ -286,12 +286,104 @@ describe("Client State Reducer", () => {
     t->expect(TestHelpers.getCurrentTaskId(nextState)->Option.isSome)->Expect.toBe(true)
 
     let messages = Reducer.Selectors.messages(nextState)
-    t->expect(messages->Array.length)->Expect.toBe(0)
+    t->expect(messages->Array.length)->Expect.toBe(1)
+    switch messages->Array.getUnsafe(0) {
+    | Reducer.Message.User({id, agentId, _}) =>
+      t->expect(id)->Expect.toBe("optimistic-1")
+      t->expect(agentId)->Expect.toBe("executor-id")
+    | _ => JsExn.throw("Expected optimistic User message")
+    }
 
     switch effects->Array.get(0) {
     | Some(Reducer.TaskEffect({effect: SendMessage({agentId})})) =>
       t->expect(agentId)->Expect.toBe("executor-id")
     | _ => JsExn.throw("Expected SendMessage effect")
+    }
+  })
+
+  test("server echo replaces the optimistic message instead of duplicating it", t => {
+    let (state, _) = Reducer.next(
+      Reducer.defaultState,
+      Reducer.AddUserMessage({
+        id: "optimistic-local-1",
+        sessionId: "session-1",
+        content: [UserContentPart.text("Hello")],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let taskId = TestHelpers.getCurrentTaskId(state)->Option.getOrThrow
+
+    let nextState = TestHelpers.acceptUserMessage(
+      state,
+      ~taskId,
+      ~id="server-row-1",
+      ~content=[UserContentPart.text("Hello")],
+    )
+
+    let messages = Reducer.Selectors.messages(nextState)
+    t->expect(messages->Array.length)->Expect.toBe(1)
+    t->expect(Reducer.Selectors.queuedUserMessages(nextState)->Array.length)->Expect.toBe(0)
+
+    switch messages->Array.getUnsafe(0) {
+    | Reducer.Message.User({id, content, _}) =>
+      t->expect(id)->Expect.toBe("server-row-1")
+      t->expect(content->Array.length)->Expect.toBe(1)
+    | _ => JsExn.throw("Expected User message")
+    }
+  })
+
+  test("AddUserMessage during a running turn queues optimistically and reconciles", t => {
+    let (state, _) = Reducer.next(
+      Reducer.defaultState,
+      Reducer.AddUserMessage({
+        id: "optimistic-local-1",
+        sessionId: "session-1",
+        content: [UserContentPart.text("First")],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let taskId = TestHelpers.getCurrentTaskId(state)->Option.getOrThrow
+    let state = TestHelpers.acceptUserMessage(
+      state,
+      ~taskId,
+      ~id="server-row-1",
+      ~content=[UserContentPart.text("First")],
+    )
+    let (state, _) = Reducer.next(
+      state,
+      TaskAction({target: ForTask(taskId), action: ExecutionStateRunning}),
+    )
+
+    let (state, _) = Reducer.next(
+      state,
+      Reducer.AddUserMessage({
+        id: "optimistic-local-2",
+        sessionId: taskId,
+        content: [UserContentPart.text("Second")],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+
+    let queued = Reducer.Selectors.queuedUserMessages(state)
+    t->expect(queued->Array.length)->Expect.toBe(1)
+
+    let state = TestHelpers.acceptUserMessage(
+      state,
+      ~taskId,
+      ~id="server-row-2",
+      ~content=[UserContentPart.text("Second")],
+    )
+
+    let queued = Reducer.Selectors.queuedUserMessages(state)
+    t->expect(queued->Array.length)->Expect.toBe(1)
+    switch queued->Array.getUnsafe(0) {
+    | Reducer.Message.User({id, content, _}) =>
+      t->expect(id)->Expect.toBe("server-row-2")
+      t->expect(content->Array.length)->Expect.toBe(1)
+    | _ => JsExn.throw("Expected User message")
     }
   })
 
@@ -301,7 +393,7 @@ describe("Client State Reducer", () => {
     let (state, _) = Reducer.next(
       state,
       AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session-1",
         content: [UserContentPart.text("Hi")],
         annotations: [],
@@ -682,7 +774,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
     let (state1, _effects1) = Reducer.next(
       state,
       AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "sessionId",
         content: [UserContentPart.text("First message")],
         annotations: [],
@@ -716,7 +808,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
     let (state1, effects1) = Reducer.next(
       state,
       AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "sessionId",
         content: [UserContentPart.text("First message")],
         annotations: [],
@@ -873,7 +965,7 @@ describe("Client State Reducer - Task Management Actions", () => {
     t->expect(newTaskId)->Expect.not->Expect.toBe("task-1")
 
     let messages = Reducer.Selectors.messages(stateAfterMsg)
-    t->expect(messages->Array.length)->Expect.toBe(0)
+    t->expect(messages->Array.length)->Expect.toBe(1)
 
     switch effects->Array.get(0) {
     | Some(Reducer.TaskEffect({target: ForTask(effectTaskId), effect: SendMessage(_)})) =>
@@ -897,7 +989,7 @@ describe("Client State Reducer - Task Management Actions", () => {
     let (state1, effects1) = Reducer.next(
       state,
       AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session",
         content: [UserContentPart.Text({text: "Message in task 1"})],
         annotations: [],
@@ -1125,7 +1217,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session-1",
         content: [UserContentPart.text("Fix this")],
         annotations: _sampleAnnotations,
@@ -1141,7 +1233,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
       ~annotations=_sampleAnnotations,
     )
 
-    let messages = Reducer.Selectors.queuedUserMessages(nextState)
+    let messages = Reducer.Selectors.messages(nextState)
     t->expect(messages->Array.length)->Expect.toBe(1)
 
     switch messages->Array.get(0)->Option.getOrThrow {
@@ -1162,7 +1254,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session-1",
         content: [],
         annotations: _sampleAnnotations,
@@ -1178,7 +1270,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
       ~annotations=_sampleAnnotations,
     )
 
-    let messages = Reducer.Selectors.queuedUserMessages(nextState)
+    let messages = Reducer.Selectors.messages(nextState)
     t->expect(messages->Array.length)->Expect.toBe(1)
 
     switch messages->Array.get(0)->Option.getOrThrow {
@@ -1194,7 +1286,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session-1",
         content: [UserContentPart.text("Hello")],
         annotations: [],
@@ -1205,7 +1297,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
 
     let nextState = TestHelpers.acceptUserMessage(state, ~taskId)
 
-    let messages = Reducer.Selectors.queuedUserMessages(nextState)
+    let messages = Reducer.Selectors.messages(nextState)
     switch messages->Array.get(0)->Option.getOrThrow {
     | Reducer.Message.User({annotations, _}) => t->expect(annotations->Array.length)->Expect.toBe(0)
     | _ => JsExn.throw("Expected User message")
@@ -1215,7 +1307,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
   test("SendMessage effect carries annotations from AddUserMessage", t => {
     let state = Reducer.defaultState
     let action = Reducer.AddUserMessage({
-      id: "user-1",
+      id: "optimistic-1",
       sessionId: "session-1",
       content: [UserContentPart.text("Fix this")],
       annotations: _sampleAnnotations,
@@ -1258,7 +1350,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let (state, effects) = Reducer.next(
       state,
       Reducer.AddUserMessage({
-        id: "user-1",
+        id: "optimistic-1",
         sessionId: "session-1",
         content: [UserContentPart.text("Fix this")],
         annotations: [],


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

When the first message is sent as soon as the enter key is pressed, it should appear in the chat ui. Previously, if the llm api was slow, the first message would appear lost for sometime.

https://github.com/user-attachments/assets/88b864be-2a47-4c3f-8630-465c0b124ff9

https://github.com/user-attachments/assets/407abb2c-dd6b-4ba9-aac3-bee921d4de5b

## Related Issue





<!-- Link to the issue this PR addresses, if applicable. -->





## Checklist

- [x] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
