### PR TITLE
highlight annotated element inside user message

### DIFF
--- a/.changeset/highlight-annotation-from-message.md
+++ b/.changeset/highlight-annotation-from-message.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": minor
+---
+
+Click an annotation chip in a sent user message to highlight and scroll to that element in the web preview. Click the chip again to clear the highlight.

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -47,8 +47,8 @@ let make = (
     ? "frontman-content-auto animate-in fade-in duration-100"
     : "frontman-content-auto"
   let (previewSrc, setPreviewSrc) = React.useState((): option<string> => None)
-  let highlightedSelector = Client__State.useSelector(
-    Client__State.Selectors.highlightedAnnotationSelector,
+  let highlightedAnnotation = Client__State.useSelector(
+    Client__State.Selectors.highlightedAnnotation,
   )
 
   let imageParts = content->Array.filterMap(part =>
@@ -96,9 +96,9 @@ let make = (
               | Ok(Some(selector)) => Some(selector)
               | Ok(None) | Error(_) => None
               }
-              let isHighlighted = switch (selector, highlightedSelector) {
-              | (Some(selector), Some(highlighted)) => selector == highlighted
-              | _ => false
+              let isHighlighted = switch highlightedAnnotation {
+              | Some(highlighted) => highlighted.annotationId == annotation.id
+              | None => false
               }
               let baseChipClass = "flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0 w-full text-xs font-mono"
               let chipClass = switch (selector, isHighlighted) {
@@ -122,7 +122,11 @@ let make = (
                   title=chipTitle
                   onClick={_ =>
                     switch selector {
-                    | Some(selector) => Client__State.Actions.highlightAnnotation(~selector)
+                    | Some(selector) =>
+                      Client__State.Actions.highlightAnnotation(
+                        ~annotationId=annotation.id,
+                        ~selector,
+                      )
                     | None => ()
                     }}
                 >

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -100,7 +100,7 @@ let make = (
               | Some(highlighted) => highlighted.annotationId == annotation.id
               | None => false
               }
-              let baseChipClass = "flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0 w-full text-xs font-mono"
+              let baseChipClass = "flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0 w-full text-xs font-mono text-left disabled:cursor-default"
               let chipClass = switch (selector, isHighlighted) {
               | (Some(_), true) =>
                 `${baseChipClass} bg-violet-400/80 text-white cursor-pointer ring-1 ring-white/70 transition-colors`
@@ -117,9 +117,12 @@ let make = (
                 key={`${messageId}-ann-${Int.toString(i)}`}
                 className="flex flex-col gap-0.5 min-w-0 w-full"
               >
-                <div
+                <button
+                  type_="button"
                   className=chipClass
                   title=chipTitle
+                  disabled={selector->Option.isNone}
+                  ariaPressed={isHighlighted ? #"true" : #"false"}
                   onClick={_ =>
                     switch selector {
                     | Some(selector) =>
@@ -132,7 +135,7 @@ let make = (
                 >
                   <span className="text-violet-200 shrink-0"> {React.string(badge)} </span>
                   <span className="truncate min-w-0 flex-1"> {React.string(label)} </span>
-                </div>
+                </button>
                 {switch annotation.comment {
                 | Some(comment) =>
                   <div className="text-[11px] text-violet-200/80 italic pl-1 w-full truncate">

--- a/libs/client/src/components/frontman/Client__UserMessage.res
+++ b/libs/client/src/components/frontman/Client__UserMessage.res
@@ -47,6 +47,9 @@ let make = (
     ? "frontman-content-auto animate-in fade-in duration-100"
     : "frontman-content-auto"
   let (previewSrc, setPreviewSrc) = React.useState((): option<string> => None)
+  let highlightedSelector = Client__State.useSelector(
+    Client__State.Selectors.highlightedAnnotationSelector,
+  )
 
   let imageParts = content->Array.filterMap(part =>
     switch part {
@@ -89,13 +92,39 @@ let make = (
                   : `<${annotation.tagName}>`
               | None => `<${annotation.tagName}>`
               }
+              let selector = switch annotation.selector {
+              | Ok(Some(selector)) => Some(selector)
+              | Ok(None) | Error(_) => None
+              }
+              let isHighlighted = switch (selector, highlightedSelector) {
+              | (Some(selector), Some(highlighted)) => selector == highlighted
+              | _ => false
+              }
+              let baseChipClass = "flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0 w-full text-xs font-mono"
+              let chipClass = switch (selector, isHighlighted) {
+              | (Some(_), true) =>
+                `${baseChipClass} bg-violet-400/80 text-white cursor-pointer ring-1 ring-white/70 transition-colors`
+              | (Some(_), false) =>
+                `${baseChipClass} bg-violet-500/60 text-violet-100 cursor-pointer hover:bg-violet-400/70 transition-colors`
+              | (None, _) => `${baseChipClass} bg-violet-500/60 text-violet-100`
+              }
+              let chipTitle = switch selector {
+              | Some(_) => "Click to highlight in preview"
+              | None => "No selector captured for this element"
+              }
+
               <div
                 key={`${messageId}-ann-${Int.toString(i)}`}
                 className="flex flex-col gap-0.5 min-w-0 w-full"
               >
                 <div
-                  className="flex items-center gap-1 px-2 py-0.5 rounded-md min-w-0 w-full
-                             bg-violet-500/60 text-violet-100 text-xs font-mono"
+                  className=chipClass
+                  title=chipTitle
+                  onClick={_ =>
+                    switch selector {
+                    | Some(selector) => Client__State.Actions.highlightAnnotation(~selector)
+                    | None => ()
+                    }}
                 >
                   <span className="text-violet-200 shrink-0"> {React.string(badge)} </span>
                   <span className="truncate min-w-0 flex-1"> {React.string(label)} </span>

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -102,8 +102,10 @@ module Actions = {
       TaskAction({target: CurrentTask, action: UpdateAnnotationComment({id, comment})}),
     )
 
-  let highlightAnnotation = (~selector) =>
-    Client__State__Store.dispatch(HighlightAnnotation({selector: selector}))
+  let highlightAnnotation = (~annotationId, ~selector) =>
+    Client__State__Store.dispatch(
+      HighlightAnnotation({annotationId: annotationId, selector: selector}),
+    )
 
   let closeAnnotationPopup = () =>
     Client__State__Store.dispatch(

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -102,6 +102,9 @@ module Actions = {
       TaskAction({target: CurrentTask, action: UpdateAnnotationComment({id, comment})}),
     )
 
+  let highlightAnnotation = (~selector) =>
+    Client__State__Store.dispatch(HighlightAnnotation({selector: selector}))
+
   let closeAnnotationPopup = () =>
     Client__State__Store.dispatch(
       TaskAction({target: CurrentTask, action: SetActivePopupAnnotationId({id: None})}),

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -422,17 +422,13 @@ module Selectors = {
     state.updateBannerDismissed
   }
 
-  let highlightedAnnotation = (
-    state: state,
-  ): option<Client__State__Types.highlightedAnnotation> => {
+  let highlightedAnnotation = (state: state): option<
+    Client__State__Types.highlightedAnnotation,
+  > => {
     switch state.highlightedAnnotation {
     | Some(highlighted) if highlighted.taskId == currentTaskClientId(state) => Some(highlighted)
     | Some(_) | None => None
     }
-  }
-
-  let highlightedAnnotationSelector = (state: state): option<string> => {
-    highlightedAnnotation(state)->Option.map(highlighted => highlighted.selector)
   }
 
   let pendingQuestion = (state: state): option<Client__Question__Types.pendingQuestion> => {

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -90,7 +90,7 @@ type action =
   | CheckForUpdate({installedVersion: string, npmPackage: string})
   | UpdateInfoReceived({updateInfo: Client__State__Types.updateInfo})
   | DismissUpdateBanner
-  | HighlightAnnotation({selector: string})
+  | HighlightAnnotation({annotationId: string, selector: string})
 
 type effect =
   | TaskEffect({target: taskTarget, effect: TaskReducer.effect})
@@ -242,7 +242,7 @@ let defaultState: state = {
   updateInfo: None,
   updateCheckStatus: UpdateNotChecked,
   updateBannerDismissed: false,
-  highlightedAnnotationSelector: None,
+  highlightedAnnotation: None,
 }
 
 module Selectors = {
@@ -422,8 +422,17 @@ module Selectors = {
     state.updateBannerDismissed
   }
 
+  let highlightedAnnotation = (
+    state: state,
+  ): option<Client__State__Types.highlightedAnnotation> => {
+    switch state.highlightedAnnotation {
+    | Some(highlighted) if highlighted.taskId == currentTaskClientId(state) => Some(highlighted)
+    | Some(_) | None => None
+    }
+  }
+
   let highlightedAnnotationSelector = (state: state): option<string> => {
-    state.highlightedAnnotationSelector
+    highlightedAnnotation(state)->Option.map(highlighted => highlighted.selector)
   }
 
   let pendingQuestion = (state: state): option<Client__Question__Types.pendingQuestion> => {
@@ -1122,7 +1131,7 @@ let next = (state: state, action) => {
       {
         ...updatedState,
         currentTask: Task.Selected(taskId),
-        highlightedAnnotationSelector: None,
+        highlightedAnnotation: None,
       }->StateReducer.update(
         ~sideEffects=Array.concat([LoadTaskEffect({taskId: taskId})], taskEffects),
       )
@@ -1154,6 +1163,7 @@ let next = (state: state, action) => {
         ...state,
         tasks: updatedTasks,
         currentTask: newCurrentTask,
+        highlightedAnnotation: None,
       }->StateReducer.update(~sideEffects=[DeleteSessionEffect({taskId: taskId})])
     }
 
@@ -1162,7 +1172,7 @@ let next = (state: state, action) => {
     {
       ...state,
       currentTask: Task.New(Task.makeNew(~previewUrl)),
-      highlightedAnnotationSelector: None,
+      highlightedAnnotation: None,
     }->StateReducer.update
 
   | UpdateTaskTitle({taskId, title}) =>
@@ -1566,11 +1576,12 @@ let next = (state: state, action) => {
 
   | DismissUpdateBanner => {...state, updateBannerDismissed: true}->StateReducer.update
 
-  | HighlightAnnotation({selector}) =>
-    let highlighted = switch state.highlightedAnnotationSelector {
-    | Some(current) if current == selector => None
-    | _ => Some(selector)
+  | HighlightAnnotation({annotationId, selector}) =>
+    let taskId = Selectors.currentTaskClientId(state)
+    let highlighted = switch state.highlightedAnnotation {
+    | Some(current) if current.taskId == taskId && current.annotationId == annotationId => None
+    | Some(_) | None => Some({Client__State__Types.taskId, annotationId, selector})
     }
-    {...state, highlightedAnnotationSelector: highlighted}->StateReducer.update
+    {...state, highlightedAnnotation: highlighted}->StateReducer.update
   }
 }

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -90,6 +90,7 @@ type action =
   | CheckForUpdate({installedVersion: string, npmPackage: string})
   | UpdateInfoReceived({updateInfo: Client__State__Types.updateInfo})
   | DismissUpdateBanner
+  | HighlightAnnotation({selector: string})
 
 type effect =
   | TaskEffect({target: taskTarget, effect: TaskReducer.effect})
@@ -241,6 +242,7 @@ let defaultState: state = {
   updateInfo: None,
   updateCheckStatus: UpdateNotChecked,
   updateBannerDismissed: false,
+  highlightedAnnotationSelector: None,
 }
 
 module Selectors = {
@@ -418,6 +420,10 @@ module Selectors = {
 
   let updateBannerDismissed = (state: state): bool => {
     state.updateBannerDismissed
+  }
+
+  let highlightedAnnotationSelector = (state: state): option<string> => {
+    state.highlightedAnnotationSelector
   }
 
   let pendingQuestion = (state: state): option<Client__Question__Types.pendingQuestion> => {
@@ -1116,6 +1122,7 @@ let next = (state: state, action) => {
       {
         ...updatedState,
         currentTask: Task.Selected(taskId),
+        highlightedAnnotationSelector: None,
       }->StateReducer.update(
         ~sideEffects=Array.concat([LoadTaskEffect({taskId: taskId})], taskEffects),
       )
@@ -1155,6 +1162,7 @@ let next = (state: state, action) => {
     {
       ...state,
       currentTask: Task.New(Task.makeNew(~previewUrl)),
+      highlightedAnnotationSelector: None,
     }->StateReducer.update
 
   | UpdateTaskTitle({taskId, title}) =>
@@ -1557,5 +1565,12 @@ let next = (state: state, action) => {
     {...state, updateInfo: Some(updateInfo)}->StateReducer.update
 
   | DismissUpdateBanner => {...state, updateBannerDismissed: true}->StateReducer.update
+
+  | HighlightAnnotation({selector}) =>
+    let highlighted = switch state.highlightedAnnotationSelector {
+    | Some(current) if current == selector => None
+    | _ => Some(selector)
+    }
+    {...state, highlightedAnnotationSelector: highlighted}->StateReducer.update
   }
 }

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -157,6 +157,12 @@ type updateCheckStatus =
   | UpdateNotChecked
   | UpdateChecked
 
+type highlightedAnnotation = {
+  taskId: string,
+  annotationId: string,
+  selector: string,
+}
+
 type state = {
   tasks: Dict.t<Task.t>,
   currentTask: Task.currentTask,
@@ -177,5 +183,5 @@ type state = {
   updateInfo: option<updateInfo>,
   updateCheckStatus: updateCheckStatus,
   updateBannerDismissed: bool,
-  highlightedAnnotationSelector: option<string>,
+  highlightedAnnotation: option<highlightedAnnotation>,
 }

--- a/libs/client/src/state/Client__State__Types.res
+++ b/libs/client/src/state/Client__State__Types.res
@@ -177,4 +177,5 @@ type state = {
   updateInfo: option<updateInfo>,
   updateCheckStatus: updateCheckStatus,
   updateBannerDismissed: bool,
+  highlightedAnnotationSelector: option<string>,
 }

--- a/libs/client/src/tools/Client__Tool__SelectorResolver.res
+++ b/libs/client/src/tools/Client__Tool__SelectorResolver.res
@@ -102,9 +102,13 @@ let resolveBySelector = (~doc: WebAPI.DomTypes.document, ~selector: string, ~ind
   option<WebAPI.DomTypes.element>,
   int,
 ) => {
-  let elements = switch classifySelector(selector) {
-  | CssSelector(css) => resolveCssSelector(~doc, ~selector=css)
-  | XPathExpression(xpath) => resolveXPath(~doc, ~xpath)
+  let elements = try {
+    switch classifySelector(selector) {
+    | CssSelector(css) => resolveCssSelector(~doc, ~selector=css)
+    | XPathExpression(xpath) => resolveXPath(~doc, ~xpath)
+    }
+  } catch {
+  | JsExn(_) => []
   }
   (elements->Array.get(index), elements->Array.length)
 }

--- a/libs/client/src/tools/Client__Tool__SelectorResolver.res
+++ b/libs/client/src/tools/Client__Tool__SelectorResolver.res
@@ -102,13 +102,9 @@ let resolveBySelector = (~doc: WebAPI.DomTypes.document, ~selector: string, ~ind
   option<WebAPI.DomTypes.element>,
   int,
 ) => {
-  let elements = try {
-    switch classifySelector(selector) {
-    | CssSelector(css) => resolveCssSelector(~doc, ~selector=css)
-    | XPathExpression(xpath) => resolveXPath(~doc, ~xpath)
-    }
-  } catch {
-  | JsExn(_) => []
+  let elements = switch classifySelector(selector) {
+  | CssSelector(css) => resolveCssSelector(~doc, ~selector=css)
+  | XPathExpression(xpath) => resolveXPath(~doc, ~xpath)
   }
   (elements->Array.get(index), elements->Array.length)
 }

--- a/libs/client/src/webpreview/Client__WebPreview__HoveredElement.res
+++ b/libs/client/src/webpreview/Client__WebPreview__HoveredElement.res
@@ -1,5 +1,5 @@
 @react.component
-let make = (~element: option<WebAPI.DomTypes.element>, ~scrollTimestamp: float) => {
+let make = (~element: option<WebAPI.DomTypes.element>, ~scrollTimestamp: float, ~mutationTimestamp: float=0.0) => {
   let (info, setInfo) = React.useState(() => None)
   let hasElement = element->Option.isSome
 
@@ -9,7 +9,7 @@ let make = (~element: option<WebAPI.DomTypes.element>, ~scrollTimestamp: float) 
     | None => ()
     }
     None
-  }, (element, scrollTimestamp))
+  }, (element, scrollTimestamp, mutationTimestamp))
 
   switch info {
   | Some(info) => {

--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -105,19 +105,24 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     | (Some(doc), Some(selector)) =>
       let (element, _count) = Client__Tool__SelectorResolver.resolveBySelector(~doc, ~selector)
       setHighlightedElement(_ => element)
-      switch (element, lastScrolledSelector.current) {
-      | (Some(_), Some(previous)) if previous == selector => ()
-      | (Some(element), _) =>
-        lastScrolledSelector.current = Some(selector)
-        element->WebAPI.Element.scrollIntoViewWithOptions({behavior: Smooth, block: Center})
-      | (None, _) => lastScrolledSelector.current = None
-      }
-    | _ =>
-      lastScrolledSelector.current = None
-      setHighlightedElement(_ => None)
+    | (None, _) | (_, None) => setHighlightedElement(_ => None)
     }
     None
   }, (document, highlightedSelector, mutationTimestamp))
+
+  React.useEffect(() => {
+    switch (highlightedSelector, highlightedElement) {
+    | (Some(selector), Some(element)) =>
+      switch lastScrolledSelector.current {
+      | Some(previous) if previous == selector => ()
+      | Some(_) | None =>
+        lastScrolledSelector.current = Some(selector)
+        element->WebAPI.Element.scrollIntoViewWithOptions({behavior: Smooth, block: Center})
+      }
+    | (None, _) | (_, None) => lastScrolledSelector.current = None
+    }
+    None
+  }, (highlightedSelector, highlightedElement))
 
   React.useEffect(() => {
     switch (document, webPreviewIsSelecting) {

--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -87,7 +87,8 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
   > => None)
 
   let scrollTimestamp = Client__Hooks.Scroll.useIFrameDocument(~document, ~withCapture=true, ())
-  let mutationTimestamp = Client__Hooks.DOMmutations.useIFrameDocument(~document, ())
+  let domMutationTimestamp = Client__Hooks.DOMmutations.useIFrameDocument(~document, ())
+  let mutationTimestamp = React.useMemo2(() => Date.now(), (domMutationTimestamp, viewportStyle))
   let clickedElement = Client__Hooks.MouseClick.useIFrameDocument(
     ~document,
     ~withCapture=webPreviewIsSelecting,
@@ -380,7 +381,10 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
   let hoverOverlay = switch (webPreviewIsSelecting, dragState) {
   | (true, Idle) =>
     <Client__WebPreview__HoveredElement
-      key="hover" element={hoveredElement} scrollTimestamp={scrollTimestamp}
+      key="hover"
+      element={hoveredElement}
+      scrollTimestamp={scrollTimestamp}
+      mutationTimestamp={mutationTimestamp}
     />
   | _ => React.null
   }
@@ -407,7 +411,10 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
   let highlightOverlay = switch highlightedElement {
   | Some(_) =>
     <Client__WebPreview__HoveredElement
-      key="highlight" element={highlightedElement} scrollTimestamp={scrollTimestamp}
+      key="highlight"
+      element={highlightedElement}
+      scrollTimestamp={scrollTimestamp}
+      mutationTimestamp={mutationTimestamp}
     />
   | None => React.null
   }

--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -79,6 +79,13 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     Client__State.Selectors.activePopupAnnotationId,
   )
 
+  let highlightedSelector = Client__State.useSelector(
+    Client__State.Selectors.highlightedAnnotationSelector,
+  )
+  let (highlightedElement, setHighlightedElement) = React.useState((): option<
+    WebAPI.DomTypes.element,
+  > => None)
+
   let scrollTimestamp = Client__Hooks.Scroll.useIFrameDocument(~document, ~withCapture=true, ())
   let mutationTimestamp = Client__Hooks.DOMmutations.useIFrameDocument(~document, ())
   let clickedElement = Client__Hooks.MouseClick.useIFrameDocument(
@@ -90,6 +97,27 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     (),
   )
   let hoveredElement = Client__Hooks.MouseMove.useIFrameDocument(~document, ~withCapture=true, ())
+
+  let lastScrolledSelector = React.useRef(None)
+
+  React.useEffect(() => {
+    switch (document, highlightedSelector) {
+    | (Some(doc), Some(selector)) =>
+      let (element, _count) = Client__Tool__SelectorResolver.resolveBySelector(~doc, ~selector)
+      setHighlightedElement(_ => element)
+      switch (element, lastScrolledSelector.current) {
+      | (Some(_), Some(previous)) if previous == selector => ()
+      | (Some(element), _) =>
+        lastScrolledSelector.current = Some(selector)
+        element->WebAPI.Element.scrollIntoViewWithOptions({behavior: Smooth, block: Center})
+      | (None, _) => lastScrolledSelector.current = None
+      }
+    | _ =>
+      lastScrolledSelector.current = None
+      setHighlightedElement(_ => None)
+    }
+    None
+  }, (document, highlightedSelector, mutationTimestamp))
 
   React.useEffect(() => {
     switch (document, webPreviewIsSelecting) {
@@ -371,6 +399,14 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
   | Idle => React.null
   }
 
+  let highlightOverlay = switch highlightedElement {
+  | Some(_) =>
+    <Client__WebPreview__HoveredElement
+      key="highlight" element={highlightedElement} scrollTimestamp={scrollTimestamp}
+    />
+  | None => React.null
+  }
+
   let annotationMarkersOverlay =
     <Client__WebPreview__AnnotationMarkers
       annotations={annotations}
@@ -411,6 +447,7 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
       selectionModeIndicator
       hoverOverlay
       dragOverlay
+      highlightOverlay
       annotationMarkersOverlay
       annotationPopupOverlay
     </div>
@@ -436,6 +473,7 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
         selectionModeIndicator
         hoverOverlay
         dragOverlay
+        highlightOverlay
         annotationMarkersOverlay
         annotationPopupOverlay
       </div>

--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -79,8 +79,8 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     Client__State.Selectors.activePopupAnnotationId,
   )
 
-  let highlightedSelector = Client__State.useSelector(
-    Client__State.Selectors.highlightedAnnotationSelector,
+  let highlightedAnnotation = Client__State.useSelector(
+    Client__State.Selectors.highlightedAnnotation,
   )
   let (highlightedElement, setHighlightedElement) = React.useState((): option<
     WebAPI.DomTypes.element,
@@ -99,31 +99,27 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
   )
   let hoveredElement = Client__Hooks.MouseMove.useIFrameDocument(~document, ~withCapture=true, ())
 
-  let lastScrolledSelector = React.useRef(None)
+  let lastScrolledHighlight = React.useRef(None)
 
   React.useEffect(() => {
-    switch (document, highlightedSelector) {
-    | (Some(doc), Some(selector)) =>
+    switch (document, highlightedAnnotation) {
+    | (Some(doc), Some({annotationId, selector})) =>
       let (element, _count) = Client__Tool__SelectorResolver.resolveBySelector(~doc, ~selector)
       setHighlightedElement(_ => element)
-    | (None, _) | (_, None) => setHighlightedElement(_ => None)
-    }
-    None
-  }, (document, highlightedSelector, mutationTimestamp))
-
-  React.useEffect(() => {
-    switch (highlightedSelector, highlightedElement) {
-    | (Some(selector), Some(element)) =>
-      switch lastScrolledSelector.current {
-      | Some(previous) if previous == selector => ()
-      | Some(_) | None =>
-        lastScrolledSelector.current = Some(selector)
+      switch (element, lastScrolledHighlight.current) {
+      | (Some(element), Some((previousId, previousElement)))
+        if annotationId == previousId && element === previousElement => ()
+      | (Some(element), _) =>
+        lastScrolledHighlight.current = Some((annotationId, element))
         element->WebAPI.Element.scrollIntoViewWithOptions({behavior: Smooth, block: Center})
+      | (None, _) => lastScrolledHighlight.current = None
       }
-    | (None, _) | (_, None) => lastScrolledSelector.current = None
+    | (None, _) | (_, None) =>
+      lastScrolledHighlight.current = None
+      setHighlightedElement(_ => None)
     }
     None
-  }, (highlightedSelector, highlightedElement))
+  }, (document, highlightedAnnotation, mutationTimestamp))
 
   React.useEffect(() => {
     switch (document, webPreviewIsSelecting) {

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -48,6 +48,7 @@ let _makeState = (~selectedModelValue=None, ~pendingProviderAutoSelect=None): Ty
     updateInfo: None,
     updateCheckStatus: UpdateNotChecked,
     updateBannerDismissed: false,
+    highlightedAnnotationSelector: None,
   }
 }
 

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -48,7 +48,7 @@ let _makeState = (~selectedModelValue=None, ~pendingProviderAutoSelect=None): Ty
     updateInfo: None,
     updateCheckStatus: UpdateNotChecked,
     updateBannerDismissed: false,
-    highlightedAnnotationSelector: None,
+    highlightedAnnotation: None,
   }
 }
 

--- a/libs/client/test/Client__OpenAIOAuth.test.res
+++ b/libs/client/test/Client__OpenAIOAuth.test.res
@@ -36,7 +36,7 @@ let _makeState = (~openaiOAuthStatus: Types.openaiOAuthStatus): Types.state => {
     updateInfo: None,
     updateCheckStatus: UpdateNotChecked,
     updateBannerDismissed: false,
-    highlightedAnnotationSelector: None,
+    highlightedAnnotation: None,
   }
 }
 

--- a/libs/client/test/Client__OpenAIOAuth.test.res
+++ b/libs/client/test/Client__OpenAIOAuth.test.res
@@ -36,6 +36,7 @@ let _makeState = (~openaiOAuthStatus: Types.openaiOAuthStatus): Types.state => {
     updateInfo: None,
     updateCheckStatus: UpdateNotChecked,
     updateBannerDismissed: false,
+    highlightedAnnotationSelector: None,
   }
 }
 

--- a/libs/client/test/Client__Tool__SelectorResolver.test.res
+++ b/libs/client/test/Client__Tool__SelectorResolver.test.res
@@ -1,0 +1,8 @@
+open Vitest
+
+test("selector resolver throws for an invalid selector", t => {
+  let doc = WebAPI.Window.current->WebAPI.Window.document
+  t
+  ->expect(() => Client__Tool__SelectorResolver.resolveBySelector(~doc, ~selector="[")->ignore)
+  ->Expect.toThrow
+})


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Clicking on the annotated element inside the user message bubble now puts the element into view.

<img width="1161" height="737" alt="image" src="https://github.com/user-attachments/assets/4309a19f-b90b-483a-bdb4-052476bfe92a" />


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [x] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
