### PR TITLE
Preserve official MCP metadata through relay boundaries

### DIFF
--- a/.changeset/preserve-mcp-metadata.md
+++ b/.changeset/preserve-mcp-metadata.md
@@ -1,7 +1,10 @@
 ---
-"@frontman-ai/vite": patch
-"@frontman-ai/nextjs": patch
-"@frontman-ai/astro": patch
+"@frontman-ai/frontman-protocol": major
+"@frontman-ai/frontman-client": major
+"@frontman-ai/frontman-core": major
+"@frontman-ai/vite": major
+"@frontman-ai/nextjs": major
+"@frontman-ai/astro": major
 ---
 
-Preserve official MCP tool, content annotation, and implementation metadata through relay boundaries.
+Preserve official MCP tool, content annotation, and implementation metadata through relay boundaries. Relay tools now require protocol version 2.0 and the MCP `_meta["ai.frontman/tool-metadata"]` shape instead of legacy top-level metadata fields.

--- a/.changeset/preserve-mcp-metadata.md
+++ b/.changeset/preserve-mcp-metadata.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/vite": patch
+"@frontman-ai/nextjs": patch
+"@frontman-ai/astro": patch
+---
+
+Preserve official MCP tool, content annotation, and implementation metadata through relay boundaries.

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -84,37 +84,20 @@ let disconnect = (relay: t): unit => {
 
 let getToolsJson = (relay: t): array<JSON.t> => {
   switch relay.state.contents {
-  | Connected({tools}) =>
-    tools->Array.map(tool => {
-      let frontmanMetadata = dict{
-        "access": tool.access
-        ->Option.getOr(FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite)
-        ->S.decodeOrThrow(
-          ~from=FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.accessSchema,
-          ~to=S.json->S.noValidation(true),
-        ),
-        "visibleToAgent": JSON.Encode.bool(tool.visibleToAgent),
-      }
-      let definition = dict{
-        "name": JSON.Encode.string(tool.name),
-        "description": JSON.Encode.string(tool.description),
-        "_meta": JSON.Encode.object(
-          dict{"ai.frontman/tool-metadata": JSON.Encode.object(frontmanMetadata)},
-        ),
-        "inputSchema": tool.inputSchema,
-      }
-      tool.outputSchema->Option.forEach(outputSchema =>
-        definition->Dict.set("outputSchema", outputSchema)
-      )
-      JSON.Encode.object(definition)
-    })
+  | Connected({tools}) => tools
   | Disconnected | Error(_) => []
   }
 }
 
+let toolName = tool =>
+  tool
+  ->JSON.Decode.object
+  ->Option.flatMap(tool => tool->Dict.get("name"))
+  ->Option.flatMap(JSON.Decode.string)
+
 let hasTool = (relay: t, name: string): bool => {
   switch relay.state.contents {
-  | Connected({tools}) => tools->Array.some(tool => tool.name == name)
+  | Connected({tools}) => tools->Array.some(tool => tool->toolName == Some(name))
   | Disconnected | Error(_) => false
   }
 }

--- a/libs/frontman-client/test/FrontmanClient__Relay.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Relay.test.res
@@ -5,11 +5,29 @@ module Relay = FrontmanClient__Relay
 let jsonString = json => JSON.stringify(json)
 
 describe("Relay.connect", _t => {
-  test("rejects incompatible protocol versions", t => {
-    let json = JSON.parseOrThrow(`{"tools":[],"serverInfo":{"name":"test","version":"1"},"protocolVersion":"2.0"}`)
+  test("accepts only the current relay protocol version", t => {
+    let json = JSON.parseOrThrow(`{"tools":[],"serverInfo":{"name":"test","version":"1"},"protocolVersion":"1.0"}`)
     t
     ->expect(() => json->S.parseOrThrow(~to=FrontmanClient__Relay__Types.toolsResponseSchema))
     ->Expect.toThrow
+  })
+
+  test("requires relay v2 tool metadata shape", t => {
+    let legacy = JSON.parseOrThrow(`{
+      "tools":[{"name":"hidden","inputSchema":{"type":"object"},"access":"read","visibleToAgent":false}],
+      "serverInfo":{"name":"test","version":"1"},
+      "protocolVersion":"2.0"
+    }`)
+    let current = JSON.parseOrThrow(`{
+      "tools":[{"name":"hidden","inputSchema":{"type":"object"},"_meta":{"ai.frontman/tool-metadata":{"access":"read","visibleToAgent":false}}}],
+      "serverInfo":{"name":"test","version":"1"},
+      "protocolVersion":"2.0"
+    }`)
+
+    t
+    ->expect(() => legacy->S.parseOrThrow(~to=FrontmanClient__Relay__Types.toolsResponseSchema))
+    ->Expect.toThrow
+    current->S.parseOrThrow(~to=FrontmanClient__Relay__Types.toolsResponseSchema)->ignore
   })
 })
 

--- a/libs/frontman-client/test/FrontmanClient__Relay.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Relay.test.res
@@ -2,6 +2,8 @@ open Vitest
 
 module Relay = FrontmanClient__Relay
 
+let jsonString = json => JSON.stringify(json)
+
 describe("Relay.connect", _t => {
   test("rejects incompatible protocol versions", t => {
     let json = JSON.parseOrThrow(`{"tools":[],"serverInfo":{"name":"test","version":"1"},"protocolVersion":"2.0"}`)
@@ -11,25 +13,28 @@ describe("Relay.connect", _t => {
   })
 })
 
-test("preserves optional output schemas and parses legacy results", t => {
+test("preserves relayed MCP tool metadata and parses legacy results", t => {
   let relay = Relay.make(~baseUrl="http://localhost")
-  let tool = (outputSchema): FrontmanClient__Relay__Types.remoteTool => {
-    name: "tool",
-    description: "tool",
-    access: None,
-    inputSchema: JSON.Encode.object(Dict.make()),
-    outputSchema,
-    visibleToAgent: true,
-  }
+  let tool = JSON.parseOrThrow(`{
+    "name":"tool",
+    "title":"Tool",
+    "description":"tool",
+    "icons":[{"src":"data:image/png;base64,AA==","theme":"light"}],
+    "inputSchema":{"type":"object"},
+    "outputSchema":{"type":"object"},
+    "annotations":{"title":"Tool annotation","readOnlyHint":true},
+    "_meta":{"ai.frontman/tool-metadata":{"visibleToAgent":true,"access":"read"},"vendor/example":{"x":1}}
+  }`)
   relay.state :=
     Relay.Connected({
-      tools: [tool(Some(JSON.Encode.object(Dict.make()))), tool(None)],
+      tools: [tool],
       serverInfo: {name: "test", version: "1"},
     })
 
-  let definitions = relay->Relay.getToolsJson->Array.map(json => JSON.stringify(json))
-  t->expect(definitions[0]->Option.getOrThrow->String.includes("outputSchema"))->Expect.toBe(true)
-  t->expect(definitions[1]->Option.getOrThrow->String.includes("outputSchema"))->Expect.toBe(false)
+  t
+  ->expect(relay->Relay.getToolsJson->Array.get(0)->Option.map(jsonString))
+  ->Expect.toEqual(Some(JSON.stringify(tool)))
+  t->expect(relay->Relay.hasTool("tool"))->Expect.toBe(true)
   JSON.parseOrThrow(`{"content":[]}`)
   ->S.parseOrThrow(~to=FrontmanClient__MCP__Types.callToolResultSchema)
   ->ignore

--- a/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
+++ b/libs/frontman-core/src/FrontmanCore__ToolRegistry.res
@@ -58,14 +58,20 @@ external jsonSchemaAsJson: JSONSchema.t => JSON.t = "%identity"
 
 let serializeTool = (m: tool): Relay.remoteTool => {
   module T = unpack(m)
-  {
-    name: T.name,
-    description: T.description,
-    access: Some(T.access),
-    inputSchema: T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
-    outputSchema: T.outputJsonSchema->Option.map(jsonSchemaAsJson),
-    visibleToAgent: T.visibleToAgent,
+  let metadata = dict{
+    "access": T.access->S.decodeOrThrow(~from=Tool.accessSchema, ~to=S.json->S.noValidation(true)),
+    "visibleToAgent": JSON.Encode.bool(T.visibleToAgent),
   }
+  let tool = dict{
+    "name": JSON.Encode.string(T.name),
+    "description": JSON.Encode.string(T.description),
+    "inputSchema": T.inputSchema->S.toJSONSchema->jsonSchemaAsJson,
+    "_meta": JSON.Encode.object(dict{"ai.frontman/tool-metadata": JSON.Encode.object(metadata)}),
+  }
+  T.outputJsonSchema->Option.forEach(outputSchema =>
+    tool->Dict.set("outputSchema", outputSchema->jsonSchemaAsJson)
+  )
+  JSON.Encode.object(tool)
 }
 
 let getToolDefinitions = (registry: t): array<Relay.remoteTool> => {

--- a/libs/frontman-core/test/FrontmanCore__ToolRegistry.test.res
+++ b/libs/frontman-core/test/FrontmanCore__ToolRegistry.test.res
@@ -1,7 +1,6 @@
 open Vitest
 
 module ToolRegistry = FrontmanCore__ToolRegistry
-module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 
 describe("ToolRegistry", _t => {
   test("make creates empty registry", t => {
@@ -40,13 +39,27 @@ describe("ToolRegistry", _t => {
     t->expect(merged->ToolRegistry.getToolByName("write_file")->Option.isSome)->Expect.toBe(true)
   })
 
-  test("serializes access and only real output schemas", t => {
+  test("serializes metadata and only real output schemas", t => {
     let definitions = ToolRegistry.coreTools()->ToolRegistry.getToolDefinitions
-    let readFile = definitions->Array.find(d => d.name == "read_file")->Option.getOrThrow
-    let listFiles = definitions->Array.find(d => d.name == "list_files")->Option.getOrThrow
+    let object = tool => tool->JSON.Decode.object->Option.getOrThrow
+    let name = tool => object(tool)->Dict.get("name")->Option.flatMap(JSON.Decode.string)
+    let metadata = tool =>
+      object(tool)
+      ->Dict.get("_meta")
+      ->Option.flatMap(JSON.Decode.object)
+      ->Option.flatMap(meta => meta->Dict.get("ai.frontman/tool-metadata"))
+      ->Option.flatMap(JSON.Decode.object)
+    let readFile = definitions->Array.find(d => name(d) == Some("read_file"))->Option.getOrThrow
+    let listFiles = definitions->Array.find(d => name(d) == Some("list_files"))->Option.getOrThrow
 
-    t->expect(readFile.access)->Expect.toEqual(Some(Tool.Read))
-    t->expect(readFile.outputSchema->Option.isSome)->Expect.toBe(true)
-    t->expect(listFiles.outputSchema)->Expect.toEqual(None)
+    t
+    ->expect(
+      metadata(readFile)
+      ->Option.flatMap(meta => meta->Dict.get("access"))
+      ->Option.flatMap(JSON.Decode.string),
+    )
+    ->Expect.toEqual(Some("read"))
+    t->expect(object(readFile)->Dict.get("outputSchema")->Option.isSome)->Expect.toBe(true)
+    t->expect(object(listFiles)->Dict.get("outputSchema"))->Expect.toEqual(None)
   })
 })

--- a/libs/frontman-nextjs/test/FrontmanNextjs__ToolRegistry.test.res
+++ b/libs/frontman-nextjs/test/FrontmanNextjs__ToolRegistry.test.res
@@ -18,13 +18,18 @@ describe("ToolRegistry", _t => {
   test("serializes tools with correct structure", t => {
     let registry = ToolRegistry.make()
     let definitions = registry->ToolRegistry.getToolDefinitions
-    let readFile = definitions->Array.find(d => d.name == "read_file")
+    let object = tool => tool->JSON.Decode.object->Option.getOrThrow
+    let fieldString = (tool, field) =>
+      object(tool)->Dict.get(field)->Option.flatMap(JSON.Decode.string)
+    let readFile = definitions->Array.find(d => fieldString(d, "name") == Some("read_file"))
 
     t->expect(readFile->Option.isSome)->Expect.toBe(true)
     switch readFile {
     | Some(tool) =>
-      t->expect(tool.name)->Expect.toBe("read_file")
-      t->expect(tool.description->String.length > 0)->Expect.toBe(true)
+      t->expect(fieldString(tool, "name"))->Expect.toEqual(Some("read_file"))
+      t
+      ->expect(fieldString(tool, "description")->Option.getOrThrow->String.length > 0)
+      ->Expect.toBe(true)
     | None => ()
     }
   })

--- a/libs/frontman-protocol/schemas/acp/contentBlock.json
+++ b/libs/frontman-protocol/schemas/acp/contentBlock.json
@@ -14,7 +14,23 @@
         "annotations": {
           "type": "object",
           "properties": {
-            "_meta": {}
+            "audience": {
+              "items": {
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "type": "array"
+            },
+            "priority": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0
+            },
+            "lastModified": {
+              "type": "string"
+            }
           }
         }
       },
@@ -40,7 +56,23 @@
         "annotations": {
           "type": "object",
           "properties": {
-            "_meta": {}
+            "audience": {
+              "items": {
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "type": "array"
+            },
+            "priority": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0
+            },
+            "lastModified": {
+              "type": "string"
+            }
           }
         }
       },
@@ -67,7 +99,23 @@
         "annotations": {
           "type": "object",
           "properties": {
-            "_meta": {}
+            "audience": {
+              "items": {
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "type": "array"
+            },
+            "priority": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0
+            },
+            "lastModified": {
+              "type": "string"
+            }
           }
         }
       },
@@ -87,14 +135,44 @@
         "name": {
           "type": "string"
         },
+        "title": {
+          "type": "string"
+        },
         "uri": {
           "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer",
+          "minimum": -2147483648,
+          "maximum": 2147483647
         },
         "_meta": {},
         "annotations": {
           "type": "object",
           "properties": {
-            "_meta": {}
+            "audience": {
+              "items": {
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "type": "array"
+            },
+            "priority": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0
+            },
+            "lastModified": {
+              "type": "string"
+            }
           }
         }
       },
@@ -115,7 +193,23 @@
         "annotations": {
           "type": "object",
           "properties": {
-            "_meta": {}
+            "audience": {
+              "items": {
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "type": "array"
+            },
+            "priority": {
+              "type": "number",
+              "maximum": 1,
+              "minimum": 0
+            },
+            "lastModified": {
+              "type": "string"
+            }
           }
         },
         "resource": {
@@ -131,7 +225,8 @@
                 },
                 "text": {
                   "type": "string"
-                }
+                },
+                "_meta": {}
               },
               "required": [
                 "uri",
@@ -149,7 +244,8 @@
                 },
                 "blob": {
                   "type": "string"
-                }
+                },
+                "_meta": {}
               },
               "required": [
                 "uri",

--- a/libs/frontman-protocol/schemas/acp/contentBlock.json
+++ b/libs/frontman-protocol/schemas/acp/contentBlock.json
@@ -30,7 +30,8 @@
             },
             "lastModified": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           }
         }
       },
@@ -72,7 +73,8 @@
             },
             "lastModified": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           }
         }
       },
@@ -115,7 +117,8 @@
             },
             "lastModified": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           }
         }
       },
@@ -148,9 +151,9 @@
           "type": "string"
         },
         "size": {
-          "type": "integer",
-          "minimum": -2147483648,
-          "maximum": 2147483647
+          "type": "number",
+          "multipleOf": 1,
+          "minimum": 0
         },
         "_meta": {},
         "annotations": {
@@ -172,7 +175,8 @@
             },
             "lastModified": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           }
         }
       },
@@ -209,7 +213,8 @@
             },
             "lastModified": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           }
         },
         "resource": {

--- a/libs/frontman-protocol/schemas/acp/embeddedResource.json
+++ b/libs/frontman-protocol/schemas/acp/embeddedResource.json
@@ -21,7 +21,8 @@
         },
         "lastModified": {
           "type": "string"
-        }
+        },
+        "_meta": {}
       }
     },
     "resource": {

--- a/libs/frontman-protocol/schemas/acp/embeddedResource.json
+++ b/libs/frontman-protocol/schemas/acp/embeddedResource.json
@@ -5,7 +5,23 @@
     "annotations": {
       "type": "object",
       "properties": {
-        "_meta": {}
+        "audience": {
+          "items": {
+            "enum": [
+              "user",
+              "assistant"
+            ]
+          },
+          "type": "array"
+        },
+        "priority": {
+          "type": "number",
+          "maximum": 1,
+          "minimum": 0
+        },
+        "lastModified": {
+          "type": "string"
+        }
       }
     },
     "resource": {
@@ -21,7 +37,8 @@
             },
             "text": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           },
           "required": [
             "uri",
@@ -39,7 +56,8 @@
             },
             "blob": {
               "type": "string"
-            }
+            },
+            "_meta": {}
           },
           "required": [
             "uri",

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -43,7 +43,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -85,7 +86,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -128,7 +130,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -161,9 +164,9 @@
                   "type": "string"
                 },
                 "size": {
-                  "type": "integer",
-                  "minimum": -2147483648,
-                  "maximum": 2147483647
+                  "type": "number",
+                  "multipleOf": 1,
+                  "minimum": 0
                 },
                 "_meta": {},
                 "annotations": {
@@ -185,7 +188,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -222,7 +226,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 },
                 "resource": {
@@ -344,7 +349,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -386,7 +392,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -429,7 +436,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -462,9 +470,9 @@
                   "type": "string"
                 },
                 "size": {
-                  "type": "integer",
-                  "minimum": -2147483648,
-                  "maximum": 2147483647
+                  "type": "number",
+                  "multipleOf": 1,
+                  "minimum": 0
                 },
                 "_meta": {},
                 "annotations": {
@@ -486,7 +494,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -523,7 +532,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 },
                 "resource": {
@@ -668,7 +678,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -710,7 +721,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -753,7 +765,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -786,9 +799,9 @@
                             "type": "string"
                           },
                           "size": {
-                            "type": "integer",
-                            "minimum": -2147483648,
-                            "maximum": 2147483647
+                            "type": "number",
+                            "multipleOf": 1,
+                            "minimum": 0
                           },
                           "_meta": {},
                           "annotations": {
@@ -810,7 +823,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -847,7 +861,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           },
                           "resource": {
@@ -1038,7 +1053,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -1080,7 +1096,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -1123,7 +1140,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -1156,9 +1174,9 @@
                             "type": "string"
                           },
                           "size": {
-                            "type": "integer",
-                            "minimum": -2147483648,
-                            "maximum": 2147483647
+                            "type": "number",
+                            "multipleOf": 1,
+                            "minimum": 0
                           },
                           "_meta": {},
                           "annotations": {
@@ -1180,7 +1198,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           }
                         },
@@ -1217,7 +1236,8 @@
                               },
                               "lastModified": {
                                 "type": "string"
-                              }
+                              },
+                              "_meta": {}
                             }
                           },
                           "resource": {

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -27,7 +27,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -53,7 +69,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -80,7 +112,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -100,14 +148,44 @@
                 "name": {
                   "type": "string"
                 },
+                "title": {
+                  "type": "string"
+                },
                 "uri": {
                   "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer",
+                  "minimum": -2147483648,
+                  "maximum": 2147483647
                 },
                 "_meta": {},
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -128,7 +206,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 },
                 "resource": {
@@ -144,7 +238,8 @@
                         },
                         "text": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",
@@ -162,7 +257,8 @@
                         },
                         "blob": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",
@@ -232,7 +328,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -258,7 +370,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -285,7 +413,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -305,14 +449,44 @@
                 "name": {
                   "type": "string"
                 },
+                "title": {
+                  "type": "string"
+                },
                 "uri": {
                   "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer",
+                  "minimum": -2147483648,
+                  "maximum": 2147483647
                 },
                 "_meta": {},
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -333,7 +507,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 },
                 "resource": {
@@ -349,7 +539,8 @@
                         },
                         "text": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",
@@ -367,7 +558,8 @@
                         },
                         "blob": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",
@@ -460,7 +652,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -486,7 +694,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -513,7 +737,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -533,14 +773,44 @@
                           "name": {
                             "type": "string"
                           },
+                          "title": {
+                            "type": "string"
+                          },
                           "uri": {
                             "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
                           },
                           "_meta": {},
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -561,7 +831,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           },
                           "resource": {
@@ -577,7 +863,8 @@
                                   },
                                   "text": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "_meta": {}
                                 },
                                 "required": [
                                   "uri",
@@ -595,7 +882,8 @@
                                   },
                                   "blob": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "_meta": {}
                                 },
                                 "required": [
                                   "uri",
@@ -734,7 +1022,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -760,7 +1064,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -787,7 +1107,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -807,14 +1143,44 @@
                           "name": {
                             "type": "string"
                           },
+                          "title": {
+                            "type": "string"
+                          },
                           "uri": {
                             "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
                           },
                           "_meta": {},
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           }
                         },
@@ -835,7 +1201,23 @@
                           "annotations": {
                             "type": "object",
                             "properties": {
-                              "_meta": {}
+                              "audience": {
+                                "items": {
+                                  "enum": [
+                                    "user",
+                                    "assistant"
+                                  ]
+                                },
+                                "type": "array"
+                              },
+                              "priority": {
+                                "type": "number",
+                                "maximum": 1,
+                                "minimum": 0
+                              },
+                              "lastModified": {
+                                "type": "string"
+                              }
                             }
                           },
                           "resource": {
@@ -851,7 +1233,8 @@
                                   },
                                   "text": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "_meta": {}
                                 },
                                 "required": [
                                   "uri",
@@ -869,7 +1252,8 @@
                                   },
                                   "blob": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "_meta": {}
                                 },
                                 "required": [
                                   "uri",

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -60,7 +60,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -102,7 +103,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -145,7 +147,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -178,9 +181,9 @@
                           "type": "string"
                         },
                         "size": {
-                          "type": "integer",
-                          "minimum": -2147483648,
-                          "maximum": 2147483647
+                          "type": "number",
+                          "multipleOf": 1,
+                          "minimum": 0
                         },
                         "_meta": {},
                         "annotations": {
@@ -202,7 +205,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -239,7 +243,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         },
                         "resource": {
@@ -361,7 +366,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -403,7 +409,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -446,7 +453,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -479,9 +487,9 @@
                           "type": "string"
                         },
                         "size": {
-                          "type": "integer",
-                          "minimum": -2147483648,
-                          "maximum": 2147483647
+                          "type": "number",
+                          "multipleOf": 1,
+                          "minimum": 0
                         },
                         "_meta": {},
                         "annotations": {
@@ -503,7 +511,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         }
                       },
@@ -540,7 +549,8 @@
                             },
                             "lastModified": {
                               "type": "string"
-                            }
+                            },
+                            "_meta": {}
                           }
                         },
                         "resource": {
@@ -685,7 +695,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -727,7 +738,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -770,7 +782,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -803,9 +816,9 @@
                                     "type": "string"
                                   },
                                   "size": {
-                                    "type": "integer",
-                                    "minimum": -2147483648,
-                                    "maximum": 2147483647
+                                    "type": "number",
+                                    "multipleOf": 1,
+                                    "minimum": 0
                                   },
                                   "_meta": {},
                                   "annotations": {
@@ -827,7 +840,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -864,7 +878,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   },
                                   "resource": {
@@ -1055,7 +1070,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -1097,7 +1113,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -1140,7 +1157,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -1173,9 +1191,9 @@
                                     "type": "string"
                                   },
                                   "size": {
-                                    "type": "integer",
-                                    "minimum": -2147483648,
-                                    "maximum": 2147483647
+                                    "type": "number",
+                                    "multipleOf": 1,
+                                    "minimum": 0
                                   },
                                   "_meta": {},
                                   "annotations": {
@@ -1197,7 +1215,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   }
                                 },
@@ -1234,7 +1253,8 @@
                                       },
                                       "lastModified": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "_meta": {}
                                     }
                                   },
                                   "resource": {

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -44,7 +44,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -70,7 +86,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -97,7 +129,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -117,14 +165,44 @@
                         "name": {
                           "type": "string"
                         },
+                        "title": {
+                          "type": "string"
+                        },
                         "uri": {
                           "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "size": {
+                          "type": "integer",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647
                         },
                         "_meta": {},
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -145,7 +223,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         },
                         "resource": {
@@ -161,7 +255,8 @@
                                 },
                                 "text": {
                                   "type": "string"
-                                }
+                                },
+                                "_meta": {}
                               },
                               "required": [
                                 "uri",
@@ -179,7 +274,8 @@
                                 },
                                 "blob": {
                                   "type": "string"
-                                }
+                                },
+                                "_meta": {}
                               },
                               "required": [
                                 "uri",
@@ -249,7 +345,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -275,7 +387,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -302,7 +430,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -322,14 +466,44 @@
                         "name": {
                           "type": "string"
                         },
+                        "title": {
+                          "type": "string"
+                        },
                         "uri": {
                           "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        },
+                        "size": {
+                          "type": "integer",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647
                         },
                         "_meta": {},
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         }
                       },
@@ -350,7 +524,23 @@
                         "annotations": {
                           "type": "object",
                           "properties": {
-                            "_meta": {}
+                            "audience": {
+                              "items": {
+                                "enum": [
+                                  "user",
+                                  "assistant"
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            "priority": {
+                              "type": "number",
+                              "maximum": 1,
+                              "minimum": 0
+                            },
+                            "lastModified": {
+                              "type": "string"
+                            }
                           }
                         },
                         "resource": {
@@ -366,7 +556,8 @@
                                 },
                                 "text": {
                                   "type": "string"
-                                }
+                                },
+                                "_meta": {}
                               },
                               "required": [
                                 "uri",
@@ -384,7 +575,8 @@
                                 },
                                 "blob": {
                                   "type": "string"
-                                }
+                                },
+                                "_meta": {}
                               },
                               "required": [
                                 "uri",
@@ -477,7 +669,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -503,7 +711,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -530,7 +754,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -550,14 +790,44 @@
                                   "name": {
                                     "type": "string"
                                   },
+                                  "title": {
+                                    "type": "string"
+                                  },
                                   "uri": {
                                     "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "size": {
+                                    "type": "integer",
+                                    "minimum": -2147483648,
+                                    "maximum": 2147483647
                                   },
                                   "_meta": {},
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -578,7 +848,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   },
                                   "resource": {
@@ -594,7 +880,8 @@
                                           },
                                           "text": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "_meta": {}
                                         },
                                         "required": [
                                           "uri",
@@ -612,7 +899,8 @@
                                           },
                                           "blob": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "_meta": {}
                                         },
                                         "required": [
                                           "uri",
@@ -751,7 +1039,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -777,7 +1081,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -804,7 +1124,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -824,14 +1160,44 @@
                                   "name": {
                                     "type": "string"
                                   },
+                                  "title": {
+                                    "type": "string"
+                                  },
                                   "uri": {
                                     "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "mimeType": {
+                                    "type": "string"
+                                  },
+                                  "size": {
+                                    "type": "integer",
+                                    "minimum": -2147483648,
+                                    "maximum": 2147483647
                                   },
                                   "_meta": {},
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 },
@@ -852,7 +1218,23 @@
                                   "annotations": {
                                     "type": "object",
                                     "properties": {
-                                      "_meta": {}
+                                      "audience": {
+                                        "items": {
+                                          "enum": [
+                                            "user",
+                                            "assistant"
+                                          ]
+                                        },
+                                        "type": "array"
+                                      },
+                                      "priority": {
+                                        "type": "number",
+                                        "maximum": 1,
+                                        "minimum": 0
+                                      },
+                                      "lastModified": {
+                                        "type": "string"
+                                      }
                                     }
                                   },
                                   "resource": {
@@ -868,7 +1250,8 @@
                                           },
                                           "text": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "_meta": {}
                                         },
                                         "required": [
                                           "uri",
@@ -886,7 +1269,8 @@
                                           },
                                           "blob": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "_meta": {}
                                         },
                                         "required": [
                                           "uri",

--- a/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
+++ b/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
@@ -39,7 +39,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -81,7 +82,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -124,7 +126,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -157,9 +160,9 @@
                   "type": "string"
                 },
                 "size": {
-                  "type": "integer",
-                  "minimum": -2147483648,
-                  "maximum": 2147483647
+                  "type": "number",
+                  "multipleOf": 1,
+                  "minimum": 0
                 },
                 "_meta": {},
                 "annotations": {
@@ -181,7 +184,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 }
               },
@@ -218,7 +222,8 @@
                     },
                     "lastModified": {
                       "type": "string"
-                    }
+                    },
+                    "_meta": {}
                   }
                 },
                 "resource": {

--- a/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
+++ b/libs/frontman-protocol/schemas/acp/toolCallContentItem.json
@@ -23,7 +23,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -49,7 +65,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -76,7 +108,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -96,14 +144,44 @@
                 "name": {
                   "type": "string"
                 },
+                "title": {
+                  "type": "string"
+                },
                 "uri": {
                   "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer",
+                  "minimum": -2147483648,
+                  "maximum": 2147483647
                 },
                 "_meta": {},
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -124,7 +202,23 @@
                 "annotations": {
                   "type": "object",
                   "properties": {
-                    "_meta": {}
+                    "audience": {
+                      "items": {
+                        "enum": [
+                          "user",
+                          "assistant"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "maximum": 1,
+                      "minimum": 0
+                    },
+                    "lastModified": {
+                      "type": "string"
+                    }
                   }
                 },
                 "resource": {
@@ -140,7 +234,8 @@
                         },
                         "text": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",
@@ -158,7 +253,8 @@
                         },
                         "blob": {
                           "type": "string"
-                        }
+                        },
+                        "_meta": {}
                       },
                       "required": [
                         "uri",

--- a/libs/frontman-protocol/schemas/mcp/callToolResult.json
+++ b/libs/frontman-protocol/schemas/mcp/callToolResult.json
@@ -38,7 +38,8 @@
                   },
                   "lastModified": {
                     "type": "string"
-                  }
+                  },
+                  "_meta": {}
                 }
               }
             },
@@ -80,7 +81,8 @@
                   },
                   "lastModified": {
                     "type": "string"
-                  }
+                  },
+                  "_meta": {}
                 }
               }
             },
@@ -123,7 +125,8 @@
                   },
                   "lastModified": {
                     "type": "string"
-                  }
+                  },
+                  "_meta": {}
                 }
               }
             },
@@ -156,9 +159,9 @@
                 "type": "string"
               },
               "size": {
-                "type": "integer",
-                "minimum": -2147483648,
-                "maximum": 2147483647
+                "type": "number",
+                "multipleOf": 1,
+                "minimum": 0
               },
               "_meta": {},
               "annotations": {
@@ -180,7 +183,8 @@
                   },
                   "lastModified": {
                     "type": "string"
-                  }
+                  },
+                  "_meta": {}
                 }
               }
             },
@@ -217,7 +221,8 @@
                   },
                   "lastModified": {
                     "type": "string"
-                  }
+                  },
+                  "_meta": {}
                 }
               },
               "resource": {

--- a/libs/frontman-protocol/schemas/mcp/callToolResult.json
+++ b/libs/frontman-protocol/schemas/mcp/callToolResult.json
@@ -22,7 +22,23 @@
               "annotations": {
                 "type": "object",
                 "properties": {
-                  "_meta": {}
+                  "audience": {
+                    "items": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "number",
+                    "maximum": 1,
+                    "minimum": 0
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -48,7 +64,23 @@
               "annotations": {
                 "type": "object",
                 "properties": {
-                  "_meta": {}
+                  "audience": {
+                    "items": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "number",
+                    "maximum": 1,
+                    "minimum": 0
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -75,7 +107,23 @@
               "annotations": {
                 "type": "object",
                 "properties": {
-                  "_meta": {}
+                  "audience": {
+                    "items": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "number",
+                    "maximum": 1,
+                    "minimum": 0
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -95,14 +143,44 @@
               "name": {
                 "type": "string"
               },
+              "title": {
+                "type": "string"
+              },
               "uri": {
                 "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer",
+                "minimum": -2147483648,
+                "maximum": 2147483647
               },
               "_meta": {},
               "annotations": {
                 "type": "object",
                 "properties": {
-                  "_meta": {}
+                  "audience": {
+                    "items": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "number",
+                    "maximum": 1,
+                    "minimum": 0
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -123,7 +201,23 @@
               "annotations": {
                 "type": "object",
                 "properties": {
-                  "_meta": {}
+                  "audience": {
+                    "items": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "number",
+                    "maximum": 1,
+                    "minimum": 0
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  }
                 }
               },
               "resource": {
@@ -139,7 +233,8 @@
                       },
                       "text": {
                         "type": "string"
-                      }
+                      },
+                      "_meta": {}
                     },
                     "required": [
                       "uri",
@@ -157,7 +252,8 @@
                       },
                       "blob": {
                         "type": "string"
-                      }
+                      },
+                      "_meta": {}
                     },
                     "required": [
                       "uri",

--- a/libs/frontman-protocol/schemas/mcp/discoverParams.json
+++ b/libs/frontman-protocol/schemas/mcp/discoverParams.json
@@ -29,7 +29,13 @@
             "name": {
               "type": "string"
             },
+            "title": {
+              "type": "string"
+            },
             "version": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           },

--- a/libs/frontman-protocol/schemas/mcp/discoverResult.json
+++ b/libs/frontman-protocol/schemas/mcp/discoverResult.json
@@ -58,7 +58,13 @@
             "name": {
               "type": "string"
             },
+            "title": {
+              "type": "string"
+            },
             "version": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           },

--- a/libs/frontman-protocol/schemas/mcp/info.json
+++ b/libs/frontman-protocol/schemas/mcp/info.json
@@ -4,7 +4,13 @@
     "name": {
       "type": "string"
     },
+    "title": {
+      "type": "string"
+    },
     "version": {
+      "type": "string"
+    },
+    "description": {
       "type": "string"
     }
   },

--- a/libs/frontman-protocol/schemas/mcp/toolCallParams.json
+++ b/libs/frontman-protocol/schemas/mcp/toolCallParams.json
@@ -29,7 +29,13 @@
             "name": {
               "type": "string"
             },
+            "title": {
+              "type": "string"
+            },
             "version": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           },

--- a/libs/frontman-protocol/schemas/mcp/toolsListParams.json
+++ b/libs/frontman-protocol/schemas/mcp/toolsListParams.json
@@ -29,7 +29,13 @@
             "name": {
               "type": "string"
             },
+            "title": {
+              "type": "string"
+            },
             "version": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           },

--- a/libs/frontman-protocol/schemas/mcp/toolsListResult.json
+++ b/libs/frontman-protocol/schemas/mcp/toolsListResult.json
@@ -13,8 +13,40 @@
             "type": "string",
             "minLength": 1
           },
+          "title": {
+            "type": "string"
+          },
           "description": {
             "type": "string"
+          },
+          "icons": {
+            "items": {
+              "type": "object",
+              "properties": {
+                "src": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "sizes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "theme": {
+                  "enum": [
+                    "light",
+                    "dark"
+                  ]
+                }
+              },
+              "required": [
+                "src"
+              ]
+            },
+            "type": "array"
           },
           "inputSchema": {
             "type": "object",
@@ -31,6 +63,26 @@
           "outputSchema": {
             "type": "object",
             "additionalProperties": true
+          },
+          "annotations": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "readOnlyHint": {
+                "type": "boolean"
+              },
+              "destructiveHint": {
+                "type": "boolean"
+              },
+              "idempotentHint": {
+                "type": "boolean"
+              },
+              "openWorldHint": {
+                "type": "boolean"
+              }
+            }
           },
           "_meta": {
             "type": "object",
@@ -89,7 +141,13 @@
             "name": {
               "type": "string"
             },
+            "title": {
+              "type": "string"
+            },
             "version": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           },

--- a/libs/frontman-protocol/schemas/relay/remoteTool.json
+++ b/libs/frontman-protocol/schemas/relay/remoteTool.json
@@ -2,28 +2,109 @@
   "type": "object",
   "properties": {
     "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
       "type": "string"
     },
     "description": {
       "type": "string"
     },
-    "access": {
-      "enum": [
-        "read",
-        "write",
-        "read-write"
+    "icons": {
+      "items": {
+        "type": "object",
+        "properties": {
+          "src": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "sizes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "theme": {
+            "enum": [
+              "light",
+              "dark"
+            ]
+          }
+        },
+        "required": [
+          "src"
+        ]
+      },
+      "type": "array"
+    },
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "object"
+        }
+      },
+      "required": [
+        "type"
       ]
     },
-    "inputSchema": {},
-    "outputSchema": {},
-    "visibleToAgent": {
-      "type": "boolean"
+    "outputSchema": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "annotations": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "readOnlyHint": {
+          "type": "boolean"
+        },
+        "destructiveHint": {
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "type": "boolean"
+        }
+      }
+    },
+    "_meta": {
+      "type": "object",
+      "properties": {
+        "ai.frontman/tool-metadata": {
+          "type": "object",
+          "properties": {
+            "visibleToAgent": {
+              "type": "boolean"
+            },
+            "executionMode": {
+              "enum": [
+                "Synchronous",
+                "Interactive"
+              ]
+            },
+            "access": {
+              "enum": [
+                "read",
+                "write",
+                "read-write"
+              ]
+            }
+          }
+        }
+      }
     }
   },
   "required": [
     "name",
-    "description",
-    "inputSchema",
-    "visibleToAgent"
+    "inputSchema"
   ]
 }

--- a/libs/frontman-protocol/schemas/relay/remoteTool.json
+++ b/libs/frontman-protocol/schemas/relay/remoteTool.json
@@ -85,26 +85,34 @@
             "visibleToAgent": {
               "type": "boolean"
             },
-            "executionMode": {
-              "enum": [
-                "Synchronous",
-                "Interactive"
-              ]
-            },
             "access": {
               "enum": [
                 "read",
                 "write",
                 "read-write"
               ]
+            },
+            "executionMode": {
+              "enum": [
+                "Synchronous",
+                "Interactive"
+              ]
             }
-          }
+          },
+          "required": [
+            "visibleToAgent",
+            "access"
+          ]
         }
-      }
+      },
+      "required": [
+        "ai.frontman/tool-metadata"
+      ]
     }
   },
   "required": [
     "name",
-    "inputSchema"
+    "inputSchema",
+    "_meta"
   ]
 }

--- a/libs/frontman-protocol/schemas/relay/toolsResponse.json
+++ b/libs/frontman-protocol/schemas/relay/toolsResponse.json
@@ -89,27 +89,35 @@
                   "visibleToAgent": {
                     "type": "boolean"
                   },
-                  "executionMode": {
-                    "enum": [
-                      "Synchronous",
-                      "Interactive"
-                    ]
-                  },
                   "access": {
                     "enum": [
                       "read",
                       "write",
                       "read-write"
                     ]
+                  },
+                  "executionMode": {
+                    "enum": [
+                      "Synchronous",
+                      "Interactive"
+                    ]
                   }
-                }
+                },
+                "required": [
+                  "visibleToAgent",
+                  "access"
+                ]
               }
-            }
+            },
+            "required": [
+              "ai.frontman/tool-metadata"
+            ]
           }
         },
         "required": [
           "name",
-          "inputSchema"
+          "inputSchema",
+          "_meta"
         ]
       },
       "type": "array"
@@ -137,7 +145,7 @@
     },
     "protocolVersion": {
       "type": "string",
-      "const": "1.0"
+      "const": "2.0"
     }
   },
   "required": [

--- a/libs/frontman-protocol/schemas/relay/toolsResponse.json
+++ b/libs/frontman-protocol/schemas/relay/toolsResponse.json
@@ -6,29 +6,110 @@
         "type": "object",
         "properties": {
           "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
             "type": "string"
           },
           "description": {
             "type": "string"
           },
-          "access": {
-            "enum": [
-              "read",
-              "write",
-              "read-write"
+          "icons": {
+            "items": {
+              "type": "object",
+              "properties": {
+                "src": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "sizes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "theme": {
+                  "enum": [
+                    "light",
+                    "dark"
+                  ]
+                }
+              },
+              "required": [
+                "src"
+              ]
+            },
+            "type": "array"
+          },
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "object"
+              }
+            },
+            "required": [
+              "type"
             ]
           },
-          "inputSchema": {},
-          "outputSchema": {},
-          "visibleToAgent": {
-            "type": "boolean"
+          "outputSchema": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "annotations": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "readOnlyHint": {
+                "type": "boolean"
+              },
+              "destructiveHint": {
+                "type": "boolean"
+              },
+              "idempotentHint": {
+                "type": "boolean"
+              },
+              "openWorldHint": {
+                "type": "boolean"
+              }
+            }
+          },
+          "_meta": {
+            "type": "object",
+            "properties": {
+              "ai.frontman/tool-metadata": {
+                "type": "object",
+                "properties": {
+                  "visibleToAgent": {
+                    "type": "boolean"
+                  },
+                  "executionMode": {
+                    "enum": [
+                      "Synchronous",
+                      "Interactive"
+                    ]
+                  },
+                  "access": {
+                    "enum": [
+                      "read",
+                      "write",
+                      "read-write"
+                    ]
+                  }
+                }
+              }
+            }
           }
         },
         "required": [
           "name",
-          "description",
-          "inputSchema",
-          "visibleToAgent"
+          "inputSchema"
         ]
       },
       "type": "array"
@@ -39,7 +120,13 @@
         "name": {
           "type": "string"
         },
+        "title": {
+          "type": "string"
+        },
         "version": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         }
       },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ContentBlock.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ContentBlock.res
@@ -1,11 +1,21 @@
-@schema
-type annotations = {_meta: option<JSON.t>}
+let prioritySchema =
+  S.float
+  ->S.refine(value => value >= 0. && value <= 1., ~error="Expected number between 0 and 1")
+  ->S.extendJSONSchema({minimum: 0., maximum: 1.})
+let audienceSchema = S.union([S.literal("user"), S.literal("assistant")])
 
 @schema
-type textResourceContents = {uri: string, mimeType: option<string>, text: string}
+type annotations = {
+  audience: option<array<@s.matches(audienceSchema) string>>,
+  priority: option<@s.matches(prioritySchema) float>,
+  lastModified: option<string>,
+}
 
 @schema
-type blobResourceContents = {uri: string, mimeType: option<string>, blob: string}
+type textResourceContents = {uri: string, mimeType: option<string>, text: string, _meta?: JSON.t}
+
+@schema
+type blobResourceContents = {uri: string, mimeType: option<string>, blob: string, _meta?: JSON.t}
 
 type embeddedResourceResource =
   | TextResourceContents(textResourceContents)
@@ -17,6 +27,7 @@ let embeddedResourceResourceSchema = S.union([
       uri: s.field("uri", S.string),
       mimeType: s.field("mimeType", S.option(S.string)),
       text: s.field("text", S.string),
+      _meta: ?s.field("_meta", S.option(S.json)),
     })
   }),
   S.object(s => {
@@ -24,6 +35,7 @@ let embeddedResourceResourceSchema = S.union([
       uri: s.field("uri", S.string),
       mimeType: s.field("mimeType", S.option(S.string)),
       blob: s.field("blob", S.string),
+      _meta: ?s.field("_meta", S.option(S.json)),
     })
   }),
 ])
@@ -54,7 +66,11 @@ type t =
   | AudioContent(mediaContent)
   | ResourceLink({
       name: string,
+      title: option<string>,
       uri: string,
+      description: option<string>,
+      mimeType: option<string>,
+      size: option<int>,
       _meta: option<JSON.t>,
       annotations: option<annotations>,
     })
@@ -91,7 +107,11 @@ let schema = S.union([
     s.tag("type", "resource_link")
     ResourceLink({
       name: s.field("name", S.string),
+      title: s.field("title", S.option(S.string)),
       uri: s.field("uri", S.string),
+      description: s.field("description", S.option(S.string)),
+      mimeType: s.field("mimeType", S.option(S.string)),
+      size: s.field("size", S.option(S.int)),
       _meta: s.field("_meta", S.option(S.json)),
       annotations: s.field("annotations", S.option(annotationsSchema)),
     })

--- a/libs/frontman-protocol/src/FrontmanProtocol__ContentBlock.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ContentBlock.res
@@ -9,7 +9,16 @@ type annotations = {
   audience: option<array<@s.matches(audienceSchema) string>>,
   priority: option<@s.matches(prioritySchema) float>,
   lastModified: option<string>,
+  _meta: option<JSON.t>,
 }
+
+@scope("Number") @val
+external numberIsInteger: float => bool = "isInteger"
+
+let sizeWireSchema =
+  S.float
+  ->S.refine(value => value >= 0. && numberIsInteger(value), ~error="Expected nonnegative integer")
+  ->S.extendJSONSchema({minimum: 0., multipleOf: 1.})
 
 @schema
 type textResourceContents = {uri: string, mimeType: option<string>, text: string, _meta?: JSON.t}
@@ -70,7 +79,7 @@ type t =
       uri: string,
       description: option<string>,
       mimeType: option<string>,
-      size: option<int>,
+      size: option<float>,
       _meta: option<JSON.t>,
       annotations: option<annotations>,
     })
@@ -111,7 +120,7 @@ let schema = S.union([
       uri: s.field("uri", S.string),
       description: s.field("description", S.option(S.string)),
       mimeType: s.field("mimeType", S.option(S.string)),
-      size: s.field("size", S.option(S.int)),
+      size: s.field("size", S.option(sizeWireSchema)),
       _meta: s.field("_meta", S.option(S.json)),
       annotations: s.field("annotations", S.option(annotationsSchema)),
     })

--- a/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__MCP.res
@@ -35,7 +35,9 @@ let extensionsSchema =
 @schema
 type info = {
   name: string,
+  title?: string,
   version: string,
+  description?: string,
 }
 
 @schema
@@ -120,7 +122,21 @@ let resultMetaWireSchema = S.object(s => {
 
 let cacheScopeWireSchema = S.union([S.literal("public"), S.literal("private")])
 
-let discoverResultWireSchema = S.object(s => {
+let preservingJson = schema =>
+  S.json
+  ->S.transform(_ => {
+    parser: json => {
+      json->S.parseOrThrow(~to=schema)->ignore
+      json
+    },
+    serializer: json => {
+      json->S.parseOrThrow(~to=schema)->ignore
+      json
+    },
+  })
+  ->S.extendJSONSchema(schema->S.toJSONSchema)
+
+let discoverResultWireShapeSchema = S.object(s => {
   s.field("resultType", S.literal("complete"))->ignore
   s.field("supportedVersions", S.array(S.string))->ignore
   s.field("capabilities", serverCapabilitiesWireSchema)->ignore
@@ -130,6 +146,7 @@ let discoverResultWireSchema = S.object(s => {
   s.field("_meta", S.option(resultMetaWireSchema))->ignore
   s.flatten(S.dict(S.json))->JSON.Encode.object
 })
+let discoverResultWireSchema = preservingJson(discoverResultWireShapeSchema)
 
 @schema
 type toolsListParams = {_meta: requestMeta, cursor: option<string>}
@@ -310,14 +327,35 @@ let toolInputSchema = S.object(s => {
   s.flatten(S.dict(S.json))->JSON.Encode.object
 })
 
-let toolJsonSchema = S.object(s => {
+let iconSchema = S.object(s => {
+  s.field("src", S.string)->ignore
+  s.field("mimeType", S.option(S.string))->ignore
+  s.field("sizes", S.option(S.array(S.string)))->ignore
+  s.field("theme", S.option(S.union([S.literal("light"), S.literal("dark")])))->ignore
+  s.flatten(S.dict(S.json))->JSON.Encode.object
+})
+
+let toolAnnotationsSchema = S.object(s => {
+  s.field("title", S.option(S.string))->ignore
+  s.field("readOnlyHint", S.option(S.bool))->ignore
+  s.field("destructiveHint", S.option(S.bool))->ignore
+  s.field("idempotentHint", S.option(S.bool))->ignore
+  s.field("openWorldHint", S.option(S.bool))->ignore
+  s.flatten(S.dict(S.json))->JSON.Encode.object
+})
+
+let toolJsonShapeSchema = S.object(s => {
   s.field("name", S.string->S.min(1))->ignore
+  s.field("title", S.option(S.string))->ignore
   s.field("description", S.option(S.string))->ignore
+  s.field("icons", S.option(S.array(iconSchema)))->ignore
   s.field("inputSchema", toolInputSchema)->ignore
   s.field("outputSchema", S.option(S.dict(S.json)))->ignore
+  s.field("annotations", S.option(toolAnnotationsSchema))->ignore
   s.field("_meta", S.option(toolMetaSchema))->ignore
   s.flatten(S.dict(S.json))->JSON.Encode.object
 })
+let toolJsonSchema = preservingJson(toolJsonShapeSchema)
 
 @schema
 type toolsListResult = {
@@ -328,7 +366,7 @@ type toolsListResult = {
   _meta: resultMeta,
 }
 
-let toolsListResultWireSchema = S.object(s => {
+let toolsListResultWireShapeSchema = S.object(s => {
   s.field("resultType", S.literal("complete"))->ignore
   s.field("tools", S.array(toolJsonSchema))->ignore
   s.field("nextCursor", S.option(S.string))->ignore
@@ -337,6 +375,7 @@ let toolsListResultWireSchema = S.object(s => {
   s.field("_meta", S.option(resultMetaWireSchema))->ignore
   s.flatten(S.dict(S.json))->JSON.Encode.object
 })
+let toolsListResultWireSchema = preservingJson(toolsListResultWireShapeSchema)
 
 type executeToolResult =
   | Completed(CallToolResult.t)

--- a/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
@@ -2,22 +2,21 @@ module MCP = FrontmanProtocol__MCP
 
 let protocolVersion = "1.0"
 
-@schema
-type remoteTool = {
-  name: string,
-  description: string,
-  access: option<FrontmanProtocol__Tool.access>,
-  inputSchema: JSON.t,
-  outputSchema: option<JSON.t>,
-  visibleToAgent: bool,
-}
+type remoteTool = JSON.t
 
-@schema
+let remoteToolSchema = MCP.toolJsonSchema
+
 type toolsResponse = {
   tools: array<remoteTool>,
   serverInfo: MCP.info,
-  protocolVersion: @s.matches(S.literal("1.0")) string,
+  protocolVersion: string,
 }
+
+let toolsResponseSchema = S.object(s => {
+  tools: s.field("tools", S.array(MCP.toolJsonSchema)),
+  serverInfo: s.field("serverInfo", MCP.infoSchema),
+  protocolVersion: s.field("protocolVersion", S.literal("1.0")),
+})
 
 @schema
 type toolCallRequest = {

--- a/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
@@ -1,10 +1,40 @@
 module MCP = FrontmanProtocol__MCP
 
-let protocolVersion = "1.0"
+let protocolVersion = "2.0"
 
 type remoteTool = JSON.t
 
-let remoteToolSchema = MCP.toolJsonSchema
+let relayToolMetadataSchema = S.object(s => {
+  s.field("visibleToAgent", S.bool)->ignore
+  s.field(
+    "access",
+    S.union([S.literal("read"), S.literal("write"), S.literal("read-write")]),
+  )->ignore
+  s.field(
+    "executionMode",
+    S.option(S.union([S.literal("Synchronous"), S.literal("Interactive")])),
+  )->ignore
+  s.flatten(S.dict(S.json))->JSON.Encode.object
+})
+
+let remoteToolMetaSchema = S.object(s => {
+  s.field("ai.frontman/tool-metadata", relayToolMetadataSchema)->ignore
+  s.flatten(S.dict(S.json))->JSON.Encode.object
+})
+
+let remoteToolShapeSchema = S.object(s => {
+  s.field("name", S.string->S.min(1))->ignore
+  s.field("title", S.option(S.string))->ignore
+  s.field("description", S.option(S.string))->ignore
+  s.field("icons", S.option(S.array(MCP.iconSchema)))->ignore
+  s.field("inputSchema", MCP.toolInputSchema)->ignore
+  s.field("outputSchema", S.option(S.dict(S.json)))->ignore
+  s.field("annotations", S.option(MCP.toolAnnotationsSchema))->ignore
+  s.field("_meta", remoteToolMetaSchema)->ignore
+  s.flatten(S.dict(S.json))->JSON.Encode.object
+})
+
+let remoteToolSchema = MCP.preservingJson(remoteToolShapeSchema)
 
 type toolsResponse = {
   tools: array<remoteTool>,
@@ -13,9 +43,9 @@ type toolsResponse = {
 }
 
 let toolsResponseSchema = S.object(s => {
-  tools: s.field("tools", S.array(MCP.toolJsonSchema)),
+  tools: s.field("tools", S.array(remoteToolSchema)),
   serverInfo: s.field("serverInfo", MCP.infoSchema),
-  protocolVersion: s.field("protocolVersion", S.literal("1.0")),
+  protocolVersion: s.field("protocolVersion", S.literal(protocolVersion)),
 })
 
 @schema

--- a/libs/frontman-protocol/test/FrontmanProtocol__MCP.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__MCP.test.res
@@ -11,32 +11,102 @@ let parses = (schema, json) => {
   }
 }
 
+let parseJson = (schema, json) => json->JSON.parseOrThrow->S.parseOrThrow(~to=schema)
+let typedRoundTrip = (schema, json) =>
+  json
+  ->JSON.parseOrThrow
+  ->S.parseOrThrow(~to=schema)
+  ->S.decodeOrThrow(~from=schema, ~to=S.json->S.noValidation(true))
+
 describe("MCP wire contracts", () => {
-  test("accepts broad discovery results", t => {
+  test("round-trips discovery implementation metadata", t => {
     let json = `{
       "resultType":"complete",
       "supportedVersions":["2026-07-28","2027-01-01"],
       "capabilities":{"tools":{},"logging":{}},
       "instructions":"Use tools carefully",
       "ttlMs":1,
-      "cacheScope":"public"
+      "cacheScope":"public",
+      "_meta":{
+        "io.modelcontextprotocol/serverInfo":{
+          "name":"server",
+          "title":"Server",
+          "version":"1.0.0",
+          "description":"A test MCP server"
+        }
+      }
     }`
 
-    t->expect(parses(MCP.discoverResultWireSchema, json))->Expect.toBe(true)
+    t
+    ->expect(parseJson(MCP.discoverResultWireSchema, json))
+    ->Expect.toEqual(JSON.parseOrThrow(json))
   })
 
-  test("accepts broad tools/list results", t => {
+  test("round-trips official tool metadata and rejects malformed known fields", t => {
     let json = `{
       "resultType":"complete",
-      "tools":[{"name":"search","inputSchema":{"type":"object"},"title":"Search"}],
+      "tools":[{
+        "name":"search",
+        "title":"Search",
+        "description":"Search files",
+        "icons":[{"src":"data:image/png;base64,AA==","mimeType":"image/png","sizes":["48x48"],"theme":"dark"}],
+        "inputSchema":{"type":"object","properties":{"q":{"type":"string","title":"Query"}}},
+        "outputSchema":{"type":"object","properties":{"matches":{"type":"array"}}},
+        "annotations":{
+          "title":"Search files",
+          "readOnlyHint":true,
+          "destructiveHint":false,
+          "idempotentHint":true,
+          "openWorldHint":false
+        },
+        "_meta":{"ai.frontman/tool-metadata":{"visibleToAgent":true,"access":"read"}}
+      }],
       "nextCursor":"opaque",
       "ttlMs":2,
       "cacheScope":"public"
     }`
-    let invalid = `{"resultType":"complete","tools":[{"name":"search","inputSchema":{"type":"object"},"_meta":{"ai.frontman/tool-metadata":{"executionMode":"invalid"}}}],"ttlMs":2,"cacheScope":"public"}`
 
-    t->expect(parses(MCP.toolsListResultWireSchema, json))->Expect.toBe(true)
-    t->expect(parses(MCP.toolsListResultWireSchema, invalid))->Expect.toBe(false)
+    let invalid = [
+      `{"resultType":"complete","tools":[{"name":"search","inputSchema":{"type":"object"},"title":123}],"ttlMs":2,"cacheScope":"public"}`,
+      `{"resultType":"complete","tools":[{"name":"search","inputSchema":{"type":"object"},"icons":[{"src":"x","theme":"system"}]}],"ttlMs":2,"cacheScope":"public"}`,
+      `{"resultType":"complete","tools":[{"name":"search","inputSchema":{"type":"object"},"annotations":{"readOnlyHint":"yes"}}],"ttlMs":2,"cacheScope":"public"}`,
+      `{"resultType":"complete","tools":[{"name":"search","inputSchema":{"type":"object"},"_meta":{"ai.frontman/tool-metadata":{"executionMode":"invalid"}}}],"ttlMs":2,"cacheScope":"public"}`,
+    ]
+
+    t
+    ->expect(parseJson(MCP.toolsListResultWireSchema, json))
+    ->Expect.toEqual(JSON.parseOrThrow(json))
+    invalid->Array.forEach(
+      json => t->expect(parses(MCP.toolsListResultWireSchema, json))->Expect.toBe(false),
+    )
+  })
+
+  test("round-trips official content annotations", t => {
+    let json = `{
+      "resultType":"complete",
+      "content":[{
+        "type":"text",
+        "text":"hello",
+        "annotations":{"audience":["user","assistant"],"priority":0.5,"lastModified":"2025-01-12T15:00:58Z"},
+        "_meta":{"trace":"1"}
+      },{
+        "type":"resource_link",
+        "name":"file",
+        "title":"File",
+        "uri":"file:///tmp/a.txt",
+        "description":"A file",
+        "mimeType":"text/plain",
+        "size":12,
+        "annotations":{"audience":["assistant"],"priority":1},
+        "_meta":{"trace":"2"}
+      }]
+    }`
+    let invalid = `{"resultType":"complete","content":[{"type":"text","text":"hello","annotations":{"priority":2}}]}`
+
+    t
+    ->expect(typedRoundTrip(MCP.callToolResultSchema, json))
+    ->Expect.toEqual(JSON.parseOrThrow(json))
+    t->expect(parses(MCP.callToolResultSchema, invalid))->Expect.toBe(false)
   })
 
   test("requires finite nonnegative ttlMs", t => {

--- a/libs/frontman-protocol/test/FrontmanProtocol__MCP.test.res
+++ b/libs/frontman-protocol/test/FrontmanProtocol__MCP.test.res
@@ -87,7 +87,7 @@ describe("MCP wire contracts", () => {
       "content":[{
         "type":"text",
         "text":"hello",
-        "annotations":{"audience":["user","assistant"],"priority":0.5,"lastModified":"2025-01-12T15:00:58Z"},
+        "annotations":{"audience":["user","assistant"],"priority":0.5,"lastModified":"2025-01-12T15:00:58Z","_meta":{"vendor":"annotation"}},
         "_meta":{"trace":"1"}
       },{
         "type":"resource_link",
@@ -96,8 +96,8 @@ describe("MCP wire contracts", () => {
         "uri":"file:///tmp/a.txt",
         "description":"A file",
         "mimeType":"text/plain",
-        "size":12,
-        "annotations":{"audience":["assistant"],"priority":1},
+        "size":3000000000,
+        "annotations":{"audience":["assistant"],"priority":1,"_meta":{"vendor":"resource-annotation"}},
         "_meta":{"trace":"2"}
       }]
     }`


### PR DESCRIPTION
## Summary
- preserve validated MCP tool JSON through relay boundaries instead of narrowing and rebuilding it
- add official MCP metadata fields for implementation info, tool presentation metadata, icons, and content annotations
- update generated protocol schemas and adjust existing tests to assert round-trip preservation plus malformed known-field rejection

Closes #1553

## Validation
- make rescript-build
- cd libs/frontman-protocol && make export-schemas
- cd libs/frontman-protocol && yarn vitest run
- cd libs/frontman-client && yarn vitest run FrontmanClient__Relay.test.res.mjs FrontmanClient__MCP.test.res.mjs
- cd libs/frontman-core && yarn vitest run FrontmanCore__ToolRegistry.test.res.mjs
- cd libs/frontman-nextjs && yarn vitest run FrontmanNextjs__ToolRegistry.test.res.mjs
- git diff --check
- pre-push reanalyze hook