### PR TITLE
Isolate tool-result registry keys by task

### DIFF
--- a/.changeset/isolate-tool-result-registry.md
+++ b/.changeset/isolate-tool-result-registry.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Scope pending MCP tool-result registry entries by task so concurrent tasks can safely reuse a tool call ID.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -726,8 +726,8 @@ defmodule FrontmanServer.Tasks do
     end
   end
 
-  defp resolve_recorded_tool_result({:ok, interaction}, _task_id, _turn_number, _tool_call_id) do
-    notify_recorded_tool_result(interaction)
+  defp resolve_recorded_tool_result({:ok, interaction}, task_id, _turn_number, _tool_call_id) do
+    notify_recorded_tool_result(interaction, task_id)
   end
 
   defp resolve_recorded_tool_result(
@@ -747,15 +747,15 @@ defmodule FrontmanServer.Tasks do
           |> Repo.one!()
           |> Map.fetch!(:data)
 
-        notify_recorded_tool_result(interaction)
+        notify_recorded_tool_result(interaction, task_id)
 
       false ->
         {:error, changeset}
     end
   end
 
-  defp notify_recorded_tool_result(interaction) do
-    {:ok, interaction, Execution.notify_tool_result(interaction)}
+  defp notify_recorded_tool_result(interaction, task_id) do
+    {:ok, interaction, Execution.notify_tool_result(task_id, interaction)}
   end
 
   defp tool_result_turn_number(task_id, tool_call_id, opts) do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution.ex
@@ -139,18 +139,21 @@ defmodule FrontmanServer.Tasks.Execution do
   Returns `:notified` when the result was delivered to a live executor,
   `:no_executor` when no executor was waiting (e.g., server restarted).
   """
-  def notify_tool_result(%Interaction.ToolResult{
+  def notify_tool_result(task_id, %Interaction.ToolResult{
         tool_call_id: tool_call_id,
         result: %{"content" => content},
         is_error: is_error
       })
       when is_list(content),
-      do: notify_tool_result(tool_call_id, content, is_error)
+      do: notify_tool_result(task_id, tool_call_id, content, is_error)
 
-  def notify_tool_result(%Interaction.ToolResult{}), do: :no_executor
+  def notify_tool_result(_task_id, %Interaction.ToolResult{}), do: :no_executor
 
-  defp notify_tool_result(tool_call_id, content, is_error) do
-    case Elixir.Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, tool_call_id}) do
+  defp notify_tool_result(task_id, tool_call_id, content, is_error) do
+    case Elixir.Registry.lookup(
+           FrontmanServer.ProcessRegistry,
+           tool_registry_key(task_id, tool_call_id)
+         ) do
       [{_pid, %{caller_pid: caller}}] ->
         content_parts =
           content
@@ -164,6 +167,8 @@ defmodule FrontmanServer.Tasks.Execution do
         :no_executor
     end
   end
+
+  defp tool_registry_key(task_id, tool_call_id), do: {:tool_call, task_id, tool_call_id}
 
   defp prompt_messages(rows, turn_number)
        when is_list(rows) and is_integer(turn_number) and turn_number > 0 do

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -135,7 +135,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
     Logger.info("ToolExecutor: Routing to MCP tool #{tool_call.name}")
 
-    register_mcp_tool(tool_call)
+    register_mcp_tool(task_id, tool_call)
     publish_mcp_tool_call(scope, task_id, turn_number, tool_call)
     :ok
   end
@@ -198,11 +198,23 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     )
   end
 
-  defp register_mcp_tool(tool_call) do
-    Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, tool_call.id}, %{
-      caller_pid: self()
-    })
+  defp register_mcp_tool(task_id, tool_call) do
+    case Registry.register(
+           FrontmanServer.ProcessRegistry,
+           tool_registry_key(task_id, tool_call.id),
+           %{
+             caller_pid: self()
+           }
+         ) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_registered, _pid}} ->
+        raise "Duplicate MCP tool executor registration for task #{task_id}, call #{tool_call.id}"
+    end
   end
+
+  defp tool_registry_key(task_id, tool_call_id), do: {:tool_call, task_id, tool_call_id}
 
   defp publish_mcp_tool_call(%Scope{} = scope, task_id, turn_number, tool_call) do
     case Tasks.request_client_tool(scope, task_id, turn_number, tool_call) do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -160,7 +160,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
       )
 
       registered =
-        case Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, expected_id}) do
+        case Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, task_id, expected_id}) do
           [{_pid, _}] -> true
           [] -> false
         end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -124,6 +124,24 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       end
     end
 
+    test "raises when an MCP tool executor registration unexpectedly collides", %{
+      scope: scope,
+      task_id: task_id,
+      turn_number: turn_number
+    } do
+      tc = %SwarmAi.ToolCall{
+        id: "tc_collision_#{System.unique_integer([:positive])}",
+        name: "some_tool",
+        arguments: "{}"
+      }
+
+      assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tc)
+
+      assert_raise RuntimeError,
+                   ~r/Duplicate MCP tool executor registration/,
+                   fn -> ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tc) end
+    end
+
     test "rejects a filtered backend tool even when an MCP tool has the same name", %{
       scope: scope,
       task_id: task_id,

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -8,8 +8,59 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Repo
   alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
+  alias FrontmanServer.Tools.MCP, as: MCPTool
   alias ModelContextProtocol, as: MCP
+
+  test "two tasks with the same tool call id receive only their own result" do
+    Sandbox.unboxed_run(Repo, fn ->
+      scope = user_scope_fixture()
+
+      try do
+        shared_tool_call_id = "call_shared_#{System.unique_integer([:positive])}"
+        first_task_id = task_fixture(scope).id
+        second_task_id = task_fixture(scope).id
+        first_turn_number = start_turn_fixture(scope, first_task_id)
+        second_turn_number = start_turn_fixture(scope, second_task_id)
+
+        first_executor =
+          start_executor(scope, first_task_id, first_turn_number, shared_tool_call_id)
+
+        second_executor =
+          start_executor(scope, second_task_id, second_turn_number, shared_tool_call_id)
+
+        assert_tool_executor_registered(first_task_id, shared_tool_call_id)
+        assert_tool_executor_registered(second_task_id, shared_tool_call_id)
+
+        assert {:ok, _interaction, :notified} =
+                 resolve(
+                   scope,
+                   first_task_id,
+                   first_turn_number,
+                   "first task result",
+                   shared_tool_call_id
+                 )
+
+        assert {:ok, _interaction, :notified} =
+                 resolve(
+                   scope,
+                   second_task_id,
+                   second_turn_number,
+                   "second task result",
+                   shared_tool_call_id
+                 )
+
+        assert {:ok, [%SwarmAi.ToolResult{content: [%{text: "first task result"}]}]} =
+                 Task.await(first_executor, 1_000)
+
+        assert {:ok, [%SwarmAi.ToolResult{content: [%{text: "second task result"}]}]} =
+                 Task.await(second_executor, 1_000)
+      after
+        Repo.delete!(Scope.user(scope))
+      end
+    end)
+  end
 
   test "concurrent tool results resolve to one canonical interaction" do
     Sandbox.unboxed_run(Repo, fn ->
@@ -45,7 +96,7 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
 
         [{:ok, canonical, :no_executor}, {:ok, canonical, :no_executor}] = results
 
-        Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, "call_dedup"}, %{
+        Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, task_id, "call_dedup"}, %{
           caller_pid: self()
         })
 
@@ -65,11 +116,58 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
     end)
   end
 
-  defp resolve(scope, task_id, turn_number, result) do
+  defp start_executor(scope, task_id, turn_number, tool_call_id) do
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        ToolExecutor.execute(scope, %{
+          task_id: task_id,
+          turn_number: turn_number,
+          tool_calls: [%SwarmAi.ToolCall{id: tool_call_id, name: "some_tool", arguments: "{}"}],
+          task_supervisor: SwarmAi.task_supervisor_name(FrontmanServer.AgentRuntime),
+          backend_tool_modules: [],
+          mcp_tool_defs: [mcp_tool_def()],
+          execution_mode: :serial
+        })
+      end)
+    end)
+  end
+
+  defp mcp_tool_def do
+    %MCPTool{
+      name: "some_tool",
+      description: "Some client tool",
+      input_schema: %{},
+      timeout_ms: 1_000,
+      on_timeout: :error
+    }
+  end
+
+  defp assert_tool_executor_registered(task_id, tool_call_id) do
+    assert eventually(fn ->
+             Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, task_id, tool_call_id})
+           end) == [{:registered}]
+  end
+
+  defp eventually(fun), do: eventually(fun, 50)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      [] ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+
+      [_entry] ->
+        [{:registered}]
+    end
+  end
+
+  defp eventually(_fun, 0), do: []
+
+  defp resolve(scope, task_id, turn_number, result, tool_call_id \\ "call_dedup") do
     Tasks.resolve_tool_request(
       scope,
       task_id,
-      %{id: "call_dedup", name: "some_tool"},
+      %{id: tool_call_id, name: "some_tool"},
       MCP.tool_result_text(result),
       turn_number: turn_number
     )

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -142,8 +142,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
            "Agent should not be running after completion"
   end
 
-  defp register_tool_receiver(tool_call_id) do
-    Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, tool_call_id}, %{
+  defp register_tool_receiver(task_id, tool_call_id) do
+    Registry.register(FrontmanServer.ProcessRegistry, {:tool_call, task_id, tool_call_id}, %{
       caller_pid: self()
     })
   end
@@ -153,7 +153,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     result = %{"resultType" => "complete", "content" => content}
     result = Map.put(result, "structuredContent", %{"logged" => true})
     tool_call = tool_call("call_invalid_result", "testTool")
-    register_tool_receiver(tool_call.tool_call_id)
+    register_tool_receiver(task_id, tool_call.tool_call_id)
 
     persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call)
 
@@ -175,7 +175,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     tool_call = tool_call("call_unsupported_result", "testTool")
     tool_call_id = tool_call.tool_call_id
     message = "Unsupported MCP tool result content type: #{content_type}"
-    register_tool_receiver(tool_call_id)
+    register_tool_receiver(task_id, tool_call_id)
 
     persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call)
 
@@ -872,7 +872,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         tool_call("call_123", "consoleLog", %{"message" => "hello"})
 
       turn_number = start_turn_fixture(scope, task_id)
-      register_tool_receiver(tool_call.tool_call_id)
+      register_tool_receiver(task_id, tool_call.tool_call_id)
 
       {:ok, _interaction} = persist_tool_call_fixture(scope, task_id, turn_number, tool_call)
 
@@ -1121,7 +1121,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       tool_call = tool_call("call_valid_test", "testTool")
       tool_call_id = tool_call.tool_call_id
       turn_number = start_turn_fixture(scope, task_id)
-      register_tool_receiver(tool_call.tool_call_id)
+      register_tool_receiver(task_id, tool_call.tool_call_id)
 
       {:ok, _interaction} = persist_tool_call_fixture(scope, task_id, turn_number, tool_call)
 


### PR DESCRIPTION
## Summary
- Scope pending MCP tool-result registry keys by task ID and tool call ID
- Route persisted tool results through task-scoped registry lookup
- Raise loudly when duplicate executor registration happens for the same task/tool call
- Add concurrency coverage for two tasks sharing the same tool call ID

Fixes #1544

## Tests
- `cd apps/frontman_server && mix test test/frontman_server/tasks/tool_result_concurrency_test.exs test/frontman_server/tasks/execution/tool_executor_test.exs test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs test/frontman_server_web/channels/task_channel_test.exs`