### PR TITLE
Refresh acquisition pages from Search Console data

### DIFF
--- a/apps/marketing/src/content/blog/6-ai-coding-tools-production.md
+++ b/apps/marketing/src/content/blog/6-ai-coding-tools-production.md
@@ -1,11 +1,11 @@
 ---
-title: 'AI Coding Tools for Existing Codebases'
-seoTitle: '6 AI Coding Tools for Existing Codebases (2026)'
+title: 'Best AI Coding Tools for Large Existing Codebases in 2026'
+seoTitle: 'Best AI Coding Tools for Large Existing Codebases in 2026'
 pubDate: 2026-03-23T05:00:00Z
-description: 'Compare Cursor, Claude Code, Windsurf, GitHub Copilot, Cline, and Frontman for working inside existing production codebases.'
+description: 'Compare AI coding tools for large existing codebases: repo context, safe edits, frontend runtime context, tests, and production workflow fit.'
 image: '/blog/ai-coding-tools.png'
 tags: ['ai', 'tools', 'cursor', 'claude-code', 'windsurf', 'github-copilot', 'cline', 'production']
-updatedDate: 2026-06-17T00:00:00Z
+updatedDate: 2026-09-03T00:00:00Z
 faq:
   - question: 'Which AI coding tool is best for non-engineers?'
     answer: 'Frontman. It runs in the browser and lets you select elements visually. You don''t need to know your way around an IDE or terminal.'
@@ -22,7 +22,20 @@ articleSection: 'Comparison or Buyer Guide'
 imageAlt: 'Comparison of six AI coding tools for existing production codebases'
 ---
 
-For existing production codebases, Cursor is the strongest AI IDE, Claude Code is best for terminal-native deep context, Windsurf is a cheaper IDE workflow, GitHub Copilot is the lowest-friction default, Cline is the open-source VS Code agent, and Frontman is best for browser-based visual UI edits.
+The best AI coding tools for large existing codebases are Cursor for IDE-native codebase work, Claude Code for terminal-native deep context, Cline for open-source agent workflows, GitHub Copilot for low-friction team adoption, Windsurf for cheaper IDE flow, and Frontman when the existing codebase problem starts in the running frontend UI.
+
+## Quick answer: best AI coding tools for large existing codebases
+
+| Need | Best fit |
+| --- | --- |
+| Deep IDE codebase context | Cursor |
+| Terminal-native repo exploration and large-context work | Claude Code |
+| Open-source VS Code agent with BYOK | Cline |
+| GitHub/Microsoft team default | GitHub Copilot |
+| Lower-cost AI IDE workflow | Windsurf |
+| Browser-visible frontend edits in an existing app | Frontman |
+
+For large existing codebases, prioritize tools that can read project structure, make small reviewable edits, run tests or checks, preserve your current stack, and expose enough context for humans to catch bad changes. For frontend work, repo context is not enough: DOM, screenshots, console logs, dev-server logs, and hot-reload feedback matter.
 
 You open your laptop on a Monday morning. There's a button on the homepage that's supposed to be blue. It's gray. The designer filed a ticket two weeks ago. The developer has three higher-priority items in the sprint. You can see exactly what's wrong, but you can't fix it.
 

--- a/apps/marketing/src/content/blog/best-frontend-coding-agent.md
+++ b/apps/marketing/src/content/blog/best-frontend-coding-agent.md
@@ -2,8 +2,8 @@
 title: 'Best Frontend Coding Agent for Semi-Technical Teams'
 seoTitle: 'Best Frontend Coding Agent: 2026 Guide for Teams'
 pubDate: 2026-05-23T05:00:00Z
-updatedDate: 2026-05-25T05:00:00Z
-description: 'Compare frontend coding agents for UI edits, React code, existing codebases, pricing, and ease of use. See the best option for semi-technical teams.'
+updatedDate: 2026-09-03T00:00:00Z
+description: 'Compare frontend coding agents for UI edits, React code, existing codebases, browser runtime context, screenshots, logs, pricing, and review.'
 image: '/blog/best-frontend-coding-agent-cover.webp'
 tags: ['comparison', 'ai', 'frontend']
 comparisonItems:
@@ -78,6 +78,8 @@ author: 'Danni Friedland'
 articleSection: 'Comparison or Buyer Guide'
 imageAlt: 'Comparison guide cover for frontend coding agents'
 ---
+
+The best frontend coding agents are the ones that can inspect the running app, not just the repo. For frontend work, screenshots, DOM state, console logs, dev-server logs, responsive behavior, HMR feedback, and human review often matter as much as source context.
 
 The best frontend coding agent for semi-technical teams depends on the job: Frontman for visual edits in an existing app, Kombai for frontend-specialized design-to-code work, Cursor for developers in an IDE, Claude Code for terminal-native engineers, and v0 for fast React UI generation. This guide is for founders, PMs, marketers, designers, and frontend leads who need a shortlist without fake benchmark theater. We build Frontman. This is a source-backed buyer guide based on official docs, pricing pages, public workflows, and one narrow Frontman case study, not a multi-tool test. [Try Frontman free](/#install), or start with the table.
 

--- a/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
+++ b/apps/marketing/src/content/blog/best-open-source-ai-coding-tools-2026.md
@@ -5,7 +5,7 @@ pubDate: 2026-03-03T10:00:00Z
 description: 'Compare open-source AI coding tools in 2026 by workflow: agents, assistants, CLI, BYOK, local models, and self-hosted options, with current licenses.'
 image: '/blog/best-open-source-ai-coding-tools-2026-cover.png'
 tags: ['comparison', 'ai', 'developer-tools', 'open-source']
-updatedDate: 2026-08-15T00:00:00Z
+updatedDate: 2026-09-03T00:00:00Z
 faq:
   - question: 'What are the best open-source AI coding tools in 2026?'
     answer: 'The best choice depends on workflow: OpenCode or Aider for terminal work, Cline or Kilo Code for IDE and CLI agents, OpenHands for autonomous tasks, Goose for desktop and CLI automation, Tabby for self-hosted completion, and Stagewise for browser-centered frontend work.'
@@ -64,9 +64,9 @@ imageAlt: 'Open-source AI coding tools compared by terminal, IDE, autonomous, se
 
 Stars show project visibility, not output quality or production readiness. License names also do not describe the entire commercial boundary: OpenHands and Tabby have separately licensed enterprise directories, Cline's JetBrains plugin is closed-source, bolt.diy depends on WebContainers terms for some commercial use, and Frontman's server includes supplementary AI restrictions.
 
-## OpenHands vs OpenCode: which should you choose?
+## OpenHands vs OpenCode: quick answer
 
-Choose **OpenCode** when you want to drive coding sessions directly from a terminal, desktop app, web UI, or IDE. Choose **OpenHands** when you want a self-hosted control plane for delegating autonomous work across agents and execution backends.
+For **OpenHands vs OpenCode**, choose **OpenCode** when you want to drive coding sessions directly from a terminal, desktop app, web UI, or IDE. Choose **OpenHands** when you want a self-hosted control plane for delegating autonomous work across agents and execution backends. In the reverse phrasing, **OpenCode vs OpenHands** is interactive developer workflow versus autonomous task platform.
 
 | Decision | OpenCode | OpenHands |
 | --- | --- | --- |
@@ -76,8 +76,9 @@ Choose **OpenCode** when you want to drive coding sessions directly from a termi
 | Local models | Supports local providers such as Ollama and LM Studio | Supports local servers such as Ollama, LM Studio, vLLM, and SGLang |
 | Extensibility | Custom agents, commands, tools, plugins, and MCP servers | OpenHands agents plus ACP-compatible third-party agents |
 | License | MIT | MIT core; enterprise directory under PolyForm Free Trial |
+| When Frontman is relevant | Not a replacement; use Frontman when the coding task starts from visible frontend runtime state | Not a replacement; use Frontman when autonomous code edits still need browser verification |
 
-Both can run with local models and both can modify code. The difference is workflow: OpenCode centers the developer's interactive session; OpenHands centers agent orchestration and execution environments.
+Both can run with local models and both can modify code. The difference is workflow: OpenCode centers the developer's interactive session; OpenHands centers agent orchestration and execution environments. Neither is primarily a browser-runtime frontend agent; if the hard part is seeing the rendered UI, console output, route state, or HMR result, add a browser-aware workflow such as Frontman.
 
 ## Cline AI coding agent official status in 2026
 

--- a/apps/marketing/src/content/blog/cline-ai-coding-tool-review.md
+++ b/apps/marketing/src/content/blog/cline-ai-coding-tool-review.md
@@ -1,14 +1,14 @@
 ---
 title: 'Cline AI Coding Tool Review 2026: BYOK, Pricing, Pros, Cons, and Alternatives'
-seoTitle: 'Cline AI Coding Tool Review 2026'
+seoTitle: 'Cline AI Review 2026: Strengths, Limits, Pricing, and Alternatives'
 pubDate: 2026-06-28T14:00:00Z
-description: 'A practical Cline AI coding tool review for 2026: BYOK setup, pricing model, model costs, VS Code and JetBrains support, MCP, CLI, pros, cons, Roo Code comparison, and alternatives.'
+description: 'Cline AI review for 2026: strengths, limits, BYOK pricing, VS Code and JetBrains support, MCP, CLI, Roo Code comparison, and alternatives.'
 author: 'Danni Friedland'
 articleSection: 'Comparison or Buyer Guide'
 image: '/blog/cline-ai-coding-tool-review-cover.png'
 imageAlt: 'Cline AI coding tool review and alternatives guide'
 tags: ['comparison', 'ai', 'developer-tools', 'open-source']
-updatedDate: 2026-06-28T14:00:00Z
+updatedDate: 2026-09-03T00:00:00Z
 comparisonItems:
   - name: 'Cline'
     url: 'https://cline.bot/'
@@ -53,9 +53,9 @@ faq:
     answer: 'Cline is good for developer-led frontend code edits. It can change components, styles, and tests. It is less natural when the work starts from the browser UI or from a non-engineer pointing at the page.'
 ---
 
-Cline is one of the default names people find when they search for an open-source AI coding tool in 2026. It is popular because it gives developers an agentic workflow without forcing one model provider, one editor, or one hosted workflow.
+This Cline AI review covers the practical question: is Cline a good AI coding tool in 2026, what are its strengths and limits, how does BYOK pricing work, and which alternatives should you compare before adopting it?
 
-The short version: **Cline is a strong AI coding tool if you want an open-source, developer-first agent with BYOK, VS Code support, CLI workflows, MCP, and human approval. It is not the best fit when your main problem is browser-visible frontend UI work.**
+The short version: **Cline is a strong AI coding tool if you want an open-source, developer-first agent with BYOK, VS Code support, CLI workflows, MCP, and human approval. Its main limits are setup friction, variable model costs, and weaker fit when the task starts from browser-visible frontend UI rather than source files.**
 
 We build [Frontman](/), a browser-aware frontend agent. That creates a conflict of interest in any AI coding tool comparison, so this review separates the Cline recommendation from the Frontman wedge. If you are choosing a general-purpose developer agent, Cline deserves serious consideration. If your team needs to click a broken UI, inspect runtime layout, and produce a reviewable source edit, compare Cline with browser-aware tools later in this guide.
 

--- a/apps/marketing/src/content/blog/roo-code-vs-cline.md
+++ b/apps/marketing/src/content/blog/roo-code-vs-cline.md
@@ -8,7 +8,7 @@ image: '/blog/best-open-source-ai-coding-tools-2026-cover.png'
 imageAlt: 'Best Open-Source AI Coding Tools cover used for Roo Code vs Cline comparison'
 articleSection: 'Comparison or Buyer Guide'
 tags: ['comparison', 'ai', 'developer-tools', 'open-source']
-updatedDate: 2026-06-15T10:00:00Z
+updatedDate: 2026-09-03T00:00:00Z
 comparisonItems:
   - name: 'Cline'
     url: 'https://cline.bot/'
@@ -36,6 +36,10 @@ faq:
 ---
 
 Roo Code vs Cline used to be a close comparison between two Cline-family AI coding agents for VS Code. In June 2026, the practical answer is simpler: **Cline is the safer default for most new users because Roo Code was shut down and its GitHub repository was archived on May 15, 2026.**
+
+## Roo Code, Zoo Code, and Cline: quick clarification
+
+Some people search `zoo code vs cline` or `cline vs zoo code` when they mean the Roo-style fork [ZooCode](https://github.com/Zoo-Code-Org/Zoo-Code/). This article compares the archived Roo Code project with Cline first, then treats ZooCode as a community fork to evaluate separately if you specifically want the Roo-style mode workflow.
 
 That does not make Roo Code irrelevant. Roo Code popularized a useful mode-driven workflow: Architect for planning, Code for implementation, Debug for troubleshooting, Ask for answers, and Custom Modes for team-specific behavior. If you are comparing Roo Code and Cline because you liked that structure, the right comparison is now Cline vs Roo-style community forks such as [ZooCode](https://github.com/Zoo-Code-Org/Zoo-Code/) as much as Cline vs the archived Roo Code project.
 


### PR DESCRIPTION
## Summary
- retitle the existing-codebases article around the high-ranking zero-click query
- strengthen OpenHands/OpenCode, Cline review, Roo/Zoo/Cline, and frontend-agent sections
- keep changes to existing ranked pages; no new pages or dependencies

## Search Console basis
- /blog/6-ai-coding-tools-production/: 732 impressions, avg position 2.0, 0 clicks for `best ai coding tools for large existing codebases`
- /blog/best-open-source-ai-coding-tools-2026/: OpenHands/OpenCode impressions grew from 110/30 to 246/126
- /blog/cline-ai-coding-tool-review/: clicks 22 → 39 and impressions 5,672 → 10,860
- /blog/roo-code-vs-cline/: typo variants `zoo code vs cline` and `cline vs zoo code` already rank/click
- /blog/best-frontend-coding-agent/: still strong CTR, but clicks fell 150 → 128

## Checks
- mise exec -- yarn workspace marketing astro check
- mise exec -- yarn workspace marketing build