### PR TITLE
Remove unused protocol observers

### DIFF
--- a/.changeset/remove-protocol-observers.md
+++ b/.changeset/remove-protocol-observers.md
@@ -1,0 +1,8 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-core": patch
+"@frontman-ai/frontman-protocol": patch
+---
+
+Remove unused ACP, MCP, and relay progress observers so diagnostic callbacks cannot interrupt protocol delivery.

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -14,7 +14,6 @@ type initConfig = {
   loginUrl: string,
   clientName: string,
   clientVersion: string,
-  onACPMessage: (ACP.messageDirection, JSON.t) => unit,
   _meta: JSON.t,
   onTitleUpdated: option<(string, string) => unit>,
 }
@@ -81,7 +80,6 @@ type loadTaskRequest = {
   needsHistory: bool,
   onUpdate: (string, ACPTypes.sessionUpdate) => unit,
   onTitleUpdated: (string, string) => unit,
-  onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
   onComplete: result<unit, string> => unit,
 }
 
@@ -89,7 +87,6 @@ type createSessionRequest = {
   sessionId: string,
   onUpdate: (string, ACPTypes.sessionUpdate) => unit,
   onTitleUpdated: (string, string) => unit,
-  onMcpMessage: (FrontmanAiFrontmanClient.FrontmanClient__MCP.messageDirection, JSON.t) => unit,
   onComplete: result<string, string> => unit,
 }
 
@@ -228,7 +225,6 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
       ~name=config.clientName,
       ~version=config.clientVersion,
       ~_meta=config._meta,
-      ~onMessage=config.onACPMessage,
       ~onTitleUpdated=?config.onTitleUpdated,
       ~onConfigOptionsUpdated=configOptions => {
         Client__State__Store.dispatch(ConfigOptionsReceived({configOptions: configOptions}))
@@ -623,7 +619,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
   | CreateSessionEffect({
       connection,
       mcpServer,
-      request: {sessionId, onUpdate, onTitleUpdated, onMcpMessage, onComplete},
+      request: {sessionId, onUpdate, onTitleUpdated, onComplete},
     }) =>
     let create = async () => {
       let mcpServerInterface = MCPServer.toInterface(mcpServer)
@@ -639,7 +635,6 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
           dispatch(SessionFailed({sessionId, error}))
         },
         ~mcpServerInterface,
-        ~onMcpMessage,
       )
       switch result {
       | Ok((sess, sessionNewResult)) =>
@@ -689,7 +684,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
   | LoadTaskEffect({
       connection,
       mcpServer,
-      request: {taskId, needsHistory, onUpdate, onTitleUpdated, onMcpMessage, onComplete},
+      request: {taskId, needsHistory, onUpdate, onTitleUpdated, onComplete},
     }) =>
     let activateSession = async () => {
       let mcpServerInterface = MCPServer.toInterface(mcpServer)
@@ -706,7 +701,6 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
             dispatch(SessionFailed({sessionId: taskId, error: err}))
           },
           ~mcpServerInterface,
-          ~onMcpMessage,
         )
         loadResult->Result.map(((session, _)) => session)
       | false =>
@@ -720,7 +714,6 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
             dispatch(SessionFailed({sessionId: taskId, error: err}))
           },
           ~mcpServerInterface,
-          ~onMcpMessage,
         )
       }
       switch result {

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -145,16 +145,6 @@ module Provider = {
     ~clientVersion: string="1.0.0",
     ~children: React.element,
   ) => {
-    let logACPMessage = React.useCallback0((direction: ACP.messageDirection, payload: JSON.t) => {
-      let arrow = direction == Send ? `→` : `←`
-      Log.debug(~ctx={"payload": payload}, `ACP ${arrow}`)
-    })
-
-    let logMCPMessage = React.useCallback0((direction, payload) => {
-      let arrow = direction == FrontmanAiFrontmanClient.FrontmanClient__MCP.Send ? `→` : `←`
-      Log.debug(~ctx={"payload": payload}, `MCP ${arrow}`)
-    })
-
     let (state, dispatch) = StateReducer.useReducer(module(Reducer), Reducer.initialState)
     let connectionStateRef = React.useRef(state)
 
@@ -189,7 +179,6 @@ module Provider = {
         loginUrl,
         clientName,
         clientVersion,
-        onACPMessage: logACPMessage,
         _meta,
         onTitleUpdated: Some(
           (taskId, title) => {
@@ -354,7 +343,6 @@ module Provider = {
           sessionId: WebAPI.Window.current->WebAPI.Window.crypto->WebAPI.Crypto.randomUUID,
           onUpdate: handleSessionUpdate,
           onTitleUpdated: handleTitleUpdated,
-          onMcpMessage: logMCPMessage,
           onComplete,
         }),
       )
@@ -381,7 +369,6 @@ module Provider = {
           needsHistory,
           onUpdate: handleSessionUpdate,
           onTitleUpdated: handleTitleUpdated,
-          onMcpMessage: logMCPMessage,
           onComplete,
         }),
       )

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -40,7 +40,6 @@ let initConfig: Reducer.initConfig = {
   loginUrl: "http://test/users/log-in",
   clientName: "test",
   clientVersion: "1.0.0",
-  onACPMessage: (_, _) => (),
   onTitleUpdated: None,
   _meta: JSON.Encode.object(Dict.fromArray([("framework", JSON.Encode.string("test"))])),
 }
@@ -55,7 +54,6 @@ let loadTask = taskId => Reducer.LoadTask({
   needsHistory: true,
   onUpdate: (_, _) => (),
   onTitleUpdated: (_, _) => (),
-  onMcpMessage: (_, _) => (),
   onComplete: _ => (),
 })
 describe("Connection Reducer", () => {
@@ -494,7 +492,6 @@ describe("Connection Reducer", () => {
             sessionId: "sess-1",
             onUpdate: (_, _) => (),
             onTitleUpdated: (_, _) => (),
-            onMcpMessage: (_, _) => (),
             onComplete: _ => (),
           }),
         )

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -11,7 +11,6 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #ACP
 })
 
-type messageDirection = Protocol.messageDirection
 @@live
 type config = {
   endpoint: string,
@@ -19,7 +18,6 @@ type config = {
   loginUrl: string,
   clientInfo: Types.implementation,
   clientCapabilities: Types.clientCapabilities,
-  onMessage: option<(messageDirection, JSON.t) => unit>,
   onTitleUpdated: option<(string, string) => unit>,
   onConfigOptionsUpdated: option<array<Types.sessionConfigOption> => unit>,
 }
@@ -32,7 +30,6 @@ let makeConfig = (
   ~name: string,
   ~version: string,
   ~_meta: JSON.t,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>=?,
   ~onTitleUpdated: option<(string, string) => unit>=?,
   ~onConfigOptionsUpdated: option<array<Types.sessionConfigOption> => unit>=?,
 ): config => {
@@ -53,7 +50,6 @@ let makeConfig = (
     elicitation: None,
     _meta: None,
   },
-  onMessage,
 }
 
 type connection = {
@@ -61,7 +57,6 @@ type connection = {
   channel: Channel.t,
   clientConfig: Client.config,
   state: ref<Client.state>,
-  onMessage: option<(messageDirection, JSON.t) => unit>,
 }
 
 @@live
@@ -196,13 +191,7 @@ let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSign
       clientCapabilities: config.clientCapabilities,
     }
 
-    Protocol.attachMessageHandler(
-      ~channel,
-      ~state,
-      ~onUpdate=None,
-      ~onMessage=config.onMessage,
-      ~onParseError=None,
-    )
+    Protocol.attachMessageHandler(~channel, ~state, ~onUpdate=None, ~onParseError=None)
 
     let socketResult = await waitForSocket(socket)
 
@@ -244,25 +233,14 @@ let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSign
       }
 
       Sentry.addBreadcrumb(~category=#acp, ~message="Channel joined, sending initialize")
-      switch await Protocol.sendInitialize(
-        ~channel,
-        ~state,
-        ~clientConfig,
-        ~onMessage=config.onMessage,
-      ) {
+      switch await Protocol.sendInitialize(~channel, ~state, ~clientConfig) {
       | Error(e) =>
         Log.error(`ACP initialize failed: ${e}`)
         Error(ConnectionFailed(e))
       | Ok(result) =>
         Sentry.addBreadcrumb(~category=#acp, ~message="ACP initialized successfully")
         state := state.contents->Client.reduce(Client.ACPStateChanged(Client.Initialized(result)))
-        Ok({
-          socket,
-          channel,
-          clientConfig,
-          state,
-          onMessage: config.onMessage,
-        })
+        Ok({socket, channel, clientConfig, state})
       }
     }
   }
@@ -305,7 +283,6 @@ let joinSession = async (
   ~onParseError: option<string => unit>=?,
   ~cleanupOnParseError: option<ref<bool>>=?,
   ~mcpServerInterface: option<MCPTypes.serverInterface<'server>>=?,
-  ~onMcpMessage: option<(MCP.messageDirection, JSON.t) => unit>=?,
 ): result<session, string> => {
   let sessionChannel = conn.socket->Socket.channel(~topic=Constants.makeTaskTopic(sessionId))
   let handleParseError = err => {
@@ -323,7 +300,6 @@ let joinSession = async (
     ~channel=sessionChannel,
     ~state=conn.state,
     ~onUpdate=Some(onUpdate),
-    ~onMessage=conn.onMessage,
     ~onParseError=Some(handleParseError),
   )
 
@@ -332,7 +308,6 @@ let joinSession = async (
       serverInterface,
       channel: sessionChannel,
       sessionId,
-      onMessage: onMcpMessage,
     }
     sessionChannel->Channel.on(~event=#"mcp:message", ~callback=payload => {
       MCP.handleMessage(handler, payload)->ignore
@@ -377,7 +352,6 @@ let createSession = async (
   ~onTitleUpdated: (string, string) => unit,
   ~onParseError: option<string => unit>=?,
   ~mcpServerInterface: option<MCPTypes.serverInterface<'server>>=?,
-  ~onMcpMessage: option<(MCP.messageDirection, JSON.t) => unit>=?,
 ): result<(session, Types.sessionNewResult), string> => {
   Sentry.addBreadcrumb(~category=#session, ~message=`Creating new session with id: ${sessionId}`)
 
@@ -385,7 +359,6 @@ let createSession = async (
     ~channel=conn.channel,
     ~state=conn.state,
     ~sessionId,
-    ~onMessage=conn.onMessage,
   )
 
   switch sessionNewResult {
@@ -400,7 +373,6 @@ let createSession = async (
         ~onTitleUpdated,
         ~onParseError?,
         ~mcpServerInterface?,
-        ~onMcpMessage?,
       )
       switch joinResult {
       | Ok(session) => Ok((session, result))
@@ -436,25 +408,14 @@ let sendPrompt = async (
     ~sessionId=session.sessionId,
     ~prompt=allBlocks,
     ~_meta,
-    ~onMessage=session.connection.onMessage,
   )
 }
 
-let cancelPrompt = (session: session): unit => {
-  Protocol.sendCancel(
-    ~channel=session.channel,
-    ~sessionId=session.sessionId,
-    ~onMessage=session.connection.onMessage,
-  )
-}
+let cancelPrompt = (session: session): unit =>
+  Protocol.sendCancel(~channel=session.channel, ~sessionId=session.sessionId)
 
 let retryTurn = (session: session, ~retriedErrorId: string): unit => {
-  Protocol.sendRetryTurn(
-    ~channel=session.channel,
-    ~sessionId=session.sessionId,
-    ~retriedErrorId,
-    ~onMessage=session.connection.onMessage,
-  )
+  Protocol.sendRetryTurn(~channel=session.channel, ~sessionId=session.sessionId, ~retriedErrorId)
 }
 
 let listSessions = (conn: connection): promise<result<array<Types.sessionSummary>, string>> => {
@@ -497,7 +458,6 @@ let loadSession = async (
   ~onTitleUpdated: (string, string) => unit,
   ~onParseError: option<string => unit>=?,
   ~mcpServerInterface: option<MCPTypes.serverInterface<'server>>=?,
-  ~onMcpMessage: option<(MCP.messageDirection, JSON.t) => unit>=?,
 ): result<(session, Types.sessionLoadResult), string> => {
   let buffering = ref(true)
   let bufferedUpdates = ref([])
@@ -534,7 +494,6 @@ let loadSession = async (
       },
     ~cleanupOnParseError,
     ~mcpServerInterface?,
-    ~onMcpMessage?,
   )
 
   switch joinResult {
@@ -557,7 +516,6 @@ let loadSession = async (
         ),
       ),
       ~parseResult=Client.parseSessionLoadResult,
-      ~onMessage=conn.onMessage,
     )
     cleanupOnParseError := true
 

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -7,15 +7,12 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #ACP
 })
 
-type messageDirection = Send | Receive
-
 let sendRequest = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
   ~method: string,
   ~params: option<JSON.t>,
   ~parseResult: JSON.t => result<'a, string>,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
 ): promise<result<'a, string>> => {
   Promise.make((resolve, _) => {
     let id = state.contents.currentId + 1
@@ -34,7 +31,6 @@ let sendRequest = (
     state := state.contents->Client.reduce(Client.RequestSent(id, pending))
 
     let payload = request->JsonRpc.Request.toJson
-    onMessage->Option.forEach(cb => cb(Send, payload))
     channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore
   })
 }
@@ -43,7 +39,6 @@ let sendInitialize = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
   ~clientConfig: Client.config,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
 ): promise<result<Types.initializeResult, string>> => {
   let params = Client.buildInitializeParams(clientConfig)
   sendRequest(
@@ -52,16 +47,12 @@ let sendInitialize = (
     ~method="initialize",
     ~params=Some(params),
     ~parseResult=Client.parseInitializeResult,
-    ~onMessage,
   )
 }
 
-let sendSessionNew = (
-  ~channel: Channel.t,
-  ~state: ref<Client.state>,
-  ~sessionId: string,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
-): promise<result<Types.sessionNewResult, string>> => {
+let sendSessionNew = (~channel: Channel.t, ~state: ref<Client.state>, ~sessionId: string): promise<
+  result<Types.sessionNewResult, string>,
+> => {
   let params = Dict.make()
   params->Dict.set("sessionId", JSON.Encode.string(sessionId))
   sendRequest(
@@ -70,7 +61,6 @@ let sendSessionNew = (
     ~method="session/new",
     ~params=Some(JSON.Encode.object(params)),
     ~parseResult=Client.parseSessionNewResult,
-    ~onMessage,
   )
 }
 
@@ -80,7 +70,6 @@ let sendPrompt = (
   ~sessionId: string,
   ~prompt: array<JSON.t>,
   ~_meta: option<JSON.t>,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
 ): promise<result<Types.promptResult, string>> => {
   let entries = [
     ("sessionId", JSON.Encode.string(sessionId)),
@@ -97,30 +86,19 @@ let sendPrompt = (
     ~method="session/prompt",
     ~params=Some(promptParams),
     ~parseResult=Client.parsePromptResult,
-    ~onMessage,
   )
 }
 
-let sendCancel = (
-  ~channel: Channel.t,
-  ~sessionId: string,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
-): unit => {
+let sendCancel = (~channel: Channel.t, ~sessionId: string): unit => {
   let cancelParams = JSON.Encode.object(
     Dict.fromArray([("sessionId", JSON.Encode.string(sessionId))]),
   )
   let notification = JsonRpc.Notification.make(~method="session/cancel", ~params=Some(cancelParams))
   let payload = notification->JsonRpc.Notification.toJson
-  onMessage->Option.forEach(cb => cb(Send, payload))
   channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore
 }
 
-let sendRetryTurn = (
-  ~channel: Channel.t,
-  ~sessionId: string,
-  ~retriedErrorId: string,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
-): unit => {
+let sendRetryTurn = (~channel: Channel.t, ~sessionId: string, ~retriedErrorId: string): unit => {
   let params = JSON.Encode.object(
     Dict.fromArray([
       ("sessionId", JSON.Encode.string(sessionId)),
@@ -129,7 +107,6 @@ let sendRetryTurn = (
   )
   let notification = JsonRpc.Notification.make(~method="session/retry_turn", ~params=Some(params))
   let payload = notification->JsonRpc.Notification.toJson
-  onMessage->Option.forEach(cb => cb(Send, payload))
   channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore
 }
 
@@ -143,12 +120,9 @@ let getMethod = (payload: JSON.t): option<string> => {
 let handleIncomingMessage = (
   ~state: ref<Client.state>,
   ~onUpdate: option<(string, Types.sessionUpdate) => unit>,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
   ~onParseError: option<string => unit>,
   payload: JSON.t,
 ): unit => {
-  onMessage->Option.forEach(cb => cb(Receive, payload))
-
   switch getMethod(payload) {
   | Some("session/update") =>
     switch Client.parseSessionUpdateNotification(state.contents, payload) {
@@ -178,10 +152,9 @@ let attachMessageHandler = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
   ~onUpdate: option<(string, Types.sessionUpdate) => unit>,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>,
   ~onParseError: option<string => unit>,
 ): unit => {
   channel->Channel.on(~event=Constants.acpMessageEvent, ~callback=payload =>
-    handleIncomingMessage(~state, ~onUpdate, ~onMessage, ~onParseError, payload)
+    handleIncomingMessage(~state, ~onUpdate, ~onParseError, payload)
   )
 }

--- a/libs/frontman-client/src/FrontmanClient__MCP.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP.res
@@ -6,13 +6,10 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #MCP
 })
 
-type messageDirection = Send | Receive
-
 type mcpHandler<'server> = {
   serverInterface: Types.serverInterface<'server>,
   channel: Channel.t,
   sessionId: string,
-  onMessage: option<(messageDirection, JSON.t) => unit>,
 }
 
 @@live
@@ -56,7 +53,6 @@ let parseParams = (params, schema, missingMessage) =>
 
 let sendResponse = (handler: mcpHandler<'server>, id: JsonRpc.Id.t, result: JSON.t): unit => {
   let payload = JsonRpc.Response.makeSuccess(~id, ~result)->JsonRpc.Response.toJson
-  handler.onMessage->Option.forEach(cb => cb(Send, payload))
   handler.channel->Channel.push(~event=#"mcp:message", ~payload)->ignore
 }
 
@@ -69,14 +65,12 @@ let sendError = (
 ): unit => {
   let error = JsonRpc.RpcError.make(~code, ~message, ~data)
   let payload = JsonRpc.Response.makeError(~id, ~error)->JsonRpc.Response.toJson
-  handler.onMessage->Option.forEach(cb => cb(Send, payload))
   handler.channel->Channel.push(~event=#"mcp:message", ~payload)->ignore
 }
 
 let sendErrorWithoutId = (handler: mcpHandler<'server>, code: int, message: string): unit => {
   let error = JsonRpc.RpcError.make(~code, ~message, ~data=None)
   let payload = JsonRpc.Response.makeErrorWithoutId(~error)->JsonRpc.Response.toJson
-  handler.onMessage->Option.forEach(cb => cb(Send, payload))
   handler.channel->Channel.push(~event=#"mcp:message", ~payload)->ignore
 }
 
@@ -168,11 +162,7 @@ let handleToolsCall = async (
     | Ok(authorizedToolCall) =>
       try {
         let {serverInterface} = handler
-        let result = await serverInterface.executeTool(
-          serverInterface.server,
-          authorizedToolCall,
-          ~onProgress=None,
-        )
+        let result = await serverInterface.executeTool(serverInterface.server, authorizedToolCall)
         switch result {
         | Completed(callToolResult) =>
           let resultJson =
@@ -197,8 +187,6 @@ let handleToolsCall = async (
 
 let handleMessage = async (handler: mcpHandler<'server>, payload: JSON.t): unit => {
   try {
-    handler.onMessage->Option.forEach(cb => cb(Receive, payload))
-
     switch parse(payload) {
     | Ok(Request({id, method, params})) =>
       switch parseParams(params, Types.discoverParamsSchema, "Missing request params") {
@@ -237,9 +225,8 @@ let attach = (
   ~channel: Channel.t,
   ~sessionId: string,
   ~serverInterface: Types.serverInterface<'server>,
-  ~onMessage: option<(messageDirection, JSON.t) => unit>=?,
 ): mcpHandler<'server> => {
-  let handler = {serverInterface, channel, sessionId, onMessage}
+  let handler = {serverInterface, channel, sessionId}
 
   channel->Channel.on(~event=#"mcp:message", ~callback=payload => {
     handleMessage(handler, payload)->ignore

--- a/libs/frontman-client/src/FrontmanClient__MCP__Server.res
+++ b/libs/frontman-client/src/FrontmanClient__MCP__Server.res
@@ -187,7 +187,6 @@ let executeTool = async (
   ~arguments: option<Dict.t<JSON.t>>=?,
   ~taskId: string,
   ~callId: string,
-  ~onProgress: option<string => unit>=?,
 ): Types.executeToolResult => {
   switch getToolByName(server, name) {
   | Some(toolModule) => await executeLocalTool(toolModule, ~arguments, ~taskId, ~toolCallId=callId)
@@ -219,11 +218,7 @@ let executeTool = async (
       switch resolvedArgs {
       | Error(msg) => Completed(toolError(msg))
       | Ok(finalArgs) =>
-        let result = await server.relay->Relay.executeTool(
-          ~name,
-          ~arguments=?finalArgs,
-          ~onProgress?,
-        )
+        let result = await server.relay->Relay.executeTool(~name, ~arguments=?finalArgs)
         switch result {
         | Ok(toolResult) => Completed(toolResult)
         | Error(msg) => Completed(toolError(msg))
@@ -261,13 +256,12 @@ let toInterface = (server: t): Types.serverInterface<t> => {
   server,
   buildDiscoverResult,
   buildToolsListResult,
-  executeTool: (server, toolCall, ~onProgress) =>
+  executeTool: (server, toolCall) =>
     executeTool(
       server,
       ~name=Types.AuthorizedToolCall.name(toolCall),
       ~arguments=?Types.AuthorizedToolCall.arguments(toolCall),
       ~taskId=Types.AuthorizedToolCall.taskId(toolCall),
       ~callId=Types.AuthorizedToolCall.callId(toolCall),
-      ~onProgress?,
     ),
 }

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -119,12 +119,10 @@ let hasTool = (relay: t, name: string): bool => {
   }
 }
 
-let executeTool = async (
-  relay: t,
-  ~name: string,
-  ~arguments: option<Dict.t<JSON.t>>=?,
-  ~onProgress: option<string => unit>=?,
-): result<MCPTypes.CallToolResult.t, string> => {
+let executeTool = async (relay: t, ~name: string, ~arguments: option<Dict.t<JSON.t>>=?): result<
+  MCPTypes.CallToolResult.t,
+  string,
+> => {
   switch relay->isConnected {
   | false => Error("Relay not connected")
   | true =>
@@ -155,7 +153,7 @@ let executeTool = async (
         Log.error(~ctx={"tool": name}, msg)
         Error(msg)
       | true =>
-        switch await SSE.readStream(response, ~onProgress?) {
+        switch await SSE.readStream(response) {
         | Ok(json) =>
           json
           ->Decoders.parseSchema(MCPTypes.callToolResultSchema)

--- a/libs/frontman-client/src/FrontmanClient__SSE.res
+++ b/libs/frontman-client/src/FrontmanClient__SSE.res
@@ -38,50 +38,33 @@ let parseEventBlock = (block: string): option<sseEvent> => {
   }
 }
 
-let processEvent = (event: sseEvent, ~onProgress: option<string => unit>): option<
-  result<JSON.t, string>,
-> => {
-  switch event.eventType {
-  | #progress =>
-    onProgress->Option.forEach(cb => cb(event.data))
-    None
-  | #result =>
-    let parsed = try {
-      Ok(JSON.parseOrThrow(event.data))
-    } catch {
-    | exn =>
-      let msg = exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("unknown")
-      Error(`Failed to parse result JSON: ${msg}`)
-    }
-    Some(parsed)
-  | #error => Some(Error(event.data))
-  | #unknown => None
-  }
-}
-
 let exnMessage = (exn: exn): string => {
   exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("unknown")
 }
 
-let processBlocks = (blocks: array<string>, ~onProgress: option<string => unit>): option<
-  result<JSON.t, string>,
-> => {
-  blocks->Array.reduceWithIndex(None, (acc, block, _i) => {
+let processBlocks = (blocks: array<string>): option<result<JSON.t, string>> => {
+  blocks->Array.reduce(None, (acc, block) => {
     switch acc {
     | Some(_) => acc
     | None =>
       switch parseEventBlock(block) {
       | None => None
-      | Some(event) => processEvent(event, ~onProgress)
+      | Some({eventType: #progress | #unknown}) => None
+      | Some({eventType: #error, data}) => Some(Error(data))
+      | Some({eventType: #result, data}) =>
+        Some(
+          try {
+            Ok(JSON.parseOrThrow(data))
+          } catch {
+          | exn => Error(`Failed to parse result JSON: ${exnMessage(exn)}`)
+          },
+        )
       }
     }
   })
 }
 
-let readStream = async (response: WebAPI.Response.t, ~onProgress: option<string => unit>=?): result<
-  JSON.t,
-  string,
-> => {
+let readStream = async (response: WebAPI.Response.t): result<JSON.t, string> => {
   switch response.body->Null.toOption {
   | None => Error("No response body")
   | Some(body) =>
@@ -108,7 +91,7 @@ let readStream = async (response: WebAPI.Response.t, ~onProgress: option<string 
             incompleteChunk := parts->Array.getUnsafe(partsCount - 1)
 
             let completeBlocks = parts->Array.slice(~start=0, ~end=partsCount - 1)
-            result := processBlocks(completeBlocks, ~onProgress)
+            result := processBlocks(completeBlocks)
           })
           ->Option.getOr()
         }

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -73,7 +73,6 @@ let loadConnectionWithTransport = (history, result): (ACP.connection, mockTransp
     channel: transport.channel,
     clientConfig,
     state: ref(Client.initialState),
-    onMessage: None,
   }
   (connection, transport)
 }
@@ -473,7 +472,6 @@ describe("ACP Client handleResponse", _t => {
           | _ => ()
           },
       ),
-      ~onMessage=None,
       ~onParseError=Some(error => parseError := Some(error)),
       payload,
     )

--- a/libs/frontman-client/test/FrontmanClient__MCP.test.res
+++ b/libs/frontman-client/test/FrontmanClient__MCP.test.res
@@ -71,7 +71,7 @@ let makeInterface = (
     cacheScope: "private",
     _meta: {serverInfo: serverInfo},
   },
-  executeTool: async (_, toolCall, ~onProgress as _) => {
+  executeTool: async (_, toolCall) => {
     switch failure == Some(Tool) {
     | true => JsError.throwWithMessage("tool exploded")
     | false => ()
@@ -121,7 +121,6 @@ let handler = (channel, context, ~sessionId="task-1", ~failure=?) => {
   MCP.serverInterface: makeInterface(~context, ~failure?),
   channel,
   sessionId,
-  onMessage: None,
 }
 
 describe("MCP 2026-07-28", () => {
@@ -302,7 +301,6 @@ describe("MCP 2026-07-28", () => {
         MCP.serverInterface: MCPServer.toInterface(server),
         channel,
         sessionId: "task-1",
-        onMessage: None,
       },
       request(
         ~id=21,
@@ -327,7 +325,6 @@ describe("MCP 2026-07-28", () => {
         MCP.serverInterface: MCPServer.toInterface(server),
         channel,
         sessionId: "task-1",
-        onMessage: None,
       },
       request(
         ~id=22,

--- a/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
+++ b/libs/frontman-core/src/FrontmanCore__RequestHandlers.res
@@ -199,7 +199,6 @@ let handleToolCall = async (
     let ctx: CoreServer.executionContext = {
       projectRoot: config.projectRoot,
       sourceRoot: config.sourceRoot,
-      onProgress: None,
     }
 
     let resultPromise = CoreServer.executeTool(

--- a/libs/frontman-core/src/FrontmanCore__Server.res
+++ b/libs/frontman-core/src/FrontmanCore__Server.res
@@ -7,8 +7,6 @@ module ToolRegistry = FrontmanCore__ToolRegistry
 type executionContext = {
   projectRoot: string,
   sourceRoot: string,
-  @live
-  onProgress: option<string => unit>,
 }
 
 type executeResult =

--- a/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
@@ -356,9 +356,5 @@ type serverInterface<'server> = {
   server: 'server,
   buildDiscoverResult: 'server => discoverResult,
   buildToolsListResult: 'server => toolsListResult,
-  executeTool: (
-    'server,
-    AuthorizedToolCall.t,
-    ~onProgress: option<string => unit>,
-  ) => promise<executeToolResult>,
+  executeTool: ('server, AuthorizedToolCall.t) => promise<executeToolResult>,
 }


### PR DESCRIPTION
## Summary

- remove MCP and ACP wire observer callbacks that could interrupt protocol delivery
- remove unused relay/SSE progress plumbing that never emitted MCP progress notifications
- keep ACP session updates and MCP wire behavior unchanged
- reduce authored code by 134 lines

## Verification

- `make clean && make rescript-build`
- `make reanalyze`
- frontman-client: 83 tests passed
- client: 394 tests passed
- frontman-protocol: 11 tests passed
- frontman-core: 321 tests passed
- pre-commit ReScript formatting and source-comment checks passed

## Notes

Client Biome check remains blocked by pre-existing formatting errors in untouched `src/styles/frontman-theme.css` and `test/Client__Task__AnnotationEnrichment.test.mjs`.

Closes #1550