### PR TITLE
Fail closed Next.js Frontman routes outside dev

### DIFF
--- a/.changeset/fail-closed-nextjs-routes.md
+++ b/.changeset/fail-closed-nextjs-routes.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/nextjs": patch
+---
+
+Fail closed for Next.js Frontman routes outside development unless explicitly enabled with `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`.

--- a/apps/marketing/src/content/blog/edit-nextjs-visually.md
+++ b/apps/marketing/src/content/blog/edit-nextjs-visually.md
@@ -9,7 +9,7 @@ imageAlt: 'Next.js component selected for visual editing in the browser'
 tags: ['nextjs', 'tutorial', 'developer-tools']
 faq:
   - question: 'Do I need to eject from Next.js or change my build setup?'
-    answer: 'No. Frontman runs inside supported Next.js dev servers through middleware on Next.js 15.x (15.5 minimum) or proxy on Next.js 16.x. You run your usual dev server and open the browser. Nothing is ejected or replaced. The generated entrypoint has no automatic development-only guard, so remove it or add a guard when Frontman must be absent from production.'
+    answer: 'No. Frontman runs inside supported Next.js dev servers through middleware on Next.js 15.x (15.5 minimum) or proxy on Next.js 16.x. You run your usual dev server and open the browser. Nothing is ejected or replaced. The package runtime only handles routes in NODE_ENV=development by default.'
   - question: 'Does this work with the App Router?'
     answer: 'Yes. Frontman supports both the App Router and the Pages Router. It understands Server Components and Client Components and handles them appropriately — server-only components are edited in source, client components get live hot-reload verification.'
   - question: 'What happens when I click a shared component — does it change every instance?'
@@ -53,7 +53,7 @@ npm run dev
 
 Open your browser. The Frontman sidebar appears. Click anything.
 
-There is no step 3 for development. The generated entrypoint can remain in production builds because it has no automatic development-only guard. Add an environment guard or remove the integration when Frontman must be absent, then verify the production build and deployed `/frontman` route.
+There is no step 3 for development. The generated entrypoint can remain in production builds, but the package runtime only handles routes when `NODE_ENV=development` by default. Set `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1` to opt in outside development. Set `FRONTMAN_ENABLED=0` to force it off.
 
 ## The Workflow
 

--- a/apps/marketing/src/content/blog/security.md
+++ b/apps/marketing/src/content/blog/security.md
@@ -13,7 +13,7 @@ faq:
   - question: 'Is Frontman safe to use?'
     answer: 'No development tool can be guaranteed safe for every environment. Frontman separates browser tools, local filesystem tools, server orchestration, and external AI-provider processing. Teams should assess those boundaries, connected providers, data categories, deployment configuration, and generated diffs against their own threat model before use.'
   - question: 'Does Frontman run in production?'
-    answer: 'The JavaScript integrations are intended for development workflows, but Next.js middleware or proxy code can remain active in a production build unless you add an environment guard or remove it. The WordPress plugin is a live-site integration and can mutate production WordPress data. Verify deployed routes, restrict access, test built artifacts, and use staging or current backups before production changes.'
+    answer: 'The JavaScript integrations are intended for development workflows. Next.js route handling is off outside NODE_ENV=development unless explicitly enabled, but you should still verify deployed routes and configuration. The WordPress plugin is a live-site integration and can mutate production WordPress data. Restrict access, test built artifacts, and use staging or current backups before production changes.'
   - question: 'What does the AI agent see when using Frontman?'
     answer: 'Depending on the task and tools used, Customer Content can include prompts, source-code snippets, project files, DOM and component information, computed CSS, screenshots, logs, routes, source maps, build errors, metadata, tool results, generated output, and task history. Relevant content passes through the Frontman server to the customer-selected AI provider.'
   - question: 'Can Frontman edit any file on my system?'
@@ -107,7 +107,7 @@ For each framework and release:
 4. Apply network and authentication controls appropriate to any reachable route.
 5. Keep code deployment, secrets, production credentials, and approval authority outside the agent workflow.
 
-Next.js needs particular attention: the [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write middleware for supported Next.js 15.x releases (15.5 minimum) or a proxy for Next.js 16.x. Those generated handlers and matchers contain no `NODE_ENV` guard. Next.js 15.x middleware declares the Node.js runtime; Next.js 16.x proxy uses its supported default runtime because the generated proxy omits the runtime field. If the files remain in a production build, Frontman request handling can remain present. Add an explicit environment guard or remove the integration for deployment, then build and test the deployed artifact. Avoid absolute claims such as “cannot exist in production” unless your own artifact and controls prove that statement.
+Next.js needs particular attention: the [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write middleware for supported Next.js 15.x releases (15.5 minimum) or a proxy for Next.js 16.x. The package runtime handles routes only when `NODE_ENV=development` by default. Production and preview builds require `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`; `FRONTMAN_ENABLED=0` forces the integration off. If you opt in outside development, apply the same deployment verification and access controls that you use for other sensitive developer tools.
 
 ## WordPress live-site threat model
 

--- a/apps/marketing/src/content/docs/docs/installation.md
+++ b/apps/marketing/src/content/docs/docs/installation.md
@@ -68,7 +68,7 @@ For Next.js, Astro, or Vite:
 
 Use the framework's development server for this functional installation check. Then run the normal production build and deployment verification for your app: confirm whether Frontman routes and client assets are present, whether `/frontman` is reachable, and whether your intended environment or network controls block access.
 
-Next.js differs from Astro and Vite here. Its [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write request middleware for Next.js 15.x (15.5 minimum) or proxy for Next.js 16.x. Generated code has no automatic development-only guard, so it can compile into and run with a production deployment while its matcher includes Frontman routes. Add your own environment guard or remove the integration before deployment when Frontman must be absent, then verify the built artifact rather than assuming `next build` removes it.
+Next.js differs from Astro and Vite here. Its [installer templates](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) write request middleware for Next.js 15.x (15.5 minimum) or proxy for Next.js 16.x. The package runtime handles routes only when `NODE_ENV=development` by default. Production and preview builds require `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`; `FRONTMAN_ENABLED=0` forces the integration off. Verify the built artifact and deployed `/frontman` route when deployment behavior matters.
 
 For WordPress, verify that an administrator can open `/frontman`, complete hosted sign-in, and see the site preview beside chat.
 

--- a/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
+++ b/apps/marketing/src/content/docs/docs/integrations/nextjs.mdx
@@ -9,7 +9,7 @@ import CodeFromFile from '../../../../components/docs/CodeFromFile.astro';
 
 `@frontman-ai/nextjs` integrates the Frontman AI agent into your Next.js dev server through middleware on Next.js 15.x (15.5 minimum) or proxy on Next.js 16.x. It intercepts requests to `/frontman/*`, giving the AI access to your source files, dev server logs, route manifest, and optionally OpenTelemetry spans covering HTTP requests and route render timing.
 
-**Frontman is intended for development workflows.** Installer-generated middleware or proxy code has no automatic development-only guard, so it can compile into and run with a production deployment while its matcher includes Frontman routes. Add an environment guard or remove the integration when Frontman must be absent, then verify the built artifact and deployed `/frontman` route instead of assuming the production build removes it.
+**Frontman is intended for development workflows.** The Next.js runtime handles Frontman routes only when `process.env.NODE_ENV === "development"` by default. Production and preview builds fail closed unless you set `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`. Set `FRONTMAN_ENABLED=0` to force Frontman off in any environment.
 
 ## Quick Start
 
@@ -74,7 +74,7 @@ All options are optional.
 | `clientCssUrl` | `string` | Production CDN URL; `undefined` in dev | Override the Frontman client CSS URL. |
 | `entrypointUrl` | `string` | — | Custom entrypoint URL for the AI API. |
 | `isLightTheme` | `boolean` | `false` | Render the Frontman UI with a light color scheme. |
-| `isDev` | `boolean` | `true` unless `host === "api.frontman.sh"` | Override dev/prod mode detection. |
+| `isDev` | `boolean` | `true` unless `host === "api.frontman.sh"` | Override client asset dev/prod mode. This does not override the route runtime guard. |
 
 ### Monorepo configuration
 
@@ -89,6 +89,20 @@ const frontman = createMiddleware({
 
 Start your dev server (`next dev` or `npm run dev`) and open `http://localhost:3000/frontman`. The port matches whatever `next dev` binds to.
 
+## Runtime environment guard
+
+Next.js sets `process.env.NODE_ENV` to `development` for `next dev` and to `production` for other commands. Frontman follows that value for route handling:
+
+| Environment setting | Behavior |
+|---|---|
+| `NODE_ENV=development` | Frontman routes are handled |
+| `NODE_ENV=production` | Frontman routes pass through by default |
+| `FRONTMAN_ENABLE_IN_PRODUCTION=1` | Enables Frontman routes outside development |
+| `FRONTMAN_ENABLED=1` or `FRONTMAN_ENABLED=true` | Enables Frontman routes in any environment |
+| `FRONTMAN_ENABLED=0` | Disables Frontman routes in any environment |
+
+The `isDev` option only controls client asset selection. It does not enable route handling outside development.
+
 ## How It Works
 
 ### Request handling
@@ -100,7 +114,7 @@ Start your dev server (`next dev` or `npm run dev`) and open `http://localhost:3
 3. **SSE** (`GET /frontman/tools`) opens a server-sent event stream for streaming tool responses.
 4. All other requests to `/frontman/` serve the Frontman UI, injecting the client JS and CSS.
 
-When the request does not match a Frontman path, `frontman(req)` returns `undefined` (Next.js 15.x) or a pass-through `NextResponse.next()` (Next.js 16.x).
+When the request does not match a Frontman path, `frontman(req)` returns `undefined` (Next.js 15.x) or a pass-through `NextResponse.next()` (Next.js 16.x). The same pass-through behavior applies outside development unless `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1` is set.
 
 ### Route discovery
 

--- a/apps/marketing/src/content/docs/docs/reference/compatibility.md
+++ b/apps/marketing/src/content/docs/docs/reference/compatibility.md
@@ -57,8 +57,8 @@ See [Tool Capabilities](/docs/using/tool-capabilities/) for the shared file, log
 
 **Notes**
 
-- The [generated middleware/proxy](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) contains no automatic development-only guard. Next.js 15.x uses generated middleware with `runtime: 'nodejs'`; Next.js 16.x uses proxy without a runtime declaration, matching Next.js proxy runtime requirements.
-- If that entrypoint remains in the application, its Frontman route matcher can be included in production builds. Add an explicit environment guard or remove it when deployed Frontman access is not intended, and verify the production build and route behavior.
+- The [generated middleware/proxy](https://github.com/frontman-ai/frontman/blob/main/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res) uses a package runtime guard. Routes are handled only when `NODE_ENV=development` by default. Use `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1` to opt in outside development, and `FRONTMAN_ENABLED=0` to force the integration off.
+- If that entrypoint remains in the application, its Frontman route matcher can be included in production builds. Verify production build and route behavior when deployment behavior matters.
 - App Router and Pages Router can coexist in the same project.
 - The integration works with both Webpack and Turbopack because it hooks at the Next.js request-entrypoint layer, not the bundler layer.
 
@@ -168,9 +168,9 @@ In practice, that means:
 
 - Astro support applies to `astro dev`, not `astro build` or `astro preview`
 - Vite support applies to `vite dev`, not `vite build` or `vite preview`
-- Next.js middleware/proxy can execute in a production deployment if the generated or manually integrated entrypoint remains. Frontman does not add an environment guard; deployment owners must add one or remove the integration when needed.
+- Next.js middleware/proxy can execute in a production deployment if the generated or manually integrated entrypoint remains. Frontman routes fail closed outside `NODE_ENV=development` by default, unless deployment owners opt in with `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`.
 
-For every integration, run the framework's production build and inspect the deployed result. Confirm whether Frontman routes, middleware/proxy logic, and client assets are emitted and reachable, then apply environment, authentication, reverse-proxy, and network controls appropriate to that result.
+For every integration, run the framework's production build and inspect the deployed result. Confirm whether Frontman routes, middleware/proxy logic, and client assets are emitted and reachable, then apply environment, authentication, reverse-proxy, and network controls appropriate to that result. For Next.js, also confirm the intended `FRONTMAN_ENABLED` / `FRONTMAN_ENABLE_IN_PRODUCTION` settings.
 
 ### Access outside the integration boundary
 

--- a/apps/marketing/src/content/docs/docs/reference/configuration.mdx
+++ b/apps/marketing/src/content/docs/docs/reference/configuration.mdx
@@ -47,7 +47,7 @@ Frontman uses a few simple rules across integrations:
 2. **`PROJECT_ROOT` overrides auto-detected root resolution** if you do not pass `projectRoot` directly.
 3. **`FRONTMAN_CLIENT_URL` overrides the generated client bundle URL** if you do not pass `clientUrl` directly.
 4. **`sourceRoot` defaults to `projectRoot`** when omitted.
-5. **Non-production hosts are treated as dev mode** in Astro and Vite, and in Next.js unless you explicitly override `isDev`.
+5. **Non-production hosts are treated as dev mode** in Astro and Vite, and for Next.js client asset selection unless you explicitly override `isDev`. Next.js route handling also requires `NODE_ENV=development` unless you set `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1`.
 
 ## `host`
 
@@ -299,7 +299,10 @@ Place the file next to your `app/` or `pages/` directory. For projects using `sr
 
 ### Next.js-specific notes
 
-- Next.js exposes an explicit `isDev` override in addition to the shared options.
+- Next.js handles Frontman routes only when `NODE_ENV=development` by default.
+- Set `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1` to opt in outside development.
+- Set `FRONTMAN_ENABLED=0` to force Frontman off in any environment.
+- Next.js exposes an explicit `isDev` override for client asset selection in addition to the shared options.
 - Host values are normalized, so full URLs and bare hostnames are both accepted.
 - If you override `clientUrl`, it must include a `host` query parameter or Frontman throws immediately.
 - OpenTelemetry setup is separate from config and is recommended if you want richer logs and request traces.
@@ -308,7 +311,7 @@ Place the file next to your `app/` or `pages/` directory. For projects using `sr
 
 | Option | Type | Default |
 |---|---|---|
-| `isDev` | `boolean` | inferred from `host` |
+| `isDev` | `boolean` | inferred from `host`; does not override the route runtime guard |
 | `basePath` | `string` | `"frontman"` |
 | `serverName` | `string` | `"frontman-nextjs"` |
 | `serverVersion` | `string` | installed package version |
@@ -351,13 +354,15 @@ Use the Vite plugin inside `vite.config.ts`.
 
 ## Environment variables
 
-Frontman supports these environment variables across integrations:
+Frontman supports these environment variables:
 
 | Variable | Used by | Purpose |
 |---|---|---|
 | `FRONTMAN_HOST` | Astro, Next.js, Vite | Default Frontman server host when `host` is not passed explicitly |
 | `PROJECT_ROOT` | Astro, Next.js, Vite | Default project root when `projectRoot` is omitted |
 | `FRONTMAN_CLIENT_URL` | Astro, Next.js, Vite | Overrides the generated browser client bundle URL |
+| `FRONTMAN_ENABLE_IN_PRODUCTION` | Next.js | Set to `1` to enable route handling when `NODE_ENV` is not `development` |
+| `FRONTMAN_ENABLED` | Next.js | Global override. Set to `1` or `true` to enable route handling, or `0` to force it off |
 
 ### Example `.env`
 
@@ -365,6 +370,9 @@ Frontman supports these environment variables across integrations:
 FRONTMAN_HOST=frontman.local:4000
 PROJECT_ROOT=/Users/you/code/acme-web
 FRONTMAN_CLIENT_URL=http://localhost:5174/frontman.es.js
+
+# Next.js only: opt in outside NODE_ENV=development
+FRONTMAN_ENABLE_IN_PRODUCTION=1
 ```
 
 ## Common configuration patterns

--- a/apps/marketing/src/content/docs/snippets/nextjs/middleware.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/nextjs/middleware.ts.txt
@@ -4,6 +4,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 const frontman = createMiddleware({
   projectRoot: process.cwd(),
 });
+// Frontman handles routes only when NODE_ENV === 'development' by default.
+// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere.
 
 export async function middleware(req: NextRequest) {
   const response = await frontman(req);

--- a/apps/marketing/src/content/docs/snippets/nextjs/proxy.ts.txt
+++ b/apps/marketing/src/content/docs/snippets/nextjs/proxy.ts.txt
@@ -4,6 +4,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 const frontman = createMiddleware({
   projectRoot: process.cwd(),
 });
+// Frontman handles routes only when NODE_ENV === 'development' by default.
+// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere.
 
 export async function proxy(req: NextRequest): Promise<NextResponse> {
   const response = await frontman(req);

--- a/libs/frontman-nextjs/README.md
+++ b/libs/frontman-nextjs/README.md
@@ -56,6 +56,8 @@ Then open your browser to `http://localhost:3000/frontman` to access the Frontma
 
 With the default hosted setup, Frontman redirects you to `api.frontman.sh` to sign in with GitHub or Google, then returns you to the local `/frontman` URL. Before your first prompt, connect a supported AI provider with OAuth or add an API key. If you configured another Frontman server, sign in on that server instead.
 
+Frontman routes are enabled only when `process.env.NODE_ENV === 'development'` by default. Set `FRONTMAN_ENABLE_IN_PRODUCTION=1` or `FRONTMAN_ENABLED=1` to opt in outside development. Set `FRONTMAN_ENABLED=0` to force Frontman off in any environment.
+
 ## Manual Setup
 
 ### Next.js 15.x (middleware.ts, 15.5 minimum)
@@ -69,6 +71,8 @@ import { NextRequest, NextResponse } from 'next/server';
 const frontman = createMiddleware({
   host: 'api.frontman.sh', // or 'frontman.local:4000' for local development
 });
+// Handles routes only when NODE_ENV === 'development' by default.
+// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere.
 
 export async function middleware(req: NextRequest) {
   const response = await frontman(req);
@@ -92,6 +96,8 @@ import { NextRequest, NextResponse } from 'next/server';
 const frontman = createMiddleware({
   host: 'api.frontman.sh', // or 'frontman.local:4000' for local development
 });
+// Handles routes only when NODE_ENV === 'development' by default.
+// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere.
 
 export function proxy(req: NextRequest): NextResponse | Promise<NextResponse> {
   if (req.nextUrl.pathname === '/frontman' || req.nextUrl.pathname.startsWith('/frontman/')) {

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Instrumentation.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Instrumentation.res
@@ -1,13 +1,31 @@
 module LogCapture = FrontmanNextjs__LogCapture
 module Sentry = FrontmanNextjs__Sentry
+module RuntimeEnv = FrontmanNextjs__RuntimeEnv
+open FrontmanNextjs__OpenTelemetry__Bindings
+
+let noopLogRecordProcessor = (): Logs.logRecordProcessor =>
+  Logs.makeProcessor({
+    "onEmit": (_logRecord, _context) => (),
+    "forceFlush": () => Promise.resolve(),
+    "shutdown": () => Promise.resolve(),
+  })
+
+let noopSpanProcessor = (): Trace.spanProcessor =>
+  Trace.makeProcessor({
+    "onStart": (_span, _context) => (),
+    "onEnd": _span => (),
+    "forceFlush": () => Promise.resolve(),
+    "shutdown": () => Promise.resolve(),
+  })
 
 @@live
-let setup = (): (
-  FrontmanNextjs__OpenTelemetry__Bindings.Logs.logRecordProcessor,
-  FrontmanNextjs__OpenTelemetry__Bindings.Trace.spanProcessor,
-) => {
-  LogCapture.initialize()
-  Sentry.initialize()
+let setup = (): (Logs.logRecordProcessor, Trace.spanProcessor) => {
+  switch RuntimeEnv.isRuntimeEnabled() {
+  | true =>
+    LogCapture.initialize()
+    Sentry.initialize()
 
-  (FrontmanNextjs__LogRecordProcessor.make(), FrontmanNextjs__SpanProcessor.make())
+    (FrontmanNextjs__LogRecordProcessor.make(), FrontmanNextjs__SpanProcessor.make())
+  | false => (noopLogRecordProcessor(), noopSpanProcessor())
+  }
 }

--- a/libs/frontman-nextjs/src/FrontmanNextjs__LogCapture.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__LogCapture.res
@@ -13,9 +13,3 @@ let getInstance = (): state => getOrCreateInstance(~config=defaultConfig)
 let initialize = (~config: config=defaultConfig, ()): unit => {
   CoreLogCapture.initialize(~config, ())
 }
-
-%%raw(`
-if (typeof window === 'undefined') {
-  initialize();
-}
-`)

--- a/libs/frontman-nextjs/src/FrontmanNextjs__Middleware.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__Middleware.res
@@ -4,6 +4,7 @@ module CoreMiddlewareConfig = Core.FrontmanCore__MiddlewareConfig
 module Server = FrontmanNextjs__Server
 module Config = FrontmanNextjs__Config
 module LogCapture = FrontmanNextjs__LogCapture
+module RuntimeEnv = FrontmanNextjs__RuntimeEnv
 
 type config = Config.t
 
@@ -30,5 +31,15 @@ let createMiddleware = (configInput: Config.jsConfigInput) => {
     ~serverVersion=config.serverVersion,
   )
 
-  CoreMiddleware.createMiddleware(~config=middlewareConfig, ~registry=server.registry)
+  let middleware = CoreMiddleware.createMiddleware(
+    ~config=middlewareConfig,
+    ~registry=server.registry,
+  )
+
+  switch RuntimeEnv.isRuntimeEnabled() {
+  | true =>
+    LogCapture.initialize()
+    middleware
+  | false => async _req => None
+  }
 }

--- a/libs/frontman-nextjs/src/FrontmanNextjs__RuntimeEnv.res
+++ b/libs/frontman-nextjs/src/FrontmanNextjs__RuntimeEnv.res
@@ -1,0 +1,24 @@
+module Bindings = FrontmanBindings
+
+let envValueIsEnabled = (value: string): bool =>
+  switch value->String.trim->String.toLowerCase {
+  | "1" | "true" => true
+  | _ => false
+  }
+
+let isRuntimeEnabled = (): bool => {
+  let env = Bindings.Process.env
+
+  switch env->Dict.get("FRONTMAN_ENABLED") {
+  | Some(value) => envValueIsEnabled(value)
+  | None =>
+    switch env->Dict.get("NODE_ENV") {
+    | Some("development") => true
+    | _ =>
+      env
+      ->Dict.get("FRONTMAN_ENABLE_IN_PRODUCTION")
+      ->Option.map(envValueIsEnabled)
+      ->Option.getOr(false)
+    }
+  }
+}

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__AutoEdit.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__AutoEdit.res
@@ -36,10 +36,10 @@ let buildSystemPrompt = (~fileType: fileType, ~host: string): string => {
       Templates.proxyTemplate(host),
       `- Add the import for '@frontman-ai/nextjs' at the top of the file
 - Create the frontman middleware instance with host: '${host}'
-- CRITICAL: The Frontman path check MUST be the very first thing that runs inside the proxy function body, before ANY other logic — before auth checks, redirects, rewrites, header modifications, or any other proxy behavior. If another handler intercepts the request first, Frontman routes will break.
+- CRITICAL: The Frontman handler MUST be the very first thing that runs inside the proxy function body. Place 'const response = await frontman(req); if (response) return response;' as the first two lines of the function, before ANY other logic — before auth checks, redirects, rewrites, header modifications, or any other proxy behavior. If another handler intercepts the request first, Frontman routes will break.
+- Do NOT wrap the Frontman handler inside any condition, if-block, or path check — it must run unconditionally on every request so it can handle its own routes
 - Include '/frontman' and '/frontman/:path*' in the matcher config alongside existing matchers
-- Preserve ALL existing functionality unchanged - do not remove or modify any existing code
-- Add runtime: 'nodejs' to the config export`,
+- Preserve ALL existing functionality unchanged - do not remove or modify any existing code`,
     )
   | Instrumentation => (
       "instrumentation.ts",

--- a/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
+++ b/libs/frontman-nextjs/src/cli/FrontmanNextjs__Cli__Templates.res
@@ -91,6 +91,10 @@ module ManualInstructions = {
   ${bar}
   ${bar}  ${s("3.")} In your middleware function, add as the ${b("very first lines")}:
   ${bar}
+  ${bar}     ${d("// Handles routes only when NODE_ENV === 'development' by default")}
+  ${bar}     ${d(
+        "// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere",
+      )}
   ${bar}     ${d("const response = await frontman(req);")}
   ${bar}     ${d("if (response) return response;")}
   ${bar}
@@ -129,6 +133,10 @@ module ManualInstructions = {
   ${bar}
   ${bar}  ${s("3.")} In your proxy function, add Frontman handler as the ${b("very first lines")}:
   ${bar}
+  ${bar}     ${d("// Handles routes only when NODE_ENV === 'development' by default")}
+  ${bar}     ${d(
+        "// Set FRONTMAN_ENABLE_IN_PRODUCTION=1 or FRONTMAN_ENABLED=1 to opt in elsewhere",
+      )}
   ${bar}     ${d("const response = await frontman(req);")}
   ${bar}     ${d("if (response) return response;")}
   ${bar}

--- a/libs/frontman-nextjs/test/FrontmanNextjs__Middleware.test.res
+++ b/libs/frontman-nextjs/test/FrontmanNextjs__Middleware.test.res
@@ -4,17 +4,26 @@ module Middleware = FrontmanNextjs__Middleware
 module Config = FrontmanNextjs__Config
 
 module Helpers = {
+  let configInput = (): Config.jsConfigInput => {
+    projectRoot: "/test/project",
+    sourceRoot: "/test/project",
+    basePath: "frontman",
+    serverName: "test-nextjs",
+    serverVersion: "1.0.0",
+    host: "localhost:3000",
+    clientUrl: "http://localhost:3000/client.js?clientName=nextjs&host=localhost:3000",
+  }
+
   let createTestMiddleware = () => {
-    let configInput: Config.jsConfigInput = {
-      projectRoot: "/test/project",
-      sourceRoot: "/test/project",
-      basePath: "frontman",
-      serverName: "test-nextjs",
-      serverVersion: "1.0.0",
-      host: "localhost:3000",
-      clientUrl: "http://localhost:3000/client.js?clientName=nextjs&host=localhost:3000",
+    FrontmanBindings.Process.env->Dict.set("FRONTMAN_ENABLED", "1")
+    Middleware.createMiddleware(configInput())
+  }
+
+  let restoreEnv = (key: string, value: option<string>) => {
+    switch value {
+    | Some(value) => FrontmanBindings.Process.env->Dict.set(key, value)
+    | None => FrontmanBindings.Process.env->Dict.delete(key)
     }
-    Middleware.createMiddleware(configInput)
   }
 
   let makeGetRequest = (url: string): WebAPI.Request.t => {
@@ -212,6 +221,104 @@ describe("FrontmanNextjs Middleware (adapter)", _t => {
         | Some(response) => t->expect(response.status)->Expect.toBe(400)
         | None => failwith("Expected Some(response) for invalid POST")
         }
+      },
+    )
+  })
+
+  describe("runtime environment guard", _t => {
+    testAsync(
+      "returns None in production by default",
+      async t => {
+        let env = FrontmanBindings.Process.env
+        let nodeEnv = env->Dict.get("NODE_ENV")
+        let frontmanEnabled = env->Dict.get("FRONTMAN_ENABLED")
+        let enableInProduction = env->Dict.get("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        env->Dict.set("NODE_ENV", "production")
+        env->Dict.delete("FRONTMAN_ENABLED")
+        env->Dict.delete("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        let mw = Middleware.createMiddleware(Helpers.configInput())
+        let req = Helpers.makeGetRequest("http://localhost:3000/frontman/tools")
+        let result = await mw(req)
+
+        Helpers.restoreEnv("NODE_ENV", nodeEnv)
+        Helpers.restoreEnv("FRONTMAN_ENABLED", frontmanEnabled)
+        Helpers.restoreEnv("FRONTMAN_ENABLE_IN_PRODUCTION", enableInProduction)
+
+        t->expect(result->Option.isNone)->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "FRONTMAN_ENABLE_IN_PRODUCTION enables production handling",
+      async t => {
+        let env = FrontmanBindings.Process.env
+        let nodeEnv = env->Dict.get("NODE_ENV")
+        let frontmanEnabled = env->Dict.get("FRONTMAN_ENABLED")
+        let enableInProduction = env->Dict.get("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        env->Dict.set("NODE_ENV", "production")
+        env->Dict.delete("FRONTMAN_ENABLED")
+        env->Dict.set("FRONTMAN_ENABLE_IN_PRODUCTION", "1")
+
+        let mw = Middleware.createMiddleware(Helpers.configInput())
+        let req = Helpers.makeGetRequest("http://localhost:3000/frontman/tools")
+        let result = await mw(req)
+
+        Helpers.restoreEnv("NODE_ENV", nodeEnv)
+        Helpers.restoreEnv("FRONTMAN_ENABLED", frontmanEnabled)
+        Helpers.restoreEnv("FRONTMAN_ENABLE_IN_PRODUCTION", enableInProduction)
+
+        t->expect(result->Option.isSome)->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "FRONTMAN_ENABLED overrides production guard",
+      async t => {
+        let env = FrontmanBindings.Process.env
+        let nodeEnv = env->Dict.get("NODE_ENV")
+        let frontmanEnabled = env->Dict.get("FRONTMAN_ENABLED")
+        let enableInProduction = env->Dict.get("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        env->Dict.set("NODE_ENV", "production")
+        env->Dict.set("FRONTMAN_ENABLED", "true")
+        env->Dict.delete("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        let mw = Middleware.createMiddleware(Helpers.configInput())
+        let req = Helpers.makeGetRequest("http://localhost:3000/frontman/tools")
+        let result = await mw(req)
+
+        Helpers.restoreEnv("NODE_ENV", nodeEnv)
+        Helpers.restoreEnv("FRONTMAN_ENABLED", frontmanEnabled)
+        Helpers.restoreEnv("FRONTMAN_ENABLE_IN_PRODUCTION", enableInProduction)
+
+        t->expect(result->Option.isSome)->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "FRONTMAN_ENABLED can disable development handling",
+      async t => {
+        let env = FrontmanBindings.Process.env
+        let nodeEnv = env->Dict.get("NODE_ENV")
+        let frontmanEnabled = env->Dict.get("FRONTMAN_ENABLED")
+        let enableInProduction = env->Dict.get("FRONTMAN_ENABLE_IN_PRODUCTION")
+
+        env->Dict.set("NODE_ENV", "development")
+        env->Dict.set("FRONTMAN_ENABLED", "0")
+        env->Dict.set("FRONTMAN_ENABLE_IN_PRODUCTION", "1")
+
+        let mw = Middleware.createMiddleware(Helpers.configInput())
+        let req = Helpers.makeGetRequest("http://localhost:3000/frontman/tools")
+        let result = await mw(req)
+
+        Helpers.restoreEnv("NODE_ENV", nodeEnv)
+        Helpers.restoreEnv("FRONTMAN_ENABLED", frontmanEnabled)
+        Helpers.restoreEnv("FRONTMAN_ENABLE_IN_PRODUCTION", enableInProduction)
+
+        t->expect(result->Option.isNone)->Expect.toBe(true)
       },
     )
   })

--- a/test/ripgrep-runtime/run-consumer.mjs
+++ b/test/ripgrep-runtime/run-consumer.mjs
@@ -35,6 +35,8 @@ try {
   await writeFile(resolve(consumer, "search-target.txt"), "packed ripgrep runtime\n")
   run("npm", ["install", "--strict-peer-deps", "--save-exact"])
 
+  if (integration === "nextjs") process.env.FRONTMAN_ENABLED = "1"
+
   const packageRoot = resolve(consumer, "node_modules", packageConfig.packageName)
   const frontman = await import(pathToFileURL(resolve(packageRoot, "dist", "index.js")))
   const configInput = {projectRoot: consumer, sourceRoot: consumer, basePath: "frontman"}


### PR DESCRIPTION
## Summary
- gate Next.js Frontman route handling on `NODE_ENV=development` by default
- add `FRONTMAN_ENABLE_IN_PRODUCTION=1` and `FRONTMAN_ENABLED` overrides
- update installer templates, auto-edit prompt, docs, and changeset

## Testing
- `cd libs/frontman-nextjs && yarn rescript build && yarn vitest run`
- pre-push `reanalyze` hook

Closes #1567