### PR TITLE
make plan list collapsed and add header

### DIFF
--- a/libs/client/src/components/frontman/Client__PlanList.res
+++ b/libs/client/src/components/frontman/Client__PlanList.res
@@ -71,7 +71,7 @@ module PlanItem = {
 
 @react.component
 let make = (~entries: array<ACPTypes.planEntry>) => {
-  let (isExpanded, setIsExpanded) = React.useState(() => true)
+  let (isExpanded, setIsExpanded) = React.useState(() => false)
 
   switch shouldRender(entries) {
   | false => React.null
@@ -94,7 +94,9 @@ let make = (~entries: array<ACPTypes.planEntry>) => {
                 : "-rotate-90"}`}
           />
           <span className="text-xs font-medium text-zinc-300">
-            {React.string(`Plan (${completedCount->Int.toString}/${totalCount->Int.toString})`)}
+            {React.string(
+              `Agent is working (${completedCount->Int.toString}/${totalCount->Int.toString})`,
+            )}
           </span>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Description

Make the PlanList collapsed by default and add a header "agent is working"

<img width="526" height="509" alt="image" src="https://github.com/user-attachments/assets/da38a08f-9efd-41b8-91c6-0c96ce032284" />


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [x] Ran `yarn changeset` (if user-facing change)
- [x] Tested locally with `make dev`
