### PR TITLE
Reject duplicate MCP tool names during discovery

### DIFF
--- a/.changeset/reject-duplicate-mcp-tool-names.md
+++ b/.changeset/reject-duplicate-mcp-tool-names.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Reject MCP catalogs containing duplicate tool names before publishing any discovered tools.

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
@@ -35,6 +35,7 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
       project_rules_request_id: nil,
       project_structure_request_id: nil,
       seen_tool_cursors: MapSet.new(),
+      seen_tool_names: MapSet.new(),
       tools_size: 0,
       load_project_context: Frameworks.load_project_context?(framework),
       tools: []
@@ -135,8 +136,8 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
   end
 
   defp handle_tools_response(result, state) do
-    case validate_tools_response(result) do
-      {:ok, raw_tools, cursor} ->
+    case validate_tools_response(result, state.seen_tool_names) do
+      {:ok, raw_tools, cursor, seen_tool_names} ->
         Logger.info("MCPInitializer: Received #{length(raw_tools)} tools from MCP server")
         tools_size = state.tools_size + :erlang.external_size(raw_tools)
 
@@ -147,6 +148,7 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
         state = %{
           state
           | tools: Enum.reverse(MCPTools.from_maps(raw_tools), state.tools),
+            seen_tool_names: seen_tool_names,
             tools_size: tools_size,
             tools_request_id: nil
         }
@@ -161,13 +163,27 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
     end
   end
 
-  defp validate_tools_response(result) do
+  defp validate_tools_response(result, seen_tool_names) do
     with :ok <- MCPSchema.validate_tools_list_result(result),
-         %{"tools" => tools} <- result do
-      {:ok, tools, Map.get(result, "nextCursor")}
+         %{"tools" => tools} <- result,
+         {:ok, seen_tool_names} <- track_tool_names(tools, seen_tool_names) do
+      {:ok, tools, Map.get(result, "nextCursor"), seen_tool_names}
     else
-      _ -> {:error, "Invalid MCP tools/list response"}
+      {:error, {:duplicate_tool_name, name}} ->
+        {:error, "MCP tools/list returned duplicate tool name: #{name}"}
+
+      _ ->
+        {:error, "Invalid MCP tools/list response"}
     end
+  end
+
+  defp track_tool_names(tools, seen_tool_names) do
+    Enum.reduce_while(tools, {:ok, seen_tool_names}, fn %{"name" => name}, {:ok, names} ->
+      case MapSet.member?(names, name) do
+        true -> {:halt, {:error, {:duplicate_tool_name, name}}}
+        false -> {:cont, {:ok, MapSet.put(names, name)}}
+      end
+    end)
   end
 
   defp request_next_tools_page(state, cursor) do

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
@@ -110,6 +110,34 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializerTest do
       assert {first.name, second.name} == {"first", "second"}
     end
 
+    test "fails initialization when one tools page contains duplicate names" do
+      state = tools_state(1)
+
+      duplicate_tools = [
+        %{"name" => "duplicate", "inputSchema" => %{"type" => "object"}},
+        %{"name" => "duplicate", "inputSchema" => %{"type" => "object"}}
+      ]
+
+      assert {%{status: :failed, tools: []}, [{:initialization_failed, message}]} =
+               MCPInitializer.handle_response(state, 1, tools_result(duplicate_tools))
+
+      assert message == "MCP tools/list returned duplicate tool name: duplicate"
+    end
+
+    test "fails initialization when tools pages contain duplicate names" do
+      state = tools_state(1)
+      tool = %{"name" => "duplicate", "inputSchema" => %{"type" => "object"}}
+      first_page = tools_result([tool], %{"nextCursor" => "page-2"})
+
+      assert {new_state, [{:push_mcp, request}]} =
+               MCPInitializer.handle_response(state, 1, first_page)
+
+      assert {%{status: :failed}, [{:initialization_failed, message}]} =
+               MCPInitializer.handle_response(new_state, request["id"], tools_result([tool]))
+
+      assert message == "MCP tools/list returned duplicate tool name: duplicate"
+    end
+
     test "fails initialization when a tools cursor repeats" do
       state = tools_state(1)
       first_page = tools_result([], %{"nextCursor" => "same-cursor"})


### PR DESCRIPTION
## Summary
- track MCP tool names throughout paginated discovery
- fail initialization on first same-page or cross-page duplicate
- prevent duplicate catalogs from reaching publication

## Testing
- `make precommit` (776 tests passed)

Closes #1547