### PR TITLE
Fix JSON-RPC numeric IDs above signed 32-bit

### DIFF
--- a/.changeset/support-large-json-rpc-ids.md
+++ b/.changeset/support-large-json-rpc-ids.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-protocol": patch
+---
+
+Preserve integral JSON-RPC numeric IDs above signed 32-bit range.

--- a/libs/frontman-client/test/FrontmanClient__MCP.test.res
+++ b/libs/frontman-client/test/FrontmanClient__MCP.test.res
@@ -281,6 +281,18 @@ describe("MCP 2026-07-28", () => {
     t->expect(response(calls)->Dict.get("id"))->Expect.toEqual(Some(JSON.Encode.string("call-1")))
   })
 
+  testAsync("echoes numeric JSON-RPC ids above signed 32-bit", async t => {
+    let (channel, calls) = MockChannel.make()
+    await MCP.handleMessage(
+      handler(channel, ref(None)),
+      requestWithId(~id="2147483648", ~method="tools/list", ~params=metadata),
+    )
+
+    t
+    ->expect(response(calls)->Dict.get("id"))
+    ->Expect.toEqual(Some(JSON.parseOrThrow("2147483648")))
+  })
+
   testAsync("returns invalid params for an unknown tool", async t => {
     let server = MCPServer.make(~relay=Relay.make(~baseUrl="http://relay.invalid"))
     let (channel, calls) = MockChannel.make()

--- a/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
@@ -17,25 +17,34 @@ module Id: {
   let toInt: t => option<int>
   let schema: S.t<t>
 } = {
-  type t = IntId(int) | StringId(string)
+  type t = NumberId(float) | StringId(string)
 
-  let fromInt = value => IntId(value)
+  @scope("Number") @val
+  external isInteger: float => bool = "isInteger"
+
+  let fromInt = value => NumberId(Float.fromInt(value))
 
   let toInt = id =>
     switch id {
-    | IntId(value) => Some(value)
+    | NumberId(value) => {
+        let intValue = Float.toInt(value)
+        switch Float.fromInt(intValue) == value {
+        | true => Some(intValue)
+        | false => None
+        }
+      }
     | StringId(_) => None
     }
 
   let schema: S.t<t> = S.union([
     S.float
-    ->S.refine(value => Float.fromInt(Float.toInt(value)) == value, ~error="Expected integer")
+    ->S.refine(isInteger, ~error="Expected integer")
     ->S.extendJSONSchema(S.int->S.toJSONSchema)
     ->S.transform(s => {
-      parser: value => IntId(Float.toInt(value)),
+      parser: value => NumberId(value),
       serializer: id =>
         switch id {
-        | IntId(value) => Float.fromInt(value)
+        | NumberId(value) => value
         | StringId(_) => s.fail("Expected integer JSON-RPC id")
         },
     }),
@@ -44,7 +53,7 @@ module Id: {
       serializer: id =>
         switch id {
         | StringId(value) => value
-        | IntId(_) => s.fail("Expected string JSON-RPC id")
+        | NumberId(_) => s.fail("Expected string JSON-RPC id")
         },
     }),
   ])

--- a/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__JsonRpc.res
@@ -20,7 +20,7 @@ module Id: {
   type t = NumberId(float) | StringId(string)
 
   @scope("Number") @val
-  external isInteger: float => bool = "isInteger"
+  external isSafeInteger: float => bool = "isSafeInteger"
 
   let fromInt = value => NumberId(Float.fromInt(value))
 
@@ -38,7 +38,7 @@ module Id: {
 
   let schema: S.t<t> = S.union([
     S.float
-    ->S.refine(isInteger, ~error="Expected integer")
+    ->S.refine(isSafeInteger, ~error="Expected safe integer")
     ->S.extendJSONSchema(S.int->S.toJSONSchema)
     ->S.transform(s => {
       parser: value => NumberId(value),

--- a/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
@@ -28,6 +28,13 @@ describe("JSON-RPC wire contracts", () => {
     )
   })
 
+  test("preserves integer request IDs above signed 32-bit", t => {
+    let json = JSON.parseOrThrow(`{"jsonrpc":"2.0","id":2147483648,"method":"tools/list"}`)
+    let request = json->S.parseOrThrow(~to=JsonRpc.Request.schema)
+
+    t->expect(JsonRpc.Request.toJson(request))->Expect.toEqual(json)
+  })
+
   test("requires success ID and result without error", t => {
     let valid = `{"jsonrpc":"2.0","id":"request-1","result":null}`
     let invalid = [

--- a/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__JsonRpc.test.res
@@ -35,6 +35,26 @@ describe("JSON-RPC wire contracts", () => {
     t->expect(JsonRpc.Request.toJson(request))->Expect.toEqual(json)
   })
 
+  test("accepts request IDs at JavaScript safe integer boundaries", t => {
+    let valid = [
+      `{"jsonrpc":"2.0","id":9007199254740991,"method":"tools/list"}`,
+      `{"jsonrpc":"2.0","id":-9007199254740991,"method":"tools/list"}`,
+    ]
+
+    valid->Array.forEach(json => t->expect(parses(JsonRpc.Request.schema, json))->Expect.toBe(true))
+  })
+
+  test("rejects request IDs outside JavaScript safe integer boundaries", t => {
+    let invalid = [
+      `{"jsonrpc":"2.0","id":9007199254740992,"method":"tools/list"}`,
+      `{"jsonrpc":"2.0","id":-9007199254740992,"method":"tools/list"}`,
+    ]
+
+    invalid->Array.forEach(
+      json => t->expect(parses(JsonRpc.Request.schema, json))->Expect.toBe(false),
+    )
+  })
+
   test("requires success ID and result without error", t => {
     let valid = `{"jsonrpc":"2.0","id":"request-1","result":null}`
     let invalid = [


### PR DESCRIPTION
## Summary
- preserve integral JSON-RPC numeric IDs as JavaScript numbers instead of coercing through ReScript `int`
- keep existing `fromInt` and safe `toInt` behavior for ACP request correlation
- add protocol round-trip and MCP response echo coverage for `2147483648`
- add patch changeset for protocol and client packages

## Verification
- `make -C libs/frontman-protocol test`
- `make -C libs/frontman-client test`
- `make -C libs/frontman-protocol check-schemas`
- `make rescript-build`
- pre-commit source-comment checks
- pre-push ReScript reanalysis

Fixes #1552