### PR TITLE
Handle MCP tool-result content types safely

### DIFF
--- a/.changeset/handle-mcp-tool-result-content.md
+++ b/.changeset/handle-mcp-tool-result-content.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Keep task channels alive when MCP tools return audio, resource links, or embedded resources by reporting unsupported content as tool errors.

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -381,19 +381,33 @@ defmodule FrontmanServerWeb.TaskChannel do
     %{output_schema: output_schema} =
       Enum.find(tools, %{output_schema: nil}, &(&1.name == tool_call.tool_name))
 
-    with :ok <- MCPSchema.validate_call_tool_result(result, output_schema),
-         nil <- Enum.find(result["content"], &(&1["type"] not in ["text", "image"])) do
-      :ok
-    else
-      :error ->
-        raise "Invalid MCP tools/call result for task #{socket.assigns.task_id}, tool #{tool_call.tool_name}, call #{tool_call.tool_call_id}"
+    result =
+      case MCPSchema.validate_call_tool_result(result, output_schema) do
+        :ok ->
+          normalize_tool_call_result(result)
 
-      %{"type" => type} ->
-        raise "Unsupported MCP tools/call content type #{inspect(type)} for task #{socket.assigns.task_id}, tool #{tool_call.tool_name}, call #{tool_call.tool_call_id}"
-    end
+        :error ->
+          raise "Invalid MCP tools/call result for task #{socket.assigns.task_id}, tool #{tool_call.tool_name}, call #{tool_call.tool_call_id}"
+      end
 
     {:noreply, persist_tool_call_result(tool_call, result, socket)}
   end
+
+  defp normalize_tool_call_result(%{"content" => content} = result) do
+    case Enum.find(content, &(not supported_tool_result_content?(&1))) do
+      nil ->
+        result
+
+      %{"type" => type} ->
+        MCP.tool_result_error("Unsupported MCP tool result content type: #{type}")
+    end
+  end
+
+  defp supported_tool_result_content?(%{"type" => "text"}), do: true
+  defp supported_tool_result_content?(%{"type" => "image"}), do: true
+  defp supported_tool_result_content?(%{"type" => "audio"}), do: false
+  defp supported_tool_result_content?(%{"type" => "resource_link"}), do: false
+  defp supported_tool_result_content?(%{"type" => "resource"}), do: false
 
   defp persist_tool_call_result(tool_call, result, socket) do
     task_id = socket.assigns.task_id

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -174,6 +174,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     %{socket: socket, task_id: task_id, scope: scope} = context
     tool_call = tool_call("call_unsupported_result", "testTool")
     tool_call_id = tool_call.tool_call_id
+    message = "Unsupported MCP tool result content type: #{content_type}"
     register_tool_receiver(tool_call_id)
 
     persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call)
@@ -190,26 +191,16 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     :sys.get_state(socket.channel_pid)
 
     assert Process.alive?(socket.channel_pid)
-    assert_receive {:tool_result, ^tool_call_id, [%SwarmAi.Message.ContentPart{text: text}], true}
-    assert text == "Unsupported MCP tool result content type: #{content_type}"
 
-    assert_push("acp:message", %{
-      "method" => "session/update",
-      "params" => %{
-        "sessionId" => ^task_id,
-        "update" => %{"status" => "failed"}
-      }
-    })
+    assert_receive {:tool_result, ^tool_call_id,
+                    [%SwarmAi.Message.ContentPart{type: :text, text: ^message}], true}
 
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    assert {:ok, task} = Tasks.get_task(scope, task_id)
 
-    assert %Interaction.ToolResult{
-             result: %{
-               "content" => [%{"type" => "text", "text" => ^text}],
-               "isError" => true
-             },
-             is_error: true
-           } = Enum.find(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
+    assert Enum.any?(
+             Tasks.interactions(task),
+             &match?(%Interaction.ToolResult{is_error: true}, &1)
+           )
   end
 
   defp question_tool_call(id, header, label) do
@@ -1149,15 +1140,11 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       image_data =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
 
-      mcp_result = %{
-        "resultType" => "complete",
-        "content" => [
-          %{"type" => "text", "text" => "done"},
-          %{"type" => "image", "data" => image_data, "mimeType" => "image/png"}
-        ],
-        "structuredContent" => %{"logged" => true},
-        "_meta" => %{"envApiKey" => "sk-fake-valid-mcp-marker"}
-      }
+      mcp_result =
+        image_data
+        |> MCP.tool_result_image("image/png")
+        |> Map.put("structuredContent", %{"logged" => true})
+        |> Map.put("_meta", %{"envApiKey" => "sk-fake-valid-mcp-marker"})
 
       log =
         capture_log([level: :info], fn ->
@@ -1170,7 +1157,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       assert_receive {:tool_result, ^tool_call_id,
                       [
-                        %SwarmAi.Message.ContentPart{type: :text, text: "done"},
                         %SwarmAi.Message.ContentPart{
                           type: :image,
                           data: decoded_image_data,
@@ -1189,61 +1175,39 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
     end
 
-    test "converts audio content to a tool error", context do
-      assert_unsupported_tool_result(
-        context,
-        [%{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}],
-        "audio"
-      )
-    end
-
-    test "converts resource link content to a tool error", context do
-      assert_unsupported_tool_result(
-        context,
-        [%{"type" => "resource_link", "name" => "Example", "uri" => "https://example.com"}],
-        "resource_link"
-      )
-    end
-
-    test "converts embedded text resource content to a tool error", context do
-      assert_unsupported_tool_result(
-        context,
-        [
-          %{
-            "type" => "resource",
-            "resource" => %{"uri" => "file:///example.txt", "text" => "example"}
-          }
-        ],
-        "resource"
-      )
-    end
-
-    test "converts embedded blob resource content to a tool error", context do
-      assert_unsupported_tool_result(
-        context,
-        [
-          %{
-            "type" => "resource",
-            "resource" => %{
-              "uri" => "file:///example.bin",
-              "mimeType" => "application/octet-stream",
-              "blob" => "YmxvYg=="
-            }
-          }
-        ],
-        "resource"
-      )
-    end
-
-    test "converts mixed supported and unsupported content to one tool error", context do
-      assert_unsupported_tool_result(
-        context,
-        [
-          %{"type" => "text", "text" => "partial result"},
-          %{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}
-        ],
-        "audio"
-      )
+    for {name, content, content_type} <- [
+          {"audio", [%{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}],
+           "audio"},
+          {"resource link",
+           [%{"type" => "resource_link", "name" => "Example", "uri" => "https://example.com"}],
+           "resource_link"},
+          {"embedded text resource",
+           [
+             %{
+               "type" => "resource",
+               "resource" => %{"uri" => "file:///example.txt", "text" => "example"}
+             }
+           ], "resource"},
+          {"embedded blob resource",
+           [
+             %{
+               "type" => "resource",
+               "resource" => %{"uri" => "file:///example.bin", "blob" => "YmxvYg=="}
+             }
+           ], "resource"},
+          {"mixed supported and audio",
+           [
+             %{"type" => "text", "text" => "partial result"},
+             %{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}
+           ], "audio"}
+        ] do
+      test "converts #{name} content to a tool error", context do
+        assert_unsupported_tool_result(
+          context,
+          unquote(Macro.escape(content)),
+          unquote(content_type)
+        )
+      end
     end
 
     test "crashes loudly for malformed MCP tool results", context do

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -170,6 +170,48 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
   end
 
+  defp assert_unsupported_tool_result(context, content, content_type) do
+    %{socket: socket, task_id: task_id, scope: scope} = context
+    tool_call = tool_call("call_unsupported_result", "testTool")
+    tool_call_id = tool_call.tool_call_id
+    register_tool_receiver(tool_call_id)
+
+    persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call)
+
+    assert_push("mcp:message", %{"method" => "tools/call", "id" => mcp_request_id})
+
+    result = %{
+      "resultType" => "complete",
+      "content" => content,
+      "structuredContent" => %{"logged" => true}
+    }
+
+    push(socket, "mcp:message", JsonRpc.success_response(mcp_request_id, result))
+    :sys.get_state(socket.channel_pid)
+
+    assert Process.alive?(socket.channel_pid)
+    assert_receive {:tool_result, ^tool_call_id, [%SwarmAi.Message.ContentPart{text: text}], true}
+    assert text == "Unsupported MCP tool result content type: #{content_type}"
+
+    assert_push("acp:message", %{
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => ^task_id,
+        "update" => %{"status" => "failed"}
+      }
+    })
+
+    {:ok, task} = Tasks.get_task(scope, task_id)
+
+    assert %Interaction.ToolResult{
+             result: %{
+               "content" => [%{"type" => "text", "text" => ^text}],
+               "isError" => true
+             },
+             is_error: true
+           } = Enum.find(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
+  end
+
   defp question_tool_call(id, header, label) do
     args =
       Jason.encode!(%{
@@ -1104,9 +1146,15 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       assert is_integer(mcp_request_id)
 
+      image_data =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
       mcp_result = %{
         "resultType" => "complete",
-        "content" => [],
+        "content" => [
+          %{"type" => "text", "text" => "done"},
+          %{"type" => "image", "data" => image_data, "mimeType" => "image/png"}
+        ],
         "structuredContent" => %{"logged" => true},
         "_meta" => %{"envApiKey" => "sk-fake-valid-mcp-marker"}
       }
@@ -1119,7 +1167,18 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       refute log =~ "sk-fake-valid-mcp-marker"
       refute log =~ "envApiKey"
-      assert_receive {:tool_result, ^tool_call_id, [], false}
+
+      assert_receive {:tool_result, ^tool_call_id,
+                      [
+                        %SwarmAi.Message.ContentPart{type: :text, text: "done"},
+                        %SwarmAi.Message.ContentPart{
+                          type: :image,
+                          data: decoded_image_data,
+                          media_type: "image/png"
+                        }
+                      ], false}
+
+      assert decoded_image_data == Base.decode64!(image_data)
 
       assert_push("acp:message", %{
         "method" => "session/update",
@@ -1130,11 +1189,60 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
     end
 
-    test "crashes loudly for unsupported MCP tool result content", context do
-      assert_tool_result_crash(
+    test "converts audio content to a tool error", context do
+      assert_unsupported_tool_result(
         context,
         [%{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}],
-        ~s(Unsupported MCP tools/call content type "audio")
+        "audio"
+      )
+    end
+
+    test "converts resource link content to a tool error", context do
+      assert_unsupported_tool_result(
+        context,
+        [%{"type" => "resource_link", "name" => "Example", "uri" => "https://example.com"}],
+        "resource_link"
+      )
+    end
+
+    test "converts embedded text resource content to a tool error", context do
+      assert_unsupported_tool_result(
+        context,
+        [
+          %{
+            "type" => "resource",
+            "resource" => %{"uri" => "file:///example.txt", "text" => "example"}
+          }
+        ],
+        "resource"
+      )
+    end
+
+    test "converts embedded blob resource content to a tool error", context do
+      assert_unsupported_tool_result(
+        context,
+        [
+          %{
+            "type" => "resource",
+            "resource" => %{
+              "uri" => "file:///example.bin",
+              "mimeType" => "application/octet-stream",
+              "blob" => "YmxvYg=="
+            }
+          }
+        ],
+        "resource"
+      )
+    end
+
+    test "converts mixed supported and unsupported content to one tool error", context do
+      assert_unsupported_tool_result(
+        context,
+        [
+          %{"type" => "text", "text" => "partial result"},
+          %{"type" => "audio", "data" => "YXVkaW8=", "mimeType" => "audio/wav"}
+        ],
+        "audio"
       )
     end
 


### PR DESCRIPTION
## Summary
- define explicit runtime handling for every MCP tool-result content type
- convert unsupported audio, resource links, and embedded resources into deterministic tool errors before persistence
- preserve valid text/image handling and malformed-result crashes
- add channel-level regression coverage and patch changeset

## Verification
- `make precommit` in `apps/frontman_server`
- 780 tests passed
- compile with warnings as errors, formatting, and Credo passed

Closes #1545