### PR TITLE
build(preview): emit immutable runtime capsules

### DIFF
--- a/.changeset/build-preview-capsules.md
+++ b/.changeset/build-preview-capsules.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/client": minor
+"@frontman-ai/frontman-preview-bridge": minor
+---
+
+Add the immutable preview capsule build step that emits parent.js, parent.css, bridge.js, and a generated capsule manifest from one build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
       - name: Build project
         run: make build
 
+      - name: Build preview capsule
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+        run: make build-preview-capsule
+
+      - name: Test preview capsule manifest
+        run: make test-preview-capsule
+
   test-frontman-client:
     name: Test frontman-client
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Build client standalone bundle
+      - name: Build client capsule
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
-        run: make -C libs/client build-standalone
+        run: make build-preview-capsule
 
       - name: Upload client bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/wordpress-compatibility.yml
+++ b/.github/workflows/wordpress-compatibility.yml
@@ -41,6 +41,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '24.4.1'
+
+      - name: Enable Corepack
+        run: corepack enable && corepack install
+
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.yarn/berry/cache
+          key: yarn-berry-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-berry-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
       - name: Run isolated PHP tests
         run: |
           docker run --rm \

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,14 @@ HELP_dev-nextjs-prebuilt := Start Next.js test site with prebuilt integration
 HELP_dev-marketing := Start development server for marketing site
 
 HELP_BUILD_TITLE := Build & Quality
-HELP_BUILD_TARGETS := install hooks-install setup-elixir-tools verify-toolchain-pins build rescript-watch rescript-build rescript-format reanalyze check-source-comments clean
+HELP_BUILD_TARGETS := install hooks-install setup-elixir-tools verify-toolchain-pins build build-preview-capsule test-preview-capsule rescript-watch rescript-build rescript-format reanalyze check-source-comments clean
 HELP_install := Install dependencies
 HELP_hooks-install := Install git pre-commit hooks via Lefthook
 HELP_setup-elixir-tools := Install Hex/Rebar for the active mise Elixir
 HELP_verify-toolchain-pins := Verify Docker Elixir image matches mise.toml
 HELP_build := Build ReScript project
+HELP_build-preview-capsule := Build immutable parent/bridge capsule
+HELP_test-preview-capsule := Test immutable capsule manifest output
 HELP_rescript-watch := Watch and rebuild ReScript on changes
 HELP_rescript-build := Build ReScript project (one-shot)
 HELP_rescript-format := Format ReScript source
@@ -176,7 +178,7 @@ dev-marketing:
 
 
 
-.PHONY: install build rescript-watch rescript-build rescript-format reanalyze clean hooks-install setup-elixir-tools verify-toolchain-pins check-source-comments
+.PHONY: install build build-preview-capsule test-preview-capsule rescript-watch rescript-build rescript-format reanalyze clean hooks-install setup-elixir-tools verify-toolchain-pins check-source-comments
 
 install:
 	@printf "$(YELLOW)Installing dependencies...$(RESET)\n"
@@ -222,6 +224,13 @@ verify-toolchain-pins:
 build:
 	@printf "$(YELLOW)Building ReScript project...$(RESET)\n"
 	yarn rescript
+
+build-preview-capsule:
+	@printf "$(YELLOW)Building immutable parent/bridge capsule...$(RESET)\n"
+	node scripts/build-preview-capsule.mjs
+
+test-preview-capsule:
+	node --test test/capsule-build.test.mjs
 
 rescript-watch:
 	@printf "$(YELLOW)Starting ReScript watch mode...$(RESET)\n"

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -1229,6 +1229,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "does not revive initialization after a timeout", %{scope: scope} do
       {socket, _task_id} = join_task_channel(scope)
+
       {discovery_request_id, discovery_timer} =
         next_mcp_initialization_request(socket, "server/discover")
 

--- a/libs/client/public/_headers
+++ b/libs/client/public/_headers
@@ -3,3 +3,6 @@
 
 /frontman.css
   Cache-Control: public, max-age=0, must-revalidate
+
+/capsules/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/scripts/build-preview-capsule.mjs
+++ b/scripts/build-preview-capsule.mjs
@@ -5,7 +5,9 @@ import {join, resolve} from "node:path"
 import {spawnSync} from "node:child_process"
 
 const root = resolve(import.meta.dirname, "..")
-const clientDist = join(root, "libs", "client", "dist")
+const clientDist = process.env.FRONTMAN_CAPSULE_CLIENT_DIST ?? join(root, "libs", "client", "dist")
+const bridgeDist = process.env.FRONTMAN_CAPSULE_BRIDGE_DIST ?? join(root, "libs", "frontman-preview-bridge", "dist")
+const refDist = process.env.FRONTMAN_CAPSULE_REF_DIST ?? join(root, "dist")
 const outRoot = join(clientDist, "capsules")
 
 function run(command, args, cwd = root) {
@@ -28,7 +30,7 @@ run("make", ["-C", "libs/frontman-preview-bridge", "build"])
 
 const parentJs = join(clientDist, "frontman.es.js")
 const parentCss = join(clientDist, "frontman.css")
-const bridgeJs = join(root, "libs", "frontman-preview-bridge", "dist", "bridge.js")
+const bridgeJs = join(bridgeDist, "bridge.js")
 
 await mustExist(parentJs, "Run make -C libs/client build-standalone.")
 await mustExist(parentCss, "Client standalone build must emit CSS for capsules.")
@@ -70,8 +72,8 @@ const manifest = {
 
 const capsuleRef = {capsuleId, manifestPath: `/capsules/${capsuleId}/manifest.json`}
 await writeFile(join(capsuleDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
-await mkdir(join(root, "dist"), {recursive: true})
-await writeFile(join(root, "dist", "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
+await mkdir(refDist, {recursive: true})
+await writeFile(join(refDist, "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
 await writeFile(join(clientDist, "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
 
 console.log(capsuleId)

--- a/scripts/build-preview-capsule.mjs
+++ b/scripts/build-preview-capsule.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import {createHash} from "node:crypto"
-import {copyFile, mkdir, readFile, rm, stat, writeFile} from "node:fs/promises"
+import {copyFile, mkdir, readFile, rename, rm, stat, writeFile} from "node:fs/promises"
 import {join, resolve} from "node:path"
 import {spawnSync} from "node:child_process"
 
@@ -43,20 +43,23 @@ const assets = [
 ]
 
 const hashedAssets = await Promise.all(assets.map(async (asset) => ({...asset, sha256: await sha256(asset.source)})))
-
-const idSource = JSON.stringify(hashedAssets.map(({name, sha256}) => [name, sha256]))
+const immutableCacheControl = "public, max-age=31536000, immutable"
+const manifestVersion = 1
+const idSource = JSON.stringify({
+  version: manifestVersion,
+  cacheControl: immutableCacheControl,
+  assets: hashedAssets.map(({name, sha256, contentType}) => ({
+    name,
+    sha256,
+    contentType,
+    cacheControl: immutableCacheControl,
+  })),
+})
 const capsuleId = createHash("sha256").update(idSource).digest("hex").slice(0, 32)
 const capsuleDir = join(outRoot, capsuleId)
-
-await rm(capsuleDir, {recursive: true, force: true})
-await mkdir(capsuleDir, {recursive: true})
-
-for (const asset of hashedAssets) {
-  await copyFile(asset.source, join(capsuleDir, asset.name))
-}
-
-const immutableCacheControl = "public, max-age=31536000, immutable"
+const stageDir = join(outRoot, `.${capsuleId}-${process.pid}.tmp`)
 const manifest = {
+  version: manifestVersion,
   capsuleId,
   cacheControl: immutableCacheControl,
   assets: Object.fromEntries(hashedAssets.map((asset) => [
@@ -70,8 +73,36 @@ const manifest = {
   ])),
 }
 
+async function capsuleMatches() {
+  try {
+    assertJsonEqual(JSON.parse(await readFile(join(capsuleDir, "manifest.json"), "utf8")), manifest)
+    await Promise.all(hashedAssets.map(async (asset) => {
+      if (await sha256(join(capsuleDir, asset.name)) !== asset.sha256) throw new Error("asset mismatch")
+    }))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function assertJsonEqual(left, right) {
+  if (JSON.stringify(left) !== JSON.stringify(right)) throw new Error("manifest mismatch")
+}
+
+if (!await capsuleMatches()) {
+  await rm(stageDir, {recursive: true, force: true})
+  await mkdir(stageDir, {recursive: true})
+
+  for (const asset of hashedAssets) {
+    await copyFile(asset.source, join(stageDir, asset.name))
+  }
+
+  await writeFile(join(stageDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+  await rm(capsuleDir, {recursive: true, force: true})
+  await rename(stageDir, capsuleDir)
+}
+
 const capsuleRef = {capsuleId, manifestPath: `/capsules/${capsuleId}/manifest.json`}
-await writeFile(join(capsuleDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 await mkdir(refDist, {recursive: true})
 await writeFile(join(refDist, "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
 await writeFile(join(clientDist, "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)

--- a/scripts/build-preview-capsule.mjs
+++ b/scripts/build-preview-capsule.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import {createHash} from "node:crypto"
+import {copyFile, mkdir, readFile, rm, stat, writeFile} from "node:fs/promises"
+import {join, resolve} from "node:path"
+import {spawnSync} from "node:child_process"
+
+const root = resolve(import.meta.dirname, "..")
+const clientDist = join(root, "libs", "client", "dist")
+const outRoot = join(clientDist, "capsules")
+
+function run(command, args, cwd = root) {
+  const result = spawnSync(command, args, {cwd, stdio: "inherit", shell: process.platform === "win32"})
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}
+
+async function sha256(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex")
+}
+
+async function mustExist(path, hint) {
+  await stat(path).catch(() => {
+    throw new Error(`${path} missing. ${hint}`)
+  })
+}
+
+run("make", ["-C", "libs/client", "build-standalone"])
+run("make", ["-C", "libs/frontman-preview-bridge", "build"])
+
+const parentJs = join(clientDist, "frontman.es.js")
+const parentCss = join(clientDist, "frontman.css")
+const bridgeJs = join(root, "libs", "frontman-preview-bridge", "dist", "bridge.js")
+
+await mustExist(parentJs, "Run make -C libs/client build-standalone.")
+await mustExist(parentCss, "Client standalone build must emit CSS for capsules.")
+await mustExist(bridgeJs, "Run make -C libs/frontman-preview-bridge build.")
+
+const assets = [
+  {name: "parent.js", source: parentJs, contentType: "text/javascript"},
+  {name: "parent.css", source: parentCss, contentType: "text/css"},
+  {name: "bridge.js", source: bridgeJs, contentType: "text/javascript"},
+]
+
+const hashedAssets = await Promise.all(assets.map(async (asset) => ({...asset, sha256: await sha256(asset.source)})))
+
+const idSource = JSON.stringify(hashedAssets.map(({name, sha256}) => [name, sha256]))
+const capsuleId = createHash("sha256").update(idSource).digest("hex").slice(0, 32)
+const capsuleDir = join(outRoot, capsuleId)
+
+await rm(capsuleDir, {recursive: true, force: true})
+await mkdir(capsuleDir, {recursive: true})
+
+for (const asset of hashedAssets) {
+  await copyFile(asset.source, join(capsuleDir, asset.name))
+}
+
+const immutableCacheControl = "public, max-age=31536000, immutable"
+const manifest = {
+  capsuleId,
+  cacheControl: immutableCacheControl,
+  assets: Object.fromEntries(hashedAssets.map((asset) => [
+    asset.name,
+    {
+      path: `/capsules/${capsuleId}/${asset.name}`,
+      sha256: asset.sha256,
+      contentType: asset.contentType,
+      cacheControl: immutableCacheControl,
+    },
+  ])),
+}
+
+const capsuleRef = {capsuleId, manifestPath: `/capsules/${capsuleId}/manifest.json`}
+await writeFile(join(capsuleDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+await mkdir(join(root, "dist"), {recursive: true})
+await writeFile(join(root, "dist", "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
+await writeFile(join(clientDist, "frontman-capsule.json"), `${JSON.stringify(capsuleRef, null, 2)}\n`)
+
+console.log(capsuleId)

--- a/test/capsule-build.test.mjs
+++ b/test/capsule-build.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict"
+import {createHash} from "node:crypto"
+import {chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile} from "node:fs/promises"
+import {existsSync} from "node:fs"
+import {join, resolve} from "node:path"
+import {test} from "node:test"
+import {spawnSync} from "node:child_process"
+import {tmpdir} from "node:os"
+
+const root = resolve(import.meta.dirname, "..")
+const script = join(root, "scripts", "build-preview-capsule.mjs")
+
+async function sha256(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex")
+}
+
+test("build-preview-capsule emits one immutable parent/bridge capsule", async (t) => {
+  const fakeBin = await mkdtemp(join(tmpdir(), "frontman-capsule-bin-"))
+  t.after(() => rm(fakeBin, {recursive: true, force: true}))
+  const fakeMake = join(fakeBin, "make")
+  await Promise.all([
+    mkdir(join(root, "libs", "client", "dist"), {recursive: true}),
+    mkdir(join(root, "libs", "frontman-preview-bridge", "dist"), {recursive: true}),
+  ])
+  await writeFile(fakeMake, "#!/bin/sh\nexit 0\n")
+  await chmod(fakeMake, 0o755)
+
+  await Promise.all([
+    writeFile(join(root, "libs", "client", "dist", "frontman.es.js"), "console.log('parent')\n"),
+    writeFile(join(root, "libs", "client", "dist", "frontman.css"), ".frontman{}\n"),
+    writeFile(join(root, "libs", "frontman-preview-bridge", "dist", "bridge.js"), "console.log('bridge')\n"),
+  ])
+
+  const result = spawnSync(process.execPath, [script], {
+    cwd: root,
+    env: {...process.env, PATH: `${fakeBin}:${process.env.PATH}`},
+    encoding: "utf8",
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  const capsuleId = result.stdout.trim()
+  assert.match(capsuleId, /^[a-f0-9]{32}$/)
+
+  const dir = join(root, "libs", "client", "dist", "capsules", capsuleId)
+  assert.deepEqual(await readdir(dir), ["bridge.js", "manifest.json", "parent.css", "parent.js"])
+
+  const manifest = JSON.parse(await readFile(join(dir, "manifest.json"), "utf8"))
+  assert.equal(manifest.capsuleId, capsuleId)
+  assert.equal(manifest.cacheControl, "public, max-age=31536000, immutable")
+  assert.equal(manifest.assets["parent.js"].sha256, await sha256(join(dir, "parent.js")))
+  assert.equal(manifest.assets["parent.css"].contentType, "text/css")
+  assert.equal(manifest.assets["bridge.js"].contentType, "text/javascript")
+  assert.equal(manifest.assets["bridge.js"].path, `/capsules/${capsuleId}/bridge.js`)
+
+  const ref = {capsuleId, manifestPath: `/capsules/${capsuleId}/manifest.json`}
+  assert.deepEqual(JSON.parse(await readFile(join(root, "dist", "frontman-capsule.json"), "utf8")), ref)
+  assert.deepEqual(JSON.parse(await readFile(join(root, "libs", "client", "dist", "frontman-capsule.json"), "utf8")), ref)
+
+  assert.equal(existsSync(join(dir, "latest")), false)
+})

--- a/test/capsule-build.test.mjs
+++ b/test/capsule-build.test.mjs
@@ -57,6 +57,7 @@ test("build-preview-capsule emits one immutable parent/bridge capsule", async (t
   assert.deepEqual(await readdir(dir), ["bridge.js", "manifest.json", "parent.css", "parent.js"])
 
   const manifest = JSON.parse(await readFile(join(dir, "manifest.json"), "utf8"))
+  assert.equal(manifest.version, 1)
   assert.equal(manifest.capsuleId, capsuleId)
   assert.equal(manifest.cacheControl, "public, max-age=31536000, immutable")
   assert.equal(manifest.assets["parent.js"].sha256, await sha256(join(dir, "parent.js")))
@@ -69,4 +70,21 @@ test("build-preview-capsule emits one immutable parent/bridge capsule", async (t
   assert.deepEqual(JSON.parse(await readFile(join(clientDist, "frontman-capsule.json"), "utf8")), ref)
 
   assert.equal(existsSync(join(dir, "latest")), false)
+
+  await writeFile(join(dir, "preserved"), "existing capsule was reused\n")
+  const rerun = spawnSync(process.execPath, [script], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      FRONTMAN_CAPSULE_CLIENT_DIST: clientDist,
+      FRONTMAN_CAPSULE_BRIDGE_DIST: bridgeDist,
+      FRONTMAN_CAPSULE_REF_DIST: refDist,
+    },
+    encoding: "utf8",
+  })
+
+  assert.equal(rerun.status, 0, rerun.stderr)
+  assert.equal(rerun.stdout.trim(), capsuleId)
+  assert.equal(await readFile(join(dir, "preserved"), "utf8"), "existing capsule was reused\n")
 })

--- a/test/capsule-build.test.mjs
+++ b/test/capsule-build.test.mjs
@@ -15,25 +15,37 @@ async function sha256(path) {
 }
 
 test("build-preview-capsule emits one immutable parent/bridge capsule", async (t) => {
-  const fakeBin = await mkdtemp(join(tmpdir(), "frontman-capsule-bin-"))
-  t.after(() => rm(fakeBin, {recursive: true, force: true}))
+  const tempRoot = await mkdtemp(join(tmpdir(), "frontman-capsule-test-"))
+  t.after(() => rm(tempRoot, {recursive: true, force: true}))
+
+  const fakeBin = join(tempRoot, "bin")
+  const clientDist = join(tempRoot, "client-dist")
+  const bridgeDist = join(tempRoot, "bridge-dist")
+  const refDist = join(tempRoot, "ref-dist")
   const fakeMake = join(fakeBin, "make")
   await Promise.all([
-    mkdir(join(root, "libs", "client", "dist"), {recursive: true}),
-    mkdir(join(root, "libs", "frontman-preview-bridge", "dist"), {recursive: true}),
+    mkdir(fakeBin, {recursive: true}),
+    mkdir(clientDist, {recursive: true}),
+    mkdir(bridgeDist, {recursive: true}),
   ])
   await writeFile(fakeMake, "#!/bin/sh\nexit 0\n")
   await chmod(fakeMake, 0o755)
 
   await Promise.all([
-    writeFile(join(root, "libs", "client", "dist", "frontman.es.js"), "console.log('parent')\n"),
-    writeFile(join(root, "libs", "client", "dist", "frontman.css"), ".frontman{}\n"),
-    writeFile(join(root, "libs", "frontman-preview-bridge", "dist", "bridge.js"), "console.log('bridge')\n"),
+    writeFile(join(clientDist, "frontman.es.js"), "console.log('parent')\n"),
+    writeFile(join(clientDist, "frontman.css"), ".frontman{}\n"),
+    writeFile(join(bridgeDist, "bridge.js"), "console.log('bridge')\n"),
   ])
 
   const result = spawnSync(process.execPath, [script], {
     cwd: root,
-    env: {...process.env, PATH: `${fakeBin}:${process.env.PATH}`},
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      FRONTMAN_CAPSULE_CLIENT_DIST: clientDist,
+      FRONTMAN_CAPSULE_BRIDGE_DIST: bridgeDist,
+      FRONTMAN_CAPSULE_REF_DIST: refDist,
+    },
     encoding: "utf8",
   })
 
@@ -41,7 +53,7 @@ test("build-preview-capsule emits one immutable parent/bridge capsule", async (t
   const capsuleId = result.stdout.trim()
   assert.match(capsuleId, /^[a-f0-9]{32}$/)
 
-  const dir = join(root, "libs", "client", "dist", "capsules", capsuleId)
+  const dir = join(clientDist, "capsules", capsuleId)
   assert.deepEqual(await readdir(dir), ["bridge.js", "manifest.json", "parent.css", "parent.js"])
 
   const manifest = JSON.parse(await readFile(join(dir, "manifest.json"), "utf8"))
@@ -53,8 +65,8 @@ test("build-preview-capsule emits one immutable parent/bridge capsule", async (t
   assert.equal(manifest.assets["bridge.js"].path, `/capsules/${capsuleId}/bridge.js`)
 
   const ref = {capsuleId, manifestPath: `/capsules/${capsuleId}/manifest.json`}
-  assert.deepEqual(JSON.parse(await readFile(join(root, "dist", "frontman-capsule.json"), "utf8")), ref)
-  assert.deepEqual(JSON.parse(await readFile(join(root, "libs", "client", "dist", "frontman-capsule.json"), "utf8")), ref)
+  assert.deepEqual(JSON.parse(await readFile(join(refDist, "frontman-capsule.json"), "utf8")), ref)
+  assert.deepEqual(JSON.parse(await readFile(join(clientDist, "frontman-capsule.json"), "utf8")), ref)
 
   assert.equal(existsSync(join(dir, "latest")), false)
 })


### PR DESCRIPTION
## Summary
- add a generated parent/bridge capsule build script
- emit parent.js, parent.css, bridge.js, manifest.json under one content-addressed capsule ID
- add focused manifest test and Make targets

## Verification
- make test-preview-capsule
- pre-commit source-comments hook passed

Note: full push hook could not run in this fresh worktree because Yarn reports a missing node_modules state file.

Refs #1474