### PR TITLE
add get-started tasks

### DIFF
--- a/.changeset/get-started-tasks.md
+++ b/.changeset/get-started-tasks.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Show three starter task suggestions in an empty conversation. Clicking one sends it as a message.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -103,6 +103,13 @@ let shouldRenderTurnError = (messages: array<Message.t>, turnErrorId: string): b
     )
   )
 
+let selectGetStartedTask = (~providerSetupRequired, ~onConfigureProvider, ~onSelect, text) => {
+  switch providerSetupRequired {
+  | true => onConfigureProvider()
+  | false => onSelect(text)
+  }
+}
+
 @react.component
 let make = (~onConfigureProvider: unit => unit) => {
   let {session, createSession} = Client__FrontmanProvider.useFrontman()
@@ -119,6 +126,9 @@ let make = (~onConfigureProvider: unit => unit) => {
   let agentCatalog = Client__State.useSelector(Client__State.Selectors.agentCatalog)
   let selectedAgentId = Client__State.useSelector(Client__State.Selectors.selectedAgentId)
   let selectedModelValue = Client__State.useSelector(Client__State.Selectors.selectedModelValue)
+  let providerSetupRequired = Client__State.useSelector(
+    Client__State.Selectors.providerSetupRequired,
+  )
   let webPreviewIsSelecting = Client__State.useSelector(
     Client__State.Selectors.webPreviewIsSelecting,
   )
@@ -381,7 +391,15 @@ let make = (~onConfigureProvider: unit => unit) => {
 
         {switch (hasActiveACPSession, totalItems) {
         | (true, 0) =>
-          <Client__GetStartedTasks onSelect={text => handleSubmit(~text, ~inputItems=[])} />
+          <Client__GetStartedTasks
+            onSelect={text =>
+              selectGetStartedTask(
+                ~providerSetupRequired,
+                ~onConfigureProvider,
+                ~onSelect=text => handleSubmit(~text, ~inputItems=[]),
+                text,
+              )}
+          />
         | _ => React.null
         }}
 

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -379,6 +379,12 @@ let make = (~onConfigureProvider: unit => unit) => {
           </div>
         }}
 
+        {switch (hasActiveACPSession, totalItems) {
+        | (true, 0) =>
+          <Client__GetStartedTasks onSelect={text => handleSubmit(~text, ~inputItems=[])} />
+        | _ => React.null
+        }}
+
         {displayItems
         ->Array.mapWithIndex((item, index) => renderDisplayItem(item, index))
         ->React.array}

--- a/libs/client/src/Client__GetStartedTasks.res
+++ b/libs/client/src/Client__GetStartedTasks.res
@@ -11,24 +11,32 @@ let tasks = [
 
 @react.component
 let make = (~onSelect: string => unit) => {
-  <div className="min-h-[50vh] flex flex-col items-center justify-center px-6 gap-3">
-    <div className="text-[11px] text-zinc-500 self-start max-w-[320px] w-full px-0.5">
-      {React.string("Get started")}
-    </div>
-    <div className="flex flex-col gap-2 w-full max-w-[320px]">
+  <section
+    ariaLabelledby="get-started-heading"
+    className="min-h-[50vh] flex flex-col items-center justify-center px-4 sm:px-6 gap-4"
+  >
+    <h2
+      id="get-started-heading"
+      className="text-lg leading-snug font-semibold text-zinc-100 self-start max-w-[360px] w-full"
+    >
+      {React.string("What would you like to accomplish today?")}
+    </h2>
+    <div className="flex flex-col gap-2 w-full max-w-[360px]">
       {tasks
       ->Array.map(task =>
         <button
+          type_="button"
           key={task}
           onClick={_ => onSelect(task)}
-          className="text-left text-[12px] leading-snug text-zinc-300 px-3 py-2.5 rounded-lg
+          className="text-left text-[13px] leading-snug text-zinc-300 px-3 py-3 rounded-lg
                      border border-white/10 bg-white/[0.03] hover:bg-white/[0.07]
-                     hover:border-white/20 transition-colors"
+                     hover:border-white/20 focus-visible:outline-none focus-visible:ring-2
+                     focus-visible:ring-white/30 transition-colors"
         >
           {React.string(task)}
         </button>
       )
       ->React.array}
     </div>
-  </div>
+  </section>
 }

--- a/libs/client/src/Client__GetStartedTasks.res
+++ b/libs/client/src/Client__GetStartedTasks.res
@@ -1,0 +1,34 @@
+/**
+ * Client__GetStartedTasks - Starter prompts shown in an empty conversation.
+ *
+ * Clicking a task sends it as a user message immediately.
+ */
+let tasks = [
+  "Change the page background to a dark theme",
+  "Make the main heading bigger and bolder",
+  "Add a dark mode toggle to the navigation bar",
+]
+
+@react.component
+let make = (~onSelect: string => unit) => {
+  <div className="min-h-[50vh] flex flex-col items-center justify-center px-6 gap-3">
+    <div className="text-[11px] text-zinc-500 self-start max-w-[320px] w-full px-0.5">
+      {React.string("Get started")}
+    </div>
+    <div className="flex flex-col gap-2 w-full max-w-[320px]">
+      {tasks
+      ->Array.map(task =>
+        <button
+          key={task}
+          onClick={_ => onSelect(task)}
+          className="text-left text-[12px] leading-snug text-zinc-300 px-3 py-2.5 rounded-lg
+                     border border-white/10 bg-white/[0.03] hover:bg-white/[0.07]
+                     hover:border-white/20 transition-colors"
+        >
+          {React.string(task)}
+        </button>
+      )
+      ->React.array}
+    </div>
+  </div>
+}

--- a/libs/client/test/Client__Chatbox.test.res
+++ b/libs/client/test/Client__Chatbox.test.res
@@ -27,3 +27,37 @@ describe("shouldRenderTurnError", () => {
     ->Expect.toBe(true)
   })
 })
+
+describe("selectGetStartedTask", () => {
+  test("opens provider settings instead of submitting when setup is required", t => {
+    let configuredProvider = ref(false)
+    let submittedTask = ref(None)
+
+    Chatbox.selectGetStartedTask(
+      ~providerSetupRequired=true,
+      ~onConfigureProvider=() => configuredProvider := true,
+      ~onSelect=text => submittedTask := Some(text),
+      "Make the main heading bigger and bolder",
+    )
+
+    t->expect(configuredProvider.contents)->Expect.toBe(true)
+    t->expect(submittedTask.contents)->Expect.toEqual(None)
+  })
+
+  test("submits the task when a provider is configured", t => {
+    let configuredProvider = ref(false)
+    let submittedTask = ref(None)
+
+    Chatbox.selectGetStartedTask(
+      ~providerSetupRequired=false,
+      ~onConfigureProvider=() => configuredProvider := true,
+      ~onSelect=text => submittedTask := Some(text),
+      "Make the main heading bigger and bolder",
+    )
+
+    t->expect(configuredProvider.contents)->Expect.toBe(false)
+    t
+    ->expect(submittedTask.contents)
+    ->Expect.toEqual(Some("Make the main heading bigger and bolder"))
+  })
+})


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Clicking on a task in the Get started section would dispatch the task into execution.

<img width="579" height="1320" alt="image" src="https://github.com/user-attachments/assets/e43de12f-efb4-4d3b-bee5-fdfd299f3050" />


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
