### PR TITLE
Show submitted messages before server acceptance

### DIFF
--- a/.changeset/show-pending-messages.md
+++ b/.changeset/show-pending-messages.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Show submitted messages in the queued-message drawer while awaiting server acceptance.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -391,14 +391,13 @@ let make = (~onConfigureProvider: unit => unit) => {
 
         {switch (retryStatus, turnError, currentTaskId) {
         | (Some(rs), _, _) => <Client__RetryBanner retryStatus=rs />
-        | (None, Some({id, message, category}), Some(taskId))
+        | (None, Some({id, message, category, retryErrorId}), Some(taskId))
           if shouldRenderTurnError(messages, id) =>
-          <ErrorBanner
-            error=message
-            category
-            onConfigureProvider
-            onRetry={() => Client__State.Actions.retryTurn(~taskId, ~retriedErrorId=id)}
-          />
+          let onRetry =
+            retryErrorId->Option.map(retriedErrorId =>
+              () => Client__State.Actions.retryTurn(~taskId, ~retriedErrorId)
+            )
+          <ErrorBanner error=message category onConfigureProvider onRetry=?onRetry />
         | _ => React.null
         }}
 

--- a/libs/client/src/components/frontman/Client__ErrorBanner.res
+++ b/libs/client/src/components/frontman/Client__ErrorBanner.res
@@ -2,7 +2,7 @@
 let make = (
   ~error: string,
   ~category: Client__ErrorCategory.t,
-  ~onRetry: unit => unit,
+  ~onRetry: option<unit => unit>=?,
   ~onConfigureProvider: option<unit => unit>=?,
 ) => {
   let guidance = switch category {
@@ -21,12 +21,16 @@ let make = (
     | None => React.null
     }}
     <div className="flex flex-wrap items-center gap-2 mt-2">
-      <button
-        onClick={_ => onRetry()}
-        className="text-xs text-red-300 border border-red-700/60 hover:border-red-500 hover:text-red-200 px-3 py-1 rounded transition-colors"
-      >
-        {React.string("Retry")}
-      </button>
+      {switch onRetry {
+      | Some(onRetry) =>
+        <button
+          onClick={_ => onRetry()}
+          className="text-xs text-red-300 border border-red-700/60 hover:border-red-500 hover:text-red-200 px-3 py-1 rounded transition-colors"
+        >
+          {React.string("Retry")}
+        </button>
+      | None => React.null
+      }}
       {switch (category, onConfigureProvider) {
       | (#auth, Some(onConfigureProvider))
       | (#billing, Some(onConfigureProvider))

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -485,7 +485,7 @@ let buildAttachmentContentBlocks = (attachments: array<Client__Message.fileAttac
 
 let sendMessageToAPIImpl = (
   state: state,
-  _dispatch,
+  dispatch,
   ~messageId,
   ~message,
   ~attachments: array<Client__Message.fileAttachmentData>,
@@ -519,8 +519,31 @@ let sendMessageToAPIImpl = (
     metadata->Dict.set("agent", JSON.Encode.string(agentId))
     let _meta = Some(JSON.Encode.object(metadata))
 
-    sendPrompt(message, ~additionalBlocks, ~onComplete=_result => (), ~_meta)
-  | NoAcpSession => Log.error("Cannot send message: no active ACP session")
+    sendPrompt(
+      message,
+      ~additionalBlocks,
+      ~onComplete=result =>
+        switch result {
+        | Ok(_) => ()
+        | Error(error) =>
+          dispatch(
+            TaskAction({
+              target: ForTask(taskId),
+              action: UserMessageSendFailed({id: messageId, error}),
+            }),
+          )
+        },
+      ~_meta,
+    )
+  | NoAcpSession =>
+    let error = "Cannot send message: no active ACP session"
+    Log.error(error)
+    dispatch(
+      TaskAction({
+        target: ForTask(taskId),
+        action: UserMessageSendFailed({id: messageId, error}),
+      }),
+    )
   }
 }
 

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -370,6 +370,7 @@ type action =
   | ExecutionStateRequiresAction
   | CancelTurn
   | AgentError({id: string, error: string, category: Client__ErrorCategory.t})
+  | UserMessageSendFailed({id: Message.UserMessageId.t, error: string})
   | RetryingUpdate({retryStatus: Types.Task.retryStatus})
   | RetryTurn({retriedErrorId: string})
   | ClearTurnError
@@ -457,6 +458,7 @@ let actionToString = (action: action): string =>
   | ExecutionStateRequiresAction => "ExecutionStateRequiresAction"
   | CancelTurn => "CancelTurn"
   | AgentError(_) => "AgentError"
+  | UserMessageSendFailed(_) => "UserMessageSendFailed"
   | RetryingUpdate(_) => "RetryingUpdate"
   | RetryTurn(_) => "RetryTurn"
   | ClearTurnError => "ClearTurnError"
@@ -945,6 +947,32 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
       [SendMessage({id, text, attachments, annotations, agentId})],
     )
 
+  | (Task.Loaded(data), UserMessageSendFailed({id, error})) => {
+      let messageId = Message.UserMessageId.toString(id)
+      switch data.pendingUserMessageIds->Array.includes(messageId) {
+      | true =>
+        let queuedUserMessages =
+          data.queuedUserMessages->Array.filter(message => Message.getId(message) != messageId)
+        let pendingUserMessageIds =
+          data.pendingUserMessageIds->Array.filter(pendingId => pendingId != messageId)
+        (
+          Task.Loaded({
+            ...data,
+            queuedUserMessages,
+            pendingUserMessageIds,
+            turnError: Some({
+              id: messageId,
+              message: error,
+              category: #unknown,
+              retryErrorId: None,
+            }),
+          }),
+          [],
+        )
+      | false => (task, [])
+      }
+    }
+
   | (Task.Loaded(data), PlanReceived({entries})) => (
       Task.Loaded({...data, planEntries: entries}),
       [],
@@ -1040,7 +1068,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     | Task.Loaded(data) => (
         Task.Loaded({
           ...data,
-          turnError: Some({id, message: error, category}),
+          turnError: Some({id, message: error, category, retryErrorId: Some(id)}),
           isAgentRunning: false,
           retryStatus: None,
         })->Lens.refreshCompletedFileChanges,
@@ -1253,6 +1281,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
   | (
       Task.New(_) | Task.Unloaded(_),
       AddUserMessage(_)
+      | UserMessageSendFailed(_)
       | PlanReceived(_)
       | ExecutionStateRunning
       | ExecutionStateIdle

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -77,7 +77,8 @@ module Lens = {
         }
       let firstAgentId = data.queuedUserMessages->Array.getUnsafe(0)->messageAgentId
       let prefixLength = switch data.queuedUserMessages->Array.findIndex(message =>
-        message->messageAgentId != firstAgentId
+        data.pendingUserMessageIds->Array.includes(Message.getId(message)) ||
+          message->messageAgentId != firstAgentId
       ) {
       | -1 => data.queuedUserMessages->Array.length
       | index => index
@@ -871,29 +872,41 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     }
 
   | (Task.Loaded(data), UserMessageReceived({id, content, annotations, agentId})) =>
+    let wasPending = data.pendingUserMessageIds->Array.includes(id)
+    let pendingUserMessageIds =
+      data.pendingUserMessageIds->Array.filter(pendingId => pendingId != id)
     switch data.queuedUserMessages->Array.findIndex(message => Message.getId(message) == id) {
     | index if index >= 0 =>
       let queuedUserMessages = data.queuedUserMessages->Array.copy
-      let updated = mergeUserMessage(
-        queuedUserMessages->Array.getUnsafe(index),
-        ~id,
-        ~content,
-        ~annotations,
-        ~agentId,
-      )
+      let existing = queuedUserMessages->Array.getUnsafe(index)
+      let updated = switch wasPending {
+      | true =>
+        switch existing {
+        | Message.User({agentId: existingAgentId, _}) =>
+          requireSameAgent(
+            ~existingAgentId,
+            ~agentId,
+            ~message=`[TaskReducer] Agent changed within message ${id}`,
+          )
+          Message.User({id, content, annotations, agentId})
+        | _ => failwith(`[TaskReducer] Message ${id} changed roles`)
+        }
+      | false => mergeUserMessage(existing, ~id, ~content, ~annotations, ~agentId)
+      }
       queuedUserMessages->Array.setUnsafe(index, updated)
-      (Task.Loaded({...data, queuedUserMessages}), [])
+      (Task.Loaded({...data, queuedUserMessages, pendingUserMessageIds}), [])
     | _ =>
       switch Task.getMessages(task)->Array.find(message => Message.getId(message) == id) {
       | Some(message) =>
         let updated = mergeUserMessage(message, ~id, ~content, ~annotations, ~agentId)
-        (Lens.updateMessage(task, id, _ => updated), [])
+        (Lens.updateMessage(Task.Loaded({...data, pendingUserMessageIds}), id, _ => updated), [])
       | None =>
         let userMessage = Message.User({id, content, annotations, agentId})
         (
           Task.Loaded({
             ...data,
             queuedUserMessages: Array.concat(data.queuedUserMessages, [userMessage]),
+            pendingUserMessageIds,
           }),
           [],
         )
@@ -903,6 +916,13 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
   | (Task.Loaded(data), AddUserMessage({id, content, annotations, agentId})) =>
     let text = extractTextFromUserContent(content)
     let attachments = extractAttachmentsFromUserContent(content)
+    let messageId = Message.UserMessageId.toString(id)
+    let pendingMessage = Message.User({
+      id: messageId,
+      content,
+      annotations,
+      agentId,
+    })
 
     let updatedImageAttachments = data.imageAttachments->Dict.copy
     attachments->Array.forEach(att => {
@@ -916,6 +936,8 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
         turnError: None,
         retryStatus: None,
         imageAttachments: updatedImageAttachments,
+        queuedUserMessages: Array.concat(data.queuedUserMessages, [pendingMessage]),
+        pendingUserMessageIds: Array.concat(data.pendingUserMessageIds, [messageId]),
         annotations: [],
         annotationMode: Annotation.Off,
         activePopupAnnotationId: None,
@@ -1095,6 +1117,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
           lastTurnCancelled: false,
           planEntries: [],
           queuedUserMessages: [],
+          pendingUserMessageIds: [],
           turnError: None,
           retryStatus: None,
           imageAttachments: Dict.make(),

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -15,6 +15,7 @@ module Task = {
     id: string,
     message: string,
     category: Client__ErrorCategory.t,
+    retryErrorId: option<string>,
   }
 
   type retryStatus = {

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -68,6 +68,7 @@ module Task = {
         lastTurnCancelled: bool,
         planEntries: array<ACPTypes.planEntry>,
         queuedUserMessages: array<Message.t>,
+        pendingUserMessageIds: array<string>,
         turnError: option<turnErrorInfo>,
         retryStatus: option<retryStatus>,
         imageAttachments: Dict.t<Client__Message.fileAttachmentData>,
@@ -253,6 +254,7 @@ module Task = {
         lastTurnCancelled: false,
         planEntries: [],
         queuedUserMessages: [],
+        pendingUserMessageIds: [],
         turnError: None,
         retryStatus: None,
         imageAttachments: Dict.make(),
@@ -273,6 +275,7 @@ module Task = {
     lastTurnCancelled: bool,
     planEntries: array<ACPTypes.planEntry>,
     queuedUserMessages: array<Message.t>,
+    pendingUserMessageIds: array<string>,
     turnError: option<turnErrorInfo>,
     pendingQuestion: option<Client__Question__Types.pendingQuestion>,
   }
@@ -305,6 +308,7 @@ module Task = {
         lastTurnCancelled,
         planEntries,
         queuedUserMessages,
+        pendingUserMessageIds,
         turnError,
         retryStatus,
         imageAttachments,
@@ -320,6 +324,7 @@ module Task = {
           lastTurnCancelled,
           planEntries,
           queuedUserMessages,
+          pendingUserMessageIds,
           turnError,
           pendingQuestion,
         }
@@ -339,6 +344,7 @@ module Task = {
           lastTurnCancelled: updated.lastTurnCancelled,
           planEntries: updated.planEntries,
           queuedUserMessages: updated.queuedUserMessages,
+          pendingUserMessageIds: updated.pendingUserMessageIds,
           turnError: updated.turnError,
           retryStatus,
           imageAttachments,
@@ -367,6 +373,7 @@ module Task = {
           lastTurnCancelled: false,
           planEntries: [],
           queuedUserMessages: [],
+          pendingUserMessageIds: [],
           turnError: None,
           pendingQuestion: None,
         }
@@ -394,6 +401,7 @@ module Task = {
           lastTurnCancelled: false,
           planEntries: [],
           queuedUserMessages: [],
+          pendingUserMessageIds: [],
           turnError: None,
           pendingQuestion: None,
         }

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -106,7 +106,7 @@ module TestHelpers = {
   let acceptUserMessage = (
     state,
     ~taskId,
-    ~id="user-accepted-1",
+    ~id,
     ~content=[UserContentPart.text("Hello")],
     ~annotations=[],
   ) => {
@@ -313,7 +313,7 @@ describe("Client State Reducer", () => {
     let state = TestHelpers.acceptUserMessage(
       state,
       ~taskId,
-      ~id="user-1",
+      ~id=testUserMessageId->UserMessageId.toString,
       ~content=[UserContentPart.text("Hi")],
     )
 
@@ -1156,6 +1156,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let nextState = TestHelpers.acceptUserMessage(
       state,
       ~taskId,
+      ~id=testUserMessageId->UserMessageId.toString,
       ~content=[UserContentPart.text("Fix this")],
       ~annotations=_sampleAnnotations,
     )
@@ -1193,6 +1194,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let nextState = TestHelpers.acceptUserMessage(
       state,
       ~taskId,
+      ~id=testUserMessageId->UserMessageId.toString,
       ~content=[],
       ~annotations=_sampleAnnotations,
     )
@@ -1222,9 +1224,14 @@ describe("Client State Reducer - Annotations on Messages", () => {
     )
     let taskId = TestHelpers.getCurrentTaskId(state)->Option.getOrThrow
 
-    let nextState = TestHelpers.acceptUserMessage(state, ~taskId)
+    let nextState = TestHelpers.acceptUserMessage(
+      state,
+      ~taskId,
+      ~id=testUserMessageId->UserMessageId.toString,
+    )
 
     let messages = Reducer.Selectors.queuedUserMessages(nextState)
+    t->expect(messages->Array.length)->Expect.toBe(1)
     switch messages->Array.get(0)->Option.getOrThrow {
     | Reducer.Message.User({annotations, _}) => t->expect(annotations->Array.length)->Expect.toBe(0)
     | _ => JsExn.throw("Expected User message")
@@ -1302,6 +1309,59 @@ describe("Client State Reducer - Annotations on Messages", () => {
     t
     ->expect(metadata->Dict.get("model")->Option.flatMap(JSON.Decode.string))
     ->Expect.toEqual(Some("anthropic:claude-opus-4-6"))
+  })
+
+  test("SendMessage dispatches task cleanup when sendPrompt fails", t => {
+    setRuntime(JSON.parseOrThrow(`{"framework":"nextjs","basePath":"frontman"}`))
+    let messageId = UserMessageId.make()
+    let completion = ref(None)
+    let dispatched = ref([])
+    let state = {
+      ...Reducer.defaultState,
+      acpSession: AcpSessionActive({
+        sendPrompt: (_, ~additionalBlocks as _, ~onComplete, ~_meta as _) =>
+          completion := Some(onComplete),
+        cancelPrompt: () => (),
+        retryTurn: _ => (),
+        loadTask: (_, ~needsHistory as _, ~onComplete as _) => (),
+        deleteSession: (_, ~onComplete as _) => (),
+        apiBaseUrl: "http://localhost:4000",
+      }),
+    }
+    let (state, effects) = Reducer.next(
+      state,
+      Reducer.AddUserMessage({
+        id: messageId,
+        sessionId: "session-1",
+        content: [UserContentPart.text("Fix this")],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+
+    effects->Array.forEach(
+      effect =>
+        Reducer.handleEffect(
+          effect,
+          state,
+          action => dispatched := Array.concat(dispatched.contents, [action]),
+        ),
+    )
+    let onComplete = completion.contents->Option.getOrThrow
+    onComplete(Error("Connection lost"))
+
+    switch dispatched.contents {
+    | [
+        Reducer.TaskAction({
+          target: ForTask("session-1"),
+          action: UserMessageSendFailed({id, error}),
+        }),
+      ] => {
+        t->expect(id)->Expect.toEqual(messageId)
+        t->expect(error)->Expect.toBe("Connection lost")
+      }
+    | _ => JsExn.throw("Expected targeted UserMessageSendFailed action")
+    }
   })
 
   describe("API key provider actions", () => {

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -23,13 +23,10 @@ module TestHelpers = {
   }
 
   let makeLoadingTask = () => {
-    let unloaded = Task.makeUnloaded(
-      ~id="test-task-1",
-      ~title="Test Task",
-      ~createdAt=Date.now(),
-      ~updatedAt=Date.now(),
-    )
-    TaskReducer.next(unloaded, LoadStarted({previewUrl: "http://localhost:3000"}))->Pair.first
+    TaskReducer.next(
+      makeUnloadedTask(),
+      LoadStarted({previewUrl: "http://localhost:3000"}),
+    )->Pair.first
   }
 
   let acceptUserMessage = (
@@ -70,7 +67,7 @@ describe("Task - Protocol Message Identity", () => {
     TaskReducer.next(task1, ExecutionStateRunning)->Pair.first
   }
 
-  test("TextDeltaReceived appends to streaming message", t => {
+  test("text deltas append before idle completes the message", t => {
     let task = _startAgent()
     let (task2, _) = TaskReducer.next(
       task,
@@ -96,112 +93,27 @@ describe("Task - Protocol Message Identity", () => {
       }
     | _ => t->expect(false)->Expect.toBe(true)
     }
-  })
+    let (completed, _) = TaskReducer.next(task3, ExecutionStateIdle)
 
-  test("ExecutionStateIdle converts streaming to completed", t => {
-    let task = _startAgent()
-    let (task2, _) = TaskReducer.next(
-      task,
-      TextDeltaReceived({
-        messageId: "assistant-1",
-        text: "Hello",
-        agentId: "test-agent",
-      }),
-    )
-    let (task3, _) = TaskReducer.next(task2, ExecutionStateIdle)
-
-    let messages = TestHelpers.getMessages(task3)
+    let messages = TestHelpers.getMessages(completed)
     t->expect(Array.length(messages))->Expect.toBe(2)
 
     switch messages->Array.get(1) {
-    | Some(Message.Assistant(Completed({content}))) =>
-      t->expect(Array.length(content))->Expect.toBe(1)
-    | _ => t->expect(false)->Expect.toBe(true)
-    }
-  })
-})
-
-describe("Task - Tool Call Lifecycle", () => {
-  let _startAgent = () => {
-    let task = TestHelpers.makeLoadedTask()
-    let task1 = TestHelpers.acceptUserMessage(task)
-    TaskReducer.next(task1, ExecutionStateRunning)->Pair.first
-  }
-
-  test("tool call progresses: ToolCallReceived -> ToolInputReceived -> ToolResultReceived", t => {
-    let task = _startAgent()
-    let toolId = "tool-1"
-
-    let toolCall: Message.toolCall = {
-      id: toolId,
-      toolName: "test_tool",
-      state: Message.InputAvailable,
-      inputBuffer: "",
-      input: Some(JSON.parseOrThrow(`{"key": "value"}`)),
-      result: None,
-      errorText: None,
-      parentAgentId: None,
-      spawningToolName: None,
-    }
-    let (task1, _) = TaskReducer.next(task, ToolCallReceived({toolCall: toolCall}))
-
-    let messages1 = TestHelpers.getMessages(task1)
-    switch messages1->Array.get(1) {
-    | Some(Message.ToolCall({state: InputAvailable, input: Some(_)})) =>
-      t->expect(true)->Expect.toBe(true)
-    | _ => t->expect(false)->Expect.toBe(true)
-    }
-
-    let (task2, _) = TaskReducer.next(
-      task1,
-      ToolResultReceived({
-        id: toolId,
-        rawOutput: Some(JSON.Encode.object(Dict.make())),
-        content: None,
-        complete: true,
-      }),
-    )
-
-    let messages2 = TestHelpers.getMessages(task2)
-    switch messages2->Array.get(1) {
-    | Some(Message.ToolCall({state: OutputAvailable, result: Some(_)})) =>
-      t->expect(true)->Expect.toBe(true)
-    | _ => t->expect(false)->Expect.toBe(true)
-    }
-  })
-
-  test("tool error sets OutputError state", t => {
-    let task = _startAgent()
-    let toolId = "tool-1"
-
-    let toolCall: Message.toolCall = {
-      id: toolId,
-      toolName: "test_tool",
-      state: Message.InputAvailable,
-      inputBuffer: "",
-      input: None,
-      result: None,
-      errorText: None,
-      parentAgentId: None,
-      spawningToolName: None,
-    }
-    let (task1, _) = TaskReducer.next(task, ToolCallReceived({toolCall: toolCall}))
-    let (task3, _) = TaskReducer.next(
-      task1,
-      ToolErrorReceived({id: toolId, error: "Something went wrong"}),
-    )
-
-    let messages = TestHelpers.getMessages(task3)
-    switch messages->Array.get(1) {
-    | Some(Message.ToolCall({state: OutputError, errorText: Some(error)})) =>
-      t->expect(error)->Expect.toBe("Something went wrong")
+    | Some(Message.Assistant(Completed({content, agentId}))) => {
+        t->expect(agentId)->Expect.toBe("executor-id")
+        switch content->Array.get(0) {
+        | Some(Message.AssistantContentPart.Text({text})) =>
+          t->expect(text)->Expect.toBe("Hello world")
+        | _ => t->expect("completed text")->Expect.toBe("missing")
+        }
+      }
     | _ => t->expect(false)->Expect.toBe(true)
     }
   })
 })
 
 describe("Task - Load State Machine", () => {
-  test("Unloaded -> Loading transition via LoadStarted", t => {
+  test("LoadStarted and LoadComplete transition Unloaded through Loading to Loaded", t => {
     let task = TestHelpers.makeUnloadedTask()
     t->expect(Task.isUnloaded(task))->Expect.toBe(true)
 
@@ -210,11 +122,7 @@ describe("Task - Load State Machine", () => {
       LoadStarted({previewUrl: "http://localhost:3000"}),
     )
     t->expect(Task.isLoading(loadingTask))->Expect.toBe(true)
-  })
-
-  test("Loading -> Loaded transition via LoadComplete", t => {
-    let task = TestHelpers.makeLoadingTask()
-    let (loadedTask, _) = TaskReducer.next(task, LoadComplete)
+    let (loadedTask, _) = TaskReducer.next(loadingTask, LoadComplete)
 
     t->expect(Task.isLoaded(loadedTask))->Expect.toBe(true)
   })
@@ -417,25 +325,11 @@ describe("Task - Annotation Mode", () => {
     let (task3, _) = TaskReducer.next(task2, ToggleAnnotationMode)
     t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task3))->Expect.toEqual(Some(false))
   })
-
-  test("SetAnnotationMode Off leaves annotations intact", t => {
-    let task = TestHelpers.makeLoadedTask()
-
-    let (task2, _) = TaskReducer.next(task, SetAnnotationMode({mode: Selecting}))
-    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task2))->Expect.toEqual(Some(true))
-
-    let (task3, _) = TaskReducer.next(task2, SetAnnotationMode({mode: Off}))
-    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task3))->Expect.toEqual(Some(false))
-  })
 })
 
 describe("Task - Plan Entries", () => {
   test("PlanReceived updates plan entries", t => {
     let task = TestHelpers.makeLoadedTask()
-    t
-    ->expect(TaskReducer.Selectors.planEntries(task)->Option.getOr([])->Array.length)
-    ->Expect.toBe(0)
-
     let entries: array<Client__Task__Types.ACPTypes.planEntry> = [
       {content: "Step 1", priority: High, status: Pending},
       {content: "Step 2", priority: Medium, status: InProgress},
@@ -449,20 +343,25 @@ describe("Task - Plan Entries", () => {
 })
 
 describe("Task - Error Handling", () => {
-  test("AgentError sets turnError on Loaded task", t => {
+  test("AgentError completes output, persists error, stops running, and emits no effects", t => {
     let task = TestHelpers.makeLoadedTask()
-    t->expect(TaskReducer.Selectors.turnError(task))->Expect.toEqual(None)
-
-    let (task2, _) = TaskReducer.next(
-      task,
-      AgentError({
-        id: "agent-error-1",
-        error: "Quota exhausted",
-        category: #quota,
+    let task = TestHelpers.acceptUserMessage(task)
+    let (running, _) = TaskReducer.next(task, ExecutionStateRunning)
+    let (streaming, _) = TaskReducer.next(
+      running,
+      TextDeltaReceived({
+        messageId: "assistant-1",
+        text: "Partial response",
+        agentId: "test-agent",
       }),
     )
+    let (failed, effects) = TaskReducer.next(
+      streaming,
+      AgentError({id: "agent-error-1", error: "Quota exhausted", category: #quota}),
+    )
+
     t
-    ->expect(TaskReducer.Selectors.turnError(task2))
+    ->expect(TaskReducer.Selectors.turnError(failed))
     ->Expect.toEqual(
       Some({
         id: "agent-error-1",
@@ -470,78 +369,25 @@ describe("Task - Error Handling", () => {
         category: #quota,
       }),
     )
+    t->expect(TaskReducer.Selectors.isAgentRunning(failed))->Expect.toEqual(Some(false))
+    t->expect(TaskReducer.Selectors.streamingMessage(failed))->Expect.toEqual(None)
+    t->expect(effects)->Expect.toEqual([])
 
-    switch TestHelpers.getMessages(task2)->Array.get(0) {
+    let messages = TestHelpers.getMessages(failed)
+    switch messages->Array.get(1) {
+    | Some(Message.Assistant(Completed({content}))) =>
+      switch content->Array.get(0) {
+      | Some(Message.AssistantContentPart.Text({text})) =>
+        t->expect(text)->Expect.toBe("Partial response")
+      | _ => t->expect("completed partial response")->Expect.toBe("missing")
+      }
+    | _ => t->expect("completed assistant message")->Expect.toBe("missing")
+    }
+    switch messages->Array.get(2) {
     | Some(Message.Error(error)) =>
       t->expect(Message.ErrorMessage.error(error))->Expect.toBe("Quota exhausted")
     | _ => t->expect("persistent error message")->Expect.toBe("missing")
     }
-  })
-
-  test("AgentError sets isAgentRunning to false", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let (task2, _) = TaskReducer.next(task, ExecutionStateRunning)
-    t->expect(TaskReducer.Selectors.isAgentRunning(task2))->Expect.toEqual(Some(true))
-
-    let (task3, _) = TaskReducer.next(
-      task2,
-      AgentError({
-        id: "agent-error-1",
-        error: "Some error",
-        category: #unknown,
-      }),
-    )
-    t->expect(TaskReducer.Selectors.isAgentRunning(task3))->Expect.toEqual(Some(false))
-  })
-
-  test("AgentError completes any streaming message", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let task0 = TestHelpers.acceptUserMessage(task)
-    let (runningTask, _) = TaskReducer.next(task0, ExecutionStateRunning)
-    let (task2, _) = TaskReducer.next(
-      runningTask,
-      TextDeltaReceived({
-        messageId: "assistant-1",
-        text: "Partial response",
-        agentId: "test-agent",
-      }),
-    )
-
-    switch TaskReducer.Selectors.streamingMessage(task2) {
-    | Some(Message.Streaming(_)) => t->expect(true)->Expect.toBe(true)
-    | _ => t->expect(false)->Expect.toBe(true)
-    }
-
-    let (task3, _) = TaskReducer.next(
-      task2,
-      AgentError({
-        id: "agent-error-1",
-        error: "Error occurred",
-        category: #unknown,
-      }),
-    )
-    t->expect(TaskReducer.Selectors.streamingMessage(task3))->Expect.toEqual(None)
-
-    let messages = TestHelpers.getMessages(task3)
-    switch messages->Array.get(1) {
-    | Some(Message.Assistant(Completed({content}))) =>
-      t->expect(Array.length(content))->Expect.toBe(1)
-    | _ => t->expect(false)->Expect.toBe(true)
-    }
-  })
-
-  test("AgentError emits no effects", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let (_, effects) = TaskReducer.next(
-      task,
-      AgentError({
-        id: "agent-error-1",
-        error: "Error",
-        category: #unknown,
-      }),
-    )
-
-    t->expect(Array.length(effects))->Expect.toBe(0)
   })
 
   test("ClearTurnError clears the turnError", t => {
@@ -566,14 +412,6 @@ describe("Task - Error Handling", () => {
 
     let (task3, _) = TaskReducer.next(task2, ClearTurnError)
     t->expect(TaskReducer.Selectors.turnError(task3))->Expect.toEqual(None)
-  })
-
-  test("ClearTurnError is idempotent", t => {
-    let task = TestHelpers.makeLoadedTask()
-    t->expect(TaskReducer.Selectors.turnError(task))->Expect.toEqual(None)
-
-    let (task2, _) = TaskReducer.next(task, ClearTurnError)
-    t->expect(TaskReducer.Selectors.turnError(task2))->Expect.toEqual(None)
   })
 
   test("AddUserMessage clears turnError", t => {
@@ -625,57 +463,8 @@ describe("Task - CancelTurn", () => {
     task3
   }
 
-  test("CancelTurn when agent running: sets isAgentRunning to false", t => {
+  test("CancelTurn stops running, preserves text, cancels tools, and emits CancelPrompt", t => {
     let task = _startAgentWithStreaming()
-    t->expect(TaskReducer.Selectors.isAgentRunning(task))->Expect.toEqual(Some(true))
-
-    let (cancelled, _) = TaskReducer.next(task, CancelTurn)
-    t->expect(TaskReducer.Selectors.isAgentRunning(cancelled))->Expect.toEqual(Some(false))
-  })
-
-  test("CancelTurn preserves partial text as completed message", t => {
-    let task = _startAgentWithStreaming()
-    let (cancelled, _) = TaskReducer.next(task, CancelTurn)
-
-    let messages = TestHelpers.getMessages(cancelled)
-    t->expect(Array.length(messages))->Expect.toBe(2)
-
-    switch messages->Array.get(1) {
-    | Some(Message.Assistant(Completed({content}))) =>
-      switch content->Array.get(0) {
-      | Some(Client__Task__Types.AssistantContentPart.Text({text})) =>
-        t->expect(text)->Expect.toBe("Partial resp")
-      | _ => t->expect("Text content")->Expect.toBe("not found")
-      }
-    | _ => t->expect("Completed assistant")->Expect.toBe("not found")
-    }
-  })
-
-  test("CancelTurn emits CancelPrompt effect", t => {
-    let task = _startAgentWithStreaming()
-    let (_, effects) = TaskReducer.next(task, CancelTurn)
-
-    t->expect(Array.length(effects))->Expect.toBe(1)
-    switch effects->Array.get(0) {
-    | Some(TaskReducer.CancelPrompt) => t->expect(true)->Expect.toBe(true)
-    | _ => t->expect("CancelPrompt effect")->Expect.toBe("not found")
-    }
-  })
-
-  test("CancelTurn is no-op when agent is not running", t => {
-    let task = TestHelpers.makeLoadedTask()
-    t->expect(TaskReducer.Selectors.isAgentRunning(task))->Expect.toEqual(Some(false))
-
-    let (unchanged, effects) = TaskReducer.next(task, CancelTurn)
-    t->expect(effects)->Expect.toEqual([])
-    t->expect(TaskReducer.Selectors.isAgentRunning(unchanged))->Expect.toEqual(Some(false))
-  })
-
-  test("CancelTurn marks in-progress tool calls as cancelled", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let task1 = TestHelpers.acceptUserMessage(task)
-    let (runningTask, _) = TaskReducer.next(task1, ExecutionStateRunning)
-
     let toolCall: Message.toolCall = {
       id: "tool-1",
       toolName: "edit_file",
@@ -687,11 +476,21 @@ describe("Task - CancelTurn", () => {
       parentAgentId: None,
       spawningToolName: None,
     }
-    let (task2, _) = TaskReducer.next(runningTask, ToolCallReceived({toolCall: toolCall}))
+    let (withTool, _) = TaskReducer.next(task, ToolCallReceived({toolCall: toolCall}))
+    let (cancelled, effects) = TaskReducer.next(withTool, CancelTurn)
 
-    let (cancelled, _) = TaskReducer.next(task2, CancelTurn)
-
+    t->expect(TaskReducer.Selectors.isAgentRunning(cancelled))->Expect.toEqual(Some(false))
+    t->expect(effects)->Expect.toEqual([TaskReducer.CancelPrompt])
     let messages = TestHelpers.getMessages(cancelled)
+    switch messages->Array.get(1) {
+    | Some(Message.Assistant(Completed({content}))) =>
+      switch content->Array.get(0) {
+      | Some(Client__Task__Types.AssistantContentPart.Text({text})) =>
+        t->expect(text)->Expect.toBe("Partial resp")
+      | _ => t->expect("Text content")->Expect.toBe("not found")
+      }
+    | _ => t->expect("Completed assistant")->Expect.toBe("not found")
+    }
     let toolMsg = messages->Array.find(
       msg =>
         switch msg {
@@ -706,29 +505,33 @@ describe("Task - CancelTurn", () => {
     }
   })
 
-  test("CancelTurn clears turnError", t => {
+  test("CancelTurn is no-op when agent is not running", t => {
     let task = TestHelpers.makeLoadedTask()
-    let (task1, _) = TaskReducer.next(
-      task,
-      AgentError({
-        id: "agent-error-1",
-        error: "Some error",
-        category: #unknown,
-      }),
-    )
-    let task2 = TestHelpers.acceptUserMessage(task1, ~text="retry")
-    let (runningTask, _) = TaskReducer.next(task2, ExecutionStateRunning)
-    let (cancelled, _) = TaskReducer.next(runningTask, CancelTurn)
-    t->expect(TaskReducer.Selectors.turnError(cancelled))->Expect.toEqual(None)
+    let (unchanged, effects) = TaskReducer.next(task, CancelTurn)
+
+    t->expect(unchanged)->Expect.toEqual(task)
+    t->expect(effects)->Expect.toEqual([])
   })
 
   test("after CancelTurn, new AddUserMessage creates fresh assistant message", t => {
     let task = _startAgentWithStreaming()
     let (cancelled, _) = TaskReducer.next(task, CancelTurn)
-
-    let task2 = TestHelpers.acceptUserMessage(cancelled, ~id="user-2", ~text="New question")
-
-    let (runningTask, _) = TaskReducer.next(task2, ExecutionStateRunning)
+    let messageId = UserMessageId.make()
+    let (submitted, _) = TaskReducer.next(
+      cancelled,
+      AddUserMessage({
+        id: messageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "New question"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let accepted = TestHelpers.acceptUserMessage(
+      submitted,
+      ~id=messageId->UserMessageId.toString,
+      ~text="New question",
+    )
+    let (runningTask, _) = TaskReducer.next(accepted, ExecutionStateRunning)
     let (task4, _) = TaskReducer.next(
       runningTask,
       TextDeltaReceived({
@@ -851,68 +654,46 @@ describe("Task - Annotations Cleared on Send (Issue #466)", () => {
     task3
   }
 
-  test("AddUserMessage with annotations clears task-level annotations", t => {
+  test("AddUserMessage clears annotation UI state and sends annotations", t => {
     let task = _taskWithAnnotations()
-
     t
     ->expect(TaskReducer.Selectors.annotations(task)->Option.getOr([])->Array.length)
     ->Expect.toBe(2)
-
-    let (task2, _) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: testUserMessageId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Fix this"})],
-        annotations: _sampleMessageAnnotations,
-        agentId: "executor-id",
-      }),
-    )
-
-    t
-    ->expect(TaskReducer.Selectors.annotations(task2)->Option.getOr([])->Array.length)
-    ->Expect.toBe(0)
-  })
-
-  test("AddUserMessage resets annotationMode to Off", t => {
-    let task = _taskWithAnnotations()
-
     t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task))->Expect.toEqual(Some(true))
-
-    let (task2, _) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: testUserMessageId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Fix this"})],
-        annotations: _sampleMessageAnnotations,
-        agentId: "executor-id",
-      }),
-    )
-
-    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(task2))->Expect.toEqual(Some(false))
-  })
-
-  test("AddUserMessage clears activePopupAnnotationId", t => {
-    let task = _taskWithAnnotations()
-
     t
     ->expect(TaskReducer.Selectors.activePopupAnnotationId(task)->Option.getOr(None)->Option.isSome)
     ->Expect.toBe(true)
 
-    let (task2, _) = TaskReducer.next(
+    let (updated, effects) = TaskReducer.next(
       task,
       AddUserMessage({
         id: testUserMessageId,
-        content: [],
+        content: [Client__Task__Types.UserContentPart.Text({text: "Fix this"})],
         annotations: _sampleMessageAnnotations,
         agentId: "executor-id",
       }),
     )
 
     t
+    ->expect(TaskReducer.Selectors.annotations(updated)->Option.getOr([])->Array.length)
+    ->Expect.toBe(0)
+    t->expect(TaskReducer.Selectors.webPreviewIsSelecting(updated))->Expect.toEqual(Some(false))
+    t
     ->expect(
-      TaskReducer.Selectors.activePopupAnnotationId(task2)->Option.getOr(None)->Option.isNone,
+      TaskReducer.Selectors.activePopupAnnotationId(updated)->Option.getOr(None)->Option.isNone,
     )
     ->Expect.toBe(true)
+
+    switch effects->Array.get(0) {
+    | Some(SendMessage({id, annotations, agentId})) => {
+        t
+        ->expect(id->UserMessageId.toString)
+        ->Expect.toBe(testUserMessageId->UserMessageId.toString)
+        t->expect(annotations->Array.length)->Expect.toBe(2)
+        t->expect(agentId)->Expect.toBe("executor-id")
+      }
+    | _ => t->expect("SendMessage effect")->Expect.toBe("not found")
+    }
   })
 
   test("Annotations are stored on the message itself", t => {
@@ -939,41 +720,11 @@ describe("Task - Annotations Cleared on Send (Issue #466)", () => {
     | _ => t->expect("User message")->Expect.toBe("not found")
     }
   })
-
-  test("SendMessage effect carries annotations", t => {
-    let task = TestHelpers.makeLoadedTask()
-
-    let (_task2, effects) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: testUserMessageId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Fix"})],
-        annotations: _sampleMessageAnnotations,
-        agentId: "executor-id",
-      }),
-    )
-
-    switch effects->Array.get(0) {
-    | Some(SendMessage({id, annotations, agentId})) => {
-        t
-        ->expect(id->UserMessageId.toString)
-        ->Expect.toBe(testUserMessageId->UserMessageId.toString)
-        t->expect(annotations->Array.length)->Expect.toBe(2)
-        t->expect(agentId)->Expect.toBe("executor-id")
-      }
-    | _ => t->expect("SendMessage effect")->Expect.toBe("not found")
-    }
-  })
 })
 
 describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", () => {
   test("QuestionReceived sets pendingQuestion on Loaded task with isAgentRunning=false", t => {
     let task = TestHelpers.makeLoadedTask()
-
-    let resolvedOk = ref(None)
-    let resolvedError = ref(None)
-    let resolveOk = (json: JSON.t) => resolvedOk := Some(json)
-    let resolveError = (msg: string) => resolvedError := Some(msg)
 
     let questions: array<Client__Question__Types.questionItem> = [
       {
@@ -986,7 +737,12 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
 
     let (nextTask, effects) = TaskReducer.next(
       task,
-      QuestionReceived({questions, toolCallId: "tc_1", resolveOk, resolveError}),
+      QuestionReceived({
+        questions,
+        toolCallId: "tc_1",
+        resolveOk: _ => (),
+        resolveError: _ => (),
+      }),
     )
 
     let pq = TaskReducer.Selectors.pendingQuestion(nextTask)
@@ -1002,7 +758,7 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
     }
   })
 
-  test("QuestionSubmitted resolves the tool promise and emits ResolveQuestionToolEffect", t => {
+  test("QuestionSubmitted emits and executes ResolveQuestionToolEffect", t => {
     let task = TestHelpers.makeLoadedTask()
 
     let resolvedOk = ref(None)
@@ -1022,9 +778,6 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
       task,
       QuestionReceived({questions, toolCallId: "tc_1", resolveOk, resolveError}),
     )
-    let (cancelledTask, _) = TaskReducer.next(taskWithQuestion, QuestionCancelled)
-    t->expect(Task.getCompletedFileChanges(cancelledTask).revision)->Expect.toBe(1)
-
     let (taskWithAnswer, _) = TaskReducer.next(
       taskWithQuestion,
       QuestionOptionToggled({questionIndex: 0, label: "A"}),
@@ -1036,7 +789,7 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
     t->expect(pq->Option.isNone)->Expect.toBe(true)
 
     switch effects->Array.get(0) {
-    | Some(ResolveQuestionToolEffect(_)) => t->expect(true)->Expect.toBe(true)
+    | Some(ResolveQuestionToolEffect({resolveOk, answerJson})) => resolveOk(answerJson)
     | other =>
       t
       ->expect(
@@ -1044,39 +797,6 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
       )
       ->Expect.toBe("ResolveQuestionToolEffect")
     }
-  })
-
-  test("resolveOk callback is called when ResolveQuestionToolEffect is executed", t => {
-    let task = TestHelpers.makeLoadedTask()
-
-    let resolvedOk = ref(None)
-    let resolveOk = (json: JSON.t) => resolvedOk := Some(json)
-    let resolveError = (_msg: string) => ()
-
-    let questions: array<Client__Question__Types.questionItem> = [
-      {
-        question: "Pick one",
-        header: "Test",
-        options: [{label: "A", description: "Option A"}],
-        multiple: None,
-      },
-    ]
-
-    let (taskWithQuestion, _) = TaskReducer.next(
-      task,
-      QuestionReceived({questions, toolCallId: "tc_1", resolveOk, resolveError}),
-    )
-    let (taskWithAnswer, _) = TaskReducer.next(
-      taskWithQuestion,
-      QuestionOptionToggled({questionIndex: 0, label: "A"}),
-    )
-    let (_finalTask, effects) = TaskReducer.next(taskWithAnswer, QuestionSubmitted)
-
-    switch effects->Array.get(0) {
-    | Some(ResolveQuestionToolEffect({resolveOk, answerJson})) => resolveOk(answerJson)
-    | _ => ()
-    }
-
     t->expect(resolvedOk.contents->Option.isSome)->Expect.toBe(true)
   })
 })
@@ -1101,12 +821,6 @@ describe("Task - QuestionPerQuestionSkipped", () => {
         options: [{label: "B", description: "b"}],
         multiple: None,
       },
-      {
-        question: "Q3",
-        header: "H3",
-        options: [{label: "C", description: "c"}],
-        multiple: None,
-      },
     ]
 
     let (taskWithQ, _) = TaskReducer.next(
@@ -1129,17 +843,12 @@ describe("Task - QuestionPerQuestionSkipped", () => {
     }
 
     t->expect(effects->Array.length)->Expect.toBe(0)
-
-    t
-    ->expect(TaskReducer.Selectors.pendingQuestion(afterSkip)->Option.isSome)
-    ->Expect.toBe(true)
   })
 
   test("skipping the last question auto-submits via resolveQuestion", t => {
     let task = TestHelpers.makeLoadedTask()
 
-    let resolvedOk = ref(None)
-    let resolveOk = (json: JSON.t) => resolvedOk := Some(json)
+    let resolveOk = (_json: JSON.t) => ()
     let resolveError = (_msg: string) => ()
 
     let questions: array<Client__Question__Types.questionItem> = [
@@ -1149,12 +858,6 @@ describe("Task - QuestionPerQuestionSkipped", () => {
         options: [{label: "A", description: "a"}],
         multiple: None,
       },
-      {
-        question: "Q2",
-        header: "H2",
-        options: [{label: "B", description: "b"}],
-        multiple: None,
-      },
     ]
 
     let (taskWithQ, _) = TaskReducer.next(
@@ -1162,18 +865,13 @@ describe("Task - QuestionPerQuestionSkipped", () => {
       QuestionReceived({questions, toolCallId: "tc_1", resolveOk, resolveError}),
     )
 
-    let (afterSkip0, _) = TaskReducer.next(
+    let (afterSkip, effects) = TaskReducer.next(
       taskWithQ,
       QuestionPerQuestionSkipped({questionIndex: 0}),
     )
 
-    let (afterSkip1, effects) = TaskReducer.next(
-      afterSkip0,
-      QuestionPerQuestionSkipped({questionIndex: 1}),
-    )
-
     t
-    ->expect(TaskReducer.Selectors.pendingQuestion(afterSkip1)->Option.isNone)
+    ->expect(TaskReducer.Selectors.pendingQuestion(afterSkip)->Option.isNone)
     ->Expect.toBe(true)
 
     switch effects->Array.get(0) {
@@ -1239,13 +937,7 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
     enrichmentStatus,
   })
 
-  let _resolveAnnotation = (task, effects, ~enrichmentStatus=Annotation.Enriched) => {
-    let id = _getAnnotationIdFromEffect(effects)
-    let (resolved, _) = TaskReducer.next(task, _makeResolved(~id, ~enrichmentStatus))
-    resolved
-  }
-
-  test("ToggleAnnotation creates annotation with Enriching status and Ok(None) async fields", t => {
+  test("ToggleAnnotation enriches async fields and clears enriching status", t => {
     let (task, effects) = _taskWithEnrichingAnnotation()
     let ann = _getAnnotation(task, 0)
 
@@ -1253,17 +945,10 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
     t->expect(ann.selector)->Expect.toEqual(Ok(None))
     t->expect(ann.screenshot)->Expect.toEqual(Ok(None))
     t->expect(ann.sourceLocation)->Expect.toEqual(Ok(None))
+    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(task))->Expect.toEqual(Some(true))
 
-    switch effects->Array.get(0) {
-    | Some(FetchAnnotationDetails(_)) => t->expect(true)->Expect.toBe(true)
-    | _ => t->expect("FetchAnnotationDetails effect")->Expect.toBe("not found")
-    }
-  })
-
-  test("AnnotationDetailsResolved writes all enrichment fields and sets Enriched", t => {
-    let (task, effects) = _taskWithEnrichingAnnotation()
     let id = _getAnnotationIdFromEffect(effects)
-    let (task2, _) = TaskReducer.next(
+    let (resolved, _) = TaskReducer.next(
       task,
       _makeResolved(
         ~id,
@@ -1275,14 +960,15 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
         ~boundingBox={x: 10.0, y: 20.0, width: 100.0, height: 50.0},
       ),
     )
-    let ann = _getAnnotation(task2, 0)
-    t->expect(ann.enrichmentStatus)->Expect.toEqual(Annotation.Enriched)
-    t->expect(ann.selector)->Expect.toEqual(Ok(Some(".btn-submit")))
-    t->expect(ann.elementContext)->Expect.toEqual(Ok(Some(`selected tag="button"`)))
-    t->expect(ann.screenshot)->Expect.toEqual(Ok(Some("data:image/jpeg;base64,abc")))
-    t->expect(ann.cssClasses)->Expect.toEqual(Some("btn-submit"))
-    t->expect(ann.nearbyText)->Expect.toEqual(Some("Submit"))
-    switch ann.boundingBox {
+    let enriched = _getAnnotation(resolved, 0)
+    t->expect(enriched.enrichmentStatus)->Expect.toEqual(Annotation.Enriched)
+    t->expect(enriched.selector)->Expect.toEqual(Ok(Some(".btn-submit")))
+    t->expect(enriched.elementContext)->Expect.toEqual(Ok(Some(`selected tag="button"`)))
+    t->expect(enriched.screenshot)->Expect.toEqual(Ok(Some("data:image/jpeg;base64,abc")))
+    t->expect(enriched.cssClasses)->Expect.toEqual(Some("btn-submit"))
+    t->expect(enriched.nearbyText)->Expect.toEqual(Some("Submit"))
+    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(resolved))->Expect.toEqual(Some(false))
+    switch enriched.boundingBox {
     | Some(bb) =>
       t->expect(bb.x)->Expect.toBe(10.0)
       t->expect(bb.width)->Expect.toBe(100.0)
@@ -1328,6 +1014,7 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
     t->expect(ann.selector)->Expect.toEqual(Error(errorMsg))
     t->expect(ann.screenshot)->Expect.toEqual(Error(errorMsg))
     t->expect(ann.sourceLocation)->Expect.toEqual(Error(errorMsg))
+    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(task2))->Expect.toEqual(Some(false))
   })
 
   test("AnnotationDetailsResolved on Unloaded task is silently discarded", t => {
@@ -1335,20 +1022,6 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
     let (task2, effects) = TaskReducer.next(task, _makeResolved(~id="stale-ann-id"))
     t->expect(effects)->Expect.toEqual([])
     t->expect(Task.getAnnotations(task2)->Array.length)->Expect.toBe(0)
-  })
-
-  test("hasEnrichingAnnotations is true while Enriching, false after Enriched", t => {
-    let (task, effects) = _taskWithEnrichingAnnotation()
-    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(task))->Expect.toEqual(Some(true))
-
-    let resolved = _resolveAnnotation(task, effects)
-    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(resolved))->Expect.toEqual(Some(false))
-  })
-
-  test("hasEnrichingAnnotations is false after Failed", t => {
-    let (task, effects) = _taskWithEnrichingAnnotation()
-    let resolved = _resolveAnnotation(task, effects, ~enrichmentStatus=Failed({error: "boom"}))
-    t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(resolved))->Expect.toEqual(Some(false))
   })
 
   test("hasEnrichingAnnotations is None for Unloaded task", t => {
@@ -1377,7 +1050,8 @@ describe("Task - Annotation Enrichment Lifecycle (Issue #582)", () => {
     )
     t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(task3))->Expect.toEqual(Some(true))
 
-    let task4 = _resolveAnnotation(task3, effects1)
+    let id = _getAnnotationIdFromEffect(effects1)
+    let (task4, _) = TaskReducer.next(task3, _makeResolved(~id))
     t->expect(TaskReducer.Selectors.hasEnrichingAnnotations(task4))->Expect.toEqual(Some(true))
   })
 })

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -343,6 +343,56 @@ describe("Task - Plan Entries", () => {
 })
 
 describe("Task - Error Handling", () => {
+  test("UserMessageSendFailed removes a pending optimistic message and exposes the error", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let (pending, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: testUserMessageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let messageId = testUserMessageId->UserMessageId.toString
+    let (failed, effects) = TaskReducer.next(
+      pending,
+      UserMessageSendFailed({id: testUserMessageId, error: "Connection lost"}),
+    )
+
+    t->expect(TestHelpers.getQueuedUserMessages(failed))->Expect.toEqual([])
+    t
+    ->expect(TaskReducer.Selectors.turnError(failed))
+    ->Expect.toEqual(
+      Some({id: messageId, message: "Connection lost", category: #unknown, retryErrorId: None}),
+    )
+    t->expect(effects)->Expect.toEqual([])
+  })
+
+  test("UserMessageSendFailed preserves a message already accepted by the server", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let (pending, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: testUserMessageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let accepted = TestHelpers.acceptUserMessage(
+      pending,
+      ~id=testUserMessageId->UserMessageId.toString,
+    )
+    let (unchanged, _) = TaskReducer.next(
+      accepted,
+      UserMessageSendFailed({id: testUserMessageId, error: "Connection lost"}),
+    )
+
+    t->expect(TestHelpers.getQueuedUserMessages(unchanged)->Array.length)->Expect.toBe(1)
+    t->expect(TaskReducer.Selectors.turnError(unchanged))->Expect.toEqual(None)
+  })
+
   test("AgentError completes output, persists error, stops running, and emits no effects", t => {
     let task = TestHelpers.makeLoadedTask()
     let task = TestHelpers.acceptUserMessage(task)
@@ -367,6 +417,7 @@ describe("Task - Error Handling", () => {
         id: "agent-error-1",
         message: "Quota exhausted",
         category: #quota,
+        retryErrorId: Some("agent-error-1"),
       }),
     )
     t->expect(TaskReducer.Selectors.isAgentRunning(failed))->Expect.toEqual(Some(false))
@@ -407,6 +458,7 @@ describe("Task - Error Handling", () => {
         id: "agent-error-1",
         message: "Some error",
         category: #unknown,
+        retryErrorId: Some("agent-error-1"),
       }),
     )
 
@@ -431,6 +483,7 @@ describe("Task - Error Handling", () => {
         id: "agent-error-1",
         message: "Previous error",
         category: #unknown,
+        retryErrorId: Some("agent-error-1"),
       }),
     )
 

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -267,6 +267,110 @@ describe("Task - Session Rehydration (Loading history → LoadComplete)", () => 
 })
 
 describe("Task - Agent Running State", () => {
+  test("submitted user message is queued before server acceptance", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let (submitted, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: testUserMessageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+
+    let queued = TestHelpers.getQueuedUserMessages(submitted)
+    t->expect(queued->Array.length)->Expect.toBe(1)
+    t->expect(TestHelpers.getMessages(submitted)->Array.length)->Expect.toBe(0)
+  })
+
+  test("server acceptance replaces optimistic message without duplication", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let (submitted, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: testUserMessageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let (accepted, _) = TaskReducer.next(
+      submitted,
+      UserMessageReceived({
+        id: testUserMessageId->UserMessageId.toString,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+
+    let queued = TestHelpers.getQueuedUserMessages(accepted)
+    t->expect(queued->Array.length)->Expect.toBe(1)
+    switch queued->Array.get(0) {
+    | Some(Message.User({content, _})) => t->expect(content->Array.length)->Expect.toBe(1)
+    | _ => t->expect("User message")->Expect.toBe("missing")
+    }
+  })
+
+  test("server acceptance preserves optimistic submission order", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let firstId = UserMessageId.make()
+    let secondId = UserMessageId.make()
+    let (firstSubmitted, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: firstId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "First"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let (bothSubmitted, _) = TaskReducer.next(
+      firstSubmitted,
+      AddUserMessage({
+        id: secondId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Second"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let (secondAccepted, _) = TaskReducer.next(
+      bothSubmitted,
+      UserMessageReceived({
+        id: secondId->UserMessageId.toString,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Second"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+
+    let queued = TestHelpers.getQueuedUserMessages(secondAccepted)
+    switch (queued->Array.get(0), queued->Array.get(1)) {
+    | (Some(Message.User({id: queuedFirstId, _})), Some(Message.User({id: queuedSecondId, _}))) =>
+      t->expect(queuedFirstId)->Expect.toBe(firstId->UserMessageId.toString)
+      t->expect(queuedSecondId)->Expect.toBe(secondId->UserMessageId.toString)
+    | _ => t->expect("Queued messages in submission order")->Expect.toBe("missing")
+    }
+  })
+
+  test("running does not move unaccepted message into transcript", t => {
+    let task = TestHelpers.makeLoadedTask()
+    let (submitted, _) = TaskReducer.next(
+      task,
+      AddUserMessage({
+        id: testUserMessageId,
+        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
+        annotations: [],
+        agentId: "executor-id",
+      }),
+    )
+    let (running, _) = TaskReducer.next(submitted, ExecutionStateRunning)
+
+    t->expect(TestHelpers.getMessages(running)->Array.length)->Expect.toBe(0)
+    t->expect(TestHelpers.getQueuedUserMessages(running)->Array.length)->Expect.toBe(1)
+  })
+
   test("state updates drive isAgentRunning", t => {
     let task = TestHelpers.makeLoadedTask()
     let (task2, _) = TaskReducer.next(

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -267,7 +267,7 @@ describe("Task - Session Rehydration (Loading history → LoadComplete)", () => 
 })
 
 describe("Task - Agent Running State", () => {
-  test("submitted user message is queued before server acceptance", t => {
+  test("submitted message stays queued until its accepted turn starts", t => {
     let task = TestHelpers.makeLoadedTask()
     let (submitted, _) = TaskReducer.next(
       task,
@@ -282,93 +282,23 @@ describe("Task - Agent Running State", () => {
     let queued = TestHelpers.getQueuedUserMessages(submitted)
     t->expect(queued->Array.length)->Expect.toBe(1)
     t->expect(TestHelpers.getMessages(submitted)->Array.length)->Expect.toBe(0)
-  })
 
-  test("server acceptance replaces optimistic message without duplication", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let (submitted, _) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: testUserMessageId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
-    let (accepted, _) = TaskReducer.next(
-      submitted,
-      UserMessageReceived({
-        id: testUserMessageId->UserMessageId.toString,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
+    let (prematurelyRunning, _) = TaskReducer.next(submitted, ExecutionStateRunning)
+    t->expect(TestHelpers.getMessages(prematurelyRunning)->Array.length)->Expect.toBe(0)
 
-    let queued = TestHelpers.getQueuedUserMessages(accepted)
-    t->expect(queued->Array.length)->Expect.toBe(1)
-    switch queued->Array.get(0) {
+    let accepted = TestHelpers.acceptUserMessage(
+      prematurelyRunning,
+      ~id=testUserMessageId->UserMessageId.toString,
+    )
+    t->expect(TestHelpers.getQueuedUserMessages(accepted)->Array.length)->Expect.toBe(1)
+
+    let (running, _) = TaskReducer.next(accepted, ExecutionStateRunning)
+    let messages = TestHelpers.getMessages(running)
+    t->expect(TestHelpers.getQueuedUserMessages(running)->Array.length)->Expect.toBe(0)
+    switch messages->Array.get(0) {
     | Some(Message.User({content, _})) => t->expect(content->Array.length)->Expect.toBe(1)
     | _ => t->expect("User message")->Expect.toBe("missing")
     }
-  })
-
-  test("server acceptance preserves optimistic submission order", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let firstId = UserMessageId.make()
-    let secondId = UserMessageId.make()
-    let (firstSubmitted, _) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: firstId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "First"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
-    let (bothSubmitted, _) = TaskReducer.next(
-      firstSubmitted,
-      AddUserMessage({
-        id: secondId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Second"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
-    let (secondAccepted, _) = TaskReducer.next(
-      bothSubmitted,
-      UserMessageReceived({
-        id: secondId->UserMessageId.toString,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Second"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
-
-    let queued = TestHelpers.getQueuedUserMessages(secondAccepted)
-    switch (queued->Array.get(0), queued->Array.get(1)) {
-    | (Some(Message.User({id: queuedFirstId, _})), Some(Message.User({id: queuedSecondId, _}))) =>
-      t->expect(queuedFirstId)->Expect.toBe(firstId->UserMessageId.toString)
-      t->expect(queuedSecondId)->Expect.toBe(secondId->UserMessageId.toString)
-    | _ => t->expect("Queued messages in submission order")->Expect.toBe("missing")
-    }
-  })
-
-  test("running does not move unaccepted message into transcript", t => {
-    let task = TestHelpers.makeLoadedTask()
-    let (submitted, _) = TaskReducer.next(
-      task,
-      AddUserMessage({
-        id: testUserMessageId,
-        content: [Client__Task__Types.UserContentPart.Text({text: "Hello"})],
-        annotations: [],
-        agentId: "executor-id",
-      }),
-    )
-    let (running, _) = TaskReducer.next(submitted, ExecutionStateRunning)
-
-    t->expect(TestHelpers.getMessages(running)->Array.length)->Expect.toBe(0)
-    t->expect(TestHelpers.getQueuedUserMessages(running)->Array.length)->Expect.toBe(1)
   })
 
   test("state updates drive isAgentRunning", t => {


### PR DESCRIPTION
## Summary
- show submitted user messages in the queued drawer immediately
- track pending message IDs so only accepted messages enter the transcript
- reconcile server echoes without duplication while preserving submission order
- add reducer coverage and a client changeset

## Verification
- pre-commit ReScript formatting passed
- pre-commit source-comment checks passed
- pre-push `reanalyze` passed across all ReScript workspaces
- final `make build` was not rerun after fixing the reported inline-record compiler error