### PR TITLE
Add recent tasks to empty chat

### DIFF
--- a/.changeset/add-recent-tasks-empty-chat.md
+++ b/.changeset/add-recent-tasks-empty-chat.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Show the five most recent tasks in the empty chat starter so users can resume previous work.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -245,16 +245,15 @@ let make = (~onConfigureProvider: unit => unit) => {
   }
 
   let groupCacheRef: React.ref<Dict.t<ToolGroupTypes.toolGroup>> = React.useRef(Dict.make())
-  let recentTasks = React.useMemo1(() => {
+  let recentTasks =
     tasks
-    ->Array.slice(~start=0, ~end=5)
-    ->Array.filterMap(task => {
+    ->Array.filterMap(task =>
       switch (Client__Task__Types.Task.getId(task), Client__Task__Types.Task.getTitle(task)) {
       | (Some(id), Some(title)) => Some({Client__GetStartedTasks.id, title})
       | _ => None
       }
-    })
-  }, [tasks])
+    )
+    ->Array.slice(~start=0, ~end=5)
 
   let displayItems = React.useMemo1(() => {
     let items = groupMessages(messages)

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -126,6 +126,8 @@ let make = (~onConfigureProvider: unit => unit) => {
 
   let messages = Client__State.useSelector(Client__State.Selectors.messages)
   let isAgentRunning = Client__State.useSelector(Client__State.Selectors.isAgentRunning)
+  let isNewTask = Client__State.useSelector(Client__State.Selectors.isNewTask)
+  let tasks = Client__State.useSelector(Client__State.Selectors.tasks)
   let hasActiveACPSession = Client__State.useSelector(Client__State.Selectors.hasActiveACPSession)
   let planEntries = Client__State.useSelector(Client__State.Selectors.currentPlanEntries)
   let queuedUserMessages = Client__State.useSelector(Client__State.Selectors.queuedUserMessages)
@@ -243,6 +245,17 @@ let make = (~onConfigureProvider: unit => unit) => {
   }
 
   let groupCacheRef: React.ref<Dict.t<ToolGroupTypes.toolGroup>> = React.useRef(Dict.make())
+  let recentTasks = React.useMemo1(() => {
+    tasks
+    ->Array.slice(~start=0, ~end=5)
+    ->Array.filterMap(task => {
+      switch (Client__Task__Types.Task.getId(task), Client__Task__Types.Task.getTitle(task)) {
+      | (Some(id), Some(title)) => Some({Client__GetStartedTasks.id, title})
+      | _ => None
+      }
+    })
+  }, [tasks])
+
   let displayItems = React.useMemo1(() => {
     let items = groupMessages(messages)
     let prevCache = groupCacheRef.current
@@ -399,9 +412,11 @@ let make = (~onConfigureProvider: unit => unit) => {
           </div>
         }}
 
-        {switch (hasActiveACPSession, totalItems) {
-        | (true, 0) =>
+        {switch (hasActiveACPSession, isNewTask, totalItems) {
+        | (true, true, 0) =>
           <Client__GetStartedTasks
+            recentTasks
+            onResume={taskId => Client__State.Actions.switchTask(~taskId)}
             onSelect={text =>
               selectGetStartedTask(
                 ~providerSetupRequired,

--- a/libs/client/src/Client__GetStartedTasks.res
+++ b/libs/client/src/Client__GetStartedTasks.res
@@ -9,8 +9,17 @@ let tasks = [
   "Add a dark mode toggle to the navigation bar",
 ]
 
+type recentTask = {
+  id: string,
+  title: string,
+}
+
 @react.component
-let make = (~onSelect: string => unit) => {
+let make = (
+  ~onSelect: string => unit,
+  ~recentTasks: array<recentTask>,
+  ~onResume: string => unit,
+) => {
   <section
     ariaLabelledby="get-started-heading"
     className="min-h-[50vh] flex flex-col items-center justify-center px-4 sm:px-6 gap-4"
@@ -38,5 +47,37 @@ let make = (~onSelect: string => unit) => {
       )
       ->React.array}
     </div>
+    {switch Array.length(recentTasks) > 0 {
+    | true =>
+      <div className="w-full max-w-[360px] mt-4 pt-4 border-t border-white/10">
+        <p
+          className="text-[11px] leading-none font-medium uppercase tracking-[0.14em] text-zinc-600 mb-3"
+        >
+          {React.string("Or get back to where you were")}
+        </p>
+        <div className="flex flex-col gap-1">
+          {recentTasks
+          ->Array.map(task =>
+            <button
+              type_="button"
+              key={task.id}
+              onClick={_ => onResume(task.id)}
+              className="group flex items-center gap-2 text-left text-[12px] leading-snug text-zinc-500
+                         px-1 py-1.5 rounded-md hover:text-zinc-300 hover:bg-white/[0.03]
+                         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20
+                         transition-colors"
+            >
+              <span
+                ariaHidden=true
+                className="h-1.5 w-1.5 rounded-full bg-zinc-700 group-hover:bg-zinc-500 shrink-0 transition-colors"
+              />
+              <span className="truncate"> {React.string(task.title)} </span>
+            </button>
+          )
+          ->React.array}
+        </div>
+      </div>
+    | false => React.null
+    }}
   </section>
 }

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -935,6 +935,7 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     (
       Task.Loaded({
         ...data,
+        updatedAt: Date.now(),
         turnError: None,
         retryStatus: None,
         imageAttachments: updatedImageAttachments,


### PR DESCRIPTION
## Summary
- show the five most recent tasks in the empty chat starter
- let users resume a previous task from the empty chat state
- make resumed tasks visually secondary to new-task quick starters

## Checks
- make rescript-build
- pre-commit hooks
- pre-push reanalyze