### PR TITLE
Restore todo plan lifecycle

### DIFF
--- a/.changeset/restore-todo-lifecycle.md
+++ b/.changeset/restore-todo-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Complete todo tool cards without breaking reconnecting sessions, restore the current todo plan when reopening a task, and hide the plan after every item is complete.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -1001,20 +1001,23 @@ defmodule FrontmanServer.Tasks do
   end
 
   @doc """
-  Lists all todos for a task.
+  Lists all todos from an already-loaded task.
 
   Todos are managed through tool calls, not direct API calls.
   This function is for reading the current todos only.
   """
+  @spec list_todos(TaskSchema.t()) :: [Todos.Todo.t()]
+  def list_todos(%TaskSchema{interaction_rows: rows}) when is_list(rows) do
+    rows
+    |> Todos.list_todos()
+    |> Map.values()
+    |> Enum.sort_by(& &1.created_at, DateTime)
+  end
+
+  @doc "Lists all todos for a task."
   def list_todos(scope, task_id) do
     with {:ok, task} <- get_task(scope, task_id) do
-      todos =
-        task.interaction_rows
-        |> Todos.list_todos()
-        |> Map.values()
-        |> Enum.sort_by(& &1.created_at, DateTime)
-
-      {:ok, todos}
+      {:ok, list_todos(task)}
     end
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/todos.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/todos.ex
@@ -54,6 +54,16 @@ defmodule FrontmanServer.Tasks.Todos do
               created_at: nil,
               updated_at: nil
 
+    @type t :: %__MODULE__{
+            id: Ecto.UUID.t(),
+            content: String.t(),
+            active_form: String.t(),
+            status: :pending | :in_progress | :completed,
+            priority: :high | :medium | :low,
+            created_at: DateTime.t(),
+            updated_at: DateTime.t()
+          }
+
     def schema do
       @schema
     end

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -256,8 +256,10 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     push(socket, @acp_message, notification)
 
-    if Tools.todo_mutation?(tool_result.tool_name) and not tool_result.is_error do
-      push_current_todo_plan(socket)
+    case {Tools.todo_mutation?(tool_result.tool_name), tool_result.is_error} do
+      {true, false} -> push_current_todo_plan(socket)
+      {true, true} -> :ok
+      {false, _is_error} -> :ok
     end
 
     {:noreply, socket}
@@ -577,7 +579,7 @@ defmodule FrontmanServerWeb.TaskChannel do
           )
         )
 
-        push_current_todo_plan(socket)
+        push_current_todo_plan(socket, Tasks.list_todos(task))
 
         socket =
           socket
@@ -1012,6 +1014,10 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp push_current_todo_plan(socket) do
     {:ok, todos} = Tasks.list_todos(socket.assigns.scope, socket.assigns.task_id)
+    push_current_todo_plan(socket, todos)
+  end
+
+  defp push_current_todo_plan(socket, todos) when is_list(todos) do
     entries = Enum.map(todos, &to_plan_entry/1)
     push(socket, @acp_message, ACP.plan_update(socket.assigns.task_id, entries))
   end

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -243,30 +243,21 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp handle_interaction(%Tasks.Interaction.ToolResult{} = tool_result, _turn_number, socket) do
     task_id = socket.assigns.task_id
-    scope = socket.assigns.scope
 
-    if Tools.todo_mutation?(tool_result.tool_name) do
-      case Tasks.list_todos(scope, task_id) do
-        {:ok, todos} ->
-          entries = Enum.map(todos, &to_plan_entry/1)
-          plan_notification = ACP.plan_update(task_id, entries)
-          push(socket, @acp_message, plan_notification)
+    notification =
+      ACP.tool_call_update(
+        task_id,
+        tool_result.tool_call_id,
+        ACP.tool_call_status(tool_result.is_error),
+        ACP.Content.from_tool_result(tool_result.result),
+        nil,
+        tool_result.result["structuredContent"]
+      )
 
-        {:error, _reason} ->
-          :ok
-      end
-    else
-      notification =
-        ACP.tool_call_update(
-          task_id,
-          tool_result.tool_call_id,
-          ACP.tool_call_status(tool_result.is_error),
-          ACP.Content.from_tool_result(tool_result.result),
-          nil,
-          tool_result.result["structuredContent"]
-        )
+    push(socket, @acp_message, notification)
 
-      push(socket, @acp_message, notification)
+    if Tools.todo_mutation?(tool_result.tool_name) and not tool_result.is_error do
+      push_current_todo_plan(socket)
     end
 
     {:noreply, socket}
@@ -585,6 +576,8 @@ defmodule FrontmanServerWeb.TaskChannel do
             )
           )
         )
+
+        push_current_todo_plan(socket)
 
         socket =
           socket
@@ -1015,5 +1008,11 @@ defmodule FrontmanServerWeb.TaskChannel do
       "priority" => Atom.to_string(todo.priority),
       "status" => Atom.to_string(todo.status)
     }
+  end
+
+  defp push_current_todo_plan(socket) do
+    {:ok, todos} = Tasks.list_todos(socket.assigns.scope, socket.assigns.task_id)
+    entries = Enum.map(todos, &to_plan_entry/1)
+    push(socket, @acp_message, ACP.plan_update(socket.assigns.task_id, entries))
   end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -205,6 +205,36 @@ defmodule FrontmanServer.Tasks.TodosTest do
     end
   end
 
+  describe "Tasks.list_todos/1" do
+    test "projects todos from an already-loaded task", %{
+      task_id: task_id,
+      scope: scope,
+      turn_number: turn_number
+    } do
+      todo = %{
+        "id" => Ecto.UUID.generate(),
+        "content" => "Reuse loaded history",
+        "active_form" => "Reusing loaded history",
+        "status" => "pending",
+        "priority" => "high",
+        "created_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "updated_at" => DateTime.to_iso8601(DateTime.utc_now())
+      }
+
+      Tasks.resolve_tool_request(
+        scope,
+        task_id,
+        %{id: "loaded-task", name: "todo_write"},
+        %{"content" => [], "structuredContent" => %{"todos" => [todo]}},
+        turn_number: turn_number
+      )
+
+      {:ok, task} = Tasks.get_task(scope, task_id)
+
+      assert [%{content: "Reuse loaded history", priority: :high}] = Tasks.list_todos(task)
+    end
+  end
+
   describe "Todo.make/4" do
     test "creates a todo with default priority" do
       assert {:ok, todo} = Todos.Todo.make("Fix bug", "Fixing bug", "pending")

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -849,6 +849,66 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
   end
 
+  describe "todo tool updates" do
+    test "pushes tool completion and current plan for a successful todo write", %{
+      scope: scope
+    } do
+      {socket, task_id} = join_task_channel(scope)
+      turn_number = start_turn_fixture(scope, task_id)
+
+      tool_call = tool_call("todo-call", "todo_write", %{"todos" => []})
+      {:ok, _interaction} = persist_tool_call_fixture(scope, task_id, turn_number, tool_call)
+      collect_all_pushes()
+
+      todo = %{
+        "id" => Ecto.UUID.generate(),
+        "content" => "Fix todo rendering",
+        "active_form" => "Fixing todo rendering",
+        "status" => "in_progress",
+        "priority" => "high",
+        "created_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "updated_at" => DateTime.to_iso8601(DateTime.utc_now())
+      }
+
+      assert {:ok, _interaction, _executor_status} =
+               Tasks.resolve_tool_request(
+                 scope,
+                 task_id,
+                 %{id: "todo-call", name: "todo_write"},
+                 %{"content" => [], "structuredContent" => %{"todos" => [todo]}},
+                 turn_number: turn_number
+               )
+
+      :sys.get_state(socket.channel_pid)
+
+      updates =
+        collect_all_pushes()
+        |> Enum.filter(fn {event, _payload} -> event == "acp:message" end)
+        |> Enum.map(fn {_event, payload} -> get_in(payload, ["params", "update"]) end)
+
+      assert [tool_update, plan_update] = updates
+
+      assert tool_update == %{
+               "sessionUpdate" => "tool_call_update",
+               "toolCallId" => "todo-call",
+               "status" => "completed",
+               "rawOutput" => %{"todos" => [todo]},
+               "content" => []
+             }
+
+      assert plan_update == %{
+               "sessionUpdate" => "plan",
+               "entries" => [
+                 %{
+                   "content" => "Fix todo rendering",
+                   "status" => "in_progress",
+                   "priority" => "high"
+                 }
+               ]
+             }
+    end
+  end
+
   describe "MCP initialization" do
     test "sends MCP initialize request on join", %{scope: scope} do
       {_socket, _task_id} = join_task_channel(scope)
@@ -1090,8 +1150,99 @@ defmodule FrontmanServerWeb.TaskChannelTest do
                %{
                  "id" => 90,
                  "result" => %{"configOptions" => _config_options}
+               },
+               %{
+                 "method" => "session/update",
+                 "params" => %{"update" => %{"sessionUpdate" => "plan", "entries" => []}}
                }
              ] = messages
+    end
+
+    test "restores current todo plan after the load result", %{scope: scope} do
+      task = task_fixture(scope)
+      turn_number = start_turn_fixture(scope, task.id)
+
+      todo_call = tool_call("todo-replay", "todo_write", %{"todos" => []})
+      {:ok, _interaction} = persist_tool_call_fixture(scope, task.id, turn_number, todo_call)
+
+      todo = %{
+        "id" => Ecto.UUID.generate(),
+        "content" => "Restore todo plan",
+        "active_form" => "Restoring todo plan",
+        "status" => "pending",
+        "priority" => "medium",
+        "created_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "updated_at" => DateTime.to_iso8601(DateTime.utc_now())
+      }
+
+      assert {:ok, _interaction, _executor_status} =
+               Tasks.resolve_tool_request(
+                 scope,
+                 task.id,
+                 %{id: "todo-replay", name: "todo_write"},
+                 %{"content" => [], "structuredContent" => %{"todos" => [todo]}},
+                 turn_number: turn_number
+               )
+
+      {:ok, _reply, socket} =
+        UserSocket
+        |> socket("user_id", %{scope: scope})
+        |> subscribe_and_join("task:#{task.id}", %{})
+
+      collect_all_pushes()
+
+      push(
+        socket,
+        "acp:message",
+        build_acp_request("session/load", 92, %{"sessionId" => task.id})
+      )
+
+      :sys.get_state(socket.channel_pid)
+
+      relevant_messages =
+        collect_all_pushes()
+        |> Enum.filter(fn
+          {"acp:message", %{"id" => 92}} ->
+            true
+
+          {"acp:message", payload} ->
+            get_in(payload, ["params", "update", "sessionUpdate"]) in [
+              "tool_call_update",
+              "plan"
+            ]
+
+          _other ->
+            false
+        end)
+        |> Enum.map(&elem(&1, 1))
+
+      assert [
+               %{
+                 "params" => %{
+                   "update" => %{
+                     "sessionUpdate" => "tool_call_update",
+                     "toolCallId" => "todo-replay",
+                     "status" => "completed",
+                     "rawOutput" => %{"todos" => [^todo]}
+                   }
+                 }
+               },
+               %{"id" => 92, "result" => %{"configOptions" => _config_options}},
+               %{
+                 "params" => %{
+                   "update" => %{
+                     "sessionUpdate" => "plan",
+                     "entries" => [
+                       %{
+                         "content" => "Restore todo plan",
+                         "status" => "pending",
+                         "priority" => "medium"
+                       }
+                     ]
+                   }
+                 }
+               }
+             ] = relevant_messages
     end
 
     test "drains accepted work created outside the channel prompt flow", %{scope: scope} do

--- a/libs/client/src/components/frontman/Client__PlanList.res
+++ b/libs/client/src/components/frontman/Client__PlanList.res
@@ -21,6 +21,10 @@ let statusToInProgress = (status: ACPTypes.planEntryStatus): bool => {
   }
 }
 
+let shouldRender = (entries: array<ACPTypes.planEntry>): bool => {
+  entries->Array.some(entry => entry.status != Completed)
+}
+
 module PlanItem = {
   @react.component
   let make = (~entry: ACPTypes.planEntry, ~index: int) => {
@@ -69,9 +73,9 @@ module PlanItem = {
 let make = (~entries: array<ACPTypes.planEntry>) => {
   let (isExpanded, setIsExpanded) = React.useState(() => true)
 
-  if Array.length(entries) == 0 {
-    React.null
-  } else {
+  switch shouldRender(entries) {
+  | false => React.null
+  | true =>
     let completedCount = entries->Array.filter(e => e.status == Completed)->Array.length
     let totalCount = Array.length(entries)
 

--- a/libs/client/test/Client__PlanList.test.res
+++ b/libs/client/test/Client__PlanList.test.res
@@ -1,0 +1,27 @@
+open Vitest
+
+module PlanList = Client__PlanList
+module ACPTypes = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
+
+let entry = (status: ACPTypes.planEntryStatus): ACPTypes.planEntry => {
+  content: "Test step",
+  priority: Medium,
+  status,
+}
+
+describe("PlanList visibility", () => {
+  test("hides an empty plan", t => {
+    let entries: array<ACPTypes.planEntry> = []
+    t->expect(PlanList.shouldRender(entries))->Expect.toEqual(false)
+  })
+
+  test("hides a fully completed plan", t => {
+    let entries = [entry(Completed), entry(Completed)]
+    t->expect(PlanList.shouldRender(entries))->Expect.toEqual(false)
+  })
+
+  test("shows a plan with unfinished entries", t => {
+    let entries = [entry(Completed), entry(InProgress)]
+    t->expect(PlanList.shouldRender(entries))->Expect.toEqual(true)
+  })
+})


### PR DESCRIPTION
## Summary
- complete todo tool cards before refreshing plan state
- restore current todo plan when reopening a task
- hide plan UI after every entry completes
- add server replay/update coverage and client visibility tests

## Testing
- pre-commit: ReScript format
- pre-commit: Elixir format
- pre-commit: Credo
- pre-commit: source-comment tests
- full test suite not run due session execution constraint