### PR TITLE
feat(astro): enrich get_client_pages route details

### DIFF
--- a/.changeset/enrich-astro-route-details.md
+++ b/.changeset/enrich-astro-route-details.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/astro": minor
+---
+
+Enrich `get_client_pages` with Astro route pathname, segments, redirect metadata, fallback routes, and serialized route regex details.

--- a/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
+++ b/apps/marketing/src/content/docs/docs/using/tool-capabilities.md
@@ -280,9 +280,9 @@ These tools are added when Frontman is running as an Astro integration.
 
 Lists all routes resolved by Astro's router.
 
-Returns routes from Astro's `astro:routes:resolved` hook, including pages, API endpoints, redirects, content collection routes, and integration-injected routes. Each route includes its pattern, entrypoint, type, origin, params, and prerender status.
+Returns routes from Astro's `astro:routes:resolved` hook, including pages, API endpoints, redirects, content collection routes, and integration-injected routes. Each route includes its pattern, entrypoint, type, origin, params, pathname, segments, redirects, i18n fallback routes, serialized route regex, captured order, and prerender status.
 
-This goes beyond simple filesystem scanning — it captures routes that don't exist as files in `src/pages/`, like content collection pages and config-based redirects.
+This goes beyond simple filesystem scanning — it captures routes that don't exist as files in `src/pages/`, like content collection pages and config-based redirects. Endpoint HTTP methods are not returned because Astro does not expose them via `astro:routes:resolved`.
 
 #### `get_resolved_astro_config`
 

--- a/libs/bindings/src/Astro.res
+++ b/libs/bindings/src/Astro.res
@@ -152,7 +152,7 @@ type rec integrationResolvedRoute = {
   patternRegex?: patternRegex,
   isPrerendered: bool,
   redirectRoute?: integrationResolvedRoute,
-  fallbackRoutes: array<integrationResolvedRoute>,
+  fallbackRoutes?: array<integrationResolvedRoute>,
 }
 
 type routesResolvedHookContext = {routes: array<integrationResolvedRoute>}

--- a/libs/bindings/src/Astro.res
+++ b/libs/bindings/src/Astro.res
@@ -131,7 +131,15 @@ type serverSetupHookContext = {
 type routeType = [#page | #endpoint | #redirect | #fallback]
 type routeOrigin = [#internal | #"external" | #project]
 
-type integrationResolvedRoute = {
+type routePart = {
+  content: string,
+  dynamic: bool,
+  spread: bool,
+}
+
+type patternRegex
+
+type rec integrationResolvedRoute = {
   pattern: string,
   entrypoint: string,
   @as("type")
@@ -139,7 +147,12 @@ type integrationResolvedRoute = {
   origin: routeOrigin,
   params: array<string>,
   pathname: option<string>,
+  segments?: array<array<routePart>>,
+  redirect?: JSON.t,
+  patternRegex?: patternRegex,
   isPrerendered: bool,
+  redirectRoute?: integrationResolvedRoute,
+  fallbackRoutes?: array<integrationResolvedRoute>,
 }
 
 type routesResolvedHookContext = {routes: array<integrationResolvedRoute>}

--- a/libs/bindings/src/Astro.res
+++ b/libs/bindings/src/Astro.res
@@ -152,7 +152,7 @@ type rec integrationResolvedRoute = {
   patternRegex?: patternRegex,
   isPrerendered: bool,
   redirectRoute?: integrationResolvedRoute,
-  fallbackRoutes?: array<integrationResolvedRoute>,
+  fallbackRoutes: array<integrationResolvedRoute>,
 }
 
 type routesResolvedHookContext = {routes: array<integrationResolvedRoute>}

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
@@ -118,7 +118,7 @@ let toRouteEntry = (route: Bindings.integrationResolvedRoute, order): routeEntry
   segments: ?(route.segments->Option.map(toSegments)),
   redirect: ?route.redirect,
   redirectRoute: ?(route.redirectRoute->Option.map(toRouteRef)),
-  fallbackRoutes: route.fallbackRoutes->Option.getOr([])->Array.map(toRouteRef),
+  fallbackRoutes: route.fallbackRoutes->Array.map(toRouteRef),
   patternRegex: ?(route.patternRegex->Option.map(toRegexInfo)),
   type_: route.type_->routeTypeToString,
   origin: route.origin->routeOriginToString,

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
@@ -118,7 +118,7 @@ let toRouteEntry = (route: Bindings.integrationResolvedRoute, order): routeEntry
   segments: ?(route.segments->Option.map(toSegments)),
   redirect: ?route.redirect,
   redirectRoute: ?(route.redirectRoute->Option.map(toRouteRef)),
-  fallbackRoutes: route.fallbackRoutes->Array.map(toRouteRef),
+  fallbackRoutes: route.fallbackRoutes->Option.getOr([])->Array.map(toRouteRef),
   patternRegex: ?(route.patternRegex->Option.map(toRegexInfo)),
   type_: route.type_->routeTypeToString,
   origin: route.origin->routeOriginToString,

--- a/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
+++ b/libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res
@@ -11,7 +11,9 @@ Parameters: None
 Returns routes from Astro's astro:routes:resolved hook, including pages,
 API endpoints, redirects, content collection routes, and integration-injected
 routes. Each route includes its pattern, entrypoint, type, origin, params,
-and prerender status.`
+pathname, segments, redirects, i18n fallback routes, serialized route regex, captured order, and prerender status.
+Endpoint HTTP methods are not returned because Astro does not expose them via
+astro:routes:resolved.`
 
 @schema
 type input = {
@@ -20,7 +22,39 @@ type input = {
 }
 
 @schema
+type segmentPart = {
+  @live
+  content: string,
+  @live
+  dynamic: bool,
+  @live
+  spread: bool,
+}
+
+@schema
+type regexInfo = {
+  @live
+  source: string,
+  @live
+  flags: string,
+}
+
+@schema
+type routeRef = {
+  @live
+  path: string,
+  @live
+  file: string,
+  @as("type") @live
+  type_: string,
+  @live
+  origin: string,
+}
+
+@schema
 type routeEntry = {
+  @live
+  order: int,
   @live
   path: string,
   @live
@@ -29,6 +63,18 @@ type routeEntry = {
   isDynamic: bool,
   @live
   params: array<string>,
+  @live
+  pathname?: string,
+  @live
+  segments?: array<array<segmentPart>>,
+  @live
+  redirect?: JSON.t,
+  @live
+  redirectRoute?: routeRef,
+  @live
+  fallbackRoutes: array<routeRef>,
+  @live
+  patternRegex?: regexInfo,
   @as("type") @live
   type_: string,
   @live
@@ -42,12 +88,38 @@ type output = array<routeEntry>
 
 external routeTypeToString: Bindings.routeType => string = "%identity"
 external routeOriginToString: Bindings.routeOrigin => string = "%identity"
+@get external regexSource: Bindings.patternRegex => string = "source"
+@get external regexFlags: Bindings.patternRegex => string = "flags"
 
-let toRouteEntry = (route: Bindings.integrationResolvedRoute): routeEntry => {
+let toRouteRef = (route: Bindings.integrationResolvedRoute): routeRef => {
+  path: route.pattern,
+  file: route.entrypoint,
+  type_: route.type_->routeTypeToString,
+  origin: route.origin->routeOriginToString,
+}
+
+let toRegexInfo = regex => {source: regex->regexSource, flags: regex->regexFlags}
+
+let toSegmentPart = (part: Bindings.routePart): segmentPart => {
+  content: part.content,
+  dynamic: part.dynamic,
+  spread: part.spread,
+}
+
+let toSegments = segments => segments->Array.map(segment => segment->Array.map(toSegmentPart))
+
+let toRouteEntry = (route: Bindings.integrationResolvedRoute, order): routeEntry => {
+  order,
   path: route.pattern,
   file: route.entrypoint,
   isDynamic: route.params->Array.length > 0,
   params: route.params,
+  pathname: ?route.pathname,
+  segments: ?(route.segments->Option.map(toSegments)),
+  redirect: ?route.redirect,
+  redirectRoute: ?(route.redirectRoute->Option.map(toRouteRef)),
+  fallbackRoutes: route.fallbackRoutes->Option.getOr([])->Array.map(toRouteRef),
+  patternRegex: ?(route.patternRegex->Option.map(toRegexInfo)),
   type_: route.type_->routeTypeToString,
   origin: route.origin->routeOriginToString,
   isPrerendered: route.isPrerendered,
@@ -65,7 +137,10 @@ let make = (
       type input = input
       let inputSchema = inputSchema
       let execute = async (_ctx, _input) =>
-        Tool.unstructuredResult(getRoutes()->Array.map(toRouteEntry), outputSchema)
+        Tool.unstructuredResult(
+          getRoutes()->Array.mapWithIndex((route, order) => toRouteEntry(route, order)),
+          outputSchema,
+        )
     }
   )
 }

--- a/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
+++ b/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
@@ -42,6 +42,10 @@ module Fixtures = {
     origin: #project,
     params: ["path"],
     pathname: None,
+    segments: ?Some([
+      [{content: "docs", dynamic: false, spread: false}],
+      [{content: "...path", dynamic: true, spread: true}],
+    ]),
     isPrerendered: true,
   }
 
@@ -72,6 +76,8 @@ module Fixtures = {
     origin: #project,
     params: [],
     pathname: Some("/old-blog"),
+    redirect: ?Some(JSON.Encode.string("/blog")),
+    redirectRoute: ?Some(aboutPage),
     isPrerendered: false,
   }
 
@@ -123,6 +129,7 @@ module Fixtures = {
     params: ["lang", "slug"],
     pathname: None,
     isPrerendered: false,
+    fallbackRoutes: ?Some([blogPost]),
   }
 }
 
@@ -263,6 +270,86 @@ describe("get_client_pages (resolved routes) via HTTP middleware", _t => {
 
         t->expect(sseBody->String.includes(`\\\"isPrerendered\\\":true`))->Expect.toBe(true)
         t->expect(sseBody->String.includes(`\\\"isPrerendered\\\":false`))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "includes pathname for static routes",
+      async t => {
+        let middleware = makeMiddleware(~routes=[Fixtures.aboutPage])
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes(`\\\"pathname\\\":\\\"/about\\\"`))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "includes segments for dynamic and spread routes",
+      async t => {
+        let middleware = makeMiddleware(~routes=[Fixtures.docsSection])
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes(`\\\"content\\\":\\\"...path\\\"`))->Expect.toBe(true)
+        t->expect(sseBody->String.includes(`\\\"spread\\\":true`))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "includes redirect metadata",
+      async t => {
+        let middleware = makeMiddleware(~routes=[Fixtures.redirectOldBlog])
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes(`\\\"redirect\\\":\\\"/blog\\\"`))->Expect.toBe(true)
+        t->expect(sseBody->String.includes(`\\\"redirectRoute\\\"`))->Expect.toBe(true)
+        t->expect(sseBody->String.includes("/about"))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "includes i18n fallback routes",
+      async t => {
+        let middleware = makeMiddleware(~routes=[Fixtures.i18nBlogPost])
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes(`\\\"fallbackRoutes\\\"`))->Expect.toBe(true)
+        t->expect(sseBody->String.includes("/blog/[slug]"))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
+      "includes captured route order",
+      async t => {
+        let middleware = makeMiddleware(~routes=[Fixtures.homePage, Fixtures.aboutPage])
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes(`\\\"order\\\":0`))->Expect.toBe(true)
+        t->expect(sseBody->String.includes(`\\\"order\\\":1`))->Expect.toBe(true)
       },
     )
 

--- a/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
+++ b/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
@@ -13,6 +13,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/"),
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let aboutPage: Bindings.integrationResolvedRoute = {
@@ -23,6 +24,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/about"),
     isPrerendered: true,
+    fallbackRoutes: [],
   }
 
   let blogPost: Bindings.integrationResolvedRoute = {
@@ -33,6 +35,7 @@ module Fixtures = {
     params: ["slug"],
     pathname: None,
     isPrerendered: true,
+    fallbackRoutes: [],
   }
 
   let docsSection: Bindings.integrationResolvedRoute = {
@@ -47,6 +50,7 @@ module Fixtures = {
       [{content: "...path", dynamic: true, spread: true}],
     ]),
     isPrerendered: true,
+    fallbackRoutes: [],
   }
 
   let apiHealth: Bindings.integrationResolvedRoute = {
@@ -57,6 +61,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/api/health"),
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let apiUserById: Bindings.integrationResolvedRoute = {
@@ -67,6 +72,7 @@ module Fixtures = {
     params: ["id"],
     pathname: None,
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let redirectOldBlog: Bindings.integrationResolvedRoute = {
@@ -79,6 +85,7 @@ module Fixtures = {
     redirect: ?Some(JSON.Encode.string("/blog")),
     redirectRoute: ?Some(aboutPage),
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let redirectDynamic: Bindings.integrationResolvedRoute = {
@@ -89,6 +96,7 @@ module Fixtures = {
     params: ["slug"],
     pathname: None,
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let sitemapXml: Bindings.integrationResolvedRoute = {
@@ -99,6 +107,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/sitemap.xml"),
     isPrerendered: true,
+    fallbackRoutes: [],
   }
 
   let imageEndpoint: Bindings.integrationResolvedRoute = {
@@ -109,6 +118,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/_image"),
     isPrerendered: false,
+    fallbackRoutes: [],
   }
 
   let fallback404: Bindings.integrationResolvedRoute = {
@@ -119,6 +129,7 @@ module Fixtures = {
     params: [],
     pathname: Some("/404"),
     isPrerendered: true,
+    fallbackRoutes: [],
   }
 
   let i18nBlogPost: Bindings.integrationResolvedRoute = {
@@ -129,7 +140,7 @@ module Fixtures = {
     params: ["lang", "slug"],
     pathname: None,
     isPrerendered: false,
-    fallbackRoutes: ?Some([blogPost]),
+    fallbackRoutes: [blogPost],
   }
 }
 

--- a/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
+++ b/libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res
@@ -387,6 +387,34 @@ describe("get_client_pages (resolved routes) via HTTP middleware", _t => {
 
   describe("edge cases", _t => {
     testAsync(
+      "handles Astro routes without fallbackRoutes",
+      async t => {
+        let middleware = makeMiddleware(
+          ~routes=[
+            {
+              pattern: "/legacy",
+              entrypoint: "src/pages/legacy.astro",
+              type_: #page,
+              origin: #project,
+              params: [],
+              pathname: Some("/legacy"),
+              isPrerendered: false,
+            },
+          ],
+        )
+
+        let sseBody = await Helpers.callTool(
+          middleware,
+          ~name="get_client_pages",
+          ~arguments=JSON.Encode.object(Dict.fromArray([])),
+        )
+
+        t->expect(sseBody->String.includes("Execution error"))->Expect.toBe(false)
+        t->expect(sseBody->String.includes(`\\\"fallbackRoutes\\\":[]`))->Expect.toBe(true)
+      },
+    )
+
+    testAsync(
       "returns empty array when no routes resolved",
       async t => {
         let middleware = makeMiddleware(~routes=[])


### PR DESCRIPTION
## Summary
- add Astro route pathname, segments, redirect, fallback route, pattern regex, and captured order metadata to get_client_pages
- document that endpoint HTTP methods are not exposed by astro:routes:resolved
- add a changeset for @frontman-ai/astro

Closes #1604

## Checks
- make rescript-build
- cd libs/frontman-astro && yarn vitest run test/FrontmanAstro__Tool__GetResolvedRoutes.test.res.mjs
- yarn rescript format --check libs/frontman-astro/src/tools/FrontmanAstro__Tool__GetResolvedRoutes.res libs/frontman-astro/test/FrontmanAstro__Tool__GetResolvedRoutes.test.res libs/bindings/src/Astro.res