### PR TITLE
fix(tasks): separate turns by model

### DIFF
--- a/.changeset/separate-turn-models.md
+++ b/.changeset/separate-turn-models.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Keep queued messages with different models in separate agent turns.

--- a/apps/frontman_server/lib/agent_client_protocol.ex
+++ b/apps/frontman_server/lib/agent_client_protocol.ex
@@ -8,7 +8,7 @@ defmodule AgentClientProtocol do
   @moduledoc """
   ACP (Agent Client Protocol) translation layer.
 
-  Translates between domain events and ACP wire format (JSON-RPC 2.0).
+  Translates between task timeline records and ACP wire format (JSON-RPC 2.0).
   This is the boundary where domain concepts (Tasks) become transport
   concepts (Sessions).
 

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -6,13 +6,10 @@
 
 defmodule FrontmanServer.Tasks do
   @moduledoc """
-  Public API for task management.
+  Public API for tasks.
 
-  Tasks are containers for interactions in a conversation with agents.
-  Each task represents a conversation thread with an AI agent.
-
-  This context provides the boundary for all task-related operations,
-  delegating to the domain layer and infrastructure as appropriate.
+  A task is a durable conversation between a user and one or more agents.
+  It owns user messages, turn history, project context, and execution state.
   """
 
   @exports [
@@ -29,8 +26,6 @@ defmodule FrontmanServer.Tasks do
     Interaction.AgentRetry,
     Interaction.ToolCall,
     Interaction.ToolResult,
-    Interaction.DiscoveredProjectRule,
-    Interaction.DiscoveredProjectStructure,
     RetryCoordinator,
     Todos.Todo
   ]
@@ -301,7 +296,7 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, :completed) do
-    persist_agent_run_result(scope, task_id, turn_number, :completed)
+    persist_execution_outcome(scope, task_id, turn_number, :completed)
   end
 
   defp persist_swarm_event(
@@ -313,7 +308,7 @@ defmodule FrontmanServer.Tasks do
     {reason_str, category, retryable} = ErrorClassifier.classify_error(reason)
 
     with :ok <-
-           persist_agent_run_result(
+           persist_execution_outcome(
              scope,
              task_id,
              turn_number,
@@ -335,11 +330,11 @@ defmodule FrontmanServer.Tasks do
       extra: %{task_id: task_id, reason: inspect(message)}
     )
 
-    persist_agent_run_result(scope, task_id, turn_number, {:crashed, message})
+    persist_execution_outcome(scope, task_id, turn_number, {:crashed, message})
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:cancelled, _}) do
-    persist_agent_run_result(scope, task_id, turn_number, :cancelled)
+    persist_execution_outcome(scope, task_id, turn_number, :cancelled)
   end
 
   defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:terminated, _}) do
@@ -362,7 +357,7 @@ defmodule FrontmanServer.Tasks do
 
     case interactive_tool_calls do
       [] ->
-        persist_agent_run_result(scope, task_id, turn_number, :terminated)
+        persist_execution_outcome(scope, task_id, turn_number, :terminated)
 
       [_ | _] ->
         :ok
@@ -385,7 +380,7 @@ defmodule FrontmanServer.Tasks do
       turn_number: turn_number
     )
 
-    persist_agent_run_result(
+    persist_execution_outcome(
       scope,
       task_id,
       turn_number,
@@ -396,8 +391,8 @@ defmodule FrontmanServer.Tasks do
   defp persist_swarm_event(%Scope{}, _task_id, _turn_number, {:chunk, _, _}), do: :ok
   defp persist_swarm_event(%Scope{}, _task_id, _turn_number, {:tool_call, _}), do: :ok
 
-  defp persist_agent_run_result(scope, task_id, turn_number, outcome) do
-    with {:ok, _interaction} <- record_agent_run_result(scope, task_id, turn_number, outcome) do
+  defp persist_execution_outcome(scope, task_id, turn_number, outcome) do
+    with {:ok, _interaction} <- record_execution_outcome(scope, task_id, turn_number, outcome) do
       :ok
     end
   end
@@ -441,7 +436,7 @@ defmodule FrontmanServer.Tasks do
   @doc """
   Accepts a user prompt into session history.
 
-  Starting execution is handled separately by `run_next_turn/3`.
+  Starting execution is handled separately by `execute_next_turn/3`.
   """
   def submit_user_message(
         %Scope{} = scope,
@@ -529,30 +524,26 @@ defmodule FrontmanServer.Tasks do
 
     with {:ok, history} <- History.new(rows),
          {nil, [_ | _] = accepted_messages} <-
-           {History.active_run_turn_number(history), History.pending_accepted_messages(history)} do
-      turn_number = History.next_turn_number(history)
-      default_agent_id = Agents.default_agent_id(scope)
-      agent_id = accepted_message_agent_id(List.first(accepted_messages), default_agent_id)
-
-      accepted_messages =
-        Enum.take_while(accepted_messages, fn row ->
-          accepted_message_agent_id(row, default_agent_id) == agent_id
-        end)
-
-      user_message_ids = Enum.map(accepted_messages, & &1.id)
-
-      with {:ok, turn_model} <- turn_model_for_accepted_messages(accepted_messages),
-           {:ok, agent} <- Agents.get_agent(scope, agent_id),
-           turn_started_attrs = %{
-             agent_id: agent.id,
-             user_message_ids: user_message_ids
-           },
-           {:ok, turn_started_row} <-
-             insert_turn_started(task_schema, turn_started_attrs, turn_number) do
-        {:ok, {task_schema, turn_started_row, turn_number, turn_model, agent}}
-      else
-        {:error, reason} -> {:error, reason}
-      end
+           {History.active_turn_number(history), History.pending_accepted_messages(history)},
+         turn_number = History.next_turn_number(history),
+         default_agent_id = Agents.default_agent_id(scope),
+         first_accepted_message = List.first(accepted_messages),
+         agent_id = accepted_message_agent_id(first_accepted_message, default_agent_id),
+         {:ok, turn_model} <- accepted_message_model(first_accepted_message),
+         accepted_messages =
+           Enum.take_while(accepted_messages, fn row ->
+             accepted_message_agent_id(row, default_agent_id) == agent_id and
+               accepted_message_model(row) == {:ok, turn_model}
+           end),
+         user_message_ids = Enum.map(accepted_messages, & &1.id),
+         {:ok, agent} <- Agents.get_agent(scope, agent_id),
+         turn_started_attrs = %{
+           agent_id: agent.id,
+           user_message_ids: user_message_ids
+         },
+         {:ok, turn_started_row} <-
+           insert_turn_started(task_schema, turn_started_attrs, turn_number) do
+      {:ok, {task_schema, turn_started_row, turn_number, turn_model, agent}}
     else
       {:error, reason} -> {:error, reason}
       {nil, []} -> {:error, :no_accepted_messages}
@@ -560,16 +551,11 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp turn_model_for_accepted_messages(accepted_messages) do
-    case List.last(accepted_messages) do
-      %InteractionSchema{data: %Interaction.UserMessage{model: model}}
-      when is_binary(model) and model != "" ->
-        {:ok, model}
+  defp accepted_message_model(%InteractionSchema{data: %Interaction.UserMessage{model: model}})
+       when is_binary(model) and model != "",
+       do: {:ok, model}
 
-      _missing ->
-        {:error, :missing_model}
-    end
-  end
+  defp accepted_message_model(_missing), do: {:error, :missing_model}
 
   defp accepted_message_agent_id(
          %InteractionSchema{data: %Interaction.UserMessage{agent_id: agent_id}},
@@ -622,17 +608,17 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  @doc "Records how the given agent run ended."
-  def record_agent_run_result(scope, task_id, turn_number, outcome)
+  @doc "Records how the given execution ended."
+  def record_execution_outcome(scope, task_id, turn_number, outcome)
       when is_integer(turn_number) and turn_number > 0 do
     with {:ok, task_schema} <- get_task_by_id(scope, task_id) do
-      {type, attrs} = build_agent_run_result(outcome)
+      {type, attrs} = build_execution_outcome(outcome)
 
       record_interaction(task_schema, type, attrs, turn_number)
     end
   end
 
-  defp build_agent_run_result(outcome) do
+  defp build_execution_outcome(outcome) do
     case outcome do
       :completed ->
         {:agent_completed, %{result: nil}}
@@ -760,19 +746,18 @@ defmodule FrontmanServer.Tasks do
   end
 
   @doc """
-  Returns unresolved tool calls and turn number for the active agent run.
+  Returns unresolved tool calls and the turn number for the active execution.
 
-  `TurnStarted` starts a normal agent run. `AgentRetry` starts a new agent run
-  in the same turn. Agent completed, error, and paused interactions close only
-  the active run attempt for their turn number.
+  `TurnStarted` starts execution for a new turn. `AgentRetry` restarts execution
+  in the same turn. Completion, error, and pause records stop execution.
   """
-  def get_active_run_unresolved_tool_calls(scope, task_id) do
+  def get_active_turn_unresolved_tool_calls(scope, task_id) do
     with {:ok, _schema} <- get_task_by_id(scope, task_id),
          rows = load_interaction_rows(task_id),
          {:ok, history} <- History.new(rows) do
-      case History.active_run_turn_number(history) do
+      case History.active_turn_number(history) do
         nil ->
-          {:ok, :no_active_run}
+          {:ok, :no_active_turn}
 
         turn_number ->
           tool_calls =
@@ -799,17 +784,16 @@ defmodule FrontmanServer.Tasks do
          {:ok, agent} <- turn_agent(scope, history, turn_number),
          retry_attrs = %{retried_error_id: retried_error_id},
          {:ok, _retry} <- record_interaction(schema, :agent_retry, retry_attrs, turn_number) do
-      run_execution(scope, schema, turn_number, agent, execution)
+      start_execution(scope, schema, turn_number, agent, execution)
     end
   end
 
-  @doc "Starts and runs the next accepted-message turn when work is available."
-  def run_next_turn(%Scope{} = scope, task_id, execution) when is_binary(task_id) do
+  @doc "Executes the next accepted-message turn when work is available."
+  def execute_next_turn(%Scope{} = scope, task_id, execution) when is_binary(task_id) do
     case start_next_turn(scope, task_id) do
       {:ok, task, turn_number, turn_model, agent} ->
-        with {:ok, execution} <- put_missing_execution_model(execution, turn_model) do
-          run_execution(scope, task, turn_number, agent, execution)
-        end
+        execution = Map.put(execution, :model, turn_model)
+        start_execution(scope, task, turn_number, agent, execution)
 
       stop when stop in [:already_running, :no_accepted_messages] ->
         stop
@@ -856,14 +840,14 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  @doc "Resumes execution for the active agent run."
+  @doc "Resumes execution for the active turn."
   def resume_execution(scope, task_id, execution) do
     with {:ok, task} <- get_task(scope, task_id),
          {:ok, history} <- History.new(task.interaction_rows),
-         turn_number when is_integer(turn_number) <- History.active_run_turn_number(history),
+         turn_number when is_integer(turn_number) <- History.active_turn_number(history),
          {:ok, agent} <- turn_agent(scope, history, turn_number),
          {:ok, execution} <- ensure_execution_model(history, turn_number, execution) do
-      run_execution(scope, task, turn_number, agent, execution)
+      start_execution(scope, task, turn_number, agent, execution)
     else
       nil -> {:error, :not_running}
       {:error, reason} -> {:error, reason}
@@ -888,16 +872,6 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp put_missing_execution_model(%{model: model} = execution, _turn_model)
-       when is_binary(model) and model != "" do
-    {:ok, execution}
-  end
-
-  defp put_missing_execution_model(execution, turn_model)
-       when is_binary(turn_model) and turn_model != "" do
-    {:ok, Map.put(execution, :model, turn_model)}
-  end
-
   @doc """
   Cancels a running execution for the given task.
 
@@ -909,7 +883,7 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp run_execution(scope, task, turn_number, agent, execution)
+  defp start_execution(scope, task, turn_number, agent, execution)
        when is_integer(turn_number) and turn_number > 0 do
     rows = load_interaction_rows(task.id)
     {:ok, history} = History.new(rows)
@@ -918,7 +892,7 @@ defmodule FrontmanServer.Tasks do
     tool_policy = Agents.tool_policy(agent)
     response_context = History.response_context(history, turn_number, agent.id)
 
-    case Execution.run(
+    case Execution.start(
            scope,
            task,
            turn_number,
@@ -970,7 +944,7 @@ defmodule FrontmanServer.Tasks do
     {message, category, retryable} = ErrorClassifier.classify_error(reason)
 
     {:ok, _error} =
-      record_agent_run_result(
+      record_execution_outcome(
         scope,
         task_id,
         turn_number,

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -860,15 +860,9 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp ensure_execution_model(_history, _turn_number, %{model: model} = execution)
-       when is_binary(model) and model != "" do
-    {:ok, execution}
-  end
-
   defp ensure_execution_model(history, turn_number, execution) do
-    case History.turn_model(history, turn_number) do
-      {:ok, model} -> {:ok, Map.put(execution, :model, model)}
-      {:error, reason} -> {:error, reason}
+    with {:ok, model} <- History.turn_model(history, turn_number) do
+      {:ok, Map.put(execution, :model, model)}
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -28,7 +28,7 @@ defmodule FrontmanServer.Tasks.Execution do
   alias SwarmAi.Message.Tool
 
   @doc """
-  Runs an agent execution for a task.
+  Starts an agent execution asynchronously for a task.
 
   Resolves provider auth, builds the root agent from the task,
   and submits the agent to SwarmAi.
@@ -42,7 +42,7 @@ defmodule FrontmanServer.Tasks.Execution do
   - `{:error, {:start_failed, reason}}` - Execution worker failed to start
   - `{:error, :no_api_key}` - No API key available
   """
-  def run(
+  def start(
         %Scope{} = scope,
         %TaskSchema{} = task,
         turn_number,

--- a/apps/frontman_server/lib/frontman_server/tasks/history.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/history.ex
@@ -12,7 +12,7 @@ defmodule FrontmanServer.Tasks.History do
 
   @task_scoped_types InteractionSchema.task_scoped_types()
   @terminal_types [:agent_completed, :agent_error, :agent_paused]
-  @run_types @terminal_types ++ [:agent_response, :tool_call, :tool_result]
+  @active_turn_types @terminal_types ++ [:agent_response, :tool_call, :tool_result]
 
   @enforce_keys ~w(rows ordered_rows users_by_id turns_by_number user_owners response_counts active_turn)a
   defstruct @enforce_keys
@@ -77,7 +77,7 @@ defmodule FrontmanServer.Tasks.History do
     end)
   end
 
-  def active_run_turn_number(%__MODULE__{active_turn: active_turn}), do: active_turn
+  def active_turn_number(%__MODULE__{active_turn: active_turn}), do: active_turn
   def active_turn_context(%__MODULE__{} = history), do: turn_context(history, history.active_turn)
 
   def next_turn_number(%__MODULE__{turns_by_number: turns}) do
@@ -226,7 +226,7 @@ defmodule FrontmanServer.Tasks.History do
          %{active_turn: active_turn}
        )
        when is_integer(active_turn),
-       do: {:error, {:run_already_active, active_turn, turn_number}}
+       do: {:error, {:turn_already_active, active_turn, turn_number}}
 
   defp row_context(_history, %InteractionSchema{type: type, turn_number: nil} = row, state)
        when type in @task_scoped_types,
@@ -251,14 +251,14 @@ defmodule FrontmanServer.Tasks.History do
          %InteractionSchema{type: :agent_retry, turn_number: turn_number},
          %{active_turn: active_turn}
        ),
-       do: {:error, {:run_already_active, active_turn, turn_number}}
+       do: {:error, {:turn_already_active, active_turn, turn_number}}
 
   defp row_context(
          history,
          %InteractionSchema{type: type, turn_number: turn_number} = row,
          %{active_turn: turn_number} = state
        )
-       when type in @run_types do
+       when type in @active_turn_types do
     with {:ok, context, state} <- turn_context(history, row, state) do
       {:ok, context, %{state | active_turn: active_turn_after(type, turn_number)}}
     end
@@ -269,8 +269,8 @@ defmodule FrontmanServer.Tasks.History do
          %InteractionSchema{type: type, turn_number: turn_number},
          %{active_turn: active_turn}
        )
-       when type in @run_types,
-       do: {:error, {:inactive_run, type, turn_number, active_turn}}
+       when type in @active_turn_types,
+       do: {:error, {:inactive_turn, type, turn_number, active_turn}}
 
   defp active_turn_after(type, _turn_number) when type in @terminal_types, do: nil
   defp active_turn_after(_type, turn_number), do: turn_number

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -6,11 +6,10 @@
 
 defmodule FrontmanServer.Tasks.Interaction do
   @moduledoc """
-  Domain interaction types for the LLM agent system.
+  Persisted timeline record types for a task.
 
-  Interactions represent domain events that occur during a task's lifecycle.
-  These are stored as the source of truth, while streaming tokens are ephemeral
-  transport mechanisms for real-time UX.
+  The timeline stores user messages, execution state, agent responses, tool
+  activity, and project context. Streaming chunks are ephemeral.
   """
 
   @interaction_modules [
@@ -751,7 +750,7 @@ defmodule FrontmanServer.Tasks.Interaction do
     @moduledoc """
     Represents an agent execution ending with an error (failed, crashed, or cancelled).
 
-    Persisted so that reconnecting clients see the terminal interaction for every agent run,
+    Persisted so that reconnecting clients see the terminal interaction for every execution,
     even when the channel process was dead when the error occurred.
     """
 

--- a/apps/frontman_server/lib/frontman_server/tasks/todos.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/todos.ex
@@ -6,14 +6,10 @@
 
 defmodule FrontmanServer.Tasks.Todos do
   @moduledoc """
-  Atomic todo projection module.
+  Projects the current todo list from the most recent `todo_write` result.
 
-  Rebuilds current todos from the last `todo_write` ToolResult interaction.
-  No incremental mutations — the LLM sends the complete list every time,
-  eliminating hallucinated IDs and todo drift between turns.
-
-  This is a subcontext under Tasks — it accepts interactions as parameters
-  and never calls back to the parent Tasks context.
+  The LLM sends the complete list each time. This prevents ID and state drift
+  between turns.
   """
 
   alias FrontmanServer.Tasks.Interaction

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -135,13 +135,13 @@ defmodule FrontmanServerWeb.TaskChannel do
     {:noreply, socket}
   end
 
-  def handle_info({:run_next_turn, execution}, socket) do
-    case Tasks.run_next_turn(socket.assigns.scope, socket.assigns.task_id, execution) do
+  def handle_info({:execute_next_turn, execution}, socket) do
+    case Tasks.execute_next_turn(socket.assigns.scope, socket.assigns.task_id, execution) do
       result when result in [:ok, :already_running, :no_accepted_messages] ->
         :ok
 
       {:error, reason} ->
-        Logger.error("Failed to run next turn: #{inspect(reason)}")
+        Logger.error("Failed to execute next turn: #{inspect(reason)}")
     end
 
     {:noreply, socket}
@@ -364,7 +364,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp open_tool_call(socket, tool_call_id) do
     with {:ok, _turn_number, tool_calls} when is_list(tool_calls) <-
-           Tasks.get_active_run_unresolved_tool_calls(
+           Tasks.get_active_turn_unresolved_tool_calls(
              socket.assigns.scope,
              socket.assigns.task_id
            ),
@@ -423,18 +423,16 @@ defmodule FrontmanServerWeb.TaskChannel do
   defp resume_after_tool_result(:notified, socket, _scope, _task_id), do: socket
 
   defp resume_after_tool_result(:no_executor, socket, scope, task_id) do
-    case Tasks.get_active_run_unresolved_tool_calls(scope, task_id) do
+    case Tasks.get_active_turn_unresolved_tool_calls(scope, task_id) do
       {:ok, _turn_number, []} ->
-        Logger.info(
-          "Active agent run has no unresolved tool calls for #{task_id}, resuming agent"
-        )
+        Logger.info("Active turn has no unresolved tool calls for #{task_id}, resuming execution")
 
         resume_agent(socket, scope, task_id)
 
       {:ok, _turn_number, [_ | _]} ->
         socket
 
-      {:ok, :no_active_run} ->
+      {:ok, :no_active_turn} ->
         socket
     end
   end
@@ -879,7 +877,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   defp wake_runner(socket, meta) do
     case socket.assigns[:mcp_status] do
       status when status in [:ready, :failed] ->
-        send(self(), {:run_next_turn, execution_context(socket, meta)})
+        send(self(), {:execute_next_turn, execution_context(socket, meta)})
 
       _pending ->
         :ok
@@ -948,11 +946,11 @@ defmodule FrontmanServerWeb.TaskChannel do
          %{assigns: %{session_loaded: true, mcp_status: status}} = socket
        )
        when status in [:ready, :failed] do
-    case Tasks.get_active_run_unresolved_tool_calls(socket.assigns.scope, socket.assigns.task_id) do
+    case Tasks.get_active_turn_unresolved_tool_calls(socket.assigns.scope, socket.assigns.task_id) do
       {:ok, turn_number, tool_calls} when is_list(tool_calls) ->
         Enum.reduce(tool_calls, socket, &redispatch_unresolved_tool_call(&2, &1, turn_number))
 
-      {:ok, :no_active_run} ->
+      {:ok, :no_active_turn} ->
         socket
     end
   end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/error_propagation_test.exs
@@ -79,7 +79,7 @@ defmodule FrontmanServer.Tasks.Execution.ErrorPropagationTest do
            })
          ) do
       {:ok, interaction} ->
-        case Tasks.run_next_turn(scope, task_id, execution_request) do
+        case Tasks.execute_next_turn(scope, task_id, execution_request) do
           :ok ->
             {:ok, interaction, latest_turn_number(task_id)}
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/execution_sentry_test.exs
@@ -29,7 +29,7 @@ defmodule FrontmanServer.Tasks.Execution.ExecutionSentryTest do
     on_exit(fn -> Sandbox.stop_owner(pid) end)
 
     scope = user_scope_fixture()
-    task_id = task_with_active_run_fixture(scope, framework: "nextjs").id
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
     Phoenix.PubSub.subscribe(FrontmanServer.PubSub, task_topic(task_id))
 
     {:ok, task_id: task_id, scope: scope}

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -94,7 +94,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
            })
          ) do
       {:ok, interaction} ->
-        case Tasks.run_next_turn(scope, task_id, execution_request) do
+        case Tasks.execute_next_turn(scope, task_id, execution_request) do
           :ok ->
             {:ok, interaction, latest_turn_number(task_id)}
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
@@ -126,7 +126,7 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
            })
          ) do
       {:ok, interaction} ->
-        case Tasks.run_next_turn(scope, task_id, execution_request) do
+        case Tasks.execute_next_turn(scope, task_id, execution_request) do
           :ok ->
             {:ok, interaction, FrontmanServer.Test.Fixtures.Tasks.latest_turn_number(task_id)}
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -22,7 +22,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
     on_exit(fn -> Sandbox.stop_owner(pid) end)
 
     scope = user_scope_fixture()
-    task_id = task_with_active_run_fixture(scope, framework: "nextjs").id
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
 
     {:ok, task_id: task_id, scope: scope, turn_number: latest_turn_number(task_id)}
   end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
@@ -234,7 +234,7 @@ defmodule FrontmanServer.Tasks.ExecutionImageHistoryTest do
            })
          ) do
       {:ok, interaction} ->
-        case Tasks.run_next_turn(scope, task_id, execution_request) do
+        case Tasks.execute_next_turn(scope, task_id, execution_request) do
           :ok ->
             {:ok, interaction, latest_turn_number(task_id)}
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -646,14 +646,15 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       insert_accepted_user_message!(task, "queued for next turn")
 
-      expect(LLMProviderMock, :stream_text, fn _model, messages, _opts ->
-        send(parent, {:provider_messages, messages})
+      expect(LLMProviderMock, :stream_text, fn model, messages, _opts ->
+        send(parent, {:provider_request, model, messages})
         ReqLLMResponses.response("done")
       end)
 
-      assert :ok = Tasks.resume_execution(scope, task_id, execution_request_fixture())
+      execution = execution_request_fixture(model: "missing:test")
+      assert :ok = Tasks.resume_execution(scope, task_id, execution)
 
-      assert_receive {:provider_messages, messages}, 1_000
+      assert_receive {:provider_request, %LLMDB.Model{id: "openai/gpt-5.5"}, messages}, 1_000
       assert [user_text] = provider_user_texts(messages)
       assert user_text =~ "included"
       refute user_text =~ "queued for next turn"

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -253,67 +253,34 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       refute_running_eventually(task_id)
     end
 
-    test "separates same-agent messages by model and executes each requested model", %{
+    test "claims and executes only the first same-agent model", %{
       task_id: task_id,
       scope: scope
     } do
       parent = self()
       verify_on_exit!()
 
-      expect(LLMProviderMock, :stream_text, 2, fn model, _messages, _opts ->
+      expect(LLMProviderMock, :stream_text, fn model, _messages, _opts ->
         send(parent, {:executed_model, model})
         ReqLLMResponses.response("Response")
       end)
 
-      {:ok, first_message} =
-        Tasks.submit_user_message(scope, %{
-          task_id: task_id,
-          message_id: Ecto.UUID.generate(),
-          message: user_content("first model"),
-          model: "openrouter:openai/gpt-5.5",
-          agent_id: "test-frontman"
-        })
-
-      {:ok, second_message} =
-        Tasks.submit_user_message(scope, %{
-          task_id: task_id,
-          message_id: Ecto.UUID.generate(),
-          message: user_content("second model"),
-          model: "openrouter:anthropic/claude-fable-5",
-          agent_id: "test-frontman"
-        })
-
-      first_message_id = first_message.id
-      second_message_id = second_message.id
+      task = task_schema!(task_id)
+      insert_accepted_user_message!(task, "first model")
+      insert_accepted_user_message!(task, "second model", "openrouter:anthropic/claude-fable-5")
 
       assert :ok =
                Tasks.execute_next_turn(
                  scope,
                  task_id,
-                 execution_request_fixture()
+                 execution_request_fixture(model: "openrouter:anthropic/claude-fable-5")
                )
 
       assert_receive {:executed_model, %LLMDB.Model{id: "openai/gpt-5.5"}}
       assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
       refute_running_eventually(task_id)
 
-      assert [%{data: %{user_message_ids: [^first_message_id]}}] = turn_started_rows(task_id)
-
-      assert :ok =
-               Tasks.execute_next_turn(
-                 scope,
-                 task_id,
-                 execution_request_fixture()
-               )
-
-      assert_receive {:executed_model, %LLMDB.Model{id: "anthropic/claude-fable-5"}}
-      assert_receive_interaction(%Interaction.AgentCompleted{}, 2)
-      refute_running_eventually(task_id)
-
-      assert [
-               %{data: %{user_message_ids: [^first_message_id]}},
-               %{data: %{user_message_ids: [^second_message_id]}}
-             ] = turn_started_rows(task_id)
+      assert [%{data: %{user_message_ids: [_first_message_id]}}] = turn_started_rows(task_id)
     end
 
     test "claims only pending message prefix with the same agent and model", %{
@@ -1463,8 +1430,8 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
   defp task_schema!(task_id), do: Repo.get!(FrontmanServer.Tasks.TaskSchema, task_id)
 
-  defp insert_accepted_user_message!(task, text) do
-    {:ok, attrs} = Interaction.UserMessage.attrs(user_content(text), "openrouter:openai/gpt-5.5")
+  defp insert_accepted_user_message!(task, text, model \\ "openrouter:openai/gpt-5.5") do
+    {:ok, attrs} = Interaction.UserMessage.attrs(user_content(text), model)
     message_id = Ecto.UUID.generate()
 
     interaction_changeset(task.id, %{

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -118,7 +118,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
            })
          ) do
       {:ok, interaction} ->
-        case Tasks.run_next_turn(scope, task_id, execution) do
+        case Tasks.execute_next_turn(scope, task_id, execution) do
           result when result in [:ok, :already_running] ->
             {:ok, interaction, latest_turn_number_or_nil(task_id)}
 
@@ -246,14 +246,77 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           agent_id: "test-frontman"
         })
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert_receive_interaction(%Interaction.TurnStarted{agent_id: "test-frontman"}, 1)
       assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
       refute_running_eventually(task_id)
     end
 
-    test "claims only same-agent pending message prefix", %{
+    test "separates same-agent messages by model and executes each requested model", %{
+      task_id: task_id,
+      scope: scope
+    } do
+      parent = self()
+      verify_on_exit!()
+
+      expect(LLMProviderMock, :stream_text, 2, fn model, _messages, _opts ->
+        send(parent, {:executed_model, model})
+        ReqLLMResponses.response("Response")
+      end)
+
+      {:ok, first_message} =
+        Tasks.submit_user_message(scope, %{
+          task_id: task_id,
+          message_id: Ecto.UUID.generate(),
+          message: user_content("first model"),
+          model: "openrouter:openai/gpt-5.5",
+          agent_id: "test-frontman"
+        })
+
+      {:ok, second_message} =
+        Tasks.submit_user_message(scope, %{
+          task_id: task_id,
+          message_id: Ecto.UUID.generate(),
+          message: user_content("second model"),
+          model: "openrouter:anthropic/claude-fable-5",
+          agent_id: "test-frontman"
+        })
+
+      first_message_id = first_message.id
+      second_message_id = second_message.id
+
+      assert :ok =
+               Tasks.execute_next_turn(
+                 scope,
+                 task_id,
+                 execution_request_fixture()
+               )
+
+      assert_receive {:executed_model, %LLMDB.Model{id: "openai/gpt-5.5"}}
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
+      refute_running_eventually(task_id)
+
+      assert [%{data: %{user_message_ids: [^first_message_id]}}] = turn_started_rows(task_id)
+
+      assert :ok =
+               Tasks.execute_next_turn(
+                 scope,
+                 task_id,
+                 execution_request_fixture()
+               )
+
+      assert_receive {:executed_model, %LLMDB.Model{id: "anthropic/claude-fable-5"}}
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 2)
+      refute_running_eventually(task_id)
+
+      assert [
+               %{data: %{user_message_ids: [^first_message_id]}},
+               %{data: %{user_message_ids: [^second_message_id]}}
+             ] = turn_started_rows(task_id)
+    end
+
+    test "claims only pending message prefix with the same agent and model", %{
       task_id: task_id,
       scope: scope
     } do
@@ -273,7 +336,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           task_id: task_id,
           message_id: Ecto.UUID.generate(),
           message: user_content("frontman two"),
-          model: "openrouter:anthropic/claude-sonnet-4-6",
+          model: "openrouter:openai/gpt-5.5",
           agent_id: "test-frontman"
         })
 
@@ -282,11 +345,11 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           task_id: task_id,
           message_id: Ecto.UUID.generate(),
           message: user_content("planner"),
-          model: "openrouter:google/gemini-3-flash-preview",
+          model: "openrouter:anthropic/claude-fable-5",
           agent_id: "test-planner"
         })
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert [first_turn] = turn_started_rows(task_id)
       assert first_turn.data.agent_id == "test-frontman"
@@ -294,14 +357,14 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       refute_running_eventually(task_id)
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert [_first_turn, second_turn] = turn_started_rows(task_id)
       assert second_turn.data.agent_id == "test-planner"
       assert length(second_turn.data.user_message_ids) == 1
     end
 
-    test "groups only contiguous messages from the same agent", %{
+    test "groups only contiguous messages with the same agent and model", %{
       task_id: task_id,
       scope: scope
     } do
@@ -321,7 +384,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           task_id: task_id,
           message_id: Ecto.UUID.generate(),
           message: user_content("planner"),
-          model: "openrouter:google/gemini-3-flash-preview",
+          model: "openrouter:anthropic/claude-fable-5",
           agent_id: "test-planner"
         })
 
@@ -330,7 +393,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           task_id: task_id,
           message_id: Ecto.UUID.generate(),
           message: user_content("frontman two"),
-          model: "openrouter:anthropic/claude-sonnet-4-6",
+          model: "openrouter:openai/gpt-5.5",
           agent_id: "test-frontman"
         })
 
@@ -343,13 +406,13 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           agent_id: "test-frontman"
         })
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
       refute_running_eventually(task_id)
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
       refute_running_eventually(task_id)
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert [first_turn, second_turn, third_turn] = turn_started_rows(task_id)
       assert first_turn.data.agent_id == "test-frontman"
@@ -379,7 +442,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       })
       |> Repo.insert!()
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert [turn_started] = turn_started_rows(task_id)
       assert turn_started.data.agent_id == "test-planner"
@@ -408,7 +471,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       refute_running_eventually(task_id)
 
-      assert :ok = Tasks.run_next_turn(scope, task_id, execution_request_fixture())
+      assert :ok = Tasks.execute_next_turn(scope, task_id, execution_request_fixture())
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
@@ -477,7 +540,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
                  type: :agent_error
                )
 
-      assert {:ok, :no_active_run} = Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+      assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end
 
     test "submits browser context prompt through production recording path" do
@@ -581,11 +644,11 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       turn_one = latest_turn_number(task_id)
 
       {:ok, error} =
-        Tasks.record_agent_run_result(scope, task_id, turn_one, {:failed, "Rate limited"})
+        Tasks.record_execution_outcome(scope, task_id, turn_one, {:failed, "Rate limited"})
 
       {:ok, _message} = user_message_fixture(scope, task_id, user_content("turn two"))
       turn_two = latest_turn_number(task_id)
-      {:ok, _done} = Tasks.record_agent_run_result(scope, task_id, turn_two, :completed)
+      {:ok, _done} = Tasks.record_execution_outcome(scope, task_id, turn_two, :completed)
 
       assert {:error, :stale_turn} =
                Tasks.retry_execution(

--- a/apps/frontman_server/test/frontman_server/tasks/history_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/history_test.exs
@@ -25,7 +25,7 @@ defmodule FrontmanServer.Tasks.HistoryTest do
     assert History.user_row(history, "accepted").id == "accepted"
     assert [%InteractionSchema{id: "pending"}] = History.pending_accepted_messages(history)
     assert {:ok, "model-a"} = History.turn_model(history, 1)
-    assert 1 = History.active_run_turn_number(history)
+    assert 1 = History.active_turn_number(history)
 
     assert %{
              turn_started_id: "row-turn-id",
@@ -58,14 +58,14 @@ defmodule FrontmanServer.Tasks.HistoryTest do
              History.new([turn_row("turn-one", 1, ["missing"])])
   end
 
-  test "rejects run rows after their turn terminated" do
+  test "rejects rows after their turn terminated" do
     rows = [
       turn_row("turn", 1, []),
       %InteractionSchema{type: :agent_paused, turn_number: 1, data: %Interaction.AgentPaused{}},
       response_row(1)
     ]
 
-    assert {:error, {:inactive_run, :agent_response, 1, nil}} = History.new(rows)
+    assert {:error, {:inactive_turn, :agent_response, 1, nil}} = History.new(rows)
   end
 
   defp user_row(id, model) do

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -10,7 +10,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
 
   setup do
     scope = user_scope_fixture()
-    task_id = task_with_active_run_fixture(scope, framework: "nextjs").id
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
 
     {:ok, task_id: task_id, scope: scope, turn_number: latest_turn_number(task_id)}
   end

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -59,29 +59,29 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
-  describe "get_active_run_unresolved_tool_calls/2" do
-    test "returns unresolved tool calls only for active agent runs", %{scope: scope} do
+  describe "get_active_turn_unresolved_tool_calls/2" do
+    test "returns unresolved tool calls only for the active turn", %{scope: scope} do
       task_id = task_fixture(scope).id
 
-      assert {:ok, :no_active_run} = Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+      assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
 
       assert 1 = start_turn_fixture(scope, task_id)
       insert_interaction_row(task_id, Interaction.ToolCall, 1, %{"tool_call_id" => "call_1"})
 
       assert {:ok, 1, [%Interaction.ToolCall{tool_call_id: "call_1"}]} =
-               Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
 
       insert_interaction_row(task_id, Interaction.ToolResult, 1, %{"tool_call_id" => "call_1"})
 
-      assert {:ok, 1, []} = Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+      assert {:ok, 1, []} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end
 
-    test "accepted user messages without turns do not create an active run", %{scope: scope} do
+    test "accepted user messages without turns do not create an active turn", %{scope: scope} do
       task = task_fixture(scope)
 
       insert_accepted_user_message!(task, "queued")
 
-      assert {:ok, :no_active_run} = Tasks.get_active_run_unresolved_tool_calls(scope, task.id)
+      assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task.id)
     end
 
     test "returns an error for task-scoped rows with turn numbers", %{scope: scope} do
@@ -90,7 +90,7 @@ defmodule FrontmanServer.TasksTest do
       insert_legacy_interaction_row(task_id, Interaction.DiscoveredProjectRule, 1, %{})
 
       assert {:error, {:unknown_interaction_type, :discovered_project_rule}} =
-               Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end
   end
 
@@ -148,7 +148,7 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
-  describe "run_next_turn/3 agent identity" do
+  describe "execute_next_turn/3 agent identity" do
     test "persists configured agent identity", %{scope: scope} do
       task = task_fixture(scope)
 
@@ -157,12 +157,12 @@ defmodule FrontmanServer.TasksTest do
                  task_id: task.id,
                  message_id: Ecto.UUID.generate(),
                  message: user_content("hello"),
-                 model: "openrouter:openai/gpt-5.5",
+                 model: "missing:test",
                  agent_id: "test-frontman"
                })
 
       assert :ok =
-               Tasks.run_next_turn(
+               Tasks.execute_next_turn(
                  scope,
                  task.id,
                  execution_request_fixture(model: "missing:test")
@@ -190,7 +190,7 @@ defmodule FrontmanServer.TasksTest do
                })
 
       assert {:error, :unknown_agent} =
-               Tasks.run_next_turn(scope, task.id, execution_request_fixture())
+               Tasks.execute_next_turn(scope, task.id, execution_request_fixture())
 
       refute Enum.any?(db_rows(task.id), &(&1.type == :turn_started))
     end
@@ -237,7 +237,7 @@ defmodule FrontmanServer.TasksTest do
              }
 
       assert {:ok, ^turn_number, [%Interaction.ToolCall{tool_call_id: "question_1"}]} =
-               Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end
   end
 
@@ -577,7 +577,7 @@ defmodule FrontmanServer.TasksTest do
       task = task_fixture(scope)
       start_turn_fixture(scope, task.id, user_content("failed"), "missing:test")
 
-      {:ok, error} = Tasks.record_agent_run_result(scope, task.id, 1, {:failed, "boom"})
+      {:ok, error} = Tasks.record_execution_outcome(scope, task.id, 1, {:failed, "boom"})
 
       assert :ok =
                Tasks.retry_execution(scope, task.id, error.id, %{
@@ -602,7 +602,7 @@ defmodule FrontmanServer.TasksTest do
   end
 
   describe "resume_execution/3" do
-    test "returns not_running when no active agent run exists", %{scope: scope} do
+    test "returns not_running when no active turn exists", %{scope: scope} do
       task_id = task_fixture(scope).id
 
       assert {:error, :not_running} =
@@ -1240,14 +1240,14 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
-  describe "record_agent_run_result/4 paused DB round-trip" do
+  describe "record_execution_outcome/4 paused DB round-trip" do
     test "persisted AgentPaused can be loaded back via get_task", %{scope: scope} do
       task_id = Ecto.UUID.generate()
       {:ok, %TaskSchema{id: ^task_id}} = Tasks.create_task(scope, task_id, "nextjs")
       turn_number = start_turn_fixture(scope, task_id)
 
       {:ok, _interaction} =
-        Tasks.record_agent_run_result(
+        Tasks.record_execution_outcome(
           scope,
           task_id,
           turn_number,
@@ -1272,7 +1272,7 @@ defmodule FrontmanServer.TasksTest do
       turn_number = latest_turn_number(task_id)
 
       {:ok, _} =
-        Tasks.record_agent_run_result(
+        Tasks.record_execution_outcome(
           scope,
           task_id,
           turn_number,

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -16,7 +16,7 @@ defmodule FrontmanServer.ToolsTest do
 
   setup do
     scope = user_scope_fixture()
-    task_id = task_with_active_run_fixture(scope, framework: "nextjs").id
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
     {:ok, task} = Tasks.get_task(scope, task_id)
     {:ok, task_id: task_id, task: task, scope: scope, turn_number: latest_turn_number(task_id)}
   end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -63,7 +63,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     turn_number = latest_turn_number(task_id)
 
     {:ok, error_interaction} =
-      Tasks.record_agent_run_result(
+      Tasks.record_execution_outcome(
         scope,
         task_id,
         turn_number,
@@ -1514,7 +1514,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       :sys.get_state(socket.channel_pid)
 
       assert {:ok, ^turn_number, [_remaining_call]} =
-               Tasks.get_active_run_unresolved_tool_calls(scope, task_id)
+               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
 
       refute SwarmAi.running?(FrontmanServer.AgentRuntime, task_id)
 
@@ -1590,7 +1590,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       )
 
       Tasks.agent_replied(scope, task_id, first_turn_number, "First done")
-      Tasks.record_agent_run_result(scope, task_id, first_turn_number, :completed)
+      Tasks.record_execution_outcome(scope, task_id, first_turn_number, :completed)
 
       user_message_fixture(scope, task_id, user_content("second turn"))
       second_turn_number = latest_turn_number(task_id)
@@ -1860,7 +1860,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       turn_number = latest_turn_number(task_id)
 
       {:ok, error_interaction} =
-        Tasks.record_agent_run_result(scope, task_id, turn_number, {:failed, "Rate limited"})
+        Tasks.record_execution_outcome(scope, task_id, turn_number, {:failed, "Rate limited"})
 
       retried_error_id = error_interaction.id
 
@@ -1899,7 +1899,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       turn_number = latest_turn_number(task_id)
 
       {:ok, _error_interaction} =
-        Tasks.record_agent_run_result(scope, task_id, turn_number, {:failed, "Rate limited"})
+        Tasks.record_execution_outcome(scope, task_id, turn_number, {:failed, "Rate limited"})
 
       retried_error_id = "error-#{task_id}-2026-06-26T17:13:06.931002Z"
 

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -43,7 +43,7 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
     task
   end
 
-  def task_with_active_run_fixture(scope, opts \\ []) do
+  def task_with_active_turn_fixture(scope, opts \\ []) do
     task = task_fixture(scope, opts)
     start_turn_fixture(scope, task.id)
     task

--- a/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
@@ -38,12 +38,14 @@ defmodule SwarmAi.ExecutionWorker do
     registry = SwarmAi.registry_name(runtime)
     task_supervisor = SwarmAi.task_supervisor_name(runtime)
 
-    try do
-      final_loop = SwarmAi.Executor.run(loop, task_supervisor)
-      final_loop.dispatch_event.(final_loop.status)
-    after
-      unregister(registry, loop)
-    end
+    final_loop =
+      try do
+        SwarmAi.Executor.run(loop, task_supervisor)
+      after
+        unregister(registry, loop)
+      end
+
+    final_loop.dispatch_event.(final_loop.status)
 
     {:stop, :normal, state}
   end

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -11,13 +11,20 @@ defmodule SwarmAiTest do
   def noop_timeout(_tool_call, _reason), do: :ok
 
   describe "run/2" do
-    test "runs without event dispatcher" do
-      runtime = start_runtime_without_dispatcher!()
+    test "unregisters before dispatching the terminal event" do
+      runtime = start_runtime!()
+      test_pid = self()
 
-      {:ok, pid} = run_agent(runtime, "task-no-dispatch", %MockLLM{response: "done"})
+      dispatch = fn event ->
+        send(test_pid, {event, SwarmAi.running?(runtime, "task-handoff")})
+        :ok
+      end
+
+      {:ok, pid} =
+        run_agent(runtime, "task-handoff", %MockLLM{response: "done"}, dispatch_event: dispatch)
+
       await_exit(pid)
-
-      refute SwarmAi.running?(runtime, "task-no-dispatch")
+      assert_receive {:completed, false}
     end
 
     test "prevents duplicate execution for same key" do
@@ -141,12 +148,6 @@ defmodule SwarmAiTest do
   end
 
   defp start_runtime! do
-    name = :"TestRuntime_#{:erlang.unique_integer([:positive])}"
-    start_supervised!({SwarmAi, name: name})
-    name
-  end
-
-  defp start_runtime_without_dispatcher! do
     name = :"TestRuntime_#{:erlang.unique_integer([:positive])}"
     start_supervised!({SwarmAi, name: name})
     name

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ Client                          Server                          LLM Provider
 **Sequence:**
 1. `TaskChannel.handle_in("acp:message")` receives prompt
 2. `Providers.prepare_llm_args/3` resolves provider auth and ReqLLM arguments
-3. `Execution.run` builds a root agent run from prompt, model config, and tools
+3. `Execution.start` starts agent execution with the prompt, model configuration, and tools
 4. `SwarmAi.run(runtime, agent)` starts supervised execution
 5. SwarmAi calls LLM via `ReqLLM` (custom Req wrapper), receives response
 6. `ToolExecutor.make` routes tool calls:
@@ -119,8 +119,7 @@ Application
 | Context | Modules | Responsibility |
 |---------|---------|---------------|
 | Accounts | User, UserToken, UserIdentity | Registration, session tokens, OAuth (WorkOS for GitHub/Google), email verification |
-| Tasks | Task, Interaction | CRUD for conversation sessions, interaction storage (JSONB), PubSub topics |
-| Execution | Execution, SwarmDispatcher, ToolExecutor | Agent run orchestration, prompt building, tool routing, result notification |
+| Tasks | Task, Interaction, Execution, ToolExecutor | Conversation tasks, timeline storage, execution, tool routing, PubSub topics |
 | Providers | ApiKey, OauthToken, ModelCatalog | Key resolution hierarchy, OAuth token management, model catalog |
 | Tools | Backend, ToolExecutor | Tool registry, backend implementations (TodoList/Add/Update/Remove), MCP aggregation |
 | Organizations | Organization, Membership | Team workspaces, membership roles |
@@ -141,9 +140,9 @@ Application
 
 Encrypted fields: `api_keys.key`, `oauth_tokens.access_token` — use `FrontmanServer.Encrypted.Binary` (Cloak vault).
 
-### Interaction Domain Model
+### Task Timeline
 
-Interactions are typed domain events persisted as JSONB:
+Interactions are typed timeline records persisted as JSONB:
 
 | Type | Purpose |
 |------|---------|

--- a/docs/how-frontman-works.md
+++ b/docs/how-frontman-works.md
@@ -176,8 +176,7 @@ The server code is organized into bounded contexts, each owning a specific domai
 | Context | What it does |
 |---------|-------------|
 | **Accounts** | User registration, authentication (email/password, GitHub, Google via WorkOS), session management |
-| **Tasks** | Conversation sessions and their interactions. Each "task" is a conversation thread. Interactions are stored as typed JSONB documents (user messages, agent responses, tool calls, tool results). |
-| **Execution** | Orchestrates agent runs. Builds root agent runs, submits to SwarmAi, routes tool calls, persists results. |
+| **Tasks** | Durable agent conversations, persisted history, and execution. Private modules handle runtime mechanics and history projections. |
 | **Providers** | API key resolution, OAuth token management, and model catalog data. |
 | **Tools** | Tool registry. Knows which tools exist, whether they run on the server or browser, and how to convert them for the LLM. |
 | **Organizations** | Team workspaces and membership roles. |


### PR DESCRIPTION
## Summary
- Claim only contiguous queued messages sharing both agent and model.
- Execute each turn, retry, and resume with the model persisted on its claimed message.
- Unregister completed workers before terminal event delivery so queued turns start without a handoff race.
- Standardize Tasks terminology around turns and executions, remove unused exports, and update architecture docs.
- Add a patch changeset for model-separated turns.

## Testing
- `make precommit` in `apps/frontman_server` (733 tests)
- `make precommit` in `apps/swarm_ai` (112 tests)
- Repository pre-commit hooks: Elixir format, Credo, and source-comment checks
- Repository pre-push hook