### PR TITLE
fix(tasks): enforce one channel per task

### DIFF
--- a/.changeset/keep-active-turn-on-late-completion.md
+++ b/.changeset/keep-active-turn-on-late-completion.md
@@ -1,5 +1,0 @@
----
-"@frontman-ai/client": patch
----
-
-Keep task channels connected when a delayed terminal event arrives after the next turn starts.

--- a/.changeset/keep-active-turn-on-late-completion.md
+++ b/.changeset/keep-active-turn-on-late-completion.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Keep task channels connected when a delayed terminal event arrives after the next turn starts.

--- a/.changeset/single-task-channel.md
+++ b/.changeset/single-task-channel.md
@@ -1,0 +1,4 @@
+---
+"@frontman-ai/client": patch
+---
+Prevent concurrent connections from owning the same task channel.

--- a/apps/frontman_server/lib/frontman_server/application.ex
+++ b/apps/frontman_server/lib/frontman_server/application.ex
@@ -51,7 +51,7 @@ defmodule FrontmanServer.Application do
       {DNSCluster, query: Application.get_env(:frontman_server, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: FrontmanServer.PubSub},
       {SwarmAi, name: FrontmanServer.AgentRuntime},
-      {Registry, keys: :unique, name: FrontmanServer.ToolCallRegistry},
+      {Registry, keys: :unique, name: FrontmanServer.ProcessRegistry},
       {Oban, Application.fetch_env!(:frontman_server, Oban)},
       FrontmanServerWeb.Endpoint
     ]

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -154,7 +154,7 @@ defmodule FrontmanServer.Tasks.Execution do
   def notify_tool_result(%Interaction.ToolResult{}), do: :no_executor
 
   defp notify_tool_result(tool_call_id, content, is_error) do
-    case Elixir.Registry.lookup(FrontmanServer.ToolCallRegistry, {:tool_call, tool_call_id}) do
+    case Elixir.Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, tool_call_id}) do
       [{_pid, %{caller_pid: caller}}] ->
         content_parts =
           content

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -199,7 +199,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   end
 
   defp register_mcp_tool(tool_call) do
-    Registry.register(FrontmanServer.ToolCallRegistry, {:tool_call, tool_call.id}, %{
+    Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, tool_call.id}, %{
       caller_pid: self()
     })
   end

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -38,35 +38,31 @@ defmodule FrontmanServerWeb.TaskChannel do
   def join("task:" <> task_id, _params, socket) do
     scope = socket.assigns.scope
 
-    case Tasks.get_task(scope, task_id) do
-      {:ok, task} ->
-        {:ok, history} = TaskHistory.new(task.interaction_rows)
+    with {:ok, task} <- Tasks.get_task(scope, task_id),
+         {:ok, _owner} <-
+           Registry.register(FrontmanServer.ProcessRegistry, {:task_channel, task_id}, nil) do
+      {:ok, history} = TaskHistory.new(task.interaction_rows)
 
-        SentryContext.set_task_scope_context(scope, task_id)
+      SentryContext.set_task_scope_context(scope, task_id)
+      {init_state, init_actions} = MCPInitializer.start(task_id, scope, task.framework)
 
-        Logger.info("Client joining: #{task_id}, socket_id: #{inspect(self())}")
+      socket =
+        socket
+        |> assign(:task_id, task_id)
+        |> assign(:framework, task.framework)
+        |> assign(:mcp_init_state, init_state)
+        |> assign(:mcp_tools, [])
+        |> assign(:mcp_status, :pending)
+        |> assign(:session_loaded, false)
+        |> assign(:active_turn, TaskHistory.active_turn_context(history))
+        |> assign(:pending_mcp_tool_requests, %{})
 
-        {init_state, init_actions} = MCPInitializer.start(task_id, scope, task.framework)
+      send(self(), {:start_mcp_init, init_actions})
 
-        socket =
-          socket
-          |> assign(:task_id, task_id)
-          |> assign(:framework, task.framework)
-          |> assign(:mcp_init_state, init_state)
-          |> assign(:mcp_tools, [])
-          |> assign(:mcp_status, :pending)
-          |> assign(:session_loaded, false)
-          |> assign(:active_turn, TaskHistory.active_turn_context(history))
-          |> assign(:latest_turn_number, TaskHistory.latest_turn_number(history))
-          |> assign(:pending_mcp_tool_requests, %{})
-
-        send(self(), {:start_mcp_init, init_actions})
-
-        {:ok, %{task_id: task_id}, socket}
-
-      {:error, :not_found} ->
-        Logger.info("Client tried to join non-existent task: #{task_id}")
-        {:error, %{reason: "task_not_found"}}
+      {:ok, %{task_id: task_id}, socket}
+    else
+      {:error, :not_found} -> {:error, %{reason: "task_not_found"}}
+      {:error, {:already_registered, _owner}} -> {:error, %{reason: "task_already_joined"}}
     end
   end
 
@@ -190,7 +186,6 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp handle_turn_started(turn, turn_started_id, turn_number, socket) do
     task_id = socket.assigns.task_id
-    latest_turn_number = max(turn_number, socket.assigns.latest_turn_number)
     notification = ACP.build_state_update_notification(task_id, "running")
     push(socket, @acp_message, notification)
 
@@ -200,7 +195,7 @@ defmodule FrontmanServerWeb.TaskChannel do
       turn_started_id: turn_started_id
     }
 
-    {:noreply, assign(socket, active_turn: context, latest_turn_number: latest_turn_number)}
+    {:noreply, assign(socket, :active_turn, context)}
   end
 
   defp handle_interaction(%Tasks.Interaction.ToolCall{} = tool_call, _turn_number, socket) do
@@ -265,14 +260,6 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     {:noreply, socket}
   end
-
-  defp handle_interaction(
-         _interaction,
-         turn_number,
-         %{assigns: %{latest_turn_number: latest_turn_number}} = socket
-       )
-       when is_integer(turn_number) and turn_number < latest_turn_number,
-       do: {:noreply, socket}
 
   defp handle_interaction(%Tasks.Interaction.AgentCompleted{}, turn_number, socket),
     do: finalize_turn(socket, {:completed, ACP.stop_reason_end_turn()}, turn_number)
@@ -880,15 +867,11 @@ defmodule FrontmanServerWeb.TaskChannel do
     push(socket, @acp_message, notification)
   end
 
-  defp wake_runner(socket, meta) do
-    case socket.assigns[:mcp_status] do
-      status when status in [:ready, :failed] ->
-        send(self(), {:execute_next_turn, execution_context(socket, meta)})
+  defp wake_runner(%{assigns: %{mcp_status: status, active_turn: nil}} = socket, meta)
+       when status in [:ready, :failed],
+       do: send(self(), {:execute_next_turn, execution_context(socket, meta)})
 
-      _pending ->
-        :ok
-    end
-  end
+  defp wake_runner(_socket, _meta), do: :ok
 
   defp execution_context(socket, meta) do
     model =

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -41,7 +41,6 @@ defmodule FrontmanServerWeb.TaskChannel do
     case Tasks.get_task(scope, task_id) do
       {:ok, task} ->
         {:ok, history} = TaskHistory.new(task.interaction_rows)
-        active_turn = TaskHistory.active_turn_context(history)
 
         SentryContext.set_task_scope_context(scope, task_id)
 
@@ -57,7 +56,8 @@ defmodule FrontmanServerWeb.TaskChannel do
           |> assign(:mcp_tools, [])
           |> assign(:mcp_status, :pending)
           |> assign(:session_loaded, false)
-          |> assign(:active_turn, active_turn)
+          |> assign(:active_turn, TaskHistory.active_turn_context(history))
+          |> assign(:latest_turn_number, TaskHistory.latest_turn_number(history))
           |> assign(:pending_mcp_tool_requests, %{})
 
         send(self(), {:start_mcp_init, init_actions})
@@ -190,6 +190,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp handle_turn_started(turn, turn_started_id, turn_number, socket) do
     task_id = socket.assigns.task_id
+    latest_turn_number = max(turn_number, socket.assigns.latest_turn_number)
     notification = ACP.build_state_update_notification(task_id, "running")
     push(socket, @acp_message, notification)
 
@@ -199,7 +200,7 @@ defmodule FrontmanServerWeb.TaskChannel do
       turn_started_id: turn_started_id
     }
 
-    {:noreply, assign(socket, :active_turn, context)}
+    {:noreply, assign(socket, active_turn: context, latest_turn_number: latest_turn_number)}
   end
 
   defp handle_interaction(%Tasks.Interaction.ToolCall{} = tool_call, _turn_number, socket) do
@@ -265,9 +266,16 @@ defmodule FrontmanServerWeb.TaskChannel do
     {:noreply, socket}
   end
 
-  defp handle_interaction(%Tasks.Interaction.AgentCompleted{}, turn_number, socket) do
-    finalize_turn(socket, {:completed, ACP.stop_reason_end_turn()}, turn_number)
-  end
+  defp handle_interaction(
+         _interaction,
+         turn_number,
+         %{assigns: %{latest_turn_number: latest_turn_number}} = socket
+       )
+       when is_integer(turn_number) and turn_number < latest_turn_number,
+       do: {:noreply, socket}
+
+  defp handle_interaction(%Tasks.Interaction.AgentCompleted{}, turn_number, socket),
+    do: finalize_turn(socket, {:completed, ACP.stop_reason_end_turn()}, turn_number)
 
   defp handle_interaction(%Tasks.Interaction.AgentRetry{}, turn_number, socket) do
     context =
@@ -279,13 +287,11 @@ defmodule FrontmanServerWeb.TaskChannel do
     {:noreply, assign(socket, :active_turn, context)}
   end
 
-  defp handle_interaction(%Tasks.Interaction.AgentPaused{}, turn_number, socket) do
-    finalize_turn(socket, :requires_action, turn_number)
-  end
+  defp handle_interaction(%Tasks.Interaction.AgentPaused{}, turn_number, socket),
+    do: finalize_turn(socket, :requires_action, turn_number)
 
-  defp handle_interaction(%Tasks.Interaction.AgentError{kind: "cancelled"}, turn_number, socket) do
-    finalize_turn(socket, {:completed, ACP.stop_reason_cancelled()}, turn_number)
-  end
+  defp handle_interaction(%Tasks.Interaction.AgentError{kind: "cancelled"}, turn_number, socket),
+    do: finalize_turn(socket, {:completed, ACP.stop_reason_cancelled()}, turn_number)
 
   defp handle_interaction(
          %Tasks.Interaction.AgentError{retryable: true} = error,
@@ -827,14 +833,6 @@ defmodule FrontmanServerWeb.TaskChannel do
         {:noreply, assign(socket, :retry_state, state)}
     end
   end
-
-  defp finalize_turn(
-         %{assigns: %{active_turn: %{turn_number: active_turn_number}}} = socket,
-         _outcome,
-         turn_number
-       )
-       when is_integer(turn_number) and turn_number < active_turn_number,
-       do: {:noreply, socket}
 
   defp finalize_turn(socket, outcome, turn_number) do
     task_id = socket.assigns.task_id

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -828,6 +828,14 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
   end
 
+  defp finalize_turn(
+         %{assigns: %{active_turn: %{turn_number: active_turn_number}}} = socket,
+         _outcome,
+         turn_number
+       )
+       when is_integer(turn_number) and turn_number < active_turn_number,
+       do: {:noreply, socket}
+
   defp finalize_turn(socket, outcome, turn_number) do
     task_id = socket.assigns.task_id
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -160,7 +160,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
       )
 
       registered =
-        case Registry.lookup(FrontmanServer.ToolCallRegistry, {:tool_call, expected_id}) do
+        case Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, expected_id}) do
           [{_pid, _}] -> true
           [] -> false
         end

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -45,7 +45,7 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
 
         [{:ok, canonical, :no_executor}, {:ok, canonical, :no_executor}] = results
 
-        Registry.register(FrontmanServer.ToolCallRegistry, {:tool_call, "call_dedup"}, %{
+        Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, "call_dedup"}, %{
           caller_pid: self()
         })
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -737,20 +737,21 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert Process.alive?(socket.channel_pid)
     end
 
-    test "channel ignores a stale completion after the next turn starts", %{
-      socket: socket,
-      task_id: task_id
-    } do
+    test "ignores stale terminal outcomes", %{socket: socket, task_id: task_id} do
       activate_turn(socket, "turn-1")
 
-      next_turn = %{turn_started([]) | id: "turn-2"}
-      send(socket.channel_pid, interaction_event(next_turn, 2))
+      send(socket.channel_pid, interaction_event(%{turn_started([]) | id: "turn-2"}, 2))
       assert_state_update_running(task_id)
 
-      send(socket.channel_pid, interaction_event(agent_completed(), 1))
+      error = agent_error("Rate limited", "failed", true, "rate_limit")
+      send(socket.channel_pid, interaction_event(error, 1))
 
-      channel_socket = :sys.get_state(socket.channel_pid)
-      assert channel_socket.assigns.active_turn.turn_number == 2
+      assert :sys.get_state(socket.channel_pid).assigns[:retry_state] == nil
+      refute_push("acp:message", %{"params" => %{"update" => %{"sessionUpdate" => "error"}}})
+
+      send(socket.channel_pid, interaction_event(agent_completed(), 2))
+      assert_state_update_idle(task_id)
+      send(socket.channel_pid, interaction_event(agent_completed(), 1))
       refute_push("acp:message", %{"params" => %{"update" => %{"state" => "idle"}}})
     end
   end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -4,6 +4,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   import FrontmanServer.InteractionCase.Helpers,
     only: [
+      agent_completed: 0,
       agent_error: 2,
       agent_error: 4,
       interaction_event: 2,
@@ -734,6 +735,23 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
 
       assert Process.alive?(socket.channel_pid)
+    end
+
+    test "channel ignores a stale completion after the next turn starts", %{
+      socket: socket,
+      task_id: task_id
+    } do
+      activate_turn(socket, "turn-1")
+
+      next_turn = %{turn_started([]) | id: "turn-2"}
+      send(socket.channel_pid, interaction_event(next_turn, 2))
+      assert_state_update_running(task_id)
+
+      send(socket.channel_pid, interaction_event(agent_completed(), 1))
+
+      channel_socket = :sys.get_state(socket.channel_pid)
+      assert channel_socket.assigns.active_turn.turn_number == 2
+      refute_push("acp:message", %{"params" => %{"update" => %{"state" => "idle"}}})
     end
   end
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -4,7 +4,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
   import FrontmanServer.InteractionCase.Helpers,
     only: [
-      agent_completed: 0,
       agent_error: 2,
       agent_error: 4,
       interaction_event: 2,
@@ -139,7 +138,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
   end
 
   defp register_tool_receiver(tool_call_id) do
-    Registry.register(FrontmanServer.ToolCallRegistry, {:tool_call, tool_call_id}, %{
+    Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, tool_call_id}, %{
       caller_pid: self()
     })
   end
@@ -198,16 +197,18 @@ defmodule FrontmanServerWeb.TaskChannelTest do
   end
 
   describe "join task:<id>" do
-    test "succeeds when task exists", %{scope: scope} do
+    test "allows one connection per task", %{scope: scope} do
       task_id = task_fixture(scope).id
 
-      {:ok, reply, socket} =
+      {:ok, %{task_id: ^task_id}, _socket} =
         UserSocket
         |> socket("user_id", %{scope: scope})
         |> subscribe_and_join("task:#{task_id}", %{})
 
-      assert reply == %{task_id: task_id}
-      assert socket.assigns.task_id == task_id
+      other = socket(UserSocket, "other_user_id", %{scope: scope})
+
+      assert {:error, %{reason: "task_already_joined"}} =
+               subscribe_and_join(other, "task:#{task_id}", %{})
     end
 
     test "fails when task does not exist", %{scope: scope} do
@@ -561,6 +562,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
 
       assert_reply(first_ref, :ok, %{"acp:message" => %{"id" => 11, "result" => %{}}})
+      :sys.get_state(socket.channel_pid)
       assert_state_update_running(task_id)
 
       second_ref =
@@ -582,6 +584,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
 
       assert_reply(second_ref, :ok, %{"acp:message" => %{"id" => 12, "result" => %{}}})
+      refute_push("acp:message", %{"params" => %{"update" => %{"state" => "running"}}}, 100)
 
       assert_state_update_idle(task_id)
       assert_state_update_running_then_idle(task_id)
@@ -735,24 +738,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
 
       assert Process.alive?(socket.channel_pid)
-    end
-
-    test "ignores stale terminal outcomes", %{socket: socket, task_id: task_id} do
-      activate_turn(socket, "turn-1")
-
-      send(socket.channel_pid, interaction_event(%{turn_started([]) | id: "turn-2"}, 2))
-      assert_state_update_running(task_id)
-
-      error = agent_error("Rate limited", "failed", true, "rate_limit")
-      send(socket.channel_pid, interaction_event(error, 1))
-
-      assert :sys.get_state(socket.channel_pid).assigns[:retry_state] == nil
-      refute_push("acp:message", %{"params" => %{"update" => %{"sessionUpdate" => "error"}}})
-
-      send(socket.channel_pid, interaction_event(agent_completed(), 2))
-      assert_state_update_idle(task_id)
-      send(socket.channel_pid, interaction_event(agent_completed(), 1))
-      refute_push("acp:message", %{"params" => %{"update" => %{"state" => "idle"}}})
     end
   end
 

--- a/apps/marketing/src/content/docs/docs/reference/architecture.md
+++ b/apps/marketing/src/content/docs/docs/reference/architecture.md
@@ -132,7 +132,7 @@ The Phoenix application is responsible for orchestration, persistence, session m
 | `SwarmAi` | Runs the agent loop and coordinates LLM interactions |
 | `TaskChannel` | Handles per-task prompt traffic, tool routing, and streamed updates |
 | `TasksChannel` | Handles task listing, creation, deletion, and session initialization |
-| `ToolCallRegistry` | Tracks pending client-executed tool calls and resolves waiting processes |
+| `ProcessRegistry` | Owns task channels and tracks pending client-executed tool calls |
 | `SwarmDispatcher` | Persists interactions and broadcasts them through PubSub |
 | `Providers` | Resolves API keys, OAuth tokens, and model catalog data |
 | `Repo` | Stores tasks, interactions, credentials, identities, and organizations |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ Client                          Server                          LLM Provider
 5. SwarmAi calls LLM via `ReqLLM` (custom Req wrapper), receives response
 6. `ToolExecutor.make` routes tool calls:
    - Backend tools → `ToolExecution.Sync`: executed in supervised tasks (todo list, web_fetch)
-   - MCP tools → `ToolExecution.Await`: registered in `ToolCallRegistry`, published to client via channel, executor blocks until Registry receives result
+   - MCP tools → `ToolExecution.Await`: registered in `ProcessRegistry`, published to client via channel, executor blocks until Registry receives result
 7. `SwarmDispatcher` persists each interaction to PostgreSQL, then broadcasts via PubSub
 8. Channel pushes events to client for UI rendering
 9. Loop repeats until LLM returns `turn_complete`
@@ -109,7 +109,7 @@ Application
 ├── DNSCluster
 ├── Phoenix.PubSub (FrontmanServer.PubSub)
 ├── SwarmAi (named: FrontmanServer.AgentRuntime)
-├── Registry (FrontmanServer.ToolCallRegistry)
+├── Registry (FrontmanServer.ProcessRegistry)
 ├── Oban (background jobs)
 └── Endpoint (HTTP/WebSocket)
 ```

--- a/docs/how-frontman-works.md
+++ b/docs/how-frontman-works.md
@@ -164,7 +164,7 @@ Application
 ├── DNSCluster              Distributed node discovery
 ├── PubSub                  Phoenix broadcasts
 ├── SwarmAi                 Agent execution engine
-├── ToolCallRegistry        Routes tool results to waiting executors
+├── ProcessRegistry         Owns task channels and routes tool results
 ├── Oban                    Background jobs (emails, title generation)
 └── Endpoint                HTTP + WebSocket server
 ```
@@ -318,7 +318,7 @@ Executed in supervised tasks. Currently includes todo list management tools. The
 ### MCP tools (browser-side)
 
 Sent to the client over WebSocket. The executor:
-1. Registers itself in the ToolCallRegistry (so the result can find its way back)
+1. Registers itself in the ProcessRegistry (so the result can find its way back)
 2. Persists the tool call to the database
 3. Sends the tool call to the client via the MCP channel
 4. **Blocks** waiting for the result (60-second timeout for regular tools, 24-hour timeout for interactive tools like Question)


### PR DESCRIPTION
## Summary
- Enforce one active task channel per task with the existing process registry.
- Keep queued prompts blocked while a turn remains active.
- Remove stale-turn watermark handling and its synthetic regression.

## Context
PR #1536 releases execution ownership before terminal dispatch so queued work can start promptly. Concurrent task channels could then advance the same task from different PubSub positions. Frontman supports one active connection per task, so this change enforces that invariant at join instead of reconciling competing event streams.

## Testing
- Duplicate task-channel join regression
- Queued follow-up active-turn regression
- `make precommit` in `apps/frontman_server` (733 tests)
- Pre-commit and pre-push hooks
- Full PR: 54 additions, 57 deletions

## Manual verification
- Submitted a second prompt while the first turn was running; it remained queued and started once after the first turn completed.
- Opened the same task in a second tab; the second channel join was rejected with `task_already_joined` while the first remained functional.
- Closed the owning tab, refreshed the second tab, and confirmed it could connect and submit prompts.