### PR TITLE
fix crashing device selector

### DIFF
--- a/libs/client/src/webpreview/Client__WebPreview__DeviceBar.res
+++ b/libs/client/src/webpreview/Client__WebPreview__DeviceBar.res
@@ -81,7 +81,7 @@ let make = (
           <DropdownMenu.Separator />
           {categories
           ->Array.mapWithIndex(((category, devices), idx) => {
-            <React.Fragment key={category}>
+            <DropdownMenu.Group key={category}>
               <DropdownMenu.Label> {React.string(category)} </DropdownMenu.Label>
               {devices
               ->Array.map(preset => {
@@ -108,7 +108,7 @@ let make = (
               })
               ->React.array}
               {idx < Array.length(categories) - 1 ? <DropdownMenu.Separator /> : React.null}
-            </React.Fragment>
+            </DropdownMenu.Group>
           })
           ->React.array}
         </DropdownMenu.Content>


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->



https://github.com/user-attachments/assets/fe31dbb7-1e5d-4a91-9e9b-a89f9f855e11

the error:

```
Uncaught Error: Base UI: MenuGroupContext is missing. Menu group parts must be used within <Menu.Group> or <Menu.RadioGroup>.
    useMenuGroupRootContext MenuGroupContext.mjs:10
    MenuGroupLabel MenuGroupLabel.mjs:24
    React 13
MenuGroupContext.mjs:10:11
```


## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
