### PR TITLE
Tighten path handling guardrails

### DIFF
--- a/.changeset/quiet-path-guardrails.md
+++ b/.changeset/quiet-path-guardrails.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-core": patch
+"@frontman/bindings": patch
+---
+
+Use Node path.relative for relative path display and reject out-of-root search paths instead of falling back to the source root.

--- a/libs/bindings/src/Path.res
+++ b/libs/bindings/src/Path.res
@@ -19,6 +19,9 @@ external isAbsolute: string => bool = "isAbsolute"
 @module("node:path")
 external normalize: string => string = "normalize"
 
+@module("node:path")
+external relative: (string, string) => string = "relative"
+
 @module("node:path") @variadic
 external resolveMany: array<string> => string = "resolve"
 

--- a/libs/frontman-core/src/FrontmanCore__FileTracker.res
+++ b/libs/frontman-core/src/FrontmanCore__FileTracker.res
@@ -1,4 +1,5 @@
 module Fs = FrontmanBindings.Fs
+module SafePath = FrontmanCore__SafePath
 
 type range = {start: int, end_: int}
 
@@ -37,13 +38,14 @@ let mergeRanges = (ranges: array<range>): array<range> => {
 }
 
 let recordRead = (
-  resolvedPath: string,
+  safePath: SafePath.t,
   ~offset: int,
   ~limit: int,
   ~totalLines: int,
   ~mtimeMs: float,
   ~size: float,
 ): unit => {
+  let resolvedPath = SafePath.toString(safePath)
   let newRange = {start: offset, end_: min(offset + limit, totalLines)}
   let existingRanges = switch readFiles.contents->Map.get(resolvedPath) {
   | Some(existing) => existing.ranges
@@ -65,11 +67,12 @@ let isLineCovered = (ranges: array<range>, line: int): bool => {
   ranges->Array.some(r => line >= r.start && line < r.end_)
 }
 
-let get = (resolvedPath: string): option<fileRecord> => {
-  readFiles.contents->Map.get(resolvedPath)
+let get = (safePath: SafePath.t): option<fileRecord> => {
+  readFiles.contents->Map.get(SafePath.toString(safePath))
 }
 
-let assertReadBefore = (resolvedPath: string): result<unit, string> => {
+let assertReadBefore = (safePath: SafePath.t): result<unit, string> => {
+  let resolvedPath = SafePath.toString(safePath)
   switch readFiles.contents->Map.has(resolvedPath) {
   | true => Ok()
   | false =>
@@ -79,7 +82,8 @@ let assertReadBefore = (resolvedPath: string): result<unit, string> => {
   }
 }
 
-let assertNotStale = async (resolvedPath: string): result<unit, string> => {
+let assertNotStale = async (safePath: SafePath.t): result<unit, string> => {
+  let resolvedPath = SafePath.toString(safePath)
   switch readFiles.contents->Map.get(resolvedPath) {
   | None => Ok()
   | Some(record) =>
@@ -103,8 +107,8 @@ let assertNotStale = async (resolvedPath: string): result<unit, string> => {
   }
 }
 
-let checkCoverage = (resolvedPath: string, ~content: string, ~oldText: string): option<string> => {
-  switch readFiles.contents->Map.get(resolvedPath) {
+let checkCoverage = (safePath: SafePath.t, ~content: string, ~oldText: string): option<string> => {
+  switch readFiles.contents->Map.get(SafePath.toString(safePath)) {
   | None => None
   | Some(record) =>
     switch record.ranges {
@@ -136,14 +140,15 @@ let checkCoverage = (resolvedPath: string, ~content: string, ~oldText: string): 
   }
 }
 
-let assertEditSafe = async (resolvedPath: string): result<unit, string> => {
-  switch assertReadBefore(resolvedPath) {
+let assertEditSafe = async (safePath: SafePath.t): result<unit, string> => {
+  switch assertReadBefore(safePath) {
   | Error(_) as e => e
-  | Ok() => await assertNotStale(resolvedPath)
+  | Ok() => await assertNotStale(safePath)
   }
 }
 
-let recordWrite = (resolvedPath: string, ~mtimeMs: float, ~size: float): unit => {
+let recordWrite = (safePath: SafePath.t, ~mtimeMs: float, ~size: float): unit => {
+  let resolvedPath = SafePath.toString(safePath)
   switch readFiles.contents->Map.get(resolvedPath) {
   | Some(record) =>
     readFiles.contents->Map.set(

--- a/libs/frontman-core/src/FrontmanCore__PathContext.res
+++ b/libs/frontman-core/src/FrontmanCore__PathContext.res
@@ -26,60 +26,41 @@ type responseContext = {
   relativePath: string,
 }
 
-let endsWithSep = (path: string): bool => {
-  path->String.endsWith("/") || path->String.endsWith("\\")
-}
+let toRelativePath = (~sourceRoot: string, ~absolutePath: string): string =>
+  Path.relative(Path.resolve(sourceRoot), absolutePath)
 
-let toRelativePath = (~sourceRoot: string, ~absolutePath: string): string => {
-  let sourceRoot = Path.resolve(sourceRoot)
-  let normalizedRoot = if endsWithSep(sourceRoot) {
-    sourceRoot
-  } else {
-    sourceRoot ++ Path.sep
-  }
-
-  if absolutePath->String.startsWith(normalizedRoot) {
-    absolutePath->String.slice(
-      ~start=normalizedRoot->String.length,
-      ~end=absolutePath->String.length,
-    )
-  } else if absolutePath->String.startsWith(sourceRoot) {
-    absolutePath->String.slice(~start=sourceRoot->String.length, ~end=absolutePath->String.length)
-  } else {
-    absolutePath
-  }
-}
-
-let resolveSearchPath = (~sourceRoot: string, ~inputPath: option<string>): string => {
+let resolveSearchPath = (~sourceRoot: string, ~inputPath: option<string>): result<
+  string,
+  resolveError,
+> => {
   switch inputPath {
-  | None => sourceRoot
+  | None => Ok(Path.resolve(sourceRoot))
   | Some(path) =>
-    if Path.isAbsolute(path) {
-      let normalizedPath = Path.normalize(path)
-      let normalizedRoot = Path.normalize(sourceRoot)
-      if normalizedPath->String.startsWith(normalizedRoot) {
-        normalizedPath
-      } else {
-        sourceRoot
-      }
-    } else {
-      Path.join([sourceRoot, path])
+    switch SafePath.resolve(~sourceRoot, ~inputPath=path) {
+    | Ok(safePath) => Ok(SafePath.toString(safePath))
+    | Error(message) => Error({message, hint: None, sourceRoot, requestedPath: path})
     }
   }
 }
 
 module Fs = FrontmanBindings.Fs
 
-let resolveSearchDir = async (~sourceRoot: string, ~inputPath: option<string>): string => {
-  let resolved = resolveSearchPath(~sourceRoot, ~inputPath)
-  try {
-    let stats = await Fs.Promises.stat(resolved)
-    switch Fs.isFile(stats) {
-    | true => Path.dirname(resolved)
-    | false => resolved
+let resolveSearchDir = async (~sourceRoot: string, ~inputPath: option<string>): result<
+  string,
+  resolveError,
+> => {
+  switch resolveSearchPath(~sourceRoot, ~inputPath) {
+  | Error(_) as error => error
+  | Ok(resolved) =>
+    try {
+      let stats = await Fs.Promises.stat(resolved)
+      switch Fs.isFile(stats) {
+      | true => Ok(Path.dirname(resolved))
+      | false => Ok(resolved)
+      }
+    } catch {
+    | _ => Ok(resolved)
     }
-  } catch {
-  | _ => resolved
   }
 }
 
@@ -103,6 +84,13 @@ let detectPathConfusion = (~sourceRoot: string, ~requestedPath: string): option<
   }
 }
 
+let makeError = (~sourceRoot: string, ~requestedPath: string, ~message: string): resolveError => {
+  message,
+  hint: detectPathConfusion(~sourceRoot, ~requestedPath),
+  sourceRoot,
+  requestedPath,
+}
+
 let dirname = (result: resolveResult): string => {
   SafePath.dirname(result.safePath)
 }
@@ -117,13 +105,7 @@ let resolve = (~sourceRoot: string, ~inputPath: string): result<resolveResult, r
       resolvedPath,
       relativePath: toRelativePath(~sourceRoot, ~absolutePath=resolvedPath),
     })
-  | Error(msg) =>
-    Error({
-      message: msg,
-      hint: detectPathConfusion(~sourceRoot, ~requestedPath=inputPath),
-      sourceRoot,
-      requestedPath: inputPath,
-    })
+  | Error(message) => Error(makeError(~sourceRoot, ~requestedPath=inputPath, ~message))
   }
 }
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__EditFile.res
@@ -71,17 +71,13 @@ let findAndReplace = async (
 ): result<execution, string> => {
   try {
     let content = await Fs.Promises.readFile(resolved.resolvedPath)
-    let coverageWarning = FileTracker.checkCoverage(resolved.resolvedPath, ~content, ~oldText)
+    let coverageWarning = FileTracker.checkCoverage(resolved.safePath, ~content, ~oldText)
 
     switch Matcher.applyEdit(~content, ~oldText, ~newText, ~replaceAll) {
     | Applied(newContent) =>
       await Fs.Promises.writeFile(resolved.resolvedPath, newContent)
       let stats = await Fs.Promises.stat(resolved.resolvedPath)
-      FileTracker.recordWrite(
-        resolved.resolvedPath,
-        ~mtimeMs=Fs.mtimeMs(stats),
-        ~size=Fs.size(stats),
-      )
+      FileTracker.recordWrite(resolved.safePath, ~mtimeMs=Fs.mtimeMs(stats), ~size=Fs.size(stats))
       let message = switch coverageWarning {
       | Some(warning) => `Edit applied successfully.\n\n${warning}`
       | None => "Edit applied successfully."
@@ -123,7 +119,7 @@ let executeOutput = async (ctx: Tool.serverExecutionContext, input: input): resu
       switch input.oldText {
       | "" => Error("oldText must not be empty; use write_file to create files")
       | oldText =>
-        switch await FileTracker.assertEditSafe(resolved.resolvedPath) {
+        switch await FileTracker.assertEditSafe(resolved.safePath) {
         | Error(msg) => Error(msg)
         | Ok() =>
           await findAndReplace(

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__FileExists.res
@@ -1,5 +1,5 @@
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
-module SafePath = FrontmanCore__SafePath
+module PathContext = FrontmanCore__PathContext
 module FsUtils = FrontmanCore__FsUtils
 
 let name = Tool.ToolNames.fileExists
@@ -20,10 +20,10 @@ type output = bool
 let (visibleToAgent, outputJsonSchema) = (true, None)
 
 let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.CallToolResult.t => {
-  switch SafePath.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
-  | Error(msg) => Tool.MCP.CallToolResult.makeError(msg)
-  | Ok(safePath) =>
-    let exists = await FsUtils.pathExists(SafePath.toString(safePath))
+  switch PathContext.resolve(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
+  | Error(err) => Tool.MCP.CallToolResult.makeError(PathContext.formatError(err))
+  | Ok(resolved) =>
+    let exists = await FsUtils.pathExists(resolved.resolvedPath)
     Tool.unstructuredResult(exists, outputSchema)
   }
 }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__Grep.res
@@ -380,25 +380,15 @@ let executePlainGrep = async (
 }
 
 let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.CallToolResult.t => {
-  let searchPath = PathContext.resolveSearchPath(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path)
-  let caseInsensitive = input.caseInsensitive->Option.getOr(false)
-  let literal = input.literal->Option.getOr(false)
-  let maxResults = input.maxResults->Option.getOr(20)
+  switch PathContext.resolveSearchPath(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
+  | Error(err) => Tool.MCP.CallToolResult.makeError(PathContext.formatError(err))
+  | Ok(searchPath) =>
+    let caseInsensitive = input.caseInsensitive->Option.getOr(false)
+    let literal = input.literal->Option.getOr(false)
+    let maxResults = input.maxResults->Option.getOr(20)
 
-  let gitGrepWithFallback = async () => {
-    let gitResult = await executeGitGrep(
-      ~pattern=input.pattern,
-      ~searchPath,
-      ~caseInsensitive,
-      ~literal,
-      ~maxResults,
-      ~glob=input.glob,
-      ~type_=input.type_,
-    )
-    switch gitResult {
-    | Ok(_) => gitResult
-    | Error(_) =>
-      await executePlainGrep(
+    let gitGrepWithFallback = async () => {
+      let gitResult = await executeGitGrep(
         ~pattern=input.pattern,
         ~searchPath,
         ~caseInsensitive,
@@ -407,31 +397,44 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.C
         ~glob=input.glob,
         ~type_=input.type_,
       )
+      switch gitResult {
+      | Ok(_) => gitResult
+      | Error(_) =>
+        await executePlainGrep(
+          ~pattern=input.pattern,
+          ~searchPath,
+          ~caseInsensitive,
+          ~literal,
+          ~maxResults,
+          ~glob=input.glob,
+          ~type_=input.type_,
+        )
+      }
     }
-  }
 
-  let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
-  | Some(rgPath) =>
-    let result = await executeRipgrep(
-      ~rgPath,
-      ~pattern=input.pattern,
-      ~searchPath,
-      ~type_=input.type_,
-      ~glob=input.glob,
-      ~caseInsensitive,
-      ~literal,
-      ~maxResults,
-    )
+    let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
+    | Some(rgPath) =>
+      let result = await executeRipgrep(
+        ~rgPath,
+        ~pattern=input.pattern,
+        ~searchPath,
+        ~type_=input.type_,
+        ~glob=input.glob,
+        ~caseInsensitive,
+        ~literal,
+        ~maxResults,
+      )
+
+      switch result {
+      | Ok(_) => result
+      | Error(_) => await gitGrepWithFallback()
+      }
+    | None => await gitGrepWithFallback()
+    }
 
     switch result {
-    | Ok(_) => result
-    | Error(_) => await gitGrepWithFallback()
+    | Ok(output) => Tool.structuredResult(output, outputSchema)
+    | Error(msg) => Tool.MCP.CallToolResult.makeError(msg)
     }
-  | None => await gitGrepWithFallback()
-  }
-
-  switch result {
-  | Ok(output) => Tool.structuredResult(output, outputSchema)
-  | Error(msg) => Tool.MCP.CallToolResult.makeError(msg)
   }
 }

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ReadFile.res
@@ -94,7 +94,7 @@ let readResolvedFile = async (
     let hasMore = offset + limit < totalLines
 
     FrontmanCore__FileTracker.recordRead(
-      resolved.resolvedPath,
+      resolved.safePath,
       ~offset,
       ~limit,
       ~totalLines,

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__SearchFiles.res
@@ -208,57 +208,56 @@ let executeOutput = async (ctx: Tool.serverExecutionContext, input: input): resu
   output,
   string,
 > => {
-  let requestedSearchPath = await PathContext.resolveSearchDir(
-    ~sourceRoot=ctx.sourceRoot,
-    ~inputPath=input.path,
-  )
+  switch await PathContext.resolveSearchDir(~sourceRoot=ctx.sourceRoot, ~inputPath=input.path) {
+  | Error(err) => Error(PathContext.formatError(err))
+  | Ok(requestedSearchPath) =>
+    let searchPath = switch await PathRecovery.nearestExistingDir(
+      ~sourceRoot=ctx.sourceRoot,
+      ~startPath=requestedSearchPath,
+    ) {
+    | Some(existingDir) => existingDir
+    | None => ctx.sourceRoot
+    }
 
-  let searchPath = switch await PathRecovery.nearestExistingDir(
-    ~sourceRoot=ctx.sourceRoot,
-    ~startPath=requestedSearchPath,
-  ) {
-  | Some(existingDir) => existingDir
-  | None => ctx.sourceRoot
-  }
+    let maxResults = input.maxResults->Option.getOr(20)
 
-  let maxResults = input.maxResults->Option.getOr(20)
+    let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
+    | Some(rgPath) =>
+      let ripgrepResult = await executeRipgrep(
+        ~rgPath,
+        ~pattern=input.pattern,
+        ~searchPath,
+        ~maxResults,
+      )
 
-  let result = switch await FrontmanBindings.Ripgrep.getRipgrepPath() {
-  | Some(rgPath) =>
-    let ripgrepResult = await executeRipgrep(
-      ~rgPath,
-      ~pattern=input.pattern,
-      ~searchPath,
-      ~maxResults,
-    )
-
-    switch ripgrepResult {
-    | Ok(output) => Ok(output)
-    | Error(ripgrepError) =>
+      switch ripgrepResult {
+      | Ok(output) => Ok(output)
+      | Error(ripgrepError) =>
+        switch await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults) {
+        | Ok(output) => Ok(output)
+        | Error(gitError) =>
+          Error(formatFallbackError(~firstError=ripgrepError, ~secondError=gitError))
+        }
+      }
+    | None =>
       switch await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults) {
       | Ok(output) => Ok(output)
-      | Error(gitError) =>
-        Error(formatFallbackError(~firstError=ripgrepError, ~secondError=gitError))
+      | Error(gitError) => Error(formatBackendError(gitError))
       }
     }
-  | None =>
-    switch await executeGitLsFiles(~pattern=input.pattern, ~searchPath, ~maxResults) {
-    | Ok(output) => Ok(output)
-    | Error(gitError) => Error(formatBackendError(gitError))
-    }
-  }
 
-  switch result {
-  | Ok(output) =>
-    ToolPathHints.recordSearch(
-      ~sourceRoot=ctx.sourceRoot,
-      ~searchPath,
-      ~pattern=input.pattern,
-      ~files=output.files,
-      ~totalResults=output.totalResults,
-    )
-    Ok(output)
-  | Error(_) as err => err
+    switch result {
+    | Ok(output) =>
+      ToolPathHints.recordSearch(
+        ~sourceRoot=ctx.sourceRoot,
+        ~searchPath,
+        ~pattern=input.pattern,
+        ~files=output.files,
+        ~totalResults=output.totalResults,
+      )
+      Ok(output)
+    | Error(_) as err => err
+    }
   }
 }
 

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__WriteFile.res
@@ -78,7 +78,7 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.C
         let previousContent = await FsUtils.readFileIfExists(resolved.resolvedPath)
         let guardResult = switch previousContent {
         | None => Ok()
-        | Some(_) => await FileTracker.assertEditSafe(resolved.resolvedPath)
+        | Some(_) => await FileTracker.assertEditSafe(resolved.safePath)
         }
         switch guardResult {
         | Error(msg) => Tool.MCP.CallToolResult.makeError(msg)
@@ -87,7 +87,7 @@ let execute = async (ctx: Tool.serverExecutionContext, input: input): Tool.MCP.C
           await writeContent(resolved.resolvedPath, content, input.encoding)
           let stats = await Fs.Promises.stat(resolved.resolvedPath)
           FileTracker.recordWrite(
-            resolved.resolvedPath,
+            resolved.safePath,
             ~mtimeMs=Fs.mtimeMs(stats),
             ~size=Fs.size(stats),
           )

--- a/libs/frontman-core/test/FrontmanCore__FileTracker.test.res
+++ b/libs/frontman-core/test/FrontmanCore__FileTracker.test.res
@@ -2,6 +2,10 @@ open Vitest
 
 module FileTracker = FrontmanCore__FileTracker
 module Fs = FrontmanBindings.Fs
+module SafePath = FrontmanCore__SafePath
+
+let _safePath = (path: string): SafePath.t =>
+  SafePath.resolve(~sourceRoot="/", ~inputPath=path)->Result.getOrThrow
 
 let _makeTempFile = async (content: string): string => {
   let dir = FrontmanBindings.Os.tmpdir()
@@ -100,7 +104,7 @@ describe("mergeRanges", _t => {
 
 describe("recordRead and assertReadBefore", _t => {
   test("unread file fails assertReadBefore", t => {
-    let result = FileTracker.assertReadBefore("/path/to/file.ts")
+    let result = FileTracker.assertReadBefore(_safePath("/path/to/file.ts"))
     t->expect(Result.isError(result))->Expect.toBe(true)
   })
 
@@ -109,8 +113,15 @@ describe("recordRead and assertReadBefore", _t => {
       "content",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=1, ~mtimeMs, ~size)
-        let result = FileTracker.assertReadBefore(path)
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.assertReadBefore(_safePath(path))
         t->expect(Result.isOk(result))->Expect.toBe(true)
       },
     )
@@ -121,8 +132,15 @@ describe("recordRead and assertReadBefore", _t => {
       "content",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=1, ~mtimeMs, ~size)
-        let result = FileTracker.assertReadBefore("/path/to/other.ts")
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.assertReadBefore(_safePath("/path/to/other.ts"))
         t->expect(Result.isError(result))->Expect.toBe(true)
       },
     )
@@ -135,8 +153,15 @@ describe("recordRead stores file stat", _t => {
       "hello\nworld\n",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=2, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=2,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.mtimeMs)->Expect.toBe(mtimeMs)
       },
     )
@@ -147,8 +172,15 @@ describe("recordRead stores file stat", _t => {
       "hello\nworld\n",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=2, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=2,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.size)->Expect.toBe(size)
       },
     )
@@ -160,26 +192,26 @@ describe("recordRead stores file stat", _t => {
       async path => {
         let (mtimeMs1, size1) = await _statFile(path)
         FileTracker.recordRead(
-          path,
+          _safePath(path),
           ~offset=0,
           ~limit=1,
           ~totalLines=2,
           ~mtimeMs=mtimeMs1,
           ~size=size1,
         )
-        let mtime1 = (FileTracker.get(path)->Option.getOrThrow).mtimeMs
+        let mtime1 = (FileTracker.get(_safePath(path))->Option.getOrThrow).mtimeMs
 
         await Fs.Promises.writeFile(path, "line1\nline2\nline3\n")
         let (mtimeMs2, size2) = await _statFile(path)
         FileTracker.recordRead(
-          path,
+          _safePath(path),
           ~offset=0,
           ~limit=3,
           ~totalLines=3,
           ~mtimeMs=mtimeMs2,
           ~size=size2,
         )
-        let mtime2 = (FileTracker.get(path)->Option.getOrThrow).mtimeMs
+        let mtime2 = (FileTracker.get(_safePath(path))->Option.getOrThrow).mtimeMs
         t->expect(mtime2 >= mtime1)->Expect.toBe(true)
       },
     )
@@ -192,8 +224,15 @@ describe("recordRead range tracking", _t => {
       _lines(1000),
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=1000, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 500}])
         t->expect(record.totalLines)->Expect.toBe(1000)
       },
@@ -205,8 +244,15 @@ describe("recordRead range tracking", _t => {
       _lines(200),
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=200, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=200,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 200}])
       },
     )
@@ -217,9 +263,23 @@ describe("recordRead range tracking", _t => {
       _lines(1000),
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=1000, ~mtimeMs, ~size)
-        FileTracker.recordRead(path, ~offset=400, ~limit=500, ~totalLines=1000, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=400,
+          ~limit=500,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 900}])
       },
     )
@@ -230,9 +290,23 @@ describe("recordRead range tracking", _t => {
       _lines(1000),
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
-        FileTracker.recordRead(path, ~offset=500, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=500,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 100}, {start: 500, end_: 600}])
       },
     )
@@ -243,11 +317,25 @@ describe("recordRead range tracking", _t => {
       _lines(1000),
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
-        let firstReadAt = (FileTracker.get(path)->Option.getOrThrow).readAt
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        let firstReadAt = (FileTracker.get(_safePath(path))->Option.getOrThrow).readAt
 
-        FileTracker.recordRead(path, ~offset=100, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
-        let secondReadAt = (FileTracker.get(path)->Option.getOrThrow).readAt
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=100,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        let secondReadAt = (FileTracker.get(_safePath(path))->Option.getOrThrow).readAt
         t->expect(secondReadAt >= firstReadAt)->Expect.toBe(true)
       },
     )
@@ -283,7 +371,11 @@ describe("isLineCovered", _t => {
 
 describe("checkCoverage", _t => {
   test("returns None for untracked file", t => {
-    let result = FileTracker.checkCoverage("/unknown.ts", ~content="hello", ~oldText="hello")
+    let result = FileTracker.checkCoverage(
+      _safePath("/unknown.ts"),
+      ~content="hello",
+      ~oldText="hello",
+    )
     t->expect(result)->Expect.toEqual(None)
   })
 
@@ -293,8 +385,15 @@ describe("checkCoverage", _t => {
       content,
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=100, ~mtimeMs, ~size)
-        let result = FileTracker.checkCoverage(path, ~content, ~oldText="line")
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=100,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.checkCoverage(_safePath(path), ~content, ~oldText="line")
         t->expect(result)->Expect.toEqual(None)
       },
     )
@@ -306,8 +405,15 @@ describe("checkCoverage", _t => {
       content,
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=500, ~mtimeMs, ~size)
-        let result = FileTracker.checkCoverage(path, ~content, ~oldText="target line")
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=500,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.checkCoverage(_safePath(path), ~content, ~oldText="target line")
         t->expect(result)->Expect.toEqual(None)
       },
     )
@@ -319,8 +425,15 @@ describe("checkCoverage", _t => {
       content,
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=500, ~mtimeMs, ~size)
-        let result = FileTracker.checkCoverage(path, ~content, ~oldText="target line")
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=500,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.checkCoverage(_safePath(path), ~content, ~oldText="target line")
         t->expect(Option.isSome(result))->Expect.toBe(true)
         let warning = result->Option.getOrThrow
         t->expect(warning->String.includes("line 300"))->Expect.toBe(true)
@@ -335,8 +448,19 @@ describe("checkCoverage", _t => {
       content,
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=500, ~mtimeMs, ~size)
-        let result = FileTracker.checkCoverage(path, ~content, ~oldText="nonexistent text")
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=500,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = FileTracker.checkCoverage(
+          _safePath(path),
+          ~content,
+          ~oldText="nonexistent text",
+        )
         t->expect(result)->Expect.toEqual(None)
       },
     )
@@ -349,8 +473,15 @@ describe("assertNotStale checks mtime and size", _t => {
       "unchanged content",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1, ~mtimeMs, ~size)
-        let result = await FileTracker.assertNotStale(path)
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
+        let result = await FileTracker.assertNotStale(_safePath(path))
         t->expect(Result.isOk(result))->Expect.toBe(true)
       },
     )
@@ -361,9 +492,16 @@ describe("assertNotStale checks mtime and size", _t => {
       "original",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1, ~mtimeMs, ~size)
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
         await Fs.Promises.writeFile(path, "modified content that is different")
-        let result = await FileTracker.assertNotStale(path)
+        let result = await FileTracker.assertNotStale(_safePath(path))
         t->expect(Result.isError(result))->Expect.toBe(true)
       },
     )
@@ -372,9 +510,9 @@ describe("assertNotStale checks mtime and size", _t => {
   testAsync("fails when file deleted from disk", async t => {
     let path = await _makeTempFile("will be deleted")
     let (mtimeMs, size) = await _statFile(path)
-    FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1, ~mtimeMs, ~size)
+    FileTracker.recordRead(_safePath(path), ~offset=0, ~limit=100, ~totalLines=1, ~mtimeMs, ~size)
     await _removeTempFile(path)
-    let result = await FileTracker.assertNotStale(path)
+    let result = await FileTracker.assertNotStale(_safePath(path))
     t->expect(Result.isError(result))->Expect.toBe(true)
     switch result {
     | Error(msg) => t->expect(msg->String.includes("no longer accessible"))->Expect.toBe(true)
@@ -390,7 +528,7 @@ describe("clear", _t => {
     let (mtimeA, sizeA) = await _statFile(pathA)
     let (mtimeB, sizeB) = await _statFile(pathB)
     FileTracker.recordRead(
-      pathA,
+      _safePath(pathA),
       ~offset=0,
       ~limit=100,
       ~totalLines=1,
@@ -398,7 +536,7 @@ describe("clear", _t => {
       ~size=sizeA,
     )
     FileTracker.recordRead(
-      pathB,
+      _safePath(pathB),
       ~offset=0,
       ~limit=100,
       ~totalLines=1,
@@ -406,8 +544,8 @@ describe("clear", _t => {
       ~size=sizeB,
     )
     FileTracker.clear()
-    t->expect(Result.isError(FileTracker.assertReadBefore(pathA)))->Expect.toBe(true)
-    t->expect(Result.isError(FileTracker.assertReadBefore(pathB)))->Expect.toBe(true)
+    t->expect(Result.isError(FileTracker.assertReadBefore(_safePath(pathA))))->Expect.toBe(true)
+    t->expect(Result.isError(FileTracker.assertReadBefore(_safePath(pathB))))->Expect.toBe(true)
     await _removeTempFile(pathA)
     await _removeTempFile(pathB)
   })
@@ -419,11 +557,18 @@ describe("recordWrite", _t => {
       "content",
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=500, ~totalLines=1, ~mtimeMs, ~size)
-        let readAtBefore = (FileTracker.get(path)->Option.getOrThrow).readAt
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=500,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
+        let readAtBefore = (FileTracker.get(_safePath(path))->Option.getOrThrow).readAt
 
-        FileTracker.recordWrite(path, ~mtimeMs, ~size)
-        let readAtAfter = (FileTracker.get(path)->Option.getOrThrow).readAt
+        FileTracker.recordWrite(_safePath(path), ~mtimeMs, ~size)
+        let readAtAfter = (FileTracker.get(_safePath(path))->Option.getOrThrow).readAt
         t->expect(readAtAfter >= readAtBefore)->Expect.toBe(true)
       },
     )
@@ -435,17 +580,24 @@ describe("recordWrite", _t => {
       content,
       async path => {
         let (mtimeMs, size) = await _statFile(path)
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=500, ~mtimeMs, ~size)
-        FileTracker.recordWrite(path, ~mtimeMs, ~size)
-        let record = FileTracker.get(path)->Option.getOrThrow
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=500,
+          ~mtimeMs,
+          ~size,
+        )
+        FileTracker.recordWrite(_safePath(path), ~mtimeMs, ~size)
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 100}])
       },
     )
   })
 
   test("no-op for untracked file", t => {
-    FileTracker.recordWrite("/untracked.ts", ~mtimeMs=0.0, ~size=0.0)
-    t->expect(FileTracker.get("/untracked.ts"))->Expect.toEqual(None)
+    FileTracker.recordWrite(_safePath("/untracked.ts"), ~mtimeMs=0.0, ~size=0.0)
+    t->expect(FileTracker.get(_safePath("/untracked.ts")))->Expect.toEqual(None)
   })
 })
 
@@ -456,20 +608,20 @@ describe("recordWrite re-stats file", _t => {
       async path => {
         let (mtimeMs1, size1) = await _statFile(path)
         FileTracker.recordRead(
-          path,
+          _safePath(path),
           ~offset=0,
           ~limit=100,
           ~totalLines=1,
           ~mtimeMs=mtimeMs1,
           ~size=size1,
         )
-        let mtimeBefore = (FileTracker.get(path)->Option.getOrThrow).mtimeMs
+        let mtimeBefore = (FileTracker.get(_safePath(path))->Option.getOrThrow).mtimeMs
 
         await Fs.Promises.writeFile(path, "updated content")
         let (mtimeMs2, size2) = await _statFile(path)
-        FileTracker.recordWrite(path, ~mtimeMs=mtimeMs2, ~size=size2)
+        FileTracker.recordWrite(_safePath(path), ~mtimeMs=mtimeMs2, ~size=size2)
 
-        let mtimeAfter = (FileTracker.get(path)->Option.getOrThrow).mtimeMs
+        let mtimeAfter = (FileTracker.get(_safePath(path))->Option.getOrThrow).mtimeMs
         t->expect(mtimeAfter >= mtimeBefore)->Expect.toBe(true)
       },
     )
@@ -481,20 +633,20 @@ describe("recordWrite re-stats file", _t => {
       async path => {
         let (mtimeMs1, size1) = await _statFile(path)
         FileTracker.recordRead(
-          path,
+          _safePath(path),
           ~offset=0,
           ~limit=100,
           ~totalLines=1,
           ~mtimeMs=mtimeMs1,
           ~size=size1,
         )
-        let sizeBefore = (FileTracker.get(path)->Option.getOrThrow).size
+        let sizeBefore = (FileTracker.get(_safePath(path))->Option.getOrThrow).size
 
         await Fs.Promises.writeFile(path, "this is much longer content than before")
         let (mtimeMs2, size2) = await _statFile(path)
-        FileTracker.recordWrite(path, ~mtimeMs=mtimeMs2, ~size=size2)
+        FileTracker.recordWrite(_safePath(path), ~mtimeMs=mtimeMs2, ~size=size2)
 
-        let sizeAfter = (FileTracker.get(path)->Option.getOrThrow).size
+        let sizeAfter = (FileTracker.get(_safePath(path))->Option.getOrThrow).size
         t->expect(sizeAfter > sizeBefore)->Expect.toBe(true)
       },
     )
@@ -506,7 +658,7 @@ describe("recordWrite re-stats file", _t => {
       async path => {
         let (mtimeMs1, size1) = await _statFile(path)
         FileTracker.recordRead(
-          path,
+          _safePath(path),
           ~offset=0,
           ~limit=100,
           ~totalLines=1,
@@ -516,9 +668,9 @@ describe("recordWrite re-stats file", _t => {
 
         await Fs.Promises.writeFile(path, "v2")
         let (mtimeMs2, size2) = await _statFile(path)
-        FileTracker.recordWrite(path, ~mtimeMs=mtimeMs2, ~size=size2)
+        FileTracker.recordWrite(_safePath(path), ~mtimeMs=mtimeMs2, ~size=size2)
 
-        let result = await FileTracker.assertNotStale(path)
+        let result = await FileTracker.assertNotStale(_safePath(path))
         t->expect(Result.isOk(result))->Expect.toBe(true)
       },
     )
@@ -534,9 +686,16 @@ describe("TOCTOU regression", _t => {
 
         await Fs.Promises.writeFile(path, "externally modified content that differs")
 
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1, ~mtimeMs, ~size)
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1,
+          ~mtimeMs,
+          ~size,
+        )
 
-        let result = await FileTracker.assertNotStale(path)
+        let result = await FileTracker.assertNotStale(_safePath(path))
         t->expect(Result.isError(result))->Expect.toBe(true)
       },
     )
@@ -550,10 +709,24 @@ describe("concurrent recordRead range preservation", _t => {
       async path => {
         let (mtimeMs, size) = await _statFile(path)
 
-        FileTracker.recordRead(path, ~offset=0, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
-        FileTracker.recordRead(path, ~offset=500, ~limit=100, ~totalLines=1000, ~mtimeMs, ~size)
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=0,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
+        FileTracker.recordRead(
+          _safePath(path),
+          ~offset=500,
+          ~limit=100,
+          ~totalLines=1000,
+          ~mtimeMs,
+          ~size,
+        )
 
-        let record = FileTracker.get(path)->Option.getOrThrow
+        let record = FileTracker.get(_safePath(path))->Option.getOrThrow
         t->expect(record.ranges)->Expect.toEqual([{start: 0, end_: 100}, {start: 500, end_: 600}])
       },
     )

--- a/libs/frontman-core/test/FrontmanCore__PathContext.test.res
+++ b/libs/frontman-core/test/FrontmanCore__PathContext.test.res
@@ -1,0 +1,40 @@
+open Vitest
+
+module Path = FrontmanBindings.Path
+module PathContext = FrontmanCore__PathContext
+
+describe("toRelativePath", () => {
+  test("uses platform path relative calculation", t => {
+    let sourceRoot = Path.resolve("/project")
+    let absolutePath = Path.join([sourceRoot, "src", "App.tsx"])
+
+    t
+    ->expect(PathContext.toRelativePath(~sourceRoot, ~absolutePath))
+    ->Expect.toBe(Path.join(["src", "App.tsx"]))
+  })
+
+  test("returns empty path for source root itself", t => {
+    let sourceRoot = Path.resolve("/project")
+
+    t->expect(PathContext.toRelativePath(~sourceRoot, ~absolutePath=sourceRoot))->Expect.toBe("")
+  })
+})
+
+describe("resolveSearchPath", () => {
+  test("rejects absolute paths outside sourceRoot", t => {
+    switch PathContext.resolveSearchPath(~sourceRoot="/project", ~inputPath=Some("/etc/passwd")) {
+    | Ok(_) => t->expect("should have failed")->Expect.toBe("")
+    | Error(err) =>
+      t
+      ->expect(err.message->String.includes("Absolute path must be under source root"))
+      ->Expect.toBe(true)
+    }
+  })
+
+  test("defaults to resolved sourceRoot", t => {
+    switch PathContext.resolveSearchPath(~sourceRoot=".", ~inputPath=None) {
+    | Ok(path) => t->expect(path)->Expect.toBe(Path.resolve("."))
+    | Error(err) => t->expect(err.message)->Expect.toBe("should not fail")
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a Node path.relative binding and use it for PathContext relative paths
- reject out-of-root grep/search paths instead of falling back to sourceRoot
- route file_exists through PathContext
- require SafePath.t for FileTracker operations

Refs #444

## Test
- make -C libs/frontman-core test