### PR TITLE
Track first task feedback CTA analytics

### DIFF
--- a/.changeset/track-first-task-feedback-analytics.md
+++ b/.changeset/track-first-task-feedback-analytics.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Track first-task feedback dialog impressions, closes, share clicks, and Discord clicks in Heap.

--- a/libs/client/src/Client__Analytics.res
+++ b/libs/client/src/Client__Analytics.res
@@ -1,0 +1,50 @@
+type relayFailureReason = HttpError | InvalidResponse | NetworkError
+
+type relayOutcome = Success | Failure(relayFailureReason)
+
+type event =
+  | RelayConnectionCompleted(relayOutcome)
+  | FirstTaskFeedbackDialogShown
+  | FirstTaskFeedbackDialogClosed
+  | FirstTaskFeedbackShareClicked
+  | FirstTaskFeedbackDiscordClicked
+
+let relayFailureReasonToString = reason =>
+  switch reason {
+  | HttpError => "http_error"
+  | InvalidResponse => "invalid_response"
+  | NetworkError => "network_error"
+  }
+
+let frameworkProperties = () => {
+  let framework = Client__RuntimeConfig.read().framework->Client__RuntimeConfig.frameworkIdToString
+  Dict.fromArray([("framework", JSON.Encode.string(framework))])
+}
+
+let eventName = event =>
+  switch event {
+  | RelayConnectionCompleted(_) => "relay_connection_completed"
+  | FirstTaskFeedbackDialogShown => "first_task_feedback_dialog_shown"
+  | FirstTaskFeedbackDialogClosed => "first_task_feedback_dialog_closed"
+  | FirstTaskFeedbackShareClicked => "first_task_feedback_share_clicked"
+  | FirstTaskFeedbackDiscordClicked => "first_task_feedback_discord_clicked"
+  }
+
+let eventProperties = event => {
+  let properties = frameworkProperties()
+  switch event {
+  | RelayConnectionCompleted(Success) =>
+    properties->Dict.set("outcome", JSON.Encode.string("success"))
+  | RelayConnectionCompleted(Failure(reason)) =>
+    properties->Dict.set("outcome", JSON.Encode.string("failure"))
+    properties->Dict.set("reason_code", JSON.Encode.string(relayFailureReasonToString(reason)))
+  | FirstTaskFeedbackDialogShown
+  | FirstTaskFeedbackDialogClosed
+  | FirstTaskFeedbackShareClicked
+  | FirstTaskFeedbackDiscordClicked => ()
+  }
+  properties
+}
+
+let track = event =>
+  Client__Heap.track(eventName(event), JSON.Encode.object(eventProperties(event)))

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -125,7 +125,7 @@ type action =
 type effect =
   | LogError(string)
   | LogInfo(string)
-  | TrackRelay(Client__Heap.relayOutcome)
+  | TrackAnalytics(Client__Analytics.event)
   | ConnectACP({config: ACP.config, signal: WebAPI.EventTypes.abortSignal})
   | ScheduleAuthRetry({signal: WebAPI.EventTypes.abortSignal})
   | LogoutEffect({
@@ -173,10 +173,10 @@ let initialState: state = {
 
 let relayFailureReason = message =>
   switch message {
-  | message if message->String.startsWith("HTTP ") => Client__Heap.HttpError
+  | message if message->String.startsWith("HTTP ") => Client__Analytics.HttpError
   | message if message->String.startsWith("Invalid tools response: ") =>
-    Client__Heap.InvalidResponse
-  | _ => Client__Heap.NetworkError
+    Client__Analytics.InvalidResponse
+  | _ => Client__Analytics.NetworkError
   }
 
 module Selectors = {
@@ -372,12 +372,12 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
 
   | ({relay: RelayConnecting}, RelayConnectSuccess) => (
       {...state, relay: RelayConnected},
-      [TrackRelay(Success)],
+      [TrackAnalytics(RelayConnectionCompleted(Success))],
     )
 
   | ({relay: RelayConnecting}, RelayConnectError(message)) => (
       {...state, relay: RelayError(message)},
-      [TrackRelay(Failure(relayFailureReason(message)))],
+      [TrackAnalytics(RelayConnectionCompleted(Failure(relayFailureReason(message))))],
     )
 
   | ({session: SessionCreating(expectedSessionId)}, SessionCreateSuccess(sess))
@@ -558,7 +558,7 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
   switch effect {
   | LogError(msg) => Log.error(msg)
   | LogInfo(msg) => Log.info(msg)
-  | TrackRelay(outcome) => Client__Heap.trackRelayConnection(outcome)
+  | TrackAnalytics(event) => Client__Analytics.track(event)
   | NotifyDeleteSessionRejected({onComplete, reason}) => onComplete(Error(reason))
   | ConnectACP({config, signal}) =>
     let connect = async () => {

--- a/libs/client/src/Client__Heap.res
+++ b/libs/client/src/Client__Heap.res
@@ -30,26 +30,10 @@ let init = () => {
 }
 
 type heapApi = {identify: string => unit, track: (string, JSON.t) => unit}
-@scope("window") @val external heap: heapApi = "heap"
+@scope("window") @val external heap: Nullable.t<heapApi> = "heap"
 
-type relayFailureReason = HttpError | InvalidResponse | NetworkError
-type relayOutcome = Success | Failure(relayFailureReason)
+let getHeap = () => heap->Nullable.toOption->Option.getOrThrow(~message="Heap is not initialized")
 
-let failureReasonToString = reason =>
-  switch reason {
-  | HttpError => "http_error"
-  | InvalidResponse => "invalid_response"
-  | NetworkError => "network_error"
-  }
+let identify = userId => getHeap().identify(userId)
 
-let trackRelayConnection = outcome => {
-  let framework = Client__RuntimeConfig.read().framework->Client__RuntimeConfig.frameworkIdToString
-  let properties = Dict.fromArray([("framework", JSON.Encode.string(framework))])
-  switch outcome {
-  | Success => properties->Dict.set("outcome", JSON.Encode.string("success"))
-  | Failure(reason) =>
-    properties->Dict.set("outcome", JSON.Encode.string("failure"))
-    properties->Dict.set("reason_code", JSON.Encode.string(failureReasonToString(reason)))
-  }
-  heap.track("relay_connection_completed", JSON.Encode.object(properties))
-}
+let track = (eventName, properties) => getHeap().track(eventName, properties)

--- a/libs/client/src/components/frontman/Client__FirstTaskFeedbackDialog.res
+++ b/libs/client/src/components/frontman/Client__FirstTaskFeedbackDialog.res
@@ -17,7 +17,7 @@ let make = () => {
     onOpenChange={(isOpen, _) =>
       switch isOpen {
       | true => ()
-      | false => Client__State.Actions.dismissFirstTaskFeedbackDialog()
+      | false => Client__State.Actions.closeFirstTaskFeedbackDialog()
       }}
   >
     <Dialog.Content className="sm:max-w-md">
@@ -49,6 +49,15 @@ let make = () => {
           | (false, false) => React.string("Share Frontman")
           }}
         </Button>
+        <a
+          href="https://discord.gg/xk8uXJSvhC"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={Button.buttonVariants(~variant=Button.Variant.Secondary)}
+          onClick={_ => Client__Analytics.track(FirstTaskFeedbackDiscordClicked)}
+        >
+          {React.string("Join Discord")}
+        </a>
         <a
           href=ratingUrl
           target="_blank"

--- a/libs/client/src/state/Client__State.res
+++ b/libs/client/src/state/Client__State.res
@@ -286,6 +286,9 @@ module Actions = {
 
   let dismissUpdateBanner = () => Client__State__Store.dispatch(DismissUpdateBanner)
 
+  let closeFirstTaskFeedbackDialog = () =>
+    Client__State__Store.dispatch(CloseFirstTaskFeedbackDialog)
+
   let dismissFirstTaskFeedbackDialog = () =>
     Client__State__Store.dispatch(DismissFirstTaskFeedbackDialog)
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -99,6 +99,7 @@ type action =
   | CheckForUpdate({installedVersion: string, npmPackage: string})
   | UpdateInfoReceived({updateInfo: Client__State__Types.updateInfo})
   | DismissUpdateBanner
+  | CloseFirstTaskFeedbackDialog
   | DismissFirstTaskFeedbackDialog
   | ShareFrontman
   | ShareFrontmanLinkCopied
@@ -166,6 +167,7 @@ type effect =
   | LoadTaskEffect({taskId: string})
   | DeleteSessionEffect({taskId: string})
   | CheckForUpdateEffect({apiBaseUrl: string, installedVersion: string, npmPackage: string})
+  | TrackAnalyticsEffect(Client__Analytics.event)
   | ShareFrontmanEffect
   | FetchCustomProvidersEffect({
       apiBaseUrl: string,
@@ -663,6 +665,16 @@ let canShowFirstTaskFeedback = (state: state, task) =>
   TaskReducer.Selectors.completedIdleTurn(task)->Option.isSome &&
   TaskReducer.Selectors.queuedUserMessages(task)->Option.getOrThrow->Array.length == 0
 
+let firstTaskFeedbackTransitionEffects = (
+  previous: Client__State__Types.firstTaskFeedbackDialogState,
+  next: Client__State__Types.firstTaskFeedbackDialogState,
+) =>
+  switch (previous, next) {
+  | (Visible, Visible) => []
+  | (_, Visible) => [TrackAnalyticsEffect(FirstTaskFeedbackDialogShown)]
+  | _ => []
+  }
+
 let addUserMessageToState = (state: state, ~id, ~sessionId, ~content, ~annotations, ~agentId) =>
   switch state.selectedModelValue {
   | None => state->StateReducer.update
@@ -736,7 +748,7 @@ let fetchUserProfileImpl = (dispatch, ~apiBaseUrl) => {
           let userProfile =
             json->S.decodeOrThrow(~from=S.json, ~to=Client__State__Types.userProfileSchema)
           dispatch(UserProfileReceived({userProfile: userProfile}))
-          Client__Heap.heap.identify(userProfile.id)
+          Client__Heap.identify(userProfile.id)
         | false => ()
         }
       | None => ()
@@ -1501,6 +1513,8 @@ let handleEffect = (effect, state: state, dispatch) => {
       }
     }
     fetch()->ignore
+  | TrackAnalyticsEffect(event) => Client__Analytics.track(event)
+
   | ShareFrontmanEffect =>
     FirstTaskFeedbackShare.run(
       ~onShared=() => dispatch(DismissFirstTaskFeedbackDialog),
@@ -1597,8 +1611,12 @@ let next = (state: state, action) => {
         }
       | _ => state.firstTaskFeedbackDialogState
       }
+      let feedbackEffects = firstTaskFeedbackTransitionEffects(
+        state.firstTaskFeedbackDialogState,
+        feedbackState,
+      )
       {...state, firstTaskFeedbackDialogState: feedbackState}->StateReducer.update(
-        ~sideEffects=effects,
+        ~sideEffects=Array.concat(effects, feedbackEffects),
       )
     }
   | TaskAction({target, action: taskAction}) => state->Lens.delegateToTask(target, taskAction)
@@ -2127,13 +2145,18 @@ let next = (state: state, action) => {
       }
     })
 
-    {
+    let loadedState = {
       ...state,
       tasks: updatedTasks,
       sessionsLoadState: Client__State__Types.SessionsLoaded,
     }
-    ->resolveFeedbackHistory
-    ->StateReducer.update
+    let resolvedState = loadedState->resolveFeedbackHistory
+    resolvedState->StateReducer.update(
+      ~sideEffects=firstTaskFeedbackTransitionEffects(
+        loadedState.firstTaskFeedbackDialogState,
+        resolvedState.firstTaskFeedbackDialogState,
+      ),
+    )
 
   | SessionsLoadError({error}) =>
     {
@@ -2160,12 +2183,24 @@ let next = (state: state, action) => {
 
   | DismissUpdateBanner => {...state, updateBannerDismissed: true}->StateReducer.update
 
+  | CloseFirstTaskFeedbackDialog =>
+    switch state.firstTaskFeedbackDialogState {
+    | Visible | LinkCopied | ShareFailed =>
+      {...state, firstTaskFeedbackDialogState: Dismissed}->StateReducer.update(
+        ~sideEffects=[TrackAnalyticsEffect(FirstTaskFeedbackDialogClosed)],
+      )
+    | Waiting | AwaitingHistory | Dismissed => state->StateReducer.update
+    }
+
   | DismissFirstTaskFeedbackDialog =>
     {...state, firstTaskFeedbackDialogState: Dismissed}->StateReducer.update
 
   | ShareFrontman =>
     switch state.firstTaskFeedbackDialogState {
-    | Visible | ShareFailed => state->StateReducer.update(~sideEffects=[ShareFrontmanEffect])
+    | Visible | ShareFailed =>
+      state->StateReducer.update(
+        ~sideEffects=[TrackAnalyticsEffect(FirstTaskFeedbackShareClicked), ShareFrontmanEffect],
+      )
     | Waiting | AwaitingHistory | LinkCopied | Dismissed => state->StateReducer.update
     }
 

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -8,7 +8,7 @@ let effectKinds = effects =>
     switch effect {
     | Reducer.LogError(_) => #logError
     | Reducer.LogInfo(_) => #logInfo
-    | Reducer.TrackRelay(_) => #trackRelay
+    | Reducer.TrackAnalytics(_) => #trackAnalytics
     | Reducer.ConnectACP(_) => #connectACP
     | Reducer.ScheduleAuthRetry(_) => #scheduleAuthRetry
     | Reducer.LogoutEffect(_) => #logout
@@ -24,10 +24,10 @@ let effectKinds = effects =>
     | Reducer.CleanupSessionEffect(_) => #cleanupSession
     }
   )
-let trackedOutcomes = effects =>
+let trackedRelayOutcomes = effects =>
   effects->Array.filterMap(e =>
     switch e {
-    | Reducer.TrackRelay(outcome) => Some(outcome)
+    | Reducer.TrackAnalytics(RelayConnectionCompleted(outcome)) => Some(outcome)
     | _ => None
     }
   )
@@ -280,8 +280,8 @@ describe("Connection Reducer", () => {
 
         t->expect(nextState.relay)->Expect.toBe(Reducer.RelayConnected)
         t
-        ->expect(trackedOutcomes(effects))
-        ->Expect.toEqual([Client__Heap.Success])
+        ->expect(trackedRelayOutcomes(effects))
+        ->Expect.toEqual([Client__Analytics.Success])
       },
     )
 
@@ -289,16 +289,18 @@ describe("Connection Reducer", () => {
       "RelayConnectError transitions to RelayError and classifies analytics",
       t => {
         [
-          ("HTTP 500: Error", Client__Heap.HttpError),
-          ("Invalid tools response: bad data", Client__Heap.InvalidResponse),
-          ("Connection refused", Client__Heap.NetworkError),
+          ("HTTP 500: Error", Client__Analytics.HttpError),
+          ("Invalid tools response: bad data", Client__Analytics.InvalidResponse),
+          ("Connection refused", Client__Analytics.NetworkError),
         ]->Array.forEach(
           ((message, reason)) => {
             let state = {...Reducer.initialState, relay: RelayConnecting}
             let (nextState, effects) = Reducer.reduce(state, RelayConnectError(message))
 
             t->expect(nextState.relay)->Expect.toEqual(Reducer.RelayError(message))
-            t->expect(trackedOutcomes(effects))->Expect.toEqual([Client__Heap.Failure(reason)])
+            t
+            ->expect(trackedRelayOutcomes(effects))
+            ->Expect.toEqual([Client__Analytics.Failure(reason)])
           },
         )
       },
@@ -315,7 +317,7 @@ describe("Connection Reducer", () => {
         actions->Array.forEach(
           action => {
             let (_, effects) = Reducer.reduce(state, action)
-            t->expect(trackedOutcomes(effects))->Expect.toEqual([])
+            t->expect(trackedRelayOutcomes(effects))->Expect.toEqual([])
           },
         )
       },

--- a/libs/client/test/Client__Heap.test.res
+++ b/libs/client/test/Client__Heap.test.res
@@ -16,7 +16,7 @@ beforeEach(() => setup())
 let property = (properties, name) => properties->Dict.get(name)->Option.flatMap(JSON.Decode.string)
 
 test("tracks normalized relay outcomes", t => {
-  Client__Heap.trackRelayConnection(Failure(NetworkError))
+  Client__Analytics.track(RelayConnectionCompleted(Failure(NetworkError)))
   let failed = trackedProperties()
 
   t->expect(trackedName())->Expect.toBe("relay_connection_completed")
@@ -24,7 +24,7 @@ test("tracks normalized relay outcomes", t => {
   t->expect(property(failed, "outcome"))->Expect.toEqual(Some("failure"))
   t->expect(property(failed, "reason_code"))->Expect.toEqual(Some("network_error"))
 
-  Client__Heap.trackRelayConnection(Success)
+  Client__Analytics.track(RelayConnectionCompleted(Success))
   let succeeded = trackedProperties()
   t->expect(property(succeeded, "outcome"))->Expect.toEqual(Some("success"))
   t->expect(property(succeeded, "reason_code"))->Expect.toEqual(None)

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -735,25 +735,33 @@ describe("Client State Reducer - First Task Feedback Dialog", () => {
   }
 
   let reduce = (state, action) => Reducer.next(state, action)->Pair.first
-  let stopTurn = (state, stopReason) => {
+  let stopTurnResult = (state, stopReason) => {
     let taskId = TestHelpers.getCurrentTaskId(state)->Option.getOrThrow
-    state->reduce(TaskExecutionStopped({taskId, stopReason}))
+    Reducer.next(state, TaskExecutionStopped({taskId, stopReason}))
   }
+  let stopTurn = (state, stopReason) => stopTurnResult(state, stopReason)->Pair.first
   let completeSuccessfulTurn = state => stopTurn(state, Some(ACP.EndTurn))
-  let loadHistory = state => state->reduce(SessionsLoadSuccess({sessions: []}))
+  let loadHistoryResult = state => Reducer.next(state, SessionsLoadSuccess({sessions: []}))
+  let loadHistory = state => state->loadHistoryResult->Pair.first
   let expectOpen = (t, state, expected) =>
     t->expect(Reducer.Selectors.showFirstTaskFeedbackDialog(state))->Expect.toBe(expected)
 
   test("opens only after the first task's first successful turn", t => {
     expectOpen(t, firstTurnState()->stopTurn(Some(ACP.Refusal)), false)
-    expectOpen(t, firstTurnState()->completeSuccessfulTurn, true)
+
+    let (completedState, effects) = firstTurnState()->stopTurnResult(Some(ACP.EndTurn))
+    expectOpen(t, completedState, true)
+    t->expect(effects)->Expect.toEqual([TrackAnalyticsEffect(FirstTaskFeedbackDialogShown)])
   })
 
   test("waits for session history and only celebrates a new user", t => {
     let pendingState =
       firstTurnState(~sessionsLoadState=StateTypes.SessionsLoading)->completeSuccessfulTurn
     expectOpen(t, pendingState, false)
-    expectOpen(t, pendingState->loadHistory, true)
+
+    let (loadedState, effects) = pendingState->loadHistoryResult
+    expectOpen(t, loadedState, true)
+    t->expect(effects)->Expect.toEqual([TrackAnalyticsEffect(FirstTaskFeedbackDialogShown)])
 
     let returningUserState = {...pendingState, tasks: pendingState.tasks->Dict.copy}
     returningUserState.tasks->Dict.set("previous-task", Task.makeNew(~previewUrl=""))
@@ -808,6 +816,14 @@ describe("Client State Reducer - First Task Feedback Dialog", () => {
     expectOpen(t, executingState->completeSuccessfulTurn, true)
   })
 
+  test("tracks close through the reducer", t => {
+    let visibleState = firstTurnState()->completeSuccessfulTurn
+    let (closedState, effects) = Reducer.next(visibleState, CloseFirstTaskFeedbackDialog)
+
+    t->expect(closedState.firstTaskFeedbackDialogState)->Expect.toEqual(Dismissed)
+    t->expect(effects)->Expect.toEqual([TrackAnalyticsEffect(FirstTaskFeedbackDialogClosed)])
+  })
+
   test("keeps failed sharing visible and retryable", t => {
     let visibleState = firstTurnState()->completeSuccessfulTurn
     let failedState = visibleState->reduce(ShareFrontmanFailed)
@@ -815,7 +831,9 @@ describe("Client State Reducer - First Task Feedback Dialog", () => {
 
     expectOpen(t, failedState, true)
     t->expect(Reducer.Selectors.firstTaskFeedbackShareFailed(failedState))->Expect.toBe(true)
-    t->expect(retryEffects)->Expect.toEqual([ShareFrontmanEffect])
+    t
+    ->expect(retryEffects)
+    ->Expect.toEqual([TrackAnalyticsEffect(FirstTaskFeedbackShareClicked), ShareFrontmanEffect])
 
     let copiedState = failedState->reduce(ShareFrontmanLinkCopied)
     t->expect(copiedState.firstTaskFeedbackDialogState)->Expect.toEqual(LinkCopied)


### PR DESCRIPTION
## Summary
- add explicit Heap events for first-task feedback dialog impressions, closes, share clicks, and Discord clicks
- add a Discord CTA to the first-task feedback dialog
- route Heap identify/track calls through safe helpers

## Test
- make -C libs/client test