### PR TITLE
fix chip appearing after double paste

### DIFF
--- a/libs/bindings/src/Bindings__Tiptap__Core.res
+++ b/libs/bindings/src/Bindings__Tiptap__Core.res
@@ -3,12 +3,12 @@ type extension
 type nodeExtension = extension
 type nodeConstructor
 type chain
-type selection = {from: int, to_: int}
+type selection = {from: int, @as("to") to_: int}
 type proseMirrorNodeType
 type proseMirrorNode
 type editorState = {selection: selection, doc: proseMirrorNode}
 
-type insertRange = {from: int, to_: int}
+type insertRange = {from: int, @as("to") to_: int}
 type htmlAttributes
 type htmlRenderContext = {"HTMLAttributes": htmlAttributes}
 type attributeSpec = {default: string}


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

The pasted chip appeared even after double pasting with cmd+v

issue:
<img width="584" height="211" alt="image" src="https://gcdnb.pbrd.co/images/e-rReievbijr.png" />


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
