### PR TITLE
Add coding-agent install handoff

### DIFF
--- a/.changeset/install-with-coding-agent.md
+++ b/.changeset/install-with-coding-agent.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Add compact framework-specific setup instructions that visitors can copy into coding agents, and clarify production-build safety guidance.

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -19,7 +19,7 @@ Frontman closes that loop. It connects to your running application and your dev 
 
 Frontman integrates at the framework level as middleware. When installed, it turns your local dev server into an MCP server that exposes both client-side tools (component tree, performance data, click targets, console logs) and server-side tools (routes, server logs, query timing, compiled modules). The agent connects to this context in real time and always knows what is actually happening in your app.
 
-It runs exclusively in development (`NODE_ENV=development`). In production builds, the code is removed entirely by tree-shaking — not disabled, not present. Every change produces a standard git diff that goes through your team's normal PR review process.
+Frontman is intended for development workflows, but installed integrations must be checked in production builds. Next.js installer-generated middleware or proxy code has no automatic development-only guard and can remain active in a deployment. Add an environment guard or remove the integration when Frontman must be absent, then verify the built artifact and deployed `/frontman` route. Every change produces a standard git diff that goes through your team's normal PR review process.
 
 ## Key capabilities
 

--- a/apps/marketing/src/components/blocks/install/InstallSteps.astro
+++ b/apps/marketing/src/components/blocks/install/InstallSteps.astro
@@ -25,7 +25,7 @@ const frameworks = [
 		id: 'astro',
 		name: 'Astro',
 		logo: astroLogo,
-		command: 'astro add @frontman-ai/astro',
+		command: 'npx astro add @frontman-ai/astro',
 		url: 'http://localhost:4321/frontman',
 		step1Title: 'Add to your project',
 		step1Description: 'Run one command in your project folder',
@@ -66,7 +66,7 @@ const frameworks = [
 ]
 ---
 
-<section id="install" class="install-section">
+<section id="install" class="install-section" data-install-agent data-agent-framework="nextjs">
 	<FloatingBlobs
 		blobs={[
 			{ color: '#9D7CFF', size: 450, startX: -12, startY: 50 },
@@ -86,7 +86,9 @@ const frameworks = [
 			<div class="framework-tabs">
 				{frameworks.map((fw, i) => (
 				<button
+					type="button"
 					class={`framework-tab ${i === 0 ? 'active' : ''}`}
+					aria-pressed={i === 0}
 					data-framework={fw.id}
 					data-command={fw.command}
 					data-url={fw.url}
@@ -114,22 +116,50 @@ const frameworks = [
 				<div class="step-card step-card--yellow">
 					<h3 class="step-title" data-step1-title>Add to your project</h3>
 					<p class="step-description" data-step1-description>Run one command in your project folder</p>
-					<div class="terminal">
-						<div class="terminal-bar">
-							<span class="terminal-dot"></span>
-							<span class="terminal-dot"></span>
-							<span class="terminal-dot"></span>
+					<div class="install-command-actions">
+						<div class="terminal">
+							<div class="terminal-bar">
+								<span class="terminal-dot"></span>
+								<span class="terminal-dot"></span>
+								<span class="terminal-dot"></span>
+							</div>
+							<div class="terminal-body">
+								<span class="terminal-prompt">$</span>
+								<code data-install-command>npx @frontman-ai/nextjs install</code>
+								<button class="copy-button" data-copy="install" aria-label="Copy to clipboard">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+										<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+										<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+									</svg>
+								</button>
+							</div>
 						</div>
-						<div class="terminal-body">
-							<span class="terminal-prompt">$</span>
-							<code data-install-command>npx @frontman-ai/nextjs install</code>
-							<button class="copy-button" data-copy="install" aria-label="Copy to clipboard">
-								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+					</div>
+					<div class="agent-handoff">
+						<span class="agent-handoff__hint">Using an AI coding agent?</span>
+						<button
+							type="button"
+							class="agent-handoff__button"
+							data-copy-agent-instructions
+							data-ga-event="copy_agent_install_instructions"
+							data-ga-category="conversion"
+							data-ga-label="install_step"
+							aria-describedby="agent-copy-status"
+						>
+							<span data-copy-agent-icon>
+								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
 									<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
 									<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
 								</svg>
-							</button>
-						</div>
+							</span>
+							<span data-copy-agent-success-icon hidden>
+								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+									<polyline points="20 6 9 17 4 12"></polyline>
+								</svg>
+							</span>
+							<span data-copy-agent-label>Copy for agent</span>
+						</button>
+						<span id="agent-copy-status" class="sr-only" data-copy-agent-status aria-live="polite"></span>
 					</div>
 					<a class="plugin-directory-link" data-plugin-directory-link href="https://wordpress.org/plugins/frontman-agentic-ai-editor/" target="_blank" rel="noopener noreferrer" hidden>Open WordPress Plugin Directory &rarr;</a>
 				</div>
@@ -368,6 +398,38 @@ const frameworks = [
 		@apply mt-4 inline-flex text-sm font-semibold text-primary-600 underline underline-offset-4 hover:text-primary-700;
 	}
 
+	.install-command-actions {
+		@apply mt-5;
+	}
+
+	.install-command-actions .terminal {
+		@apply mt-0;
+	}
+
+	.agent-handoff {
+		@apply mt-3 flex items-center gap-2;
+	}
+
+	.agent-handoff__hint {
+		@apply text-sm text-slate-600;
+	}
+
+	.agent-handoff__button {
+		@apply inline-flex cursor-pointer items-center gap-1.5 text-sm font-semibold text-amber-800 underline decoration-amber-400 underline-offset-4 transition-colors hover:text-amber-950 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-black;
+	}
+
+	.agent-handoff__button > span:first-child,
+	.agent-handoff__button > span:nth-child(2) {
+		@apply shrink-0;
+		color: #B45309;
+	}
+
+	@media (max-width: 639px) {
+		.agent-handoff {
+			@apply flex-wrap;
+		}
+	}
+
 	.ai-badges {
 		@apply mt-5 flex flex-wrap gap-2;
 	}
@@ -381,6 +443,8 @@ const frameworks = [
 </style>
 
 <script>
+	import { setupInstallAgent } from '../../../integrations/install-agent.mjs'
+
 	document.addEventListener('DOMContentLoaded', () => {
 		const tabs = document.querySelectorAll('.framework-tab')
 		const stepsTimeline = document.querySelector('.steps-timeline')
@@ -453,5 +517,7 @@ const frameworks = [
 				}
 			})
 		})
+
+		setupInstallAgent(document)
 	})
 </script>

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
@@ -9,7 +9,7 @@ import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
 
 `@frontman-ai/nextjs` integrates the Frontman AI agent into your Next.js dev server through Next.js middleware on Next.js 13-15 or proxy on Next.js 16+. It intercepts requests to `/frontman/*`, giving the AI access to your source files, dev server logs, route manifest, and optionally OpenTelemetry spans covering HTTP requests and route render timing.
 
-**Frontman is a development-only tool.** The middleware/proxy entrypoint and instrumentation have no effect in production. Your deployment bundle is identical whether Frontman is installed or not.
+**Frontman is intended for development workflows.** Installer-generated middleware or proxy code has no automatic development-only guard, so it can compile into and run with a production deployment while its matcher includes Frontman routes. Add an environment guard or remove the integration when Frontman must be absent, then verify the built artifact and deployed `/frontman` route instead of assuming the production build removes it.
 
 ## Quick Start
 

--- a/apps/marketing/src/integrations/install-agent.mjs
+++ b/apps/marketing/src/integrations/install-agent.mjs
@@ -1,0 +1,116 @@
+const commonInstructions = `Before changing files:
+- Confirm the project framework and package manager.
+- Inspect existing configuration and git status.
+- Preserve existing application behavior and merge configuration safely.
+- Follow https://frontman.sh/docs/installation/.`
+
+const verificationInstructions = `Start the project's normal development server, detect its actual local origin, and verify /frontman loads on that origin.
+
+Do not enter credentials or complete OAuth. Report:
+- commands run
+- files changed
+- verification result
+- manual sign-in and provider steps still required`
+
+export const agentInstructions = {
+  nextjs: `Install Frontman for this Next.js project.
+
+${commonInstructions}
+
+Run:
+npx @frontman-ai/nextjs install
+
+Review the generated or updated middleware or proxy carefully. Frontman routes can remain present in a production deployment unless the integration is removed or protected with an environment guard.
+
+${verificationInstructions}`,
+  astro: `Install Frontman for this Astro project.
+
+${commonInstructions}
+
+Run:
+npx astro add @frontman-ai/astro
+
+${verificationInstructions}`,
+  vite: `Install Frontman for this Vite project.
+
+${commonInstructions}
+
+Run:
+npx @frontman-ai/vite install
+
+${verificationInstructions}`,
+  wordpress: `Help me install Frontman for WordPress manually.
+
+Before making changes:
+- Confirm this is a staging site, not production.
+- Confirm a current backup exists.
+- Confirm I have WordPress administrator access.
+- Read https://frontman.sh/docs/installation/ and the linked WordPress guide.
+- Explain each wp-admin step, but leave administrator actions to me.
+
+Guide me through finding Frontman Agentic AI Editor in wp-admin, installing and activating it, then opening Frontman from the admin menu.
+
+Do not ask for or enter credentials. I will complete WordPress administrator actions, GitHub or Google OAuth, and AI provider setup. Report the verification steps and any risks I should review before using Frontman on production.`,
+}
+
+const frameworkNames = {
+  nextjs: "Next.js",
+  astro: "Astro",
+  vite: "Vite",
+  wordpress: "WordPress",
+}
+
+const defaultLabel = "Copy for agent"
+
+export const setupInstallAgent = (document, clipboard = globalThis.navigator.clipboard) => {
+  const root = document.querySelector("[data-install-agent]")
+  const button = root.querySelector("[data-copy-agent-instructions]")
+  const label = button.querySelector("[data-copy-agent-label]")
+  const copyIcon = button.querySelector("[data-copy-agent-icon]")
+  const successIcon = button.querySelector("[data-copy-agent-success-icon]")
+  const status = root.querySelector("[data-copy-agent-status]")
+  const tabs = root.querySelectorAll("[data-framework]")
+  let interactionVersion = 0
+
+  button.setAttribute("aria-label", "Copy setup instructions for coding agent")
+
+  const showCopyIcon = () => {
+    copyIcon.removeAttribute("hidden")
+    successIcon.setAttribute("hidden", "")
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      interactionVersion += 1
+      root.dataset.agentFramework = tab.dataset.framework
+      tabs.forEach(candidate => {
+        candidate.setAttribute("aria-pressed", String(candidate === tab))
+      })
+      label.textContent = defaultLabel
+      status.textContent = ""
+      showCopyIcon()
+    })
+  })
+
+  button.addEventListener("click", async () => {
+    const framework = root.dataset.agentFramework
+    const frameworkName = frameworkNames[framework]
+    const requestVersion = ++interactionVersion
+
+    try {
+      await clipboard.writeText(agentInstructions[framework])
+      if (requestVersion !== interactionVersion) return
+
+      label.textContent = "Copied!"
+      status.textContent = `${frameworkName} setup instructions copied to clipboard.`
+      copyIcon.setAttribute("hidden", "")
+      successIcon.removeAttribute("hidden")
+    } catch {
+      if (requestVersion !== interactionVersion) return
+
+      label.textContent = "Copy failed"
+      status.textContent = `Could not copy ${frameworkName} setup instructions. Try again.`
+      showCopyIcon()
+    }
+  })
+}

--- a/apps/marketing/src/integrations/install-agent.test.mjs
+++ b/apps/marketing/src/integrations/install-agent.test.mjs
@@ -1,0 +1,151 @@
+import {JSDOM} from "jsdom"
+import {afterEach, describe, expect, test, vi} from "vitest"
+import {agentInstructions, setupInstallAgent} from "./install-agent.mjs"
+
+const pages = []
+
+const createPage = clipboard => {
+  const dom = new JSDOM(`<!doctype html><html><body>
+    <section data-install-agent data-agent-framework="nextjs">
+      <button class="framework-tab active" data-framework="nextjs" aria-pressed="true">Next.js</button>
+      <button class="framework-tab" data-framework="astro" aria-pressed="false">Astro</button>
+      <button class="framework-tab" data-framework="vite" aria-pressed="false">Vite</button>
+      <button class="framework-tab" data-framework="wordpress" aria-pressed="false">WordPress</button>
+      <button data-copy-agent-instructions>
+        <svg data-copy-agent-icon></svg>
+        <svg data-copy-agent-success-icon hidden></svg>
+        <span data-copy-agent-label>Copy for agent</span>
+      </button>
+      <span data-copy-agent-status aria-live="polite"></span>
+    </section>
+  </body></html>`, {url: "https://frontman.sh/"})
+  pages.push(dom)
+  setupInstallAgent(dom.window.document, clipboard)
+  return dom
+}
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const createDeferred = () => {
+  let resolve
+  const promise = new Promise(resolvePromise => {
+    resolve = resolvePromise
+  })
+  return {promise, resolve}
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const page of pages.splice(0)) page.window.close()
+})
+
+describe("coding-agent installation instructions", () => {
+  test.each([
+    ["nextjs", "npx @frontman-ai/nextjs install"],
+    ["astro", "npx astro add @frontman-ai/astro"],
+    ["vite", "npx @frontman-ai/vite install"],
+  ])("provides safe %s instructions", (framework, command) => {
+    const instructions = agentInstructions[framework]
+
+    expect(instructions).toContain(command)
+    expect(instructions).toContain("https://frontman.sh/docs/installation/")
+    expect(instructions).toContain("git status")
+    expect(instructions).toContain("actual local origin")
+    expect(instructions).toContain("Do not enter credentials or complete OAuth")
+    expect(instructions).not.toMatch(/localhost:\d+/)
+  })
+
+  test("warns the agent to review Next.js production exposure", () => {
+    expect(agentInstructions.nextjs).toContain("production")
+    expect(agentInstructions.nextjs).toContain("middleware or proxy")
+  })
+
+  test("keeps WordPress installation manual and staging-first", () => {
+    expect(agentInstructions.wordpress).toContain("staging site")
+    expect(agentInstructions.wordpress).toContain("backup")
+    expect(agentInstructions.wordpress).toContain("wp-admin")
+    expect(agentInstructions.wordpress).toContain("Confirm I have WordPress administrator access")
+    expect(agentInstructions.wordpress).toContain("Do not ask for or enter credentials")
+    expect(agentInstructions.wordpress).not.toContain("npx")
+  })
+})
+
+describe("coding-agent instruction copy control", () => {
+  test("copies instructions for the selected framework and shows success", async () => {
+    const clipboard = {writeText: vi.fn().mockResolvedValue(undefined)}
+    const page = createPage(clipboard)
+    const {document} = page.window
+
+    document.querySelector('[data-framework="astro"]').click()
+    document.querySelector("[data-copy-agent-instructions]").click()
+    await flushPromises()
+
+    expect(clipboard.writeText).toHaveBeenCalledWith(agentInstructions.astro)
+    expect(document.querySelector("[data-copy-agent-label]").textContent).toBe("Copied!")
+    expect(document.querySelector("[data-copy-agent-instructions]").getAttribute("aria-label")).toBe(
+      "Copy setup instructions for coding agent",
+    )
+    expect(document.querySelector("[data-copy-agent-status]").textContent).toBe(
+      "Astro setup instructions copied to clipboard.",
+    )
+    expect(document.querySelector("[data-copy-agent-icon]").hasAttribute("hidden")).toBe(true)
+    expect(document.querySelector("[data-copy-agent-success-icon]").hasAttribute("hidden")).toBe(false)
+  })
+
+  test("shows an accessible error when clipboard writing fails", async () => {
+    const clipboard = {writeText: vi.fn().mockRejectedValue(new Error("denied"))}
+    const page = createPage(clipboard)
+    const {document} = page.window
+
+    document.querySelector("[data-copy-agent-instructions]").click()
+    await flushPromises()
+
+    expect(document.querySelector("[data-copy-agent-label]").textContent).toBe("Copy failed")
+    expect(document.querySelector("[data-copy-agent-status]").textContent).toBe(
+      "Could not copy Next.js setup instructions. Try again.",
+    )
+    expect(document.querySelector("[data-copy-agent-icon]").hasAttribute("hidden")).toBe(false)
+    expect(document.querySelector("[data-copy-agent-success-icon]").hasAttribute("hidden")).toBe(true)
+  })
+
+  test("resets copy feedback when framework selection changes", async () => {
+    const clipboard = {writeText: vi.fn().mockResolvedValue(undefined)}
+    const page = createPage(clipboard)
+    const {document} = page.window
+
+    document.querySelector("[data-copy-agent-instructions]").click()
+    await flushPromises()
+    document.querySelector('[data-framework="vite"]').click()
+
+    expect(document.querySelector("[data-copy-agent-label]").textContent).toBe("Copy for agent")
+    expect(document.querySelector("[data-copy-agent-status]").textContent).toBe("")
+    expect(document.querySelector("[data-copy-agent-icon]").hasAttribute("hidden")).toBe(false)
+    expect(document.querySelector("[data-copy-agent-success-icon]").hasAttribute("hidden")).toBe(true)
+  })
+
+  test("exposes the selected framework to assistive technology", () => {
+    const page = createPage({writeText: vi.fn().mockResolvedValue(undefined)})
+    const {document} = page.window
+
+    document.querySelector('[data-framework="astro"]').click()
+
+    expect(document.querySelector('[data-framework="nextjs"]').getAttribute("aria-pressed")).toBe("false")
+    expect(document.querySelector('[data-framework="astro"]').getAttribute("aria-pressed")).toBe("true")
+  })
+
+  test("ignores stale clipboard feedback after framework selection changes", async () => {
+    const deferred = createDeferred()
+    const page = createPage({writeText: vi.fn().mockReturnValue(deferred.promise)})
+    const {document} = page.window
+
+    document.querySelector("[data-copy-agent-instructions]").click()
+    document.querySelector('[data-framework="astro"]').click()
+    deferred.resolve()
+    await flushPromises()
+
+    expect(document.querySelector("[data-copy-agent-label]").textContent).toBe("Copy for agent")
+    expect(document.querySelector("[data-copy-agent-status]").textContent).toBe("")
+    expect(document.querySelector("[data-copy-agent-icon]").hasAttribute("hidden")).toBe(false)
+    expect(document.querySelector("[data-copy-agent-success-icon]").hasAttribute("hidden")).toBe(true)
+  })
+})

--- a/apps/marketing/src/pages/how-it-works.astro
+++ b/apps/marketing/src/pages/how-it-works.astro
@@ -12,7 +12,7 @@ const SEO = {
 const faqs = [
 	{
 		question: 'Does Frontman modify my production build?',
-		answer: 'No. The framework plugin only activates when NODE_ENV=development. In a production build, the middleware is stripped out by tree-shaking. Your deployment bundle is identical whether Frontman is installed or not.'
+		answer: 'Frontman is intended for development workflows, but you must verify your production build. In Next.js, installer-generated middleware or proxy code has no automatic development-only guard and can remain active in a deployment. Add an environment guard or remove the integration when Frontman must be absent, then test the built artifact and deployed /frontman route.'
 	},
 	{
 		question: 'Which frameworks does Frontman support?',

--- a/docs/plans/install-with-coding-agent.md
+++ b/docs/plans/install-with-coding-agent.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Install With a Coding Agent
+
+## Overview
+
+Implement issue #460 as a framework-aware clipboard handoff inside Step 1. Keep prompt generation and browser state testable, preserve current install flow, align safety documentation, then verify responsive behavior in a real browser.
+
+## Architecture Decisions
+
+- Extract prompt data and DOM wiring into `install-agent.mjs` because Astro inline scripts cannot be imported directly into focused Vitest/JSDOM tests.
+- Keep four explicit handoff strings. Avoid generic prompt composition because each integration has materially different safety guidance.
+- Keep the install command primary and render the coding-agent handoff as a compact, product-neutral secondary action.
+- Keep UI in `InstallSteps.astro`; no new Astro component unless implementation exceeds a focused Step 1 block.
+
+## Task List
+
+### Phase 1: Tested Clipboard Behavior
+
+#### Task 1: Specify Prompt and Copy States
+
+**Description:** Add failing tests for four framework payloads, fixed-port avoidance, WordPress manual guidance, success feedback, failure feedback, and tab-driven selection.
+
+**Acceptance criteria:**
+- Tests describe all four framework handoffs.
+- Tests require visible success and failure status.
+- Tests fail because runtime behavior does not yet exist.
+
+**Verification:**
+- `make -C apps/marketing test` fails only on new expectations.
+
+**Dependencies:** None.
+
+**Files likely touched:**
+- `apps/marketing/src/integrations/install-agent.test.mjs`
+
+**Estimated scope:** Small.
+
+#### Task 2: Implement Prompt and Copy Runtime
+
+**Description:** Add minimal exported prompt data and browser event wiring needed to satisfy Task 1.
+
+**Acceptance criteria:**
+- Selected framework determines clipboard payload.
+- Clipboard success and failure update accessible status.
+- Existing terminal copy controls remain independent.
+
+**Verification:**
+- `make -C apps/marketing test`
+
+**Dependencies:** Task 1.
+
+**Files likely touched:**
+- `apps/marketing/src/integrations/install-agent.mjs`
+- `apps/marketing/src/integrations/install-agent.test.mjs`
+
+**Estimated scope:** Small.
+
+### Checkpoint: Runtime
+
+- Marketing tests pass.
+- Prompt payloads contain no credential automation or fixed-port assumptions.
+
+### Phase 2: Step 1 User Interface
+
+#### Task 3: Integrate Compact CTA
+
+**Description:** Add the CTA, live status, analytics attributes, framework state, and responsive handoff inside Step 1.
+
+**Acceptance criteria:**
+- CTA appears inside Step 1 for every selected framework.
+- Framework tabs update both existing install content and handoff selection.
+- Terminal command remains visually primary.
+- Handoff remains product-neutral and wraps cleanly on mobile.
+- Astro command uses `npx astro add @frontman-ai/astro`.
+
+**Verification:**
+- `make -C apps/marketing test`
+- `make -C apps/marketing build`
+
+**Dependencies:** Task 2.
+
+**Files likely touched:**
+- `apps/marketing/src/components/blocks/install/InstallSteps.astro`
+- `apps/marketing/src/integrations/install-agent.mjs`
+
+**Estimated scope:** Medium.
+
+### Checkpoint: UI
+
+- Marketing tests and build pass.
+- CTA is keyboard accessible and status is announced.
+
+### Phase 3: Documentation and Release Metadata
+
+#### Task 4: Align Next.js Production Guidance
+
+**Description:** Replace conflicting development-only claims with canonical production-exposure guidance.
+
+**Acceptance criteria:**
+- Next.js integration guide matches installation guide.
+- `llms.txt` no longer claims all integrations are tree-shaken from production.
+- Guidance remains precise about framework differences.
+
+**Verification:**
+- Content search finds no remaining contradictory absolute claim in changed sources.
+- `make -C apps/marketing build`
+
+**Dependencies:** None.
+
+**Files likely touched:**
+- `apps/marketing/src/content/docs/docs/integrations/nextjs.mdx`
+- `apps/marketing/src/pages/how-it-works.astro`
+- `apps/marketing/public/llms.txt`
+
+**Estimated scope:** Small.
+
+#### Task 5: Add Changeset
+
+**Description:** Add changelog fragment for user-visible marketing install handoff and corrected guidance.
+
+**Acceptance criteria:**
+- Changeset accurately describes user-facing change.
+- Package and release level match repository convention.
+
+**Verification:**
+- Inspect changeset format against recent fragments.
+
+**Dependencies:** Tasks 4 and 5.
+
+**Files likely touched:**
+- `.changeset/*.md`
+
+**Estimated scope:** Extra small.
+
+### Phase 4: End-to-End Verification
+
+#### Task 6: Verify Homepage in Browser
+
+**Description:** Run marketing site and verify all selected-framework clipboard paths, visual layout, accessibility state, and console health.
+
+**Acceptance criteria:**
+- All four tabs copy expected handoffs.
+- Success and simulated failure feedback are visible.
+- Layout works at 320px, 768px, 1024px, and 1440px.
+- No console errors appear during flow.
+
+**Verification:**
+- Chrome DevTools DOM, accessibility snapshot, console, and screenshots.
+- Final `make -C apps/marketing test` and `make -C apps/marketing build` after any browser-found fixes.
+
+**Dependencies:** Tasks 3-5.
+
+**Files likely touched:** None unless verification finds defects.
+
+**Estimated scope:** Small.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Inline Astro state diverges from tested module | High | Make Astro import and invoke the tested runtime rather than duplicate logic. |
+| Clipboard API unavailable or denied | Medium | Expose visible failure state and retain existing manual command copy controls. |
+| Longer success text shifts Step 1 layout | Low | Give CTA stable responsive dimensions and verify narrow viewport. |
+| WordPress appears automated | High | Use manual admin verbs and explicit user-controlled authentication language. |
+
+## Open Questions
+
+None.

--- a/docs/specs/install-with-coding-agent.md
+++ b/docs/specs/install-with-coding-agent.md
@@ -1,0 +1,133 @@
+# Spec: Install With a Coding Agent
+
+## Objective
+
+Add a compact coding-agent handoff inside Step 1 of the marketing homepage install flow. A visitor selects Next.js, Astro, Vite, or WordPress, then copies safe, framework-specific setup instructions to paste into a coding agent.
+
+Success means the copied instructions help an agent install and verify Frontman without overwriting existing configuration, assuming fixed ports, or handling user credentials. WordPress receives a manual admin-oriented handoff instead of shell automation.
+
+## Confirmed Product Decisions
+
+- Place the handoff inside Step 1, after the existing install command or WordPress action.
+- Keep the install command primary and present the coding-agent handoff as a compact secondary action without a compatibility or brand row.
+- Add the CTA, behavioral tests, Astro command correction, and Next.js production-safety documentation corrections.
+- Keep canonical installation details at `https://frontman.sh/docs/installation/` and include that URL in every copied handoff.
+
+## Behavior
+
+- Default CTA text: `Copy for agent`.
+- Successful copy text: `Copied!`.
+- Failed copy text: `Copy failed`.
+- The button retains the stable accessible name `Copy setup instructions for coding agent` across visual feedback states.
+- Copy status is exposed through an `aria-live="polite"` region.
+- Selecting a framework updates the install command, displayed URL guidance, and copied handoff as one state change.
+- Next.js, Astro, and Vite handoffs require the agent to inspect project framework, package manager, existing configuration, and git status before editing.
+- JavaScript-framework handoffs include the exact selected install command and require the agent to start the project's normal development server, detect its actual local origin, verify `/frontman`, and report commands, changed files, verification results, and remaining manual steps.
+- Next.js handoff calls out production exposure and requires review of generated middleware or proxy behavior.
+- WordPress handoff requires a staging site, backup, administrator access, and user-completed wp-admin installation, OAuth, and provider setup. It does not claim the coding agent can perform privileged browser actions.
+- No handoff requests, reads, stores, or enters credentials.
+- CTA click uses existing delegated analytics attributes.
+
+## Copied Instruction Shape
+
+```text
+Install Frontman for this [framework] project.
+
+Before changing files:
+- Confirm the project and package manager.
+- Inspect existing configuration and git status.
+- Preserve existing application behavior.
+- Follow https://frontman.sh/docs/installation/.
+
+Run: [selected canonical command]
+
+Start the project's normal development server, detect its actual local origin,
+and verify /frontman loads on that origin.
+
+Do not enter credentials or complete OAuth. Report commands run, files changed,
+verification results, and manual steps still required.
+```
+
+Framework-specific safety text extends this common shape. WordPress uses separate prose suitable for wp-admin instead of a `Run:` command.
+
+## Visual Design
+
+- Preserve current Step 1 yellow card, typography, spacing scale, border treatment, and responsive behavior.
+- Keep the terminal command as the strongest action inside Step 1.
+- Render the handoff as a compact text action below the terminal with the prompt `Using an AI coding agent?`.
+- Copy feedback changes text and icon without changing button dimensions enough to shift surrounding layout.
+
+## Presentation Scope
+
+- Do not show vendor marks or imply compatibility, partnership, or endorsement for named coding-agent products.
+- Keep the handoff product-neutral so visitors can paste the instructions into their preferred coding agent.
+
+## Documentation Corrections
+
+- Change homepage Astro command from `astro add @frontman-ai/astro` to canonical `npx astro add @frontman-ai/astro`.
+- Align `apps/marketing/src/content/docs/docs/integrations/nextjs.mdx`, `apps/marketing/src/pages/how-it-works.astro`, and `apps/marketing/public/llms.txt` with the production warning in `apps/marketing/src/content/docs/docs/installation.md`.
+- Do not weaken the canonical warning: generated Next.js middleware or proxy can be included in production unless users add an environment guard or remove the integration.
+
+## Project Structure
+
+- `apps/marketing/src/components/blocks/install/InstallSteps.astro`: install metadata, compact Step 1 CTA, styles, and DOM wiring.
+- `apps/marketing/src/integrations/install-agent.mjs`: pure prompt selection and browser copy-state wiring if extraction is required for direct tests.
+- `apps/marketing/src/integrations/install-agent.test.mjs`: prompt and DOM behavior tests.
+- `apps/marketing/src/content/docs/docs/integrations/nextjs.mdx`: corrected Next.js production behavior.
+- `apps/marketing/src/pages/how-it-works.astro`: corrected public production-build FAQ.
+- `apps/marketing/public/llms.txt`: corrected machine-readable production behavior.
+
+## Code Style
+
+Follow existing Astro and browser-module patterns. Keep prompt data explicit rather than creating a generic prompt-building framework.
+
+```js
+const instructionsByFramework = {
+  nextjs: "Install Frontman for this Next.js project...",
+  astro: "Install Frontman for this Astro project...",
+}
+
+const copyInstructions = async framework => {
+  await navigator.clipboard.writeText(instructionsByFramework[framework])
+}
+```
+
+Use semantic buttons, `data-*` hooks for DOM behavior, and project Tailwind `@reference` styles. Do not add dependencies.
+
+## Testing Strategy
+
+- Write failing tests before implementation for selected-framework payloads, WordPress manual guidance, successful clipboard feedback, visible failure feedback, and framework switching.
+- Use Vitest and JSDOM following `apps/marketing/src/integrations/consent.dom.test.mjs` conventions.
+- Run marketing tests and production build.
+- Verify in a real browser at 320px, 768px, 1024px, and 1440px widths.
+- Verify keyboard focus, accessible names, live status, clipboard success/failure, all four framework tabs, and zero console errors.
+
+## Commands
+
+```bash
+make -C apps/marketing test
+make -C apps/marketing build
+make -C apps/marketing dev PORT=4321
+```
+
+## Boundaries
+
+- Always: preserve existing install flow, use canonical commands, show copy failures, keep credentials manual, and test each framework payload.
+- Ask first: adding dependencies, changing CTA placement, changing canonical install commands, or expanding the public installation skill.
+- Never: claim compatibility with every agent, automate credential entry, assume a fixed localhost port, overwrite existing middleware/configuration, or imply vendor endorsement.
+
+## Success Criteria
+
+1. Step 1 contains the coding-agent copy CTA for all four selected frameworks.
+2. Clipboard receives correct framework-specific instructions.
+3. WordPress receives manual, staging-first admin guidance.
+4. Success and failure states are visible and announced accessibly.
+5. The handoff remains visually secondary to the canonical install command and does not name or imply support for specific coding-agent products.
+6. Astro homepage command matches canonical docs.
+7. Next.js production-safety docs no longer contradict the canonical installation guide.
+8. Marketing tests and build pass.
+9. Homepage interaction and responsive layout pass real-browser verification.
+
+## Open Questions
+
+None. Product choices were confirmed before specification.


### PR DESCRIPTION
## Summary
- add framework-specific setup instructions visitors can copy into coding agents
- keep the install command primary with compact, accessible copy feedback
- correct Astro command and Next.js production-safety guidance

## Verification
- `TMPDIR=/home/bluehotdog/.cache/frontman-test-tmp make -C apps/marketing test`
- `TMPDIR=/home/bluehotdog/.cache/frontman-test-tmp make -C apps/marketing build`
- browser-verified responsive layout, framework selection, copy failure feedback, and stable accessible naming

Closes #460