### PR TITLE
Replay embedded tool calls from task history

### DIFF
--- a/.changeset/replay-embedded-tool-calls.md
+++ b/.changeset/replay-embedded-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Restore backend tool calls when loading existing task history.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,7 +9,7 @@ catalog:
   dotenv: 17.2.3
   rescript: 12.3.0
   rescript-vitest: "https://github.com/cometkim/rescript-vitest/archive/662019a08334dd1b188efe6b0b306c9c0bcdb75a.tar.gz"
-  sury: 11.0.0-alpha.10
+  sury: 11.0.0-alpha.11
   sury-ppx: 11.0.0-alpha.10
   vite: ^8.1.5
   vitest: 4.1.10

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -38,21 +38,46 @@ defmodule AgentClientProtocol.History do
         },
         session_id
       ) do
-    case response.content do
-      content when content in [nil, ""] ->
-        []
+    content_notifications =
+      case response.content do
+        content when content in [nil, ""] ->
+          []
 
-      content when is_binary(content) ->
-        [
-          ACP.build_agent_message_chunk_notification(
-            session_id,
-            content,
-            response.timestamp,
-            ACP.agent_message_id(turn_row.id, ordinal),
-            agent_id
-          )
-        ]
-    end
+        content when is_binary(content) ->
+          [
+            ACP.build_agent_message_chunk_notification(
+              session_id,
+              content,
+              response.timestamp,
+              ACP.agent_message_id(turn_row.id, ordinal),
+              agent_id
+            )
+          ]
+      end
+
+    tool_call_notifications =
+      response.metadata
+      |> Map.get("tool_calls", [])
+      |> Enum.map(fn %{"id" => id, "name" => name, "arguments" => raw_arguments} ->
+        {:ok, %{arguments: arguments}} =
+          Interaction.ToolCall.attrs(%SwarmAi.ToolCall{
+            id: id,
+            name: name,
+            arguments: raw_arguments
+          })
+
+        ACP.tool_call_create(
+          session_id,
+          id,
+          name,
+          "other",
+          response.timestamp,
+          ACP.tool_call_status_pending(),
+          arguments
+        )
+      end)
+
+    content_notifications ++ tool_call_notifications
   end
 
   def encode_row(

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -57,19 +57,19 @@ defmodule AgentClientProtocol.History do
 
     tool_call_notifications =
       response.metadata
-      |> Map.get("tool_calls", [])
-      |> Enum.map(fn %{"id" => id, "name" => name, "arguments" => raw_arguments} ->
-        {:ok, %{arguments: arguments}} =
-          Interaction.ToolCall.attrs(%SwarmAi.ToolCall{
-            id: id,
-            name: name,
-            arguments: raw_arguments
-          })
+      |> Map.get("tool_calls")
+      |> Interaction.to_swarm_tool_calls()
+      |> Enum.map(fn tool_call ->
+        arguments =
+          case Interaction.ToolCall.attrs(tool_call) do
+            {:ok, %{arguments: arguments}} -> arguments
+            {:error, {:invalid_tool_arguments, _message}} -> nil
+          end
 
         ACP.tool_call_create(
           session_id,
-          id,
-          name,
+          tool_call.id,
+          tool_call.name,
           "other",
           response.timestamp,
           ACP.tool_call_status_pending(),

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -25,19 +25,38 @@ defmodule AgentClientProtocol.History do
       when is_binary(session_id) and is_list(active_agents) do
     {rows, agent_ids} = TaskHistory.attributed_rows!(history)
     Agents.resolve_catalog!(active_agents, agent_ids)
-    notifications = Enum.flat_map(rows, &encode_row(&1, session_id))
+
+    standalone_tool_call_ids =
+      for %{
+            row: %InteractionSchema{
+              turn_number: turn_number,
+              data: %Interaction.ToolCall{tool_call_id: id}
+            }
+          } <- rows,
+          into: MapSet.new(),
+          do: {turn_number, id}
+
+    notifications =
+      Enum.flat_map(rows, &encode_row(&1, session_id, standalone_tool_call_ids))
+
     {:ok, %{notifications: notifications}}
   end
 
-  def encode_row(
-        %{
-          row: %InteractionSchema{data: %Interaction.AgentResponse{} = response},
-          turn_row: turn_row,
-          agent_id: agent_id,
-          response_ordinal: ordinal
-        },
-        session_id
-      ) do
+  def encode_row(context, session_id), do: encode_row(context, session_id, MapSet.new())
+
+  defp encode_row(
+         %{
+           row: %InteractionSchema{
+             turn_number: turn_number,
+             data: %Interaction.AgentResponse{} = response
+           },
+           turn_row: turn_row,
+           agent_id: agent_id,
+           response_ordinal: ordinal
+         },
+         session_id,
+         standalone_tool_call_ids
+       ) do
     content_notifications =
       case response.content do
         content when content in [nil, ""] ->
@@ -59,6 +78,7 @@ defmodule AgentClientProtocol.History do
       response.metadata
       |> Map.get("tool_calls")
       |> Interaction.to_swarm_tool_calls()
+      |> Enum.reject(&MapSet.member?(standalone_tool_call_ids, {turn_number, &1.id}))
       |> Enum.map(fn tool_call ->
         arguments =
           case Interaction.ToolCall.attrs(tool_call) do
@@ -80,10 +100,11 @@ defmodule AgentClientProtocol.History do
     content_notifications ++ tool_call_notifications
   end
 
-  def encode_row(
-        %{row: %InteractionSchema{data: data, type: type} = row} = context,
-        session_id
-      ) do
+  defp encode_row(
+         %{row: %InteractionSchema{data: data, type: type} = row} = context,
+         session_id,
+         _standalone_tool_call_ids
+       ) do
     case data do
       %Interaction.UserMessage{} = message ->
         message

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -1094,7 +1094,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     [
       %SwarmMessage.Assistant{
         content: [],
-        tool_calls: swarm_tool_calls(meta["tool_calls"]),
+        tool_calls: to_swarm_tool_calls(meta["tool_calls"]),
         metadata: swarm_metadata(msg),
         reasoning_details: filter_encrypted_reasoning(meta["reasoning_details"])
       }
@@ -1108,7 +1108,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     [
       %SwarmMessage.Assistant{
         content: [SwarmContentPart.text(content)],
-        tool_calls: swarm_tool_calls(meta["tool_calls"]),
+        tool_calls: to_swarm_tool_calls(meta["tool_calls"]),
         metadata: swarm_metadata(msg),
         reasoning_details: filter_encrypted_reasoning(meta["reasoning_details"])
       }
@@ -1329,10 +1329,10 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defp append_attachment_context(text, _), do: text
 
-  defp swarm_tool_calls(nil), do: []
-  defp swarm_tool_calls([]), do: []
+  @doc "Converts persisted tool-call records into Swarm tool calls."
+  def to_swarm_tool_calls(nil), do: []
 
-  defp swarm_tool_calls(tool_calls) when is_list(tool_calls) do
+  def to_swarm_tool_calls(tool_calls) when is_list(tool_calls) do
     Enum.map(tool_calls, &swarm_tool_call/1)
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -323,6 +323,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
       messages = Interaction.to_swarm_messages(interactions)
       assert length(messages) == 4
       assert Enum.map(messages, &SwarmAi.Message.role/1) == [:user, :assistant, :tool, :assistant]
+      assert [%SwarmAi.ToolCall{arguments: "{}"}] = Enum.at(messages, 1).tool_calls
     end
 
     test "formats complete page and annotation context exactly" do

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -158,10 +158,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     %SwarmAi.ToolCall{id: id, name: "question", arguments: args}
   end
 
-  defp tool_call_metadata(%SwarmAi.ToolCall{} = tool_call) do
-    %{"id" => tool_call.id, "name" => tool_call.name, "arguments" => tool_call.arguments}
-  end
-
   defp redispatched_question_header?(
          {"mcp:message",
           %{
@@ -1251,11 +1247,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       turn_number = latest_turn_number(task_id)
 
-      Tasks.agent_replied(scope, task_id, turn_number, "", %{
-        "tool_calls" => [tool_call_metadata(tool_call)]
-      })
-
-      Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+      {:ok, _tool_call} =
+        persist_response_tool_call_fixture(scope, task_id, turn_number, "", tool_call)
 
       {:ok, task_id: task_id, scope: scope, tool_call_id: tool_call_id}
     end
@@ -1331,11 +1324,9 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       second_tool_call = question_tool_call(second_tool_call_id, "Second", "B")
       turn_number = latest_turn_number(task_id)
 
-      Tasks.agent_replied(scope, task_id, turn_number, "", %{
-        "tool_calls" => [tool_call_metadata(second_tool_call)]
-      })
+      {:ok, _tool_call} =
+        persist_response_tool_call_fixture(scope, task_id, turn_number, "", second_tool_call)
 
-      Tasks.request_client_tool(scope, task_id, turn_number, second_tool_call)
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
       expect_resumed_model()
 
@@ -1437,11 +1428,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       user_message_fixture(scope, task_id, user_content("first turn"))
       first_turn_number = latest_turn_number(task_id)
 
-      Tasks.agent_replied(scope, task_id, first_turn_number, "", %{
-        "tool_calls" => [tool_call_metadata(first_tc)]
-      })
-
-      Tasks.request_client_tool(scope, task_id, first_turn_number, first_tc)
+      {:ok, _tool_call} =
+        persist_response_tool_call_fixture(scope, task_id, first_turn_number, "", first_tc)
 
       Tasks.resolve_tool_request(
         scope,
@@ -1456,11 +1444,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       user_message_fixture(scope, task_id, user_content("second turn"))
       second_turn_number = latest_turn_number(task_id)
 
-      Tasks.agent_replied(scope, task_id, second_turn_number, "", %{
-        "tool_calls" => [tool_call_metadata(second_tc)]
-      })
-
-      Tasks.request_client_tool(scope, task_id, second_turn_number, second_tc)
+      {:ok, _tool_call} =
+        persist_response_tool_call_fixture(scope, task_id, second_turn_number, "", second_tc)
 
       {:ok, _reply, socket} =
         UserSocket

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -99,6 +99,60 @@ defmodule AgentClientProtocol.HistoryTest do
     assert tool_result["toolCallId"] == "call"
   end
 
+  test "replays provider-shaped embedded tool calls" do
+    [tool_create] =
+      replay_embedded_tool_calls([
+        %{
+          "id" => "call",
+          "function" => %{
+            "name" => "todo_write",
+            "arguments" => ~s({"todos":[]})
+          }
+        }
+      ])
+
+    assert tool_create["toolCallId"] == "call"
+    assert tool_create["title"] == "todo_write"
+    assert tool_create["rawInput"] == %{"todos" => []}
+  end
+
+  test "replays embedded tool calls with decoded arguments" do
+    [tool_create] =
+      replay_embedded_tool_calls([
+        %{"id" => "call", "name" => "todo_write", "arguments" => %{"todos" => []}}
+      ])
+
+    assert tool_create["rawInput"] == %{"todos" => []}
+  end
+
+  test "treats nil embedded tool calls as empty" do
+    assert replay_embedded_tool_calls(nil) == []
+  end
+
+  test "replays failed tool calls with malformed arguments without raw input" do
+    tool_result = %Interaction.ToolResult{
+      tool_call_id: "call",
+      tool_name: "todo_write",
+      result: %{
+        "content" => [%{"type" => "text", "text" => "Failed to parse arguments for tool"}],
+        "structuredContent" => %{}
+      },
+      is_error: true,
+      timestamp: @timestamp
+    }
+
+    assert [tool_create, tool_update] =
+             replay_embedded_tool_calls(
+               [%{"id" => "call", "name" => "todo_write", "arguments" => "{invalid"}],
+               tool_result
+             )
+
+    assert tool_create["sessionUpdate"] == "tool_call"
+    refute Map.has_key?(tool_create, "rawInput")
+    assert tool_update["sessionUpdate"] == "tool_call_update"
+    assert tool_update["status"] == "failed"
+  end
+
   test "crashes when history references an agent outside the global catalog" do
     rows = [
       row("turn-row", :turn_started, 1, %{
@@ -152,6 +206,27 @@ defmodule AgentClientProtocol.HistoryTest do
 
   defp response(content) do
     %Interaction.AgentResponse{id: Ecto.UUID.generate(), content: content, timestamp: @timestamp}
+  end
+
+  defp replay_embedded_tool_calls(tool_calls, tool_result \\ nil) do
+    rows = [
+      row("turn-row", :turn_started, 1, turn("turn-id", [])),
+      row("response", :agent_response, 1, %Interaction.AgentResponse{
+        id: Ecto.UUID.generate(),
+        content: nil,
+        metadata: %{"tool_calls" => tool_calls},
+        timestamp: @timestamp
+      })
+    ]
+
+    rows =
+      case tool_result do
+        nil -> rows
+        tool_result -> rows ++ [row("tool-result", :tool_result, 1, tool_result)]
+      end
+
+    {:ok, replay} = build(rows)
+    Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
   end
 
   defp agent do

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -1,97 +1,76 @@
 defmodule AgentClientProtocol.HistoryTest do
   use ExUnit.Case, async: true
 
+  import FrontmanServer.InteractionCase.Helpers,
+    only: [
+      agent_error: 1,
+      agent_paused: 2,
+      agent_resp: 1,
+      agent_resp: 2,
+      interaction_row: 2,
+      tool_call: 3,
+      tool_result: 3,
+      tool_result: 4,
+      turn_started: 1,
+      user_msg: 1
+    ]
+
   alias AgentClientProtocol.History
   alias FrontmanServer.Agents.Agent
   alias FrontmanServer.Tasks.History, as: TaskHistory
-  alias FrontmanServer.Tasks.Interaction
-  alias FrontmanServer.Tasks.InteractionSchema
 
   @session_id "test-session-123"
   @timestamp ~U[2026-07-14 12:00:00.000000Z]
 
-  test "replays canonical row IDs, complete blocks, tools, errors, and response ordinals" do
+  test "replays canonical row IDs, complete blocks, and response ordinals" do
     rows = [
-      row("user-row", :user_message, nil, %Interaction.UserMessage{
-        id: "embedded-id",
-        agent_id: "executor-id",
-        messages: ["First", "Second"],
-        images: [],
-        timestamp: @timestamp
+      row("user-row", nil, %{
+        user_msg(["First", "Second"])
+        | id: "embedded-id",
+          agent_id: "executor-id",
+          timestamp: @timestamp
       }),
-      row("turn-row", :turn_started, 1, turn("turn-id", ["user-row"])),
-      row("empty-response", :agent_response, 1, response(nil)),
-      row("response", :agent_response, 1, response("Answer")),
-      row("tool", :tool_call, 1, %Interaction.ToolCall{
-        id: "tool",
-        tool_call_id: "call",
-        tool_name: "read_file",
-        arguments: %{"path" => "file"},
-        timestamp: @timestamp
-      }),
-      row("tool-result", :tool_result, 1, %Interaction.ToolResult{
-        tool_call_id: "call",
-        tool_name: "read_file",
-        result: %{
-          "content" => [%{"type" => "text", "text" => "{\"path\":\"file\"}"}],
-          "structuredContent" => %{"path" => "file"}
-        },
-        is_error: false,
-        timestamp: @timestamp
-      }),
-      row("error", :agent_error, 1, %Interaction.AgentError{
-        id: "error-id",
-        error: "Failed",
-        category: "unknown",
-        timestamp: @timestamp
-      })
+      row("turn-row", 1, turn("turn-id", ["user-row"])),
+      row("empty-response", 1, agent_resp(nil)),
+      row("response", 1, agent_resp("Answer"))
     ]
 
-    assert {:ok, replay} = build(rows)
-    updates = Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
-
-    assert [first, second, answer, tool_create, tool_result, error] = updates
+    assert [first, second, answer] = updates(rows)
     assert first["messageId"] == "user-row"
     assert second["messageId"] == "user-row"
     assert answer["messageId"] == "turn-row:1"
     assert answer["_meta"]["frontman.dev/agentId"] == "executor-id"
-    assert tool_create["rawInput"] == %{"path" => "file"}
-    refute Map.has_key?(tool_create, "content")
-    assert tool_result["rawOutput"] == %{"path" => "file"}
-    assert [%{"content" => %{"text" => "{\"path\":\"file\"}"}}] = tool_result["content"]
-    assert error["_meta"]["frontman.dev/agentErrorId"] == "error-id"
   end
 
-  test "replays tool calls embedded in an empty agent response before their results" do
+  test "replays one tool call when response metadata also has a standalone call" do
     rows = [
-      row("turn-row", :turn_started, 1, turn("turn-id", [])),
-      row("response", :agent_response, 1, %Interaction.AgentResponse{
-        id: Ecto.UUID.generate(),
-        content: nil,
-        metadata: %{
+      row("turn-row", 1, turn("turn-id", [])),
+      row(
+        "response",
+        1,
+        agent_resp(nil, %{
           "tool_calls" => [
             %{
               "id" => "call",
               "name" => "todo_write",
-              "arguments" => ~s({"todos":[]})
+              "arguments" => ~s({"source":"embedded"})
             }
           ]
-        },
-        timestamp: @timestamp
-      }),
-      row("tool-result", :tool_result, 1, %Interaction.ToolResult{
-        tool_call_id: "call",
-        tool_name: "todo_write",
-        result: %{"content" => [], "structuredContent" => %{"todos" => []}},
-        is_error: false,
-        timestamp: @timestamp
-      })
+        })
+      ),
+      row("tool", 1, tool_call("call", "todo_write", %{"todos" => []})),
+      row(
+        "tool-result",
+        1,
+        tool_result(
+          "call",
+          "todo_write",
+          %{"content" => [], "structuredContent" => %{"todos" => []}}
+        )
+      )
     ]
 
-    assert {:ok, replay} = build(rows)
-    updates = Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
-
-    assert [tool_create, tool_result] = updates
+    assert [tool_create, tool_result] = updates(rows)
     assert tool_create["sessionUpdate"] == "tool_call"
     assert tool_create["toolCallId"] == "call"
     assert tool_create["rawInput"] == %{"todos" => []}
@@ -99,67 +78,62 @@ defmodule AgentClientProtocol.HistoryTest do
     assert tool_result["toolCallId"] == "call"
   end
 
-  test "replays provider-shaped embedded tool calls" do
-    [tool_create] =
-      replay_embedded_tool_calls([
-        %{
-          "id" => "call",
-          "function" => %{
-            "name" => "todo_write",
-            "arguments" => ~s({"todos":[]})
-          }
-        }
-      ])
+  test "replays embedded-only calls without malformed raw input" do
+    rows = [
+      row("turn-row", 1, turn("turn-id", [])),
+      row(
+        "response",
+        1,
+        agent_resp(nil, %{
+          "tool_calls" => [
+            %{"id" => "valid-call", "name" => "todo_write", "arguments" => ~s({"todos":[]})},
+            %{"id" => "call", "name" => "todo_write", "arguments" => "{invalid"}
+          ]
+        })
+      ),
+      row(
+        "tool-result",
+        1,
+        tool_result(
+          "call",
+          "todo_write",
+          %{
+            "content" => [%{"type" => "text", "text" => "Failed to parse arguments for tool"}],
+            "structuredContent" => %{}
+          },
+          is_error: true
+        )
+      )
+    ]
 
-    assert tool_create["toolCallId"] == "call"
-    assert tool_create["title"] == "todo_write"
-    assert tool_create["rawInput"] == %{"todos" => []}
-  end
+    assert [valid_create, tool_create, tool_update] = updates(rows)
 
-  test "replays embedded tool calls with decoded arguments" do
-    [tool_create] =
-      replay_embedded_tool_calls([
-        %{"id" => "call", "name" => "todo_write", "arguments" => %{"todos" => []}}
-      ])
-
-    assert tool_create["rawInput"] == %{"todos" => []}
-  end
-
-  test "treats nil embedded tool calls as empty" do
-    assert replay_embedded_tool_calls(nil) == []
-  end
-
-  test "replays failed tool calls with malformed arguments without raw input" do
-    tool_result = %Interaction.ToolResult{
-      tool_call_id: "call",
-      tool_name: "todo_write",
-      result: %{
-        "content" => [%{"type" => "text", "text" => "Failed to parse arguments for tool"}],
-        "structuredContent" => %{}
-      },
-      is_error: true,
-      timestamp: @timestamp
-    }
-
-    assert [tool_create, tool_update] =
-             replay_embedded_tool_calls(
-               [%{"id" => "call", "name" => "todo_write", "arguments" => "{invalid"}],
-               tool_result
-             )
-
+    assert valid_create["rawInput"] == %{"todos" => []}
     assert tool_create["sessionUpdate"] == "tool_call"
     refute Map.has_key?(tool_create, "rawInput")
     assert tool_update["sessionUpdate"] == "tool_call_update"
     assert tool_update["status"] == "failed"
   end
 
+  test "replays agent errors" do
+    error = %{agent_error("Failed") | id: "error-id", timestamp: @timestamp}
+
+    assert [update] =
+             updates([
+               row("turn-row", 1, turn("turn-id", [])),
+               row("error", 1, error)
+             ])
+
+    assert update["_meta"]["frontman.dev/agentErrorId"] == "error-id"
+  end
+
   test "crashes when history references an agent outside the global catalog" do
     rows = [
-      row("turn-row", :turn_started, 1, %{
+      row("turn-row", 1, %{
         turn("archived-turn", [])
         | agent_id: "archived-id"
       }),
-      row("response", :agent_response, 1, response("Old answer"))
+      row("response", 1, agent_resp("Old answer"))
     ]
 
     assert_raise KeyError, fn -> build(rows) end
@@ -167,8 +141,8 @@ defmodule AgentClientProtocol.HistoryTest do
 
   test "crashes when persisted turn has no agent ID" do
     rows = [
-      row("turn-row", :turn_started, 1, %{turn("turn-id", []) | agent_id: nil}),
-      row("response", :agent_response, 1, response("Answer"))
+      row("turn-row", 1, %{turn("turn-id", []) | agent_id: nil}),
+      row("response", 1, agent_resp("Answer"))
     ]
 
     assert_raise FunctionClauseError, fn -> build(rows) end
@@ -176,8 +150,8 @@ defmodule AgentClientProtocol.HistoryTest do
 
   test "replays paused terminal state as requires_action" do
     rows = [
-      row("turn-row", :turn_started, 1, turn("turn-id", [])),
-      row("paused", :agent_paused, 1, %Interaction.AgentPaused{timestamp: @timestamp})
+      row("turn-row", 1, turn("turn-id", [])),
+      row("paused", 1, agent_paused("question", 120_000))
     ]
 
     assert {:ok, replay} = build(rows)
@@ -186,9 +160,8 @@ defmodule AgentClientProtocol.HistoryTest do
     assert update == %{"sessionUpdate" => "state_update", "state" => "requires_action"}
   end
 
-  defp row(id, type, turn_number, data) do
-    %InteractionSchema{id: id, type: type, turn_number: turn_number, data: data}
-  end
+  defp row(id, turn_number, interaction),
+    do: %{interaction_row(interaction, turn_number) | id: id}
 
   defp build(rows) do
     with {:ok, history} <- TaskHistory.new(rows),
@@ -196,35 +169,10 @@ defmodule AgentClientProtocol.HistoryTest do
   end
 
   defp turn(id, user_message_ids) do
-    %Interaction.TurnStarted{
-      id: id,
-      agent_id: "executor-id",
-      user_message_ids: user_message_ids,
-      timestamp: @timestamp
-    }
+    %{turn_started(user_message_ids) | id: id, agent_id: "executor-id", timestamp: @timestamp}
   end
 
-  defp response(content) do
-    %Interaction.AgentResponse{id: Ecto.UUID.generate(), content: content, timestamp: @timestamp}
-  end
-
-  defp replay_embedded_tool_calls(tool_calls, tool_result \\ nil) do
-    rows = [
-      row("turn-row", :turn_started, 1, turn("turn-id", [])),
-      row("response", :agent_response, 1, %Interaction.AgentResponse{
-        id: Ecto.UUID.generate(),
-        content: nil,
-        metadata: %{"tool_calls" => tool_calls},
-        timestamp: @timestamp
-      })
-    ]
-
-    rows =
-      case tool_result do
-        nil -> rows
-        tool_result -> rows ++ [row("tool-result", :tool_result, 1, tool_result)]
-      end
-
+  defp updates(rows) do
     {:ok, replay} = build(rows)
     Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
   end

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -62,6 +62,43 @@ defmodule AgentClientProtocol.HistoryTest do
     assert error["_meta"]["frontman.dev/agentErrorId"] == "error-id"
   end
 
+  test "replays tool calls embedded in an empty agent response before their results" do
+    rows = [
+      row("turn-row", :turn_started, 1, turn("turn-id", [])),
+      row("response", :agent_response, 1, %Interaction.AgentResponse{
+        id: Ecto.UUID.generate(),
+        content: nil,
+        metadata: %{
+          "tool_calls" => [
+            %{
+              "id" => "call",
+              "name" => "todo_write",
+              "arguments" => ~s({"todos":[]})
+            }
+          ]
+        },
+        timestamp: @timestamp
+      }),
+      row("tool-result", :tool_result, 1, %Interaction.ToolResult{
+        tool_call_id: "call",
+        tool_name: "todo_write",
+        result: %{"content" => [], "structuredContent" => %{"todos" => []}},
+        is_error: false,
+        timestamp: @timestamp
+      })
+    ]
+
+    assert {:ok, replay} = build(rows)
+    updates = Enum.map(replay.notifications, &get_in(&1, ["params", "update"]))
+
+    assert [tool_create, tool_result] = updates
+    assert tool_create["sessionUpdate"] == "tool_call"
+    assert tool_create["toolCallId"] == "call"
+    assert tool_create["rawInput"] == %{"todos" => []}
+    assert tool_result["sessionUpdate"] == "tool_call_update"
+    assert tool_result["toolCallId"] == "call"
+  end
+
   test "crashes when history references an agent outside the global catalog" do
     rows = [
       row("turn-row", :turn_started, 1, %{

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -82,6 +82,18 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
     Tasks.request_client_tool(scope, task_id, turn_number, swarm_tool_call)
   end
 
+  @doc "Persist an agent response and its matching client-handled tool call."
+  def persist_response_tool_call_fixture(scope, task_id, turn_number, content, tool_call) do
+    metadata = %{
+      "tool_calls" => [
+        %{"id" => tool_call.id, "name" => tool_call.name, "arguments" => tool_call.arguments}
+      ]
+    }
+
+    {:ok, _response} = Tasks.agent_replied(scope, task_id, turn_number, content, metadata)
+    Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+  end
+
   @doc """
   Persist a user message for tests without invoking the production execution API.
   """

--- a/yarn.lock
+++ b/yarn.lock
@@ -17775,18 +17775,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sury@npm:11.0.0-alpha.10":
-  version: 11.0.0-alpha.10
-  resolution: "sury@npm:11.0.0-alpha.10"
-  peerDependencies:
-    rescript: 12.x
-  peerDependenciesMeta:
-    rescript:
-      optional: true
-  checksum: 10c0/50af88d8c801b35fbaa8f4faac14d16e5e48a57a71d3bc69a84475a2b85c3d8278dc1021202b6cfd49280918bcc67461fa2e1afbd93aad8b36ce4e36a63cff28
-  languageName: node
-  linkType: hard
-
 "sury@npm:11.0.0-alpha.11":
   version: 11.0.0-alpha.11
   resolution: "sury@npm:11.0.0-alpha.11"


### PR DESCRIPTION
## Summary
- replay backend tool calls stored only in finalized agent-response metadata
- prefer standalone persisted tool calls when both representations exist, preventing duplicate ACP announcements
- normalize persisted arguments through the canonical interaction converter
- consolidate replay fixtures and remove duplicate normalization coverage

## Testing
- `make precommit`
- compile with warnings as errors
- Elixir format
- Credo strict
- 729 tests passed