### PR TITLE
Fix path recovery for relative source roots

### DIFF
--- a/.changeset/fix-relative-path-recovery.md
+++ b/.changeset/fix-relative-path-recovery.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-core": patch
+---
+
+Keep path recovery scoped when source roots are relative.

--- a/libs/frontman-core/src/FrontmanCore__PathRecovery.res
+++ b/libs/frontman-core/src/FrontmanCore__PathRecovery.res
@@ -9,7 +9,7 @@ type recovery = {
   siblingEntries: array<string>,
 }
 
-let normalize = (path: string): string => Path.normalize(path)
+let normalize = (path: string): string => Path.resolve(path)
 
 let isUnderSourceRoot = (~candidate: string, ~sourceRoot: string): bool => {
   switch sourceRoot {

--- a/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__PathGuardrails.test.res
@@ -190,6 +190,27 @@ describe("Tool path guardrails", _t => {
     await cleanup(dir)
   })
 
+  testAsync(
+    "nearestExistingDir keeps relative roots comparable to absolute start paths",
+    async t => {
+      let relativeDir = ".tmp-path-recovery-" ++ Float.toString(Date.now())
+      await writeFile(relativeDir, "src/components/Button.res", "let button = () => ()")
+
+      let expected = Path.resolve(Path.join([relativeDir, "src", "components"]))
+      let actual = await PathRecovery.nearestExistingDir(
+        ~sourceRoot=relativeDir,
+        ~startPath=expected,
+      )
+
+      switch actual {
+      | Some(path) => t->expect(path)->Expect.toBe(expected)
+      | None => failwith("Expected nearest existing directory")
+      }
+
+      await cleanup(relativeDir)
+    },
+  )
+
   testAsync("regression replay: 3addabc6-like sequence avoids avoidable ENOENTs", async t => {
     ToolPathHints.clear()
     let dir = await makeFixture()


### PR DESCRIPTION
## Summary\n- Resolve path recovery inputs before containment checks\n- Add regression coverage for relative source roots with absolute search paths\n- Add changeset for frontman-core\n\nFollow-up to #1620 after the PR merged before the Codex review fix landed.\n\n## Tests\n- make -C libs/frontman-core test