### PR TITLE
Fix ACP request timeout

### DIFF
--- a/.changeset/fix-acp-request-timeout.md
+++ b/.changeset/fix-acp-request-timeout.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Reject ACP client requests after a timeout instead of leaving the UI stuck when the server never responds.

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -7,28 +7,45 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #ACP
 })
 
+let requestTimeoutMs = 120000
+
 let sendRequest = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
   ~method: string,
   ~params: option<JSON.t>,
+  ~timeoutMs: int=requestTimeoutMs,
   ~parseResult: JSON.t => result<'a, string>,
 ): promise<result<'a, string>> => {
   Promise.make((resolve, _) => {
     let id = state.contents.currentId + 1
+    let idStr = Int.toString(id)
     let request = JsonRpc.Request.make(~id=JsonRpc.Id.fromInt(id), ~method, ~params)
+    let timer = ref(None)
+    let finish = result => {
+      timer.contents->Option.forEach(WebAPI.DomGlobal.clearTimeout)
+      resolve(result)
+    }
 
     let pending: Client.pendingRequest = {
       resolve: json => {
         switch parseResult(json) {
-        | Ok(result) => resolve(Ok(result))
-        | Error(e) => resolve(Error(e))
+        | Ok(result) => finish(Ok(result))
+        | Error(e) => finish(Error(e))
         }
       },
-      reject: e => resolve(Error(e)),
+      reject: e => finish(Error(e)),
     }
 
     state := state.contents->Client.reduce(Client.RequestSent(id, pending))
+    timer :=
+      Some(
+        WebAPI.DomGlobal.setTimeout(~timeout=timeoutMs, ~handler=() => {
+          state.contents.pendingRequests->Dict.get(idStr)->Option.getOrThrow->ignore
+          state := state.contents->Client.reduce(Client.ResponseReceived(id))
+          pending.reject(`Request ${method} timed out after ${Int.toString(timeoutMs)}ms`)
+        }),
+      )
 
     let payload = request->JsonRpc.Request.toJson
     channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -1,5 +1,9 @@
 open Vitest
 
+afterEach(() => {
+  Vi.useRealTimers()->ignore
+})
+
 module Client = FrontmanClient__ACP__Client
 module ACP = FrontmanClient__ACP
 module Protocol = FrontmanClient__ACP__Protocol
@@ -365,6 +369,35 @@ describe("ACP Client parseInitializeResult", _t => {
     }`)
 
     t->expect(Client.parseInitializeResult(json)->Result.isError)->Expect.toBe(true)
+  })
+})
+
+describe("ACP Protocol sendRequest", _t => {
+  testAsync("times out and removes pending request when no response arrives", async t => {
+    Vi.useFakeTimers()->ignore
+    let transport = makeLoadTransport([], loadResult)
+    let state = ref(Client.initialState)
+    let promise = Protocol.sendRequest(
+      ~channel=transport.channel,
+      ~state,
+      ~method="test/method",
+      ~params=None,
+      ~timeoutMs=10,
+      ~parseResult=json =>
+        switch json->JSON.Decode.string {
+        | Some(value) => Ok(value)
+        | None => Error("Expected string")
+        },
+    )
+
+    t->expect(state.contents.pendingRequests->Dict.get("1")->Option.isSome)->Expect.toBe(true)
+    let _ = await Vi.advanceTimersByTimeAsync(10)
+    let result = await promise
+
+    t
+    ->expect(result)
+    ->Expect.toEqual(Error("Request test/method timed out after 10ms"))
+    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
   })
 })
 


### PR DESCRIPTION
## Summary
- add a 120s timeout for ACP JSON-RPC requests
- clear pending requests when a request times out
- add a regression test for stuck requests

Fixes #590

## Tests
- make -C libs/frontman-client test