### PR TITLE
fix(client): require model before sending

### DIFF
--- a/.changeset/require-selected-model.md
+++ b/.changeset/require-selected-model.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Prevent message submission until a model is selected.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -110,6 +110,16 @@ let selectGetStartedTask = (~providerSetupRequired, ~onConfigureProvider, ~onSel
   }
 }
 
+module ExecutePlanAction = {
+  @react.component
+  let make = (~pendingPlanHandoff, ~selectedModelValue, ~onExecute) => {
+    switch (pendingPlanHandoff, selectedModelValue) {
+    | (Some(_), Some(_)) => <Client__ExecutePlanBanner onExecute />
+    | _ => React.null
+    }
+  }
+}
+
 @react.component
 let make = (~onConfigureProvider: unit => unit) => {
   let {session, createSession} = Client__FrontmanProvider.useFrontman()
@@ -407,11 +417,9 @@ let make = (~onConfigureProvider: unit => unit) => {
         ->Array.mapWithIndex((item, index) => renderDisplayItem(item, index))
         ->React.array}
 
-        {switch pendingPlanHandoff {
-        | Some(_) =>
-          <Client__ExecutePlanBanner onExecute={Client__State.Actions.executePendingPlan} />
-        | None => React.null
-        }}
+        <ExecutePlanAction
+          pendingPlanHandoff selectedModelValue onExecute={Client__State.Actions.executePendingPlan}
+        />
 
         {switch (retryStatus, turnError, currentTaskId) {
         | (Some(rs), _, _) => <Client__RetryBanner retryStatus=rs />

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -409,16 +409,22 @@ let make = (
   }
 
   let hasSubmittableContent = hasContent || hasAnnotations
-  let isInputDisabled = !hasActiveACPSession || disabled || noModelsConfigured
+  let noModelSelected = selectedModelValue->Option.isNone
+  let isInputDisabled = !hasActiveACPSession || disabled || noModelsConfigured || noModelSelected
   let isSubmitDisabled = isInputDisabled || !hasSubmittableContent || isEnrichingAnnotations
   let showStopButton = isAgentRunning && !hasSubmittableContent
 
-  let currentPlaceholder = if noModelsConfigured {
-    "Connect an AI provider to start chatting."
-  } else if disabled {
-    disabledPlaceholder->Option.getOr("Input disabled")
-  } else {
-    placeholder
+  let currentPlaceholder = switch (
+    noModelsConfigured,
+    disabled,
+    isModelsConfigLoading,
+    noModelSelected,
+  ) {
+  | (true, _, _, _) => "Connect an AI provider to start chatting."
+  | (_, true, _, _) => disabledPlaceholder->Option.getOr("Input disabled")
+  | (_, _, true, _) => "Loading models..."
+  | (_, _, _, true) => "Select a model to start chatting."
+  | _ => placeholder
   }
 
   <div

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1121,36 +1121,42 @@ let next = (state: state, action) => {
     }
   | TaskAction({target, action: taskAction}) => state->Lens.delegateToTask(target, taskAction)
 
-  | AddUserMessage({id, sessionId, content, annotations, agentId}) => {
-      let textContent = TaskReducer.extractTextFromUserContent(content)
+  | AddUserMessage({id, sessionId, content, annotations, agentId}) =>
+    switch state.selectedModelValue {
+    | None => state->StateReducer.update
+    | Some(_) => {
+        let textContent = TaskReducer.extractTextFromUserContent(content)
 
-      switch state.currentTask {
-      | Task.New(newTask) =>
-        let loadedTask = Task.newToLoaded(newTask, ~id=sessionId, ~title=textContent)
-        let updatedTasks = state.tasks->Dict.copy
-        updatedTasks->Dict.set(sessionId, loadedTask)
-        let promotedState = {
-          ...state,
-          tasks: updatedTasks,
-          currentTask: Task.Selected(sessionId),
-        }
-        promotedState->Lens.delegateToTask(
-          ForTask(sessionId),
-          TaskReducer.AddUserMessage({id, content, annotations, agentId}),
-        )
-      | Task.Selected(taskId) =>
-        let pendingPlanHandoff = Selectors.pendingPlanHandoff(state)
-        let (updatedState, sendEffects) =
-          state->Lens.delegateToTask(
-            ForTask(taskId),
+        switch state.currentTask {
+        | Task.New(newTask) =>
+          let loadedTask = Task.newToLoaded(newTask, ~id=sessionId, ~title=textContent)
+          let updatedTasks = state.tasks->Dict.copy
+          updatedTasks->Dict.set(sessionId, loadedTask)
+          let promotedState = {
+            ...state,
+            tasks: updatedTasks,
+            currentTask: Task.Selected(sessionId),
+          }
+          promotedState->Lens.delegateToTask(
+            ForTask(sessionId),
             TaskReducer.AddUserMessage({id, content, annotations, agentId}),
           )
-        switch pendingPlanHandoff {
-        | Some(_) =>
-          let (runningState, runningEffects) =
-            updatedState->Lens.delegateToTask(ForTask(taskId), TaskReducer.ExecutionStateRunning)
-          runningState->StateReducer.update(~sideEffects=Array.concat(sendEffects, runningEffects))
-        | None => updatedState->StateReducer.update(~sideEffects=sendEffects)
+        | Task.Selected(taskId) =>
+          let pendingPlanHandoff = Selectors.pendingPlanHandoff(state)
+          let (updatedState, sendEffects) =
+            state->Lens.delegateToTask(
+              ForTask(taskId),
+              TaskReducer.AddUserMessage({id, content, annotations, agentId}),
+            )
+          switch pendingPlanHandoff {
+          | Some(_) =>
+            let (runningState, runningEffects) =
+              updatedState->Lens.delegateToTask(ForTask(taskId), TaskReducer.ExecutionStateRunning)
+            runningState->StateReducer.update(
+              ~sideEffects=Array.concat(sendEffects, runningEffects),
+            )
+          | None => updatedState->StateReducer.update(~sideEffects=sendEffects)
+          }
         }
       }
     }
@@ -1162,8 +1168,8 @@ let next = (state: state, action) => {
     }
 
   | ExecutePendingPlan({id}) =>
-    switch Selectors.pendingPlanHandoff(state) {
-    | Some({taskId, executorAgentId}) =>
+    switch (state.selectedModelValue, Selectors.pendingPlanHandoff(state)) {
+    | (Some(_), Some({taskId, executorAgentId})) =>
       let (messageState, sendEffects) = state->Lens.delegateToTask(
         ForTask(taskId),
         TaskReducer.AddUserMessage({

--- a/libs/client/test/Client__Chatbox.test.res
+++ b/libs/client/test/Client__Chatbox.test.res
@@ -3,6 +3,9 @@ open Vitest
 module Chatbox = Client__Chatbox
 module Message = Client__State__Types.Message
 
+@module("react-dom/server")
+external renderToStaticMarkup: React.element => string = "renderToStaticMarkup"
+
 describe("shouldRenderTurnError", () => {
   test("hides turn error when matching error message is already rendered", t => {
     let error = Message.ErrorMessage.make(
@@ -59,5 +62,27 @@ describe("selectGetStartedTask", () => {
     t
     ->expect(submittedTask.contents)
     ->Expect.toEqual(Some("Make the main heading bigger and bolder"))
+  })
+})
+
+describe("ExecutePlanAction", () => {
+  test("hides execute action without a selected model", t => {
+    let html = renderToStaticMarkup(
+      <Chatbox.ExecutePlanAction
+        pendingPlanHandoff={Some()} selectedModelValue=None onExecute={() => ()}
+      />,
+    )
+
+    t->expect(html->String.includes("Execute plan"))->Expect.toBe(false)
+  })
+
+  test("shows execute action when a plan and model are available", t => {
+    let html = renderToStaticMarkup(
+      <Chatbox.ExecutePlanAction
+        pendingPlanHandoff={Some()} selectedModelValue={Some("test:model")} onExecute={() => ()}
+      />,
+    )
+
+    t->expect(html->String.includes("Execute plan"))->Expect.toBe(true)
   })
 })

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -45,7 +45,7 @@ module TestHelpers = {
     ...Reducer.defaultState,
     tasks,
     currentTask,
-    selectedModelValue: None,
+    selectedModelValue: Some("test:model"),
   }
 
   let makeStateWithTask = (
@@ -177,6 +177,20 @@ describe("Client State Reducer - Plan Handoff", () => {
     t->expect(duplicateEffects)->Expect.toEqual([])
   })
 
+  test("execute does nothing without a selected model", t => {
+    let state = {
+      ...TestHelpers.makeStateWithTask(~messages=[plannerPlan])->withPlanHandoffContext,
+      selectedModelValue: None,
+    }
+    let (nextState, effects) = Reducer.next(
+      state,
+      Reducer.ExecutePendingPlan({id: testUserMessageId}),
+    )
+
+    t->expect(nextState)->Expect.toEqual(state)
+    t->expect(effects)->Expect.toEqual([])
+  })
+
   test("planner follow-up consumes the handoff before the server reports running", t => {
     let state = TestHelpers.makeStateWithTask(~messages=[plannerPlan])->withPlanHandoffContext
     let (submitting, _) = Reducer.next(
@@ -274,7 +288,7 @@ describe("Client State Reducer", () => {
   })
 
   test("AddUserMessage creates task and sends without optimistic message", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
     let action = Reducer.AddUserMessage({
       id: testUserMessageId,
       sessionId: "session-1",
@@ -299,7 +313,7 @@ describe("Client State Reducer", () => {
   })
 
   test("messages maintain order", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
 
     let (state, _) = Reducer.next(
       state,
@@ -785,7 +799,7 @@ describe("Client State Reducer - Tool Lifecycle", () => {
 
 describe("Client State Reducer - Task ID Continuity", () => {
   test("multiple user messages in same conversation use same task ID in state", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
 
     let (state1, _effects1) = Reducer.next(
       state,
@@ -819,7 +833,7 @@ describe("Client State Reducer - Task ID Continuity", () => {
   })
 
   test("effect contains same task ID as state", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
 
     let (state1, effects1) = Reducer.next(
       state,
@@ -1244,7 +1258,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
   ]
 
   test("UserMessageReceived with annotations stores them on the message", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
@@ -1282,7 +1296,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
   })
 
   test("UserMessageReceived with only annotations creates valid message", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
@@ -1315,7 +1329,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
   })
 
   test("UserMessageReceived without annotations stores empty array", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
     let (state, _) = Reducer.next(
       state,
       Reducer.AddUserMessage({
@@ -1343,7 +1357,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
   })
 
   test("SendMessage effect carries annotations from AddUserMessage", t => {
-    let state = Reducer.defaultState
+    let state = {...Reducer.defaultState, selectedModelValue: Some("test:model")}
     let action = Reducer.AddUserMessage({
       id: testUserMessageId,
       sessionId: "session-1",
@@ -1368,6 +1382,27 @@ describe("Client State Reducer - Annotations on Messages", () => {
       t->expect((annotations->Array.getUnsafe(0)).id)->Expect.toBe("ann-1")
     | _ => JsExn.throw("Expected TaskEffect(SendMessage) with annotations")
     }
+  })
+
+  test("AddUserMessage does nothing without a selected model", t => {
+    let state = {
+      ...Reducer.defaultState,
+      acpSession: TestHelpers.activeAcpSession(),
+      selectedModelValue: None,
+    }
+    let (nextState, effects) = Reducer.next(
+      state,
+      Reducer.AddUserMessage({
+        id: UserMessageId.make(),
+        sessionId: "session-1",
+        content: [UserContentPart.text("Fix this")],
+        annotations: [],
+        agentId: "planner-id",
+      }),
+    )
+
+    t->expect(nextState)->Expect.toEqual(state)
+    t->expect(effects)->Expect.toEqual([])
   })
 
   test("SendMessage metadata carries message ID, submission agent, and selected model", t => {
@@ -1422,6 +1457,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     let dispatched = ref([])
     let state = {
       ...Reducer.defaultState,
+      selectedModelValue: Some("test:model"),
       acpSession: AcpSessionActive({
         sendPrompt: (_, ~additionalBlocks as _, ~onComplete, ~_meta as _) =>
           completion := Some(onComplete),


### PR DESCRIPTION
## Summary
- disable composer submission until a model is selected
- guard reducer message and pending-plan send paths against missing model metadata
- add regression coverage and client patch changeset

## Verification
- `make -C libs/client test` (380 tests passed)
- `make rescript-build`
- pre-commit ReScript formatting and source-comment checks
- pre-push Reanalyze checks

Closes #1554