### PR TITLE
Fix screenshot decode errors

### DIFF
--- a/.changeset/explain-screenshot-decode-errors.md
+++ b/.changeset/explain-screenshot-decode-errors.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Improve screenshot compatibility and return actionable guidance when browser image decoding fails.

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -53,7 +53,7 @@
 		"@types/babel__core": "^7",
 		"@types/react": "^19.2.15",
 		"@types/react-dom": "^19.2.3",
-		"@zumer/snapdom": "^2.12.9",
+		"@zumer/snapdom": "^2.24.7",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"dom-accessibility-api": "^0.7.1",
 		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",

--- a/libs/client/src/tools/Client__Tool__TakeScreenshot.res
+++ b/libs/client/src/tools/Client__Tool__TakeScreenshot.res
@@ -17,6 +17,18 @@ type input = {
   fullPage: option<bool>,
 }
 
+let decodeError = message => {
+  let normalized = message->String.toLowerCase
+  normalized->String.includes("source image cannot be decoded") ||
+    normalized->String.includes("invalid encoded image data")
+}
+
+let captureErrorMessage = (message: string) =>
+  switch decodeError(message) {
+  | true => `Screenshot could not be rendered because the browser could not decode the generated page image. The page may contain malformed HTML, unsupported SVG content, or exceed browser image limits. Try again after the page finishes loading or capture a smaller element with the selector option.`
+  | false => message
+  }
+
 let _cropCanvasToViewport = (
   sourceCanvas: WebAPI.DomTypes.htmlCanvasElement,
   ~scrollX: float,
@@ -151,7 +163,9 @@ let execute = async (
               imageResultFromDataUrl(jpgImage.src)
             }
           } catch {
-          | exn => Tool.MCP.CallToolResult.makeError(Client__Tool__PreviewContext.exnMessage(exn))
+          | exn =>
+            let message = Client__Tool__PreviewContext.exnMessage(exn)
+            Tool.MCP.CallToolResult.makeError(captureErrorMessage(message))
           }
         }
       }

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -79,4 +79,26 @@ describe("ToolRegistry", _t => {
     ->expect(JSON.stringify(json))
     ->Expect.toBe(`{"content":[{"type":"image","data":"image-data","mimeType":"image/jpeg"}]}`)
   })
+
+  test("explains generated image decode failures", t => {
+    let message = Client__Tool__TakeScreenshot.captureErrorMessage(
+      "The source image cannot be decoded.",
+    )
+    let alternateMessage = Client__Tool__TakeScreenshot.captureErrorMessage(
+      "Invalid encoded image data",
+    )
+
+    t->expect(message->String.includes("generated page image"))->Expect.toBe(true)
+    t
+    ->expect(message->String.includes("capture a smaller element with the selector option"))
+    ->Expect.toBe(true)
+    t->expect(alternateMessage)->Expect.toBe(message)
+  })
+
+  test("keeps unrelated screenshot errors unchanged", t => {
+    let message = "Canvas dimensions must be positive"
+    t
+    ->expect(Client__Tool__TakeScreenshot.captureErrorMessage(message))
+    ->Expect.toBe(message)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2387,7 +2387,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/react": "npm:^19.2.15"
     "@types/react-dom": "npm:^19.2.3"
-    "@zumer/snapdom": "npm:^2.12.9"
+    "@zumer/snapdom": "npm:^2.24.7"
     babel-plugin-react-compiler: "npm:^1.0.0"
     border-beam: "npm:^1.3.0"
     diff: "npm:^8.0.2"
@@ -7576,10 +7576,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zumer/snapdom@npm:^2.12.9":
-  version: 2.12.9
-  resolution: "@zumer/snapdom@npm:2.12.9"
-  checksum: 10c0/0a11bfadea0be7201450fc101d186574a1d30cabea4956a13375b741e47cff25873a146ad14caa83d013d89e237e56857f78e29a0f216d42461b94b0f5e60e95
+"@zumer/snapdom@npm:^2.24.7":
+  version: 2.24.7
+  resolution: "@zumer/snapdom@npm:2.24.7"
+  checksum: 10c0/7ff8763ec3607c131bba3b3abc9ab499da29db891e38776345985142a3b41143bcbaee52e3cac9bf4022a938d170965618f73193b69a436b0f0ee6f7fc4952b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- upgrade SnapDOM from 2.12.9 to 2.24.7 for improved capture compatibility
- replace known generated-image decode exceptions with actionable, privacy-safe guidance
- preserve unrelated screenshot errors and add regression coverage

## Verification
- `make -C libs/client test` (41 files, 362 tests passed)
- `make rescript-build`
- pre-commit ReScript formatting and source-comment checks
- `git diff --check`

## Known issue
- `make -C libs/client lint` remains blocked by pre-existing formatting in `libs/client/src/styles/frontman-theme.css`.