### PR TITLE
fix(mcp): bound initialization requests with owned timeouts

### DIFF
--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -35,6 +35,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   @acp_method_session_prompt ACP.method_session_prompt()
   @acp_method_session_cancel ACP.method_session_cancel()
   @acp_method_session_load ACP.method_session_load()
+  @mcp_init_timeout_ms 30_000
   @impl true
   def join("task:" <> task_id, _params, socket) do
     scope = socket.assigns.scope
@@ -52,6 +53,8 @@ defmodule FrontmanServerWeb.TaskChannel do
         |> assign(:task_id, task_id)
         |> assign(:framework, task.framework)
         |> assign(:mcp_init_state, init_state)
+        |> assign(:mcp_init_timeout_ref, nil)
+        |> assign(:mcp_init_timeout_token, nil)
         |> assign(:mcp_tools, [])
         |> assign(:mcp_status, :pending)
         |> assign(:session_loaded, false)
@@ -130,6 +133,22 @@ defmodule FrontmanServerWeb.TaskChannel do
   def handle_info({:start_mcp_init, actions}, socket) do
     socket = apply_init_actions(actions, socket)
     {:noreply, socket}
+  end
+
+  def handle_info({:mcp_init_timeout, token}, socket) do
+    case socket.assigns[:mcp_init_timeout_token] do
+      nil ->
+        {:noreply, socket}
+
+      ^token ->
+        socket = clear_mcp_init_timeout(socket)
+        {new_state, actions} = MCPInitializer.handle_timeout(socket.assigns.mcp_init_state)
+        socket = assign(socket, :mcp_init_state, new_state)
+        {:noreply, apply_init_actions(actions, socket)}
+
+      _stale_or_nil ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info({:execute_next_turn, execution}, socket) do
@@ -937,6 +956,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   defp apply_init_action(socket, {:push_mcp, msg}) do
+    socket = schedule_mcp_init_timeout(socket)
     push(socket, "mcp:message", msg)
     socket
   end
@@ -946,6 +966,7 @@ defmodule FrontmanServerWeb.TaskChannel do
     Logger.info("MCP initialization complete for task #{task_id}")
 
     socket
+    |> clear_mcp_init_timeout()
     |> assign(:mcp_status, :ready)
     |> assign(:mcp_tools, data.tools)
     |> redispatch_unresolved_tool_calls()
@@ -956,9 +977,40 @@ defmodule FrontmanServerWeb.TaskChannel do
     Logger.error("MCP initialization failed", reason: error)
 
     socket
+    |> clear_mcp_init_timeout()
     |> assign(:mcp_status, :failed)
     |> redispatch_unresolved_tool_calls()
     |> tap(&wake_runner(&1, nil))
+  end
+
+  defp schedule_mcp_init_timeout(socket) do
+    socket = clear_mcp_init_timeout(socket)
+    token = make_ref()
+
+    timeout_ref =
+      Process.send_after(
+        self(),
+        {:mcp_init_timeout, token},
+        @mcp_init_timeout_ms
+      )
+
+    socket
+    |> assign(:mcp_init_timeout_ref, timeout_ref)
+    |> assign(:mcp_init_timeout_token, token)
+  end
+
+  defp clear_mcp_init_timeout(socket) do
+    case socket.assigns[:mcp_init_timeout_ref] do
+      nil ->
+        :ok
+
+      timeout_ref ->
+        Process.cancel_timer(timeout_ref)
+    end
+
+    socket
+    |> assign(:mcp_init_timeout_ref, nil)
+    |> assign(:mcp_init_timeout_token, nil)
   end
 
   defp redispatch_unresolved_tool_calls(

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
@@ -48,6 +48,26 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
     {state, [{:push_mcp, request}]}
   end
 
+  def handle_timeout(%{status: :discovering_mcp, discovery_request_id: request_id} = state)
+      when is_integer(request_id),
+      do: fail_initialization(state, "MCP discovery timed out")
+
+  def handle_timeout(%{status: :loading_tools, tools_request_id: request_id} = state)
+      when is_integer(request_id),
+      do: fail_initialization(state, "MCP tools/list timed out")
+
+  def handle_timeout(
+        %{status: :loading_project_rules, project_rules_request_id: request_id} = state
+      )
+      when is_integer(request_id),
+      do: fail_initialization(state, "MCP project rules timed out")
+
+  def handle_timeout(
+        %{status: :loading_project_structure, project_structure_request_id: request_id} = state
+      )
+      when is_integer(request_id),
+      do: fail_initialization(state, "MCP project structure timed out")
+
   def handle_response(state, request_id, result) do
     case state do
       %{status: :discovering_mcp, discovery_request_id: ^request_id} ->

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
@@ -62,6 +62,63 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializerTest do
     assert tools_request["params"] == ModelContextProtocol.tools_list_params()
   end
 
+  describe "handle_timeout/1" do
+    test "fails the active request in every initialization phase" do
+      phases = [
+        {:discovering_mcp, :discovery_request_id, "MCP discovery timed out"},
+        {:loading_tools, :tools_request_id, "MCP tools/list timed out"},
+        {:loading_project_rules, :project_rules_request_id, "MCP project rules timed out"},
+        {:loading_project_structure, :project_structure_request_id,
+         "MCP project structure timed out"}
+      ]
+
+      for {status, request_key, message} <- phases do
+        request_id = System.unique_integer([:positive])
+
+        init_state =
+          state(%{
+            status: status,
+            discovery_request_id: nil,
+            tools_request_id: nil,
+            project_rules_request_id: nil,
+            project_structure_request_id: nil
+          })
+          |> Map.put(request_key, request_id)
+
+        assert {
+                 %{
+                   status: :failed,
+                   discovery_request_id: nil,
+                   tools_request_id: nil,
+                   project_rules_request_id: nil,
+                   project_structure_request_id: nil
+                 },
+                 [{:initialization_failed, ^message}]
+               } = MCPInitializer.handle_timeout(init_state)
+      end
+    end
+
+    test "does not silently accept a timeout without a current request" do
+      for status <- [
+            :discovering_mcp,
+            :loading_tools,
+            :loading_project_rules,
+            :loading_project_structure
+          ] do
+        state =
+          state(%{
+            status: status,
+            discovery_request_id: nil,
+            tools_request_id: nil,
+            project_rules_request_id: nil,
+            project_structure_request_id: nil
+          })
+
+        assert_raise FunctionClauseError, fn -> MCPInitializer.handle_timeout(state) end
+      end
+    end
+  end
+
   test "fails initialization for incompatible protocol or extension versions" do
     incompatible_results = [
       discovery_result(%{"supportedVersions" => ["2025-11-25"]}),

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -121,6 +121,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
                mcp_init_timeout_token: nil
              }
            } = channel_socket
+
     assert channel_socket.assigns.mcp_init_state.status == :failed
     assert Process.alive?(socket.channel_pid)
     channel_socket
@@ -132,6 +133,36 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     assert Process.cancel_timer(previous_timer.ref) == false
     assert current_timer.ref != nil
     assert current_timer.token != nil
+  end
+
+  defp complete_mcp_discovery(socket, result \\ mcp_discovery_result()) do
+    {request_id, timer} = next_mcp_initialization_request(socket, "server/discover")
+    push(socket, "mcp:message", JsonRpc.success_response(request_id, result))
+    :sys.get_state(socket.channel_pid)
+    timer
+  end
+
+  defp complete_mcp_tools_list(socket, result \\ mcp_tools_result([])) do
+    {request_id, timer} = next_mcp_initialization_request(socket, "tools/list")
+    push(socket, "mcp:message", JsonRpc.success_response(request_id, result))
+    :sys.get_state(socket.channel_pid)
+    timer
+  end
+
+  defp complete_mcp_project_rules(socket, result \\ MCP.tool_result_text("")) do
+    {request_id, timer} = next_mcp_initialization_request(socket, "tools/call")
+    push(socket, "mcp:message", JsonRpc.success_response(request_id, result))
+    :sys.get_state(socket.channel_pid)
+    timer
+  end
+
+  defp assert_mcp_initialization_terminal(socket, status) do
+    channel_socket = :sys.get_state(socket.channel_pid)
+    assert channel_socket.assigns.mcp_status == status
+    assert channel_socket.assigns.mcp_init_state.status == status
+    assert channel_socket.assigns.mcp_init_timeout_ref == nil
+    assert channel_socket.assigns.mcp_init_timeout_token == nil
+    channel_socket
   end
 
   defp assert_state_update_idle(task_id) do
@@ -1070,16 +1101,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "fails initialization when the first tools/list request times out", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
-      )
-
-      :sys.get_state(socket.channel_pid)
+      discovery_timer = complete_mcp_discovery(socket)
       {_tools_request_id, tools_timer} = next_mcp_initialization_request(socket, "tools/list")
 
       assert_mcp_timer_replaced(discovery_timer, tools_timer)
@@ -1090,16 +1112,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       scope: scope
     } do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
-      )
-
-      :sys.get_state(socket.channel_pid)
+      discovery_timer = complete_mcp_discovery(socket)
       {tools_request_id, tools_timer} = next_mcp_initialization_request(socket, "tools/list")
 
       assert_mcp_timer_replaced(discovery_timer, tools_timer)
@@ -1114,6 +1127,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       )
 
       :sys.get_state(socket.channel_pid)
+
       {next_tools_request_id, next_tools_timer} =
         next_mcp_initialization_request(socket, "tools/list")
 
@@ -1133,62 +1147,19 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "fails initialization when project rules time out", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, _discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {_rules_request_id, rules_timer} =
-        next_mcp_initialization_request(socket, "tools/call")
+      complete_mcp_discovery(socket)
+      complete_mcp_tools_list(socket)
+      {_rules_request_id, rules_timer} = next_mcp_initialization_request(socket, "tools/call")
 
       assert_mcp_initialization_timeout(socket, rules_timer)
     end
 
     test "fails initialization when project structure times out", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, _discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
+      complete_mcp_discovery(socket)
+      complete_mcp_tools_list(socket)
+      rules_timer = complete_mcp_project_rules(socket)
 
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {rules_request_id, rules_timer} =
-        next_mcp_initialization_request(socket, "tools/call")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(rules_request_id, MCP.tool_result_text(""))
-      )
-
-      :sys.get_state(socket.channel_pid)
       {_structure_request_id, structure_timer} =
         next_mcp_initialization_request(socket, "tools/call")
 
@@ -1200,27 +1171,9 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       scope: scope
     } do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, _discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
-
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
-      )
-
-      :sys.get_state(socket.channel_pid)
-      {rules_request_id, rules_timer} =
-        next_mcp_initialization_request(socket, "tools/call")
+      complete_mcp_discovery(socket)
+      complete_mcp_tools_list(socket)
+      {rules_request_id, rules_timer} = next_mcp_initialization_request(socket, "tools/call")
 
       push(
         socket,
@@ -1229,6 +1182,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       )
 
       :sys.get_state(socket.channel_pid)
+
       {structure_request_id, structure_timer} =
         next_mcp_initialization_request(socket, "tools/call")
 
@@ -1240,37 +1194,25 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         JsonRpc.error_response(structure_request_id, -32_000, "structure unavailable")
       )
 
-      channel_socket = :sys.get_state(socket.channel_pid)
-      assert channel_socket.assigns.mcp_status == :ready
-      assert channel_socket.assigns.mcp_init_state.status == :ready
-      assert channel_socket.assigns.mcp_init_timeout_ref == nil
-      assert channel_socket.assigns.mcp_init_timeout_token == nil
+      assert_mcp_initialization_terminal(socket, :ready)
     end
 
     test "clears the timer after an explicit initialization failure", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
-      {discovery_request_id, discovery_timer} =
-        next_mcp_initialization_request(socket, "server/discover")
 
-      push(
-        socket,
-        "mcp:message",
-        JsonRpc.success_response(
-          discovery_request_id,
+      discovery_timer =
+        complete_mcp_discovery(
+          socket,
           mcp_discovery_result(%{"supportedVersions" => ["unsupported"]})
         )
-      )
 
-      channel_socket = :sys.get_state(socket.channel_pid)
-      assert channel_socket.assigns.mcp_status == :failed
-      assert channel_socket.assigns.mcp_init_state.status == :failed
-      assert channel_socket.assigns.mcp_init_timeout_ref == nil
-      assert channel_socket.assigns.mcp_init_timeout_token == nil
+      assert_mcp_initialization_terminal(socket, :failed)
       assert Process.cancel_timer(discovery_timer.ref) == false
     end
 
     test "does not revive initialization after a timeout", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
+
       {discovery_request_id, discovery_timer} =
         next_mcp_initialization_request(socket, "server/discover")
 

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -91,6 +91,49 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
   end
 
+  defp next_mcp_initialization_request(socket, method) do
+    :sys.get_state(socket.channel_pid)
+    assert_push("mcp:message", %{"id" => request_id, "method" => ^method})
+    assert is_integer(request_id)
+
+    timer = mcp_initialization_timer(socket)
+    {request_id, timer}
+  end
+
+  defp mcp_initialization_timer(socket) do
+    %{assigns: %{mcp_init_timeout_ref: timeout_ref, mcp_init_timeout_token: token}} =
+      :sys.get_state(socket.channel_pid)
+
+    assert is_reference(timeout_ref)
+    assert is_reference(token)
+    %{ref: timeout_ref, token: token}
+  end
+
+  defp assert_mcp_initialization_timeout(socket, timer) do
+    send(socket.channel_pid, {:mcp_init_timeout, timer.token})
+
+    channel_socket = :sys.get_state(socket.channel_pid)
+
+    assert %{
+             assigns: %{
+               mcp_status: :failed,
+               mcp_init_timeout_ref: nil,
+               mcp_init_timeout_token: nil
+             }
+           } = channel_socket
+    assert channel_socket.assigns.mcp_init_state.status == :failed
+    assert Process.alive?(socket.channel_pid)
+    channel_socket
+  end
+
+  defp assert_mcp_timer_replaced(previous_timer, current_timer) do
+    assert previous_timer.ref != current_timer.ref
+    assert previous_timer.token != current_timer.token
+    assert Process.cancel_timer(previous_timer.ref) == false
+    assert current_timer.ref != nil
+    assert current_timer.token != nil
+  end
+
   defp assert_state_update_idle(task_id) do
     assert_push(
       "acp:message",
@@ -1018,6 +1061,243 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       })
     end
 
+    test "fails initialization when discovery times out", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {_request_id, timer} = next_mcp_initialization_request(socket, "server/discover")
+
+      assert_mcp_initialization_timeout(socket, timer)
+    end
+
+    test "fails initialization when the first tools/list request times out", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {_tools_request_id, tools_timer} = next_mcp_initialization_request(socket, "tools/list")
+
+      assert_mcp_timer_replaced(discovery_timer, tools_timer)
+      assert_mcp_initialization_timeout(socket, tools_timer)
+    end
+
+    test "replaces the timer for tools/list pagination and ignores stale timeout tokens", %{
+      scope: scope
+    } do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {tools_request_id, tools_timer} = next_mcp_initialization_request(socket, "tools/list")
+
+      assert_mcp_timer_replaced(discovery_timer, tools_timer)
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(
+          tools_request_id,
+          mcp_tools_result([], %{"nextCursor" => "page-2"})
+        )
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {next_tools_request_id, next_tools_timer} =
+        next_mcp_initialization_request(socket, "tools/list")
+
+      assert_mcp_timer_replaced(tools_timer, next_tools_timer)
+
+      send(socket.channel_pid, {:mcp_init_timeout, tools_timer.token})
+      channel_socket = :sys.get_state(socket.channel_pid)
+
+      assert channel_socket.assigns.mcp_status == :pending
+      assert channel_socket.assigns.mcp_init_state.status == :loading_tools
+      assert channel_socket.assigns.mcp_init_state.tools_request_id == next_tools_request_id
+      assert channel_socket.assigns.mcp_init_timeout_ref == next_tools_timer.ref
+      assert channel_socket.assigns.mcp_init_timeout_token == next_tools_timer.token
+
+      assert_mcp_initialization_timeout(socket, next_tools_timer)
+    end
+
+    test "fails initialization when project rules time out", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, _discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {_rules_request_id, rules_timer} =
+        next_mcp_initialization_request(socket, "tools/call")
+
+      assert_mcp_initialization_timeout(socket, rules_timer)
+    end
+
+    test "fails initialization when project structure times out", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, _discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {rules_request_id, rules_timer} =
+        next_mcp_initialization_request(socket, "tools/call")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(rules_request_id, MCP.tool_result_text(""))
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {_structure_request_id, structure_timer} =
+        next_mcp_initialization_request(socket, "tools/call")
+
+      assert_mcp_timer_replaced(rules_timer, structure_timer)
+      assert_mcp_initialization_timeout(socket, structure_timer)
+    end
+
+    test "preserves project context error transitions and clears the terminal timer", %{
+      scope: scope
+    } do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, _discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {tools_request_id, _tools_timer} = next_mcp_initialization_request(socket, "tools/list")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(tools_request_id, mcp_tools_result([]))
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {rules_request_id, rules_timer} =
+        next_mcp_initialization_request(socket, "tools/call")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.error_response(rules_request_id, -32_000, "rules unavailable")
+      )
+
+      :sys.get_state(socket.channel_pid)
+      {structure_request_id, structure_timer} =
+        next_mcp_initialization_request(socket, "tools/call")
+
+      assert_mcp_timer_replaced(rules_timer, structure_timer)
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.error_response(structure_request_id, -32_000, "structure unavailable")
+      )
+
+      channel_socket = :sys.get_state(socket.channel_pid)
+      assert channel_socket.assigns.mcp_status == :ready
+      assert channel_socket.assigns.mcp_init_state.status == :ready
+      assert channel_socket.assigns.mcp_init_timeout_ref == nil
+      assert channel_socket.assigns.mcp_init_timeout_token == nil
+    end
+
+    test "clears the timer after an explicit initialization failure", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(
+          discovery_request_id,
+          mcp_discovery_result(%{"supportedVersions" => ["unsupported"]})
+        )
+      )
+
+      channel_socket = :sys.get_state(socket.channel_pid)
+      assert channel_socket.assigns.mcp_status == :failed
+      assert channel_socket.assigns.mcp_init_state.status == :failed
+      assert channel_socket.assigns.mcp_init_timeout_ref == nil
+      assert channel_socket.assigns.mcp_init_timeout_token == nil
+      assert Process.cancel_timer(discovery_timer.ref) == false
+    end
+
+    test "does not revive initialization after a timeout", %{scope: scope} do
+      {socket, _task_id} = join_task_channel(scope)
+      {discovery_request_id, discovery_timer} =
+        next_mcp_initialization_request(socket, "server/discover")
+
+      assert_mcp_initialization_timeout(socket, discovery_timer)
+
+      push(
+        socket,
+        "mcp:message",
+        JsonRpc.success_response(discovery_request_id, mcp_discovery_result())
+      )
+
+      channel_socket = :sys.get_state(socket.channel_pid)
+
+      assert Process.alive?(socket.channel_pid)
+      assert channel_socket.assigns.mcp_status == :failed
+      assert channel_socket.assigns.mcp_init_timeout_ref == nil
+      assert channel_socket.assigns.mcp_init_timeout_token == nil
+
+      assert %{
+               status: :failed,
+               discovery_request_id: nil,
+               tools_request_id: nil,
+               project_rules_request_id: nil,
+               project_structure_request_id: nil
+             } = channel_socket.assigns.mcp_init_state
+    end
+
     test "wordpress completes after tools/list without filesystem tool calls", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope, framework: "wordpress")
 
@@ -1027,6 +1307,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       channel_socket = :sys.get_state(socket.channel_pid)
       assert channel_socket.assigns.mcp_status == :ready
+      assert channel_socket.assigns.mcp_init_timeout_ref == nil
+      assert channel_socket.assigns.mcp_init_timeout_token == nil
     end
   end
 


### PR DESCRIPTION
Closes #1546.

## Summary

* Give each MCP initialization request a tokenized OTP timeout owned by `TaskChannel`.
* Replace timeout ownership across discovery, tools/list pagination, project rules, and project structure.
* Fail initialization on matching timeouts while ignoring stale timeout tokens and late responses.
* Clear timeout ownership on terminal success/failure.
* Add regression coverage for phase timeouts, timer replacement, stale tokens, and late responses.

## Verification

* `git diff --check` passed.
* Local Elixir/Mix validation could not run because the current Windows/WSL environment does not have the required Elixir/OTP toolchain.
* Docker fallback was unavailable, so CI is the authoritative compilation/test/precommit validation.