### PR TITLE
Add Next.js dev/build compatibility matrix

### DIFF
--- a/.changeset/nextjs-build-compatibility.md
+++ b/.changeset/nextjs-build-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/nextjs": patch
+---
+
+Fix generated instrumentation type resolution during Next.js production builds and add a CI compatibility matrix for packed Next.js consumers.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,17 +86,11 @@ jobs:
       - name: Install Node.js dependencies
         run: yarn install --immutable
 
-      - name: Build ReScript
-        run: yarn rescript
-
-      - name: Build packed Next.js integration
-        run: yarn workspace @frontman-ai/nextjs build
-
       - name: Run Next.js packed-consumer dev/build compatibility
         env:
           NEXT_LABEL: ${{ matrix.next.label }}
           NEXT_VERSION: ${{ matrix.next.version }}
-        run: bash scripts/ci/nextjs-compat.sh
+        run: make e2e-nextjs-compat
 
   e2e:
     name: E2E (${{ github.event.inputs.test_suite || 'all' }})

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,12 +6,19 @@ on:
       - "test/e2e/**"
       - "libs/client/src/**"
       - "libs/frontman-client/src/**"
+      - "libs/frontman-nextjs/**"
+      - "libs/frontman-core/**"
+      - "libs/frontman-protocol/**"
+      - "libs/bindings/**"
       - "adapters/**"
       - "apps/frontman_server/lib/**"
       - "apps/frontman_server/config/**"
       - "apps/frontman_server/mix.*"
       - "apps/swarm_ai/**"
       - "mise.toml"
+      - "package.json"
+      - "yarn.lock"
+      - "scripts/ci/nextjs-compat.sh"
       - ".github/workflows/e2e.yml"
   workflow_dispatch:
     inputs:
@@ -35,6 +42,62 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nextjs-compat:
+    name: Next.js compatibility (${{ matrix.next.label }})
+    if: github.event_name == 'pull_request' || github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'nextjs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        next:
+          - label: "15.5 minimum"
+            version: "15.5.0"
+          - label: "latest 15"
+            version: "15"
+          - label: "latest 16"
+            version: "16"
+
+    env:
+      YARN_ENABLE_HARDENED_MODE: "0"
+      NEXT_TELEMETRY_DISABLED: "1"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          clean: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.4.1"
+
+      - name: Enable Corepack
+        run: corepack enable && corepack install
+
+      - name: Cache Yarn
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.yarn/berry/cache
+          key: yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-
+
+      - name: Install Node.js dependencies
+        run: yarn install --immutable
+
+      - name: Build ReScript
+        run: yarn rescript
+
+      - name: Build packed Next.js integration
+        run: yarn workspace @frontman-ai/nextjs build
+
+      - name: Run Next.js packed-consumer dev/build compatibility
+        env:
+          NEXT_LABEL: ${{ matrix.next.label }}
+          NEXT_VERSION: ${{ matrix.next.version }}
+        run: bash scripts/ci/nextjs-compat.sh
+
   e2e:
     name: E2E (${{ github.event.inputs.test_suite || 'all' }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,10 @@ HELP_test-wordpress-core-tools := Run PHP tests for WordPress tool implementatio
 HELP_test-wordpress-runtime := Run plugin integration tests in WordPress containers
 
 HELP_E2E_TITLE := E2E Tests
-HELP_E2E_TARGETS := e2e e2e-nextjs e2e-astro e2e-vite e2e-vue-vite
+HELP_E2E_TARGETS := e2e e2e-nextjs e2e-nextjs-compat e2e-astro e2e-vite e2e-vue-vite
 HELP_e2e := Run all e2e tests (loads secrets from test/e2e/.env)
 HELP_e2e-nextjs := Run Next.js e2e test
+HELP_e2e-nextjs-compat := Run packed Next.js dev/build compatibility check (NEXT_VERSION=16)
 HELP_e2e-astro := Run Astro e2e test
 HELP_e2e-vite := Run Vite e2e test
 HELP_e2e-vue-vite := Run Vue + Vite e2e test
@@ -248,7 +249,7 @@ clean:
 
 
 
-.PHONY: e2e e2e-nextjs e2e-astro e2e-vite e2e-vue-vite
+.PHONY: e2e e2e-nextjs e2e-nextjs-compat e2e-astro e2e-vite e2e-vue-vite
 
 e2e:
 	@printf "$(YELLOW)Running all e2e tests...$(RESET)\n"
@@ -257,6 +258,12 @@ e2e:
 e2e-nextjs:
 	@printf "$(YELLOW)Running Next.js e2e test...$(RESET)\n"
 	$(call run_e2e,tests/nextjs.test.ts)
+
+e2e-nextjs-compat:
+	@printf "$(YELLOW)Running packed Next.js compatibility check...$(RESET)\n"
+	yarn rescript
+	yarn workspace @frontman-ai/nextjs build
+	NEXT_VERSION=$${NEXT_VERSION:-16} bash scripts/ci/nextjs-compat.sh
 
 e2e-astro:
 	@printf "$(YELLOW)Running Astro e2e test...$(RESET)\n"

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -15,6 +15,16 @@
 			"default": "./dist/instrumentation.js"
 		}
 	},
+	"typesVersions": {
+		"*": {
+			"Instrumentation": [
+				"types/instrumentation.d.ts"
+			],
+			"*": [
+				"types/index.d.ts"
+			]
+		}
+	},
 	"bin": {
 		"frontman-nextjs": "dist/cli.js",
 		"nextjs": "dist/cli.js"

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -19,9 +19,6 @@
 		"*": {
 			"Instrumentation": [
 				"types/instrumentation.d.ts"
-			],
-			"*": [
-				"types/index.d.ts"
 			]
 		}
 	},

--- a/scripts/ci/nextjs-compat.sh
+++ b/scripts/ci/nextjs-compat.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NEXT_VERSION="${NEXT_VERSION:-}"
+NEXT_LABEL="${NEXT_LABEL:-$NEXT_VERSION}"
+PORT="${PORT:-3210}"
+FRONTMAN_SERVER="${FRONTMAN_SERVER:-localhost:4002}"
+
+if [ -z "$NEXT_VERSION" ]; then
+  echo "[nextjs-compat] NEXT_VERSION is required" >&2
+  exit 1
+fi
+
+WORK_ROOT="${RUNNER_TEMP:-/tmp}/frontman-nextjs-compat"
+rm -rf "$WORK_ROOT"
+mkdir -p "$WORK_ROOT"
+
+CONSUMER_DIR="$WORK_ROOT/consumer"
+PACK_DIR="$WORK_ROOT/pack"
+LOG_DIR="$WORK_ROOT/logs"
+mkdir -p "$CONSUMER_DIR/pages" "$PACK_DIR" "$LOG_DIR"
+
+log() {
+  printf '[nextjs-compat:%s] %s\n' "$NEXT_LABEL" "$*"
+}
+
+fail() {
+  printf '[nextjs-compat:%s] ERROR: %s\n' "$NEXT_LABEL" "$*" >&2
+  if [ -f "$LOG_DIR/next-dev.log" ]; then
+    echo "[nextjs-compat:$NEXT_LABEL] --- next dev log (tail) ---" >&2
+    tail -120 "$LOG_DIR/next-dev.log" >&2 || true
+  fi
+  exit 1
+}
+
+cleanup() {
+  if [ -n "${DEV_PID:-}" ]; then
+    kill "$DEV_PID" >/dev/null 2>&1 || true
+    wait "$DEV_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+log "packing @frontman-ai/nextjs from local build"
+TARBALL="$(npm pack "$ROOT/libs/frontman-nextjs" --pack-destination "$PACK_DIR" --silent)"
+TARBALL_PATH="$PACK_DIR/$TARBALL"
+[ -f "$TARBALL_PATH" ] || fail "package tarball was not created at $TARBALL_PATH"
+
+cp "$ROOT/test/e2e/fixtures/nextjs/pages/index.tsx" "$CONSUMER_DIR/pages/index.tsx"
+cp "$ROOT/test/e2e/fixtures/nextjs/next.config.mjs" "$CONSUMER_DIR/next.config.mjs"
+
+cat > "$CONSUMER_DIR/package.json" <<JSON
+{
+  "name": "frontman-nextjs-compat-consumer",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build"
+  },
+  "dependencies": {
+    "@frontman-ai/nextjs": "file:$TARBALL_PATH",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-node": "^0.221.0",
+    "next": "$NEXT_VERSION",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+JSON
+
+log "installing clean consumer dependencies"
+npm install --prefix "$CONSUMER_DIR" --no-audit --no-fund || fail "npm install failed for Next.js $NEXT_VERSION"
+
+INSTALLED_NEXT_VERSION="$(node -p "require('$CONSUMER_DIR/node_modules/next/package.json').version")"
+NEXT_MAJOR="${INSTALLED_NEXT_VERSION%%.*}"
+log "installed Next.js $INSTALLED_NEXT_VERSION"
+
+log "running packed installer"
+(
+  cd "$CONSUMER_DIR"
+  node node_modules/@frontman-ai/nextjs/dist/cli.js install --skip-deps --server "$FRONTMAN_SERVER"
+) || fail "frontman-nextjs installer failed for Next.js $INSTALLED_NEXT_VERSION"
+
+if [ "$NEXT_MAJOR" -ge 16 ]; then
+  GENERATED_FILE="proxy.ts"
+  UNEXPECTED_FILE="middleware.ts"
+else
+  GENERATED_FILE="middleware.ts"
+  UNEXPECTED_FILE="proxy.ts"
+fi
+GENERATED_PATH="$CONSUMER_DIR/$GENERATED_FILE"
+
+[ -f "$GENERATED_PATH" ] || fail "expected generated file missing: $GENERATED_FILE"
+[ ! -f "$CONSUMER_DIR/$UNEXPECTED_FILE" ] || fail "unexpected generated file present: $UNEXPECTED_FILE"
+grep -q "createMiddleware" "$GENERATED_PATH" || fail "$GENERATED_FILE does not import/create Frontman middleware"
+grep -q "host: '$FRONTMAN_SERVER'" "$GENERATED_PATH" || fail "$GENERATED_FILE does not include configured Frontman host"
+
+if [ "$GENERATED_FILE" = "proxy.ts" ] && grep -q "runtime:" "$GENERATED_PATH"; then
+  fail "$GENERATED_FILE contains route runtime config that Next.js $INSTALLED_NEXT_VERSION rejects"
+fi
+
+log "generated $GENERATED_FILE"
+
+log "starting next dev smoke server"
+(
+  cd "$CONSUMER_DIR"
+  NEXT_TELEMETRY_DISABLED=1 PORT="$PORT" node node_modules/next/dist/bin/next dev --turbopack -p "$PORT"
+) > "$LOG_DIR/next-dev.log" 2>&1 &
+DEV_PID=$!
+
+READY=0
+for _ in $(seq 1 180); do
+  if ! kill -0 "$DEV_PID" >/dev/null 2>&1; then
+    fail "next dev exited before becoming ready for Next.js $INSTALLED_NEXT_VERSION with $GENERATED_FILE"
+  fi
+  if curl -fsS "http://127.0.0.1:$PORT/" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 0.5
+done
+[ "$READY" = "1" ] || fail "next dev did not become ready for Next.js $INSTALLED_NEXT_VERSION with $GENERATED_FILE"
+
+curl -fsS "http://127.0.0.1:$PORT/" | grep -q "Hello World" || fail "Next.js $INSTALLED_NEXT_VERSION home page did not render"
+curl -fsS "http://127.0.0.1:$PORT/frontman/" | grep -q "frontman" || fail "Next.js $INSTALLED_NEXT_VERSION did not exercise generated $GENERATED_FILE in dev"
+log "next dev smoke passed with $GENERATED_FILE"
+
+cleanup
+unset DEV_PID
+
+log "running next build"
+(
+  cd "$CONSUMER_DIR"
+  NEXT_TELEMETRY_DISABLED=1 node node_modules/next/dist/bin/next build
+) || fail "next build failed for Next.js $INSTALLED_NEXT_VERSION with generated $GENERATED_FILE"
+
+log "compatibility check passed"


### PR DESCRIPTION
Closes #1570

## Summary
- add a CI matrix for packed Next.js consumers across 15.5.0, latest 15, and latest 16
- pack the local @frontman-ai/nextjs package into a clean consumer, run the installer, smoke next dev, and run next build
- verify generated middleware/proxy output and improve packed Instrumentation type resolution for production builds

## Validation
- yarn rescript
- yarn workspace @frontman-ai/nextjs build
- NEXT_VERSION=15.5.0 bash scripts/ci/nextjs-compat.sh
- NEXT_VERSION=15 bash scripts/ci/nextjs-compat.sh
- NEXT_VERSION=16 bash scripts/ci/nextjs-compat.sh