### PR TITLE
add fallback title and disable reasoning in title generation

### DIFF
--- a/.changeset/title-generation-fallback.md
+++ b/.changeset/title-generation-fallback.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Stop reasoning models from leaving new tasks titled "New Task": title generation now runs with reasoning disabled, and falls back to the opening line of the first prompt when the model returns no text.

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -82,6 +82,7 @@ defmodule FrontmanServer.Workers.GenerateTitle do
     fallback_title_length = 60
 
     user_prompt_text
+    |> String.trim()
     |> String.split("\n", parts: 2)
     |> hd()
     |> String.trim()

--- a/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/generate_title.ex
@@ -47,9 +47,12 @@ defmodule FrontmanServer.Workers.GenerateTitle do
     model = Map.get(args, "model")
 
     with {:ok, {model_spec, llm_opts}} <-
-           Providers.resolve_model_access(scope, model, max_tokens: 30),
+           Providers.resolve_model_access(scope, model,
+             max_tokens: 30,
+             reasoning_effort: :none
+           ),
          {:ok, raw_title} <- call_llm(model_spec, llm_opts, user_prompt_text),
-         title = String.trim(raw_title),
+         title = title_or_fallback(String.trim(raw_title), user_prompt_text),
          false <- title == "",
          :ok <- Tasks.apply_title_suggestion(scope, task_id, title) do
       :ok
@@ -74,6 +77,18 @@ defmodule FrontmanServer.Workers.GenerateTitle do
         {:cancel, :empty_title}
     end
   end
+
+  defp title_or_fallback("", user_prompt_text) do
+    fallback_title_length = 60
+
+    user_prompt_text
+    |> String.split("\n", parts: 2)
+    |> hd()
+    |> String.trim()
+    |> String.slice(0, fallback_title_length)
+  end
+
+  defp title_or_fallback(title, _user_prompt_text), do: title
 
   defp call_llm(model_spec, llm_opts, user_prompt_text) do
     messages = [

--- a/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/generate_title_test.exs
@@ -1,13 +1,28 @@
 defmodule FrontmanServer.Workers.GenerateTitleTest do
-  use FrontmanServer.DataCase, async: true
+  use FrontmanServer.DataCase, async: false
 
   import FrontmanServer.Test.Fixtures.Accounts
+  import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Providers
+  alias FrontmanServer.Repo
+  alias FrontmanServer.Tasks.TaskSchema
   alias FrontmanServer.Workers.GenerateTitle
 
   setup do
     user = user_fixture()
-    {:ok, user: user}
+    scope = Scope.for_user(user)
+    original_openrouter_config = Application.get_env(:req_llm, :openrouter)
+
+    on_exit(fn ->
+      case original_openrouter_config do
+        nil -> Application.delete_env(:req_llm, :openrouter)
+        config -> Application.put_env(:req_llm, :openrouter, config)
+      end
+    end)
+
+    {:ok, scope: scope, user: user}
   end
 
   describe "new/1" do
@@ -29,5 +44,92 @@ defmodule FrontmanServer.Workers.GenerateTitleTest do
       assert MapSet.new(Map.keys(args)) ==
                MapSet.new([:model, :task_id, :user_id, :user_prompt_text])
     end
+  end
+
+  describe "perform/1" do
+    test "uses the generated title when the LLM returns text", %{scope: scope, user: user} do
+      task = task_fixture(scope)
+
+      with_openrouter_title_response(scope, "Login Page Build", fn ->
+        assert :ok = perform_title_job(user, task, "Help me build a login page")
+      end)
+
+      assert task_title(task.id) == "Login Page Build"
+    end
+
+    test "falls back to the first prompt line when the LLM returns empty text", %{
+      scope: scope,
+      user: user
+    } do
+      task = task_fixture(scope)
+      prompt = "Build a login page\nUse React and Tailwind"
+
+      with_openrouter_title_response(scope, "", fn ->
+        assert :ok = perform_title_job(user, task, prompt)
+      end)
+
+      assert task_title(task.id) == "Build a login page"
+    end
+
+    test "fallback ignores leading blank lines", %{scope: scope, user: user} do
+      task = task_fixture(scope)
+      prompt = "\n\n  Build a login page\nUse React and Tailwind"
+
+      with_openrouter_title_response(scope, "", fn ->
+        assert :ok = perform_title_job(user, task, prompt)
+      end)
+
+      assert task_title(task.id) == "Build a login page"
+    end
+  end
+
+  defp perform_title_job(user, task, user_prompt_text) do
+    GenerateTitle.perform(%Oban.Job{
+      args: %{
+        "user_id" => user.id,
+        "task_id" => task.id,
+        "user_prompt_text" => user_prompt_text,
+        "model" => "openrouter:openai/gpt-5.5"
+      }
+    })
+  end
+
+  defp with_openrouter_title_response(scope, content, callback) do
+    bypass = Bypass.open()
+    Application.put_env(:req_llm, :openrouter, base_url: "http://localhost:#{bypass.port}/v1")
+
+    Bypass.expect_once(bypass, "POST", "/v1/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      decoded_body = Jason.decode!(body)
+
+      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer sk-test"]
+      assert decoded_body["model"] == "openai/gpt-5.5"
+      assert decoded_body["max_tokens"] == 30
+      assert [_, %{"content" => user_prompt, "role" => "user"}] = decoded_body["messages"]
+      assert is_binary(user_prompt)
+
+      response = %{
+        id: "chatcmpl-title",
+        object: "chat.completion",
+        choices: [
+          %{
+            index: 0,
+            finish_reason: "stop",
+            message: %{role: "assistant", content: content}
+          }
+        ],
+        usage: %{prompt_tokens: 1, completion_tokens: 1, total_tokens: 2}
+      }
+
+      Plug.Conn.send_resp(conn, 200, Jason.encode!(response))
+    end)
+
+    :ok = Providers.upsert_api_key(scope, "openrouter", "sk-test")
+
+    callback.()
+  end
+
+  defp task_title(task_id) do
+    Repo.get!(TaskSchema, task_id).short_desc
   end
 end


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Sometimes the generated title remains as "New Title". 
Upon looking at the `oban_jobs` table, the error is empty title.

` {"{\"at\": \"2026-08-26T13:53:18.089251Z\", \"error\": \"** (Oban.PerformError) FrontmanServer.Workers.GenerateTitle failed with {:cancel, :empty_title}\", \"attempt\": 1}"}`

The possible reason is max_tokens being set to 30 gets consumed in thinking by reasoning models and hence title generates as empty string.

issue:

<img width="357" height="365" alt="image" src="https://github.com/user-attachments/assets/b05b8d5d-7776-44c0-9c5b-e01a7ccf968a" />


Fixed by setting reasoning_effort to none and adding a title fallback from user prompt.

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->

## Checklist

- [ ] Added/updated tests
- [ ] Ran `yarn changeset` (if user-facing change)
- [ ] Tested locally with `make dev`
