### PR TITLE
Fix WebFetch DNS rebinding protection

### DIFF
--- a/apps/frontman_server/lib/frontman_server.ex
+++ b/apps/frontman_server/lib/frontman_server.ex
@@ -25,6 +25,7 @@ defmodule FrontmanServer do
     Vault,
     Image,
     CurrentPageContext,
+    PublicURL,
     Mailer,
     Release,
     Encrypted.Binary,

--- a/apps/frontman_server/lib/frontman_server/public_url.ex
+++ b/apps/frontman_server/lib/frontman_server/public_url.ex
@@ -1,0 +1,193 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.PublicURL do
+  @moduledoc "Validates and pins HTTP requests to public addresses."
+
+  @ssrf_error "Requests to private/internal addresses are not allowed. " <>
+                "For current app pages or local development URLs, use the available browser " <>
+                "or framework-specific page inspection tools instead."
+
+  @spec validate(String.t()) :: :ok | {:error, String.t()}
+  def validate(url) when is_binary(url) do
+    with {:ok, _resolved} <- resolve(url), do: :ok
+  end
+
+  @doc false
+  @spec attach(Req.Request.t()) :: Req.Request.t()
+  def attach(request) do
+    Req.Request.append_request_steps(request, public_url: &protect_req/1)
+  end
+
+  @doc false
+  @spec protect_req(Req.Request.t()) ::
+          Req.Request.t() | {Req.Request.t(), Exception.t()}
+  def protect_req(%Req.Request{adapter: Req.Plug} = request), do: request
+
+  def protect_req(%Req.Request{} = request) do
+    case Req.Request.get_private(request, :public_url_pinned, false) do
+      true ->
+        request
+
+      false ->
+        case resolve(request.url) do
+          {:ok, {host, address}} -> pin_req(request, host, address)
+          {:error, message} -> {request, ArgumentError.exception(message)}
+        end
+    end
+  end
+
+  defp resolve(url) when is_binary(url) do
+    with :ok <- validate_scheme(url) do
+      resolve(URI.parse(url))
+    end
+  end
+
+  defp resolve(%URI{scheme: scheme, host: host})
+       when scheme in ["http", "https"] and is_binary(host) and byte_size(host) > 0 do
+    host = String.downcase(host)
+
+    with :ok <- validate_host(host),
+         {:ok, address} <- resolve_address(host) do
+      {:ok, {host, address}}
+    end
+  end
+
+  defp resolve(%URI{host: host}) when not is_binary(host) or byte_size(host) == 0,
+    do: {:error, "Could not parse host from URL"}
+
+  defp resolve(%URI{}), do: {:error, "URL must start with http:// or https://"}
+
+  defp validate_scheme("http://" <> _), do: :ok
+  defp validate_scheme("https://" <> _), do: :ok
+  defp validate_scheme(_), do: {:error, "URL must start with http:// or https://"}
+
+  defp validate_host("localhost"), do: ssrf_error()
+  defp validate_host("localhost" <> _), do: ssrf_error()
+
+  defp validate_host(host) do
+    case String.ends_with?(host, [".local", ".internal", ".localhost"]) do
+      true -> ssrf_error()
+      false -> :ok
+    end
+  end
+
+  defp resolve_address(host) do
+    host_charlist = String.to_charlist(host)
+
+    case :inet.parse_address(host_charlist) do
+      {:ok, address} -> public_address([address])
+      {:error, :einval} -> resolve_hostname(host_charlist)
+    end
+  end
+
+  defp resolve_hostname(host) do
+    addresses =
+      Enum.flat_map([:inet, :inet6], fn family ->
+        case :inet.getaddrs(host, family) do
+          {:ok, addresses} -> addresses
+          {:error, _reason} -> []
+        end
+      end)
+
+    case addresses do
+      [] -> {:error, "Could not resolve hostname"}
+      addresses -> public_address(addresses)
+    end
+  end
+
+  defp public_address(addresses) do
+    case Enum.any?(addresses, &private_address?/1) do
+      true -> ssrf_error()
+      false -> {:ok, hd(addresses)}
+    end
+  end
+
+  defp pin_req(request, host, address) do
+    finch_options = normalize_finch_options(request.options[:finch])
+    finch_name = Keyword.fetch!(finch_options, :name)
+
+    {address, pool_tag} =
+      start_pool(finch_name, request.url.scheme, request.url.port, host, address)
+
+    finch_options = Keyword.put(finch_options, :pool_tag, pool_tag)
+
+    request
+    |> Req.Request.put_header("host", authority(host, request.url.scheme, request.url.port))
+    |> Req.Request.put_private(:public_url_pinned, true)
+    |> Map.update!(:url, &%{&1 | host: address})
+    |> Map.update!(:options, fn options ->
+      options
+      |> Map.delete(:connect_options)
+      |> Map.put(:finch, finch_options)
+      |> Map.put(:redirect, false)
+    end)
+  end
+
+  defp start_pool(finch_name, scheme, port, host, address) do
+    inet6? = tuple_size(address) == 8
+    address = address_string(address)
+    pool_tag = {:public_url, host}
+    pool = %Finch.Pool{scheme: normalize_scheme(scheme), host: address, port: port, tag: pool_tag}
+    conn_opts = [hostname: host, transport_opts: [inet6: inet6?]]
+
+    :ok =
+      Finch.start_pool(finch_name, pool,
+        protocols: [:http1],
+        conn_opts: conn_opts,
+        pool_max_idle_time: 60_000
+      )
+
+    {address, pool_tag}
+  end
+
+  defp normalize_finch_options(nil), do: [name: ReqLLM.Application.finch_name()]
+  defp normalize_finch_options(name) when is_atom(name), do: [name: name]
+
+  defp normalize_finch_options(options) when is_list(options) do
+    Keyword.put_new(options, :name, ReqLLM.Application.finch_name())
+  end
+
+  defp normalize_scheme("http"), do: :http
+  defp normalize_scheme("https"), do: :https
+  defp normalize_scheme(scheme), do: scheme
+
+  defp authority(host, scheme, port) do
+    host = if String.contains?(host, ":"), do: "[#{host}]", else: host
+
+    case {scheme, port} do
+      {scheme, port} when scheme in ["http", :http] and port in [nil, 80] -> host
+      {scheme, port} when scheme in ["https", :https] and port in [nil, 443] -> host
+      _other -> "#{host}:#{port}"
+    end
+  end
+
+  defp address_string(address), do: address |> :inet.ntoa() |> to_string()
+
+  defp ssrf_error, do: {:error, @ssrf_error}
+
+  defp private_address?({0, _, _, _}), do: true
+  defp private_address?({10, _, _, _}), do: true
+  defp private_address?({127, _, _, _}), do: true
+  defp private_address?({100, second, _, _}) when second in 64..127, do: true
+  defp private_address?({169, 254, _, _}), do: true
+  defp private_address?({172, second, _, _}) when second in 16..31, do: true
+  defp private_address?({192, 0, 0, _}), do: true
+  defp private_address?({192, 0, 2, _}), do: true
+  defp private_address?({192, 88, 99, _}), do: true
+  defp private_address?({192, 168, _, _}), do: true
+  defp private_address?({198, second, _, _}) when second in 18..19, do: true
+  defp private_address?({198, 51, 100, _}), do: true
+  defp private_address?({203, 0, 113, _}), do: true
+  defp private_address?({first, _, _, _}) when first in 224..255, do: true
+
+  defp private_address?({0x2001, second, _, _, _, _, _, _}) when second <= 0x1FF, do: true
+  defp private_address?({0x2001, 0xDB8, _, _, _, _, _, _}), do: true
+  defp private_address?({0x2002, _, _, _, _, _, _, _}), do: true
+  defp private_address?({0x3FFF, second, _, _, _, _, _, _}) when second <= 0xFFF, do: true
+  defp private_address?({first, _, _, _, _, _, _, _}) when first not in 0x2000..0x3FFF, do: true
+  defp private_address?(_address), do: false
+end

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -14,6 +14,7 @@ defmodule FrontmanServer.Tools.WebFetch do
 
   @behaviour FrontmanServer.Tools.Backend
 
+  alias FrontmanServer.PublicURL
   alias ModelContextProtocol, as: MCP
 
   @chrome_ua "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " <>
@@ -133,7 +134,8 @@ defmodule FrontmanServer.Tools.WebFetch do
         retry_delay: &retry_delay/1,
         retry_log_level: :debug,
         decode_body: false,
-        redirect: false
+        redirect: false,
+        plugins: [PublicURL]
       ] ++ req_options()
 
     req_opts
@@ -212,9 +214,7 @@ defmodule FrontmanServer.Tools.WebFetch do
       [location | _] ->
         resolved = base_url |> URI.merge(location) |> URI.to_string()
 
-        with :ok <- validate_scheme(resolved),
-             {:ok, host} <- extract_host(resolved),
-             :ok <- validate_host(host) do
+        with :ok <- PublicURL.validate(resolved) do
           fetch(resolved, @user_agents, redirects + 1)
         end
 
@@ -273,125 +273,12 @@ defmodule FrontmanServer.Tools.WebFetch do
 
   defp validate_url(%{"url" => url})
        when is_binary(url) and byte_size(url) > 0 do
-    with :ok <- validate_scheme(url),
-         {:ok, host} <- extract_host(url),
-         :ok <- validate_host(host) do
+    with :ok <- PublicURL.validate(url) do
       {:ok, url}
     end
   end
 
   defp validate_url(_), do: {:error, "url is required"}
-
-  defp validate_scheme("http://" <> _), do: :ok
-  defp validate_scheme("https://" <> _), do: :ok
-
-  defp validate_scheme(_) do
-    {:error, "URL must start with http:// or https://"}
-  end
-
-  defp extract_host(url) do
-    case URI.parse(url) do
-      %URI{host: host} when is_binary(host) and byte_size(host) > 0 ->
-        {:ok, host}
-
-      _ ->
-        {:error, "Could not parse host from URL"}
-    end
-  end
-
-  defp validate_host(host) do
-    host
-    |> String.downcase()
-    |> do_validate_host()
-  end
-
-  defp do_validate_host("localhost"), do: ssrf_error()
-  defp do_validate_host("localhost" <> _), do: ssrf_error()
-
-  defp do_validate_host(host) do
-    case String.ends_with?(host, [".local", ".internal", ".localhost"]) do
-      true ->
-        ssrf_error()
-
-      false ->
-        host
-        |> String.to_charlist()
-        |> check_ip_or_resolve()
-    end
-  end
-
-  defp ssrf_error do
-    {:error,
-     "Requests to private/internal addresses are not allowed. For current app pages or local development URLs, use the available browser or framework-specific page inspection tools instead."}
-  end
-
-  defp check_ip_or_resolve(host_charlist) do
-    case :inet.parse_address(host_charlist) do
-      {:ok, ip} ->
-        check_ip(ip)
-
-      {:error, :einval} ->
-        resolve_and_check(host_charlist)
-    end
-  end
-
-  defp resolve_and_check(host_charlist) do
-    ipv4 =
-      case :inet.getaddrs(host_charlist, :inet) do
-        {:ok, addrs} -> addrs
-        {:error, _} -> []
-      end
-
-    ipv6 =
-      case :inet.getaddrs(host_charlist, :inet6) do
-        {:ok, addrs} -> addrs
-        {:error, _} -> []
-      end
-
-    case ipv4 ++ ipv6 do
-      [] -> {:error, "Could not resolve hostname"}
-      all_addrs -> check_all_addrs(all_addrs)
-    end
-  end
-
-  defp check_all_addrs(addrs) do
-    case Enum.any?(addrs, &private_ip?/1) do
-      true -> ssrf_error()
-      false -> :ok
-    end
-  end
-
-  defp check_ip(ip) do
-    case private_ip?(ip) do
-      true -> ssrf_error()
-      false -> :ok
-    end
-  end
-
-  defp private_ip?({0, _, _, _}), do: true
-  defp private_ip?({10, _, _, _}), do: true
-  defp private_ip?({127, _, _, _}), do: true
-  defp private_ip?({169, 254, _, _}), do: true
-  defp private_ip?({172, b, _, _}) when b >= 16 and b <= 31, do: true
-  defp private_ip?({192, 168, _, _}), do: true
-
-  defp private_ip?({0, 0, 0, 0, 0, 0xFFFF, hi, lo}) do
-    import Bitwise
-    private_ip?({hi >>> 8, hi &&& 0xFF, lo >>> 8, lo &&& 0xFF})
-  end
-
-  defp private_ip?({0, 0, 0, 0, 0, 0, 0, 0}), do: true
-  defp private_ip?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
-
-  defp private_ip?({s, _, _, _, _, _, _, _})
-       when s >= 0xFC00 and s <= 0xFDFF,
-       do: true
-
-  defp private_ip?({s, _, _, _, _, _, _, _})
-       when s >= 0xFE80 and s <= 0xFEBF,
-       do: true
-
-  defp private_ip?(_), do: false
 
   defp clamp(val, min, :infinity) when is_integer(val) do
     max(val, min)

--- a/apps/frontman_server/test/frontman_server/public_url_test.exs
+++ b/apps/frontman_server/test/frontman_server/public_url_test.exs
@@ -1,0 +1,101 @@
+defmodule FrontmanServer.PublicURLTest do
+  use ExUnit.Case, async: false
+
+  alias FrontmanServer.PublicURL
+
+  test "accepts public HTTP and HTTPS addresses" do
+    assert :ok = PublicURL.validate("http://93.184.216.34")
+    assert :ok = PublicURL.validate("https://[2606:2800:220:1:248:1893:25c8:1946]")
+  end
+
+  @blocked_urls ~w(
+    http://localhost/secret http://localhost:8080/admin http://127.0.0.1/
+    http://127.0.0.42:9200/ http://10.0.0.1/ http://172.16.0.1/ http://192.168.1.1/
+    http://169.254.169.254/latest/meta-data/ http://0.0.0.0/ http://[::1]/
+    http://100.64.0.1/ http://192.0.0.1/ http://192.0.2.1/ http://198.18.0.1/
+    http://198.51.100.1/ http://203.0.113.1/ http://224.0.0.1/ http://240.0.0.1/
+    http://[::ffff:127.0.0.1]/ http://[::ffff:169.254.169.254]/ http://[fd01::1]/
+    http://[fdff::1]/ http://[fe90::1]/ http://[febf::1]/ http://[fec0::1]/ http://[100::1]/
+    http://[::127.0.0.1]/ http://[64:ff9b::127.0.0.1]/ http://[64:ff9b:1::1]/
+    http://[2001::1]/ http://[2001:db8::1]/ http://[2002::1]/ http://[3fff::1]/
+    http://[5f00::1]/ http://[ff02::1]/
+  )
+
+  for url <- @blocked_urls do
+    test "rejects #{url}" do
+      assert {:error, message} = PublicURL.validate(unquote(url))
+      assert message =~ "private"
+    end
+  end
+
+  test "rejects a hostname when any IPv4 or IPv6 address is private" do
+    previous_lookup = :inet_db.res_option(:lookup)
+    host = ~c"mixed-public-url.invalid"
+    public_address = {93, 184, 216, 34}
+    private_address = {0, 0, 0, 0, 0, 0, 0, 1}
+
+    on_exit(fn ->
+      :inet_db.del_host(public_address)
+      :inet_db.del_host(private_address)
+      :inet_db.set_lookup(previous_lookup)
+    end)
+
+    :inet_db.set_lookup([:file])
+    :inet_db.add_host(public_address, [host])
+    :inet_db.add_host(private_address, [host])
+
+    assert {:error, message} = PublicURL.validate("http://mixed-public-url.invalid")
+    assert message =~ "private"
+  end
+
+  test "pins Req connections to the validated address while preserving the hostname" do
+    with_host("public-url.invalid", {93, 184, 216, 34}, fn ->
+      request = Req.new(url: "https://public-url.invalid/resource")
+      protected = PublicURL.protect_req(request)
+
+      assert protected.url.host == "93.184.216.34"
+      assert Req.Request.get_header(protected, "host") == ["public-url.invalid"]
+      assert protected.options.finch[:name] == ReqLLM.Application.finch_name()
+      assert protected.options.finch[:pool_tag] == {:public_url, "public-url.invalid"}
+      refute Map.has_key?(protected.options, :connect_options)
+      assert protected.options.redirect == false
+
+      assert PublicURL.protect_req(protected) == protected
+    end)
+  end
+
+  test "Req plugin applies transport protection" do
+    with_host("public-plugin.invalid", {93, 184, 216, 36}, fn ->
+      protected =
+        [url: "https://public-plugin.invalid/resource", plugins: [PublicURL]]
+        |> Req.new()
+        |> Req.Request.prepare()
+
+      assert protected.url.host == "93.184.216.36"
+      assert Req.Request.get_header(protected, "host") == ["public-plugin.invalid"]
+    end)
+  end
+
+  test "formats a pinned IPv6 Host header with brackets" do
+    request = Req.new(url: "https://[2606:2800:220:1:248:1893:25c8:1946]/resource")
+    protected = PublicURL.protect_req(request)
+
+    assert Req.Request.get_header(protected, "host") == [
+             "[2606:2800:220:1:248:1893:25c8:1946]"
+           ]
+  end
+
+  defp with_host(host, address, fun) do
+    previous_lookup = :inet_db.res_option(:lookup)
+    host = String.to_charlist(host)
+
+    try do
+      :inet_db.set_lookup([:file])
+      :inet_db.add_host(address, [host])
+      fun.()
+    after
+      :inet_db.del_host(address)
+      :inet_db.set_lookup(previous_lookup)
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
@@ -86,30 +86,9 @@ defmodule FrontmanServer.Tools.WebFetchTest do
   describe "execute/2 — SSRF protection" do
     @public_test_url "http://93.184.216.34"
 
-    @blocked_urls [
-      {"localhost", "http://localhost/secret"},
-      {"localhost with port", "http://localhost:8080/admin"},
-      {"loopback 127.0.0.1", "http://127.0.0.1/"},
-      {"loopback 127.x", "http://127.0.0.42:9200/"},
-      {"10.x private", "http://10.0.0.1/"},
-      {"172.16.x private", "http://172.16.0.1/"},
-      {"192.168.x private", "http://192.168.1.1/"},
-      {"link-local metadata", "http://169.254.169.254/latest/meta-data/"},
-      {"0.0.0.0", "http://0.0.0.0/"},
-      {"IPv6 loopback", "http://[::1]/"},
-      {"IPv4-mapped IPv6 loopback", "http://[::ffff:127.0.0.1]/"},
-      {"IPv4-mapped IPv6 metadata", "http://[::ffff:169.254.169.254]/"},
-      {"ULA fd01::1", "http://[fd01::1]/"},
-      {"ULA fdff::1", "http://[fdff::1]/"},
-      {"link-local fe90::1", "http://[fe90::1]/"},
-      {"link-local febf::1", "http://[febf::1]/"}
-    ]
-
-    for {label, url} <- @blocked_urls do
-      test "rejects #{label}: #{url}", %{context: ctx} do
-        msg = execute_error(unquote(url), ctx)
-        assert msg =~ "private"
-      end
+    test "rejects private initial URLs", %{context: ctx} do
+      msg = execute_error("http://127.0.0.1/", ctx)
+      assert msg =~ "private"
     end
 
     test "blocks redirect to private IP", %{context: ctx} do


### PR DESCRIPTION
## Summary
- extract shared public-destination validation from WebFetch
- pin Req connections to validated IP addresses while preserving host and TLS identity
- keep redirect blocking and focused public/private address coverage

## Scope
Prerequisite for #1496. Contains no custom-provider persistence, API, or UI code. Finch streaming protection remains in custom-provider feature because WebFetch does not consume it.

## Verification
- `make -C apps/frontman_server precommit`
- 758 tests passed
- Credo found no issues
- `git diff --check`

## Diff
- 5 files
- +303/-142, net +161
- removes 142 lines of duplicated WebFetch URL policy