### PR TITLE
center the heading text in get started

### DIFF
--- a/libs/client/src/Client__GetStartedTasks.res
+++ b/libs/client/src/Client__GetStartedTasks.res
@@ -17,7 +17,7 @@ let make = (~onSelect: string => unit) => {
   >
     <h2
       id="get-started-heading"
-      className="text-lg leading-snug font-semibold text-zinc-100 self-start max-w-[360px] w-full"
+      className="text-lg leading-snug font-semibold text-zinc-100 max-w-[360px] w-full"
     >
       {React.string("What would you like to accomplish today?")}
     </h2>


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Center the heading text

| before | after |
|--------|--------|
| <img width="576" height="502" alt="image" src="https://github.com/user-attachments/assets/4228b0a3-fb79-471c-9f72-e690b286b29b" /> | <img width="565" height="695" alt="image" src="https://github.com/user-attachments/assets/741a0cd3-a670-4046-8145-0fffb85c50b4" /> | 

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
