### PR TITLE
escape selected elements when using inspector

### DIFF
--- a/.changeset/esc-clears-inspector-selection.md
+++ b/.changeset/esc-clears-inspector-selection.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Pressing Escape while the element inspector is active now closes the open comment popup, then clears all selected elements, and finally exits selection mode when nothing is selected.

--- a/libs/client/src/webpreview/Client__WebPreview__Stage.res
+++ b/libs/client/src/webpreview/Client__WebPreview__Stage.res
@@ -66,6 +66,7 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     Client__State.Selectors.webPreviewIsSelecting,
   )
   let annotations = Client__State.useSelector(Client__State.Selectors.annotations)
+  let hasAnnotations = annotations->Array.length > 0
 
   let lastProcessedClickId = React.useRef(-1)
   let wasSelecting = React.useRef(false)
@@ -126,8 +127,10 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
     | (Some(doc), true) => {
         let handleKeyDown = ev => {
           let kbEv = ev->asKeyboardEvent
-          switch kbEv.key {
-          | "Escape" => Client__State.Actions.toggleWebPreviewSelection()
+          switch (kbEv.key, activePopupAnnotationId, hasAnnotations) {
+          | ("Escape", Some(_), _) => Client__State.Actions.closeAnnotationPopup()
+          | ("Escape", None, true) => Client__State.Actions.clearAnnotations()
+          | ("Escape", None, false) => Client__State.Actions.toggleWebPreviewSelection()
           | _ => ()
           }
         }
@@ -144,7 +147,7 @@ let make = (~document, ~viewportStyle: option<(int, int, float)>=?) => {
       }
     | _ => None
     }
-  }, (document, webPreviewIsSelecting))
+  }, (document, webPreviewIsSelecting, activePopupAnnotationId, hasAnnotations))
 
   React.useEffect(() => {
     switch (document, webPreviewIsSelecting) {


### PR DESCRIPTION
## Description

use the escape key to exit the selected elements using inspector.



https://github.com/user-attachments/assets/55886860-e124-437c-802c-9e16bb5fd726



<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
