### PR TITLE
Require TL;DR in final agent responses

### DIFF
--- a/.changeset/add-agent-response-tldr.md
+++ b/.changeset/add-agent-response-tldr.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Require every final agent response to include a concise TL;DR covering outcomes and relevant next steps.

--- a/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
@@ -36,7 +36,8 @@ defmodule FrontmanServer.Agents.SystemPrompt do
         |> Enum.map(&framework_guidance/1),
         if(Frameworks.code_attachment_guidance?(Map.get(context, :framework)),
           do: code_project_attachment_guidance()
-        )
+        ),
+        final_response_guidance()
       ]
       |> List.flatten()
       |> Enum.reject(&is_nil/1)
@@ -231,6 +232,14 @@ defmodule FrontmanServer.Agents.SystemPrompt do
     ## Attachments
 
     Use `write_file` with `image_ref` only when the user asks to use an attachment; then reference the saved file. Do not save unused attachments.
+    """
+  end
+
+  defp final_response_guidance do
+    """
+    ## Final Response
+
+    Include a `TL;DR:` section in every final user-facing response. Keep it to one sentence or 1-3 bullets. Summarize the outcome, blockers, and next action when relevant. Do not replace necessary detail elsewhere in the response.
     """
   end
 

--- a/apps/frontman_server/test/frontman_server/agents_test.exs
+++ b/apps/frontman_server/test/frontman_server/agents_test.exs
@@ -113,6 +113,17 @@ defmodule FrontmanServer.AgentsTest do
   end
 
   describe "system_prompt/2" do
+    test "requires a concise TL;DR in every agent's final response", %{scope: scope} do
+      for agent <- Agents.list_agents(scope) do
+        prompt = Agents.system_prompt(agent, %{})
+
+        assert prompt =~ "Include a `TL;DR:` section in every final user-facing response"
+        assert prompt =~ "one sentence or 1-3 bullets"
+        assert prompt =~ "outcome, blockers, and next action when relevant"
+        assert prompt =~ "Do not replace necessary detail"
+      end
+    end
+
     test "uses agent system as base and appends runtime context", %{scope: scope} do
       {:ok, agent} = Agents.get_agent(scope, @executor_id)
 


### PR DESCRIPTION
## Summary
- append shared final-response guidance to every configured agent prompt
- require concise TL;DR content without replacing necessary detail
- add regression coverage and a patch changeset

## Testing
- `mix test test/frontman_server/agents_test.exs` (14 passed)
- `make precommit` (777 passed)

Closes #1023