### PR TITLE
Harden server cookie and origin security

### DIFF
--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -147,7 +147,7 @@ if config_env() == :prod do
 
   config :frontman_server, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
-  check_origin = false
+  check_origin = ["https://#{host}", "https://*.#{host}"]
 
   config :frontman_server, FrontmanServerWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],

--- a/apps/frontman_server/lib/frontman_server_web/endpoint.ex
+++ b/apps/frontman_server/lib/frontman_server_web/endpoint.ex
@@ -22,7 +22,7 @@ defmodule FrontmanServerWeb.Endpoint do
   )
 
   socket("/socket", FrontmanServerWeb.UserSocket,
-    websocket: true,
+    websocket: [check_origin: false],
     longpoll: false,
     auth_token: true
   )

--- a/apps/frontman_server/lib/frontman_server_web/plugs/cors.ex
+++ b/apps/frontman_server/lib/frontman_server_web/plugs/cors.ex
@@ -11,6 +11,11 @@ defmodule FrontmanServerWeb.Plugs.CORS do
   When used at the endpoint level, handles OPTIONS preflight requests
   before they reach the router.
 
+  Protected API routes must remain bearer-token-only and must validate the
+  request Origin against the bearer token. This plug deliberately does not set
+  Access-Control-Allow-Credentials, so browser cookies are not exposed through
+  credentialed cross-origin requests.
+
   ## Options
 
     * `:path_prefix` - Only apply CORS to paths starting with this prefix.

--- a/apps/frontman_server/lib/frontman_server_web/user_auth.ex
+++ b/apps/frontman_server/lib/frontman_server_web/user_auth.ex
@@ -24,7 +24,8 @@ defmodule FrontmanServerWeb.UserAuth do
   @remember_me_options [
     sign: true,
     max_age: @max_cookie_age_in_days * 24 * 60 * 60,
-    same_site: "Lax"
+    same_site: "Lax",
+    secure: true
   ]
 
   @session_reissue_age_in_days 7

--- a/apps/frontman_server/test/frontman_server_web/channels/user_socket_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/user_socket_test.exs
@@ -13,7 +13,7 @@ defmodule FrontmanServerWeb.UserSocketTest do
              end)
 
     assert socket_opts[:auth_token] == true
-    assert socket_opts[:websocket] == true
+    assert socket_opts[:websocket] == [check_origin: false]
   end
 
   test "connects with valid embedded client auth token" do

--- a/apps/frontman_server/test/frontman_server_web/user_auth_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/user_auth_test.exs
@@ -101,7 +101,9 @@ defmodule FrontmanServerWeb.UserAuthTest do
       assert get_session(conn, :user_token) == conn.cookies[@remember_me_cookie]
       assert get_session(conn, :user_remember_me) == true
 
-      assert %{value: signed_token, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
+      assert %{value: signed_token, max_age: max_age, secure: true} =
+               conn.resp_cookies[@remember_me_cookie]
+
       assert signed_token != get_session(conn, :user_token)
       assert max_age == @remember_me_cookie_max_age
     end
@@ -119,7 +121,10 @@ defmodule FrontmanServerWeb.UserAuthTest do
         |> init_test_session(%{user_remember_me: true})
 
       conn = conn |> UserAuth.log_in_user(user, %{})
-      assert %{value: signed_token, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
+
+      assert %{value: signed_token, max_age: max_age, secure: true} =
+               conn.resp_cookies[@remember_me_cookie]
+
       assert signed_token != get_session(conn, :user_token)
       assert max_age == @remember_me_cookie_max_age
       assert get_session(conn, :user_remember_me) == true
@@ -210,7 +215,10 @@ defmodule FrontmanServerWeb.UserAuthTest do
       assert conn.assigns.current_scope.user.authenticated_at == user.authenticated_at
       assert new_token = get_session(conn, :user_token)
       assert new_token != token
-      assert %{value: new_signed_token, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
+
+      assert %{value: new_signed_token, max_age: max_age, secure: true} =
+               conn.resp_cookies[@remember_me_cookie]
+
       assert new_signed_token != signed_token
       assert max_age == @remember_me_cookie_max_age
     end


### PR DESCRIPTION
## Summary
- enable explicit production socket origin checks for the configured Frontman host and subdomains
- mark remember-me cookies as Secure explicitly
- document the API CORS invariant that protected routes stay origin-bound bearer-token-only and non-credentialed

## Tests
- `cd apps/frontman_server && mix test test/frontman_server_web/plugs/cors_test.exs test/frontman_server_web/user_auth_test.exs`

## Changelog
- No publishable workspace package changed (`yarn changeset status --since=origin/main` reports no packages to bump).
