### PR TITLE
Fix NVIDIA model execution

### DIFF
--- a/.changeset/restore-nvidia-provider.md
+++ b/.changeset/restore-nvidia-provider.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Restore NVIDIA model execution through NVIDIA NIM and guard every advertised model with executable provider coverage.

--- a/apps/frontman_server/config/config.exs
+++ b/apps/frontman_server/config/config.exs
@@ -210,6 +210,7 @@ import_config "providers.exs"
 
 config :req_llm,
   receive_timeout: 150_000,
+  custom_providers: [FrontmanServer.Providers.Nvidia],
   finch: [
     name: ReqLLM.Finch,
     pools: %{

--- a/apps/frontman_server/lib/frontman_server/providers/nvidia.ex
+++ b/apps/frontman_server/lib/frontman_server/providers/nvidia.ex
@@ -1,0 +1,18 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 - see LICENSE for details.
+# Additional terms apply - see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Providers.Nvidia do
+  @moduledoc "ReqLLM transport for NVIDIA's OpenAI-compatible NIM API."
+
+  use ReqLLM.Provider,
+    id: :nvidia,
+    default_base_url: "https://integrate.api.nvidia.com/v1",
+    default_env_key: "NVIDIA_API_KEY"
+
+  use ReqLLM.Provider.Defaults
+
+  @provider_schema []
+end

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -11,6 +11,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Providers
+  alias FrontmanServer.Providers.Nvidia
   alias ReqLLM.Context
   alias ReqLLM.Providers.Anthropic
 
@@ -285,6 +286,101 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       assert model.capabilities.tools.enabled
       assert model.limits == %{context: 262_144, output: 262_144}
       assert model.modalities == %{input: [:text, :image, :video], output: [:text]}
+    end
+  end
+
+  describe "advertised provider execution" do
+    test "NVIDIA models cross real provider dispatch and decode streaming responses", %{
+      scope: scope
+    } do
+      {:ok, _api_key} = Providers.upsert_api_key(scope, "nvidia", "nvapi-test")
+
+      %{groups: groups} = Providers.model_config_data(scope)
+      %{options: [nvidia_model | _]} = Enum.find(groups, &(&1.id == "nvidia"))
+      bypass = Bypass.open()
+
+      assert Nvidia.default_base_url() == "https://integrate.api.nvidia.com/v1"
+
+      Bypass.expect(bypass, "POST", "/v1/chat/completions", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded_body = Jason.decode!(body)
+
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer nvapi-test"]
+        assert decoded_body["model"] == "moonshotai/kimi-k2.6"
+        assert decoded_body["stream"] == true
+        assert decoded_body["messages"] == [%{"role" => "user", "content" => "Hello"}]
+
+        text_event = %{
+          id: "chatcmpl-nvidia",
+          choices: [%{delta: %{content: "Hello from NVIDIA"}}]
+        }
+
+        tool_event = %{
+          id: "chatcmpl-nvidia",
+          choices: [
+            %{
+              delta: %{
+                tool_calls: [
+                  %{
+                    index: 0,
+                    id: "call_1",
+                    type: "function",
+                    function: %{name: "lookup", arguments: ~s({"q":"elixir"})}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+
+        finished_event = %{
+          id: "chatcmpl-nvidia",
+          choices: [%{delta: %{}, finish_reason: "tool_calls"}]
+        }
+
+        sse_body =
+          "data: #{Jason.encode!(text_event)}\n\n" <>
+            "data: #{Jason.encode!(tool_event)}\n\n" <>
+            "data: #{Jason.encode!(finished_event)}\n\n" <>
+            "data: [DONE]\n\n"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/event-stream")
+        |> Plug.Conn.send_resp(200, sse_body)
+      end)
+
+      {:ok, {model, llm_opts}} =
+        Providers.prepare_llm_args(scope, nvidia_model.value,
+          base_url: "http://localhost:#{bypass.port}/v1"
+        )
+
+      assert {:ok, stream_response} = ReqLLM.stream_text(model, "Hello", llm_opts)
+      assert {:ok, response} = ReqLLM.StreamResponse.to_response(stream_response)
+      assert ReqLLM.Response.text(response) == "Hello from NVIDIA"
+
+      assert [%ReqLLM.ToolCall{id: "call_1", function: tool_function}] =
+               ReqLLM.Response.tool_calls(response)
+
+      assert tool_function == %{name: "lookup", arguments: ~s({"q":"elixir"})}
+    end
+
+    test "every advertised model resolves to executable transport" do
+      for {group, %{models: models}} <- Application.fetch_env!(:frontman_server, :providers),
+          model_entry <- models do
+        model_id = elem(model_entry, 1)
+
+        model_spec =
+          case model_entry do
+            {_name, ^model_id, model_spec} -> model_spec
+            {_name, ^model_id} -> "#{group}:#{model_id}"
+          end
+
+        assert {:ok, model} = ReqLLM.model(model_spec),
+               "advertised model #{group}:#{model_id} has no catalog metadata"
+
+        assert {:ok, _provider} = ReqLLM.provider(model.provider),
+               "advertised model #{group}:#{model_id} has no executable transport"
+      end
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
+++ b/apps/frontman_server/test/frontman_server/providers/prepare_api_key_test.exs
@@ -26,12 +26,8 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
   describe "prepare_llm_args/3 resolution priority" do
     test "resolves OAuth token as highest priority for anthropic", %{scope: scope} do
-      expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "oauth_access", "refresh", expires_at)
-
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      {:ok, _} = upsert_anthropic_oauth_token(scope, :valid)
+      {:ok, _} = upsert_anthropic_api_key(scope)
 
       {:ok, {model, llm_opts}} =
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-6")
@@ -45,7 +41,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "falls back to user key when no OAuth token", %{scope: scope} do
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      {:ok, _} = upsert_anthropic_api_key(scope)
 
       {:ok, {model, llm_opts}} =
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-5")
@@ -57,7 +53,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "resolved Anthropic opts mark the last message for prompt caching", %{scope: scope} do
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      {:ok, _} = upsert_anthropic_api_key(scope)
 
       {:ok, {model, llm_opts}} =
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-6")
@@ -88,11 +84,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "refreshes expired Anthropic OAuth token before resolving LLM args", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
+      {:ok, _} = upsert_anthropic_oauth_token(scope, :expired)
       expect_anthropic_refresh_success()
 
       {:ok, {_model, llm_opts}} =
@@ -103,12 +95,8 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "invalid Anthropic refresh falls back to API key and deletes token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      {:ok, _} = upsert_anthropic_oauth_token(scope, :expired)
+      {:ok, _} = upsert_anthropic_api_key(scope)
 
       expect_anthropic_refresh_permanent_failure()
 
@@ -116,23 +104,19 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-6")
 
       assert llm_opts[:api_key] == "user_key_456"
-      assert is_nil(Providers.get_oauth_token(scope, "anthropic"))
+      refute Providers.get_oauth_token(scope, "anthropic")
     end
 
     test "transient Anthropic refresh failure keeps token and can recover", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
-      {:ok, _} = Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+      {:ok, _} = upsert_anthropic_oauth_token(scope, :expired)
+      {:ok, _} = upsert_anthropic_api_key(scope)
       expect_anthropic_refresh_transient_failure()
 
       {:ok, {_model, llm_opts}} =
         Providers.prepare_llm_args(scope, "anthropic:claude-sonnet-4-6")
 
       assert llm_opts[:api_key] == "user_key_456"
-      refute is_nil(Providers.get_oauth_token(scope, "anthropic"))
+      assert Providers.get_oauth_token(scope, "anthropic")
 
       expect_anthropic_refresh_success()
 
@@ -157,9 +141,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "openai codex oauth resolves direct ReqLLM args", %{scope: scope} do
-      expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
-
-      {:ok, _} = upsert_openai_oauth_token(scope, expires_at)
+      {:ok, _} = upsert_openai_oauth_token(scope, :valid)
 
       {:ok, {model, llm_opts}} =
         Providers.prepare_llm_args(scope, "openai_codex:gpt-5.6-sol", max_tokens: 16_384)
@@ -172,8 +154,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "refreshes expired OpenAI OAuth token before resolving LLM args", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      {:ok, _} = upsert_openai_oauth_token(scope, :expired)
       expect_openai_refresh_success()
 
       {:ok, {_model, llm_opts}} =
@@ -185,26 +166,23 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "permanent OpenAI refresh failure deletes expired OAuth token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      {:ok, _} = upsert_openai_oauth_token(scope, :expired)
       expect_openai_refresh_permanent_failure()
 
       assert {:error, :no_api_key} =
                Providers.prepare_llm_args(scope, "openai_codex:gpt-5.3-codex-spark")
 
-      assert is_nil(Providers.get_oauth_token(scope, "openai_codex"))
+      refute Providers.get_oauth_token(scope, "openai_codex")
     end
 
     test "openai codex oauth without account id is invalid", %{scope: scope} do
-      expires_at = DateTime.add(DateTime.utc_now(), 3600, :second)
-
       {:ok, _} =
         Providers.upsert_oauth_token(
           scope,
           "openai_codex",
           "openai_access",
           "refresh",
-          expires_at
+          oauth_expiration(:valid)
         )
 
       assert {:error, :invalid_oauth_token} =
@@ -249,11 +227,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
 
   describe "OAuth availability refresh" do
     test "model config refreshes expired Anthropic token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-
-      {:ok, _} =
-        Providers.upsert_oauth_token(scope, "anthropic", "expired_access", "refresh", expired_at)
-
+      {:ok, _} = upsert_anthropic_oauth_token(scope, :expired)
       expect_anthropic_refresh_success()
 
       config = Providers.model_config_data(scope)
@@ -262,8 +236,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
 
     test "connection status refreshes expired OpenAI token", %{scope: scope} do
-      expired_at = DateTime.add(DateTime.utc_now(), -60, :second)
-      {:ok, _} = upsert_openai_oauth_token(scope, expired_at)
+      {:ok, _} = upsert_openai_oauth_token(scope, :expired)
       expect_openai_refresh_success()
 
       assert %{
@@ -384,6 +357,23 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end
   end
 
+  defp upsert_anthropic_api_key(scope) do
+    Providers.upsert_api_key(scope, "anthropic", "user_key_456")
+  end
+
+  defp upsert_anthropic_oauth_token(scope, expiration) do
+    Providers.upsert_oauth_token(
+      scope,
+      "anthropic",
+      anthropic_access_token(expiration),
+      "refresh",
+      oauth_expiration(expiration)
+    )
+  end
+
+  defp anthropic_access_token(:valid), do: "oauth_access"
+  defp anthropic_access_token(:expired), do: "expired_access"
+
   defp expect_anthropic_refresh_success do
     Req.Test.expect(:anthropic_oauth, fn conn ->
       Req.Test.json(conn, %{
@@ -410,13 +400,13 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
     end)
   end
 
-  defp upsert_openai_oauth_token(scope, expires_at) do
+  defp upsert_openai_oauth_token(scope, expiration) do
     Providers.upsert_oauth_token(
       scope,
       "openai_codex",
       "openai_access",
       "refresh",
-      expires_at,
+      oauth_expiration(expiration),
       %{"account_id" => "acc-789"}
     )
   end
@@ -438,4 +428,7 @@ defmodule FrontmanServer.Providers.PrepareApiKeyTest do
       |> Req.Test.json(%{"error" => "invalid_grant"})
     end)
   end
+
+  defp oauth_expiration(:valid), do: DateTime.add(DateTime.utc_now(), 3600, :second)
+  defp oauth_expiration(:expired), do: DateTime.add(DateTime.utc_now(), -60, :second)
 end


### PR DESCRIPTION
## Summary

- restore NVIDIA NIM as a registered OpenAI-compatible ReqLLM provider
- cover NVIDIA request construction, bearer auth, SSE text, and tool-call decoding through the real production stack
- fail tests when any advertised model lacks catalog metadata or executable transport

## Verification

- `make precommit` (726 tests)
- `mix test test/frontman_server/providers/prepare_api_key_test.exs` (19 tests)
- pre-commit and pre-push hooks

Closes #1497