### PR TITLE
Handle ACP timeout review cleanup

### DIFF
--- a/.changeset/clean-acp-timeout-review.md
+++ b/.changeset/clean-acp-timeout-review.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Handle ACP Phoenix push replies and clean up failed initialize connections after request timeouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add an `agent_feedback` backend tool that lets agents send Frontman product feedback and feature requests to Discord.
+
 ### Fixed
 
 - Fix hosted Google/GitHub sign-in redirects after the WorkOS v3 SDK upgrade and add automatic OAuth-start smoke coverage.

--- a/apps/frontman_server/config/config.exs
+++ b/apps/frontman_server/config/config.exs
@@ -17,9 +17,11 @@ config :frontman_server,
   ecto_repos: [FrontmanServer.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true],
   stream_stall_timeout_ms: 60_000,
-  llm_max_tokens: 64_000
+  llm_max_tokens: 64_000,
+  web_fetch_req_options: []
 
 config :frontman_server, :backend_tools, [
+  FrontmanServer.Tools.AgentFeedback,
   FrontmanServer.Tools.GetToolResult,
   FrontmanServer.Tools.TodoWrite,
   FrontmanServer.Tools.WebFetch
@@ -66,6 +68,7 @@ config :frontman_server, FrontmanServer.Agents,
 
       - Lead with what changed and why. Reference file paths — don't dump full file contents.
       - After edits, summarize: what changed, why, trade-offs, alternatives. For UI changes, suggest visual verification. Never complete silently.
+      - If you complete a task and notice missing Frontman capabilities, or if you are stuck/fail because a tool, context source, or workflow is missing or broken, call `agent_feedback` before your final response.
       - Reference files as `src/app.ts:42`. Use numbered lists for multiple options.
 
       ## Code Quality
@@ -154,8 +157,20 @@ config :frontman_server, FrontmanServer.Mailer,
   segment_id: "5786d8bb-df16-413c-a06d-64d1a579cc2f"
 
 config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: false
-config :frontman_server, FrontmanServer.Workers.SyncResendContact, enabled: false
-config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser, enabled: false
+
+config :frontman_server, FrontmanServer.Workers.SyncResendContact,
+  enabled: false,
+  req_options: []
+
+config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser,
+  enabled: false,
+  webhook_url: nil,
+  req_options: []
+
+config :frontman_server, FrontmanServer.Workers.SendAgentFeedbackToDiscord,
+  enabled: false,
+  webhook_url: nil,
+  req_options: []
 
 config :frontman_server, Oban,
   repo: FrontmanServer.Repo,

--- a/apps/frontman_server/config/prod.exs
+++ b/apps/frontman_server/config/prod.exs
@@ -8,3 +8,12 @@ config :swoosh, api_client: Swoosh.ApiClient.Req
 config :swoosh, local: false
 
 config :logger, level: :info
+
+config :sentry,
+  dsn:
+    "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296",
+  environment_name: :prod,
+  release: "frontman_server@#{Mix.Project.config()[:version]}",
+  enable_source_code_context: true,
+  root_source_code_paths: [File.cwd!()],
+  tags: %{service: "frontman-server"}

--- a/apps/frontman_server/config/runtime.exs
+++ b/apps/frontman_server/config/runtime.exs
@@ -32,16 +32,9 @@ strict_boolean! = fn env_var_name, raw_value ->
 end
 
 env_boolean = fn env_var_name, default_value ->
-  case env!(env_var_name, :string, :frontman_env_boolean_missing) do
-    :frontman_env_boolean_missing ->
-      default_value
-
-    raw_value ->
-      if String.trim(raw_value) == "" do
-        default_value
-      else
-        strict_boolean!.(env_var_name, raw_value)
-      end
+  case env!(env_var_name, :string?, nil) do
+    nil -> default_value
+    raw_value -> strict_boolean!.(env_var_name, raw_value)
   end
 end
 
@@ -60,7 +53,7 @@ end
 if config_env() in [:dev, :test, :e2e] do
   db_host = env!("DB_HOST", :string, "localhost")
 
-  db_name = env!("DB_NAME", :string, nil)
+  db_name = env!("DB_NAME", :string?, nil)
 
   repo_overrides = []
 
@@ -84,38 +77,23 @@ if config_env() in [:dev, :test, :e2e] do
 end
 
 if config_env() == :prod do
-  discord_new_users_webhook_url = env!("DISCORD_NEW_USERS_WEBHOOK_URL", :string, nil)
-  resend_api_key = env!("RESEND_API_KEY", :string, nil)
+  discord_new_users_webhook_url = env!("DISCORD_NEW_USERS_WEBHOOK_URL", :string!)
+  discord_task_summaries_webhook_url = env!("DISCORD_TASK_SUMMARIES_WEBHOOK_URL", :string!)
+  resend_api_key = env!("RESEND_API_KEY", :string!)
 
-  discord_notifications_enabled =
-    is_binary(discord_new_users_webhook_url) and String.trim(discord_new_users_webhook_url) != ""
+  config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: true
 
-  resend_enabled = is_binary(resend_api_key) and String.trim(resend_api_key) != ""
-
-  config :frontman_server,
-    discord_new_users_webhook_url: discord_new_users_webhook_url
-
-  config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: resend_enabled
-  config :frontman_server, FrontmanServer.Workers.SyncResendContact, enabled: resend_enabled
+  config :frontman_server, FrontmanServer.Workers.SyncResendContact, enabled: true
 
   config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser,
-    enabled: discord_notifications_enabled
+    enabled: true,
+    webhook_url: discord_new_users_webhook_url
 
-  config :sentry,
-    dsn:
-      "https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296",
-    environment_name: config_env(),
-    release: "frontman_server@#{Application.spec(:frontman_server, :vsn) || "no_vsn"}",
-    enable_source_code_context: true,
-    root_source_code_paths: [File.cwd!()],
-    tags: %{service: "frontman-server"}
+  config :frontman_server, FrontmanServer.Workers.SendAgentFeedbackToDiscord,
+    enabled: true,
+    webhook_url: discord_task_summaries_webhook_url
 
-  database_url =
-    System.get_env("DATABASE_URL") ||
-      raise """
-      environment variable DATABASE_URL is missing.
-      For example: ecto://USER:PASS@HOST/DATABASE
-      """
+  database_url = env!("DATABASE_URL", :string!)
 
   maybe_ipv6 = if env_boolean.("ECTO_IPV6", false), do: [:inet6], else: []
 
@@ -130,25 +108,19 @@ if config_env() == :prod do
 
   config :frontman_server, FrontmanServer.Repo, [
     {:url, database_url},
-    {:pool_size, String.to_integer(System.get_env("POOL_SIZE") || "10")},
+    {:pool_size, env!("POOL_SIZE", :integer, 10)},
     {:socket_options, maybe_ipv6}
     | ssl_config
   ]
 
-  secret_key_base =
-    System.get_env("SECRET_KEY_BASE") ||
-      raise """
-      environment variable SECRET_KEY_BASE is missing.
-      You can generate one by calling: mix phx.gen.secret
-      """
+  secret_key_base = env!("SECRET_KEY_BASE", :string!)
 
-  host = System.get_env("PHX_HOST") || "example.com"
-  port = String.to_integer(System.get_env("PORT") || "4000")
+  host = env!("PHX_HOST", :string, "example.com")
+  port = env!("PORT", :integer, 4000)
 
-  http_shutdown_timeout_ms =
-    String.to_integer(System.get_env("HTTP_SHUTDOWN_TIMEOUT_MS") || "30000")
+  http_shutdown_timeout_ms = env!("HTTP_SHUTDOWN_TIMEOUT_MS", :integer, 30_000)
 
-  config :frontman_server, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
+  config :frontman_server, :dns_cluster_query, env!("DNS_CLUSTER_QUERY", :string?, nil)
 
   check_origin = ["https://#{host}", "https://*.#{host}"]
 
@@ -162,9 +134,7 @@ if config_env() == :prod do
     check_origin: check_origin,
     secret_key_base: secret_key_base
 
-  if resend_enabled do
-    config :frontman_server, FrontmanServer.Mailer,
-      adapter: Swoosh.Adapters.Resend,
-      api_key: resend_api_key
-  end
+  config :frontman_server, FrontmanServer.Mailer,
+    adapter: Swoosh.Adapters.Resend,
+    api_key: resend_api_key
 end

--- a/apps/frontman_server/config/test.exs
+++ b/apps/frontman_server/config/test.exs
@@ -26,11 +26,21 @@ config :workos, WorkOS.Client,
 
 config :frontman_server, Oban, testing: :manual
 
-config :frontman_server, discord_new_users_webhook_url: "https://discord.test/webhook"
-
 config :frontman_server, FrontmanServer.Workers.SendWelcomeEmail, enabled: true
-config :frontman_server, FrontmanServer.Workers.SyncResendContact, enabled: true
-config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser, enabled: true
+
+config :frontman_server, FrontmanServer.Workers.SyncResendContact,
+  enabled: true,
+  req_options: []
+
+config :frontman_server, FrontmanServer.Workers.NotifyDiscordNewUser,
+  enabled: true,
+  webhook_url: "https://discord.test/webhook",
+  req_options: []
+
+config :frontman_server, FrontmanServer.Workers.SendAgentFeedbackToDiscord,
+  enabled: true,
+  webhook_url: "https://discord.test/agent-feedback",
+  req_options: []
 
 config :swoosh, :api_client, false
 

--- a/apps/frontman_server/lib/frontman_server.ex
+++ b/apps/frontman_server/lib/frontman_server.ex
@@ -35,6 +35,7 @@ defmodule FrontmanServer do
     Observability.SentryContext,
     Workers.GenerateTitle,
     Workers.NotifyDiscordNewUser,
+    Workers.SendAgentFeedbackToDiscord,
     Workers.SendWelcomeEmail,
     Workers.SyncResendContact
   ]

--- a/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
@@ -1,0 +1,100 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Tools.AgentFeedback do
+  @moduledoc """
+  Lets agents send product feedback and feature requests to the Frontman team.
+  """
+
+  @behaviour FrontmanServer.Tools.Backend
+
+  alias FrontmanServer.Tools.Backend.Context
+  alias FrontmanServer.Workers.SendAgentFeedbackToDiscord
+  alias ModelContextProtocol, as: MCP
+
+  @outcomes ~w(completed stuck failed feature_request)
+
+  @impl true
+  def name, do: "agent_feedback"
+
+  @impl true
+  def description do
+    """
+    Send feedback to the Frontman team.
+
+    Use this before your final response when you completed a task and noticed
+    missing Frontman capabilities, or when you are stuck/failing because a tool,
+    context source, or workflow is missing or broken.
+    """
+  end
+
+  @impl true
+  def access, do: :write
+
+  @impl true
+  def parameter_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "outcome" => %{
+          "type" => "string",
+          "enum" => @outcomes,
+          "description" => "Task outcome: completed, stuck, failed, or feature_request."
+        },
+        "message" => %{
+          "type" => "string",
+          "description" =>
+            "What happened, what was missing, or what Frontman feature would help.",
+          "maxLength" => 2000
+        }
+      },
+      "required" => ["outcome", "message"]
+    }
+  end
+
+  @impl true
+  def timeout_ms, do: 30_000
+
+  @impl true
+  def on_timeout, do: :error
+
+  @impl true
+  def execute(args, %Context{task: task}) do
+    with {:ok, outcome} <- validate_outcome(args["outcome"]),
+         {:ok, message} <- validate_required_string(args["message"], "message") do
+      %{
+        task_id: task.id,
+        framework: Atom.to_string(task.framework),
+        task_title: task.short_desc,
+        outcome: outcome,
+        message: message
+      }
+      |> SendAgentFeedbackToDiscord.new()
+      |> Oban.insert()
+      |> case do
+        {:ok, _job} -> MCP.tool_result_text("Feedback sent")
+        {:error, reason} -> MCP.tool_result_error("Failed to send feedback: #{inspect(reason)}")
+      end
+    else
+      {:error, reason} -> MCP.tool_result_error(reason)
+    end
+  end
+
+  defp validate_outcome(outcome) when outcome in @outcomes, do: {:ok, outcome}
+
+  defp validate_outcome(_outcome),
+    do: {:error, "outcome must be one of: #{Enum.join(@outcomes, ", ")}"}
+
+  defp validate_required_string(value, _field) when is_binary(value) do
+    case byte_size(value) > 0 do
+      true -> {:ok, value}
+      false -> {:error, "message must be a non-empty string"}
+    end
+  end
+
+  defp validate_required_string(_value, field),
+    do: {:error, "#{field} must be a non-empty string"}
+end

--- a/apps/frontman_server/lib/frontman_server/workers/notify_discord_new_user.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/notify_discord_new_user.ex
@@ -41,12 +41,16 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
   end
 
   defp enabled? do
-    Application.get_env(:frontman_server, __MODULE__)[:enabled] == true
+    config()[:enabled] == true
   end
 
   defp post_to_discord(user, framework) do
-    webhook_url = Application.fetch_env!(:frontman_server, :discord_new_users_webhook_url)
+    with {:ok, webhook_url} <- webhook_url() do
+      post_to_discord(webhook_url, user, framework)
+    end
+  end
 
+  defp post_to_discord(webhook_url, user, framework) when is_binary(webhook_url) do
     body = %{
       embeds: [
         %{
@@ -77,8 +81,19 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUser do
     end
   end
 
+  defp webhook_url do
+    case config()[:webhook_url] do
+      webhook_url when is_binary(webhook_url) -> {:ok, webhook_url}
+      _missing -> {:error, "Discord new-user webhook URL is not configured"}
+    end
+  end
+
   defp req_options do
-    Application.get_env(:frontman_server, :notify_discord_req_options, [])
+    config()[:req_options] || []
+  end
+
+  defp config do
+    Application.get_env(:frontman_server, __MODULE__, [])
   end
 
   defp framework_display_name(nil), do: "—"

--- a/apps/frontman_server/lib/frontman_server/workers/send_agent_feedback_to_discord.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/send_agent_feedback_to_discord.ex
@@ -1,0 +1,101 @@
+# Frontman Server
+# Copyright (C) 2025 Frontman AI
+#
+# Licensed under the AGPL-3.0 — see LICENSE for details.
+# Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
+
+defmodule FrontmanServer.Workers.SendAgentFeedbackToDiscord do
+  @moduledoc """
+  Oban worker that posts agent feedback to a Discord webhook.
+  """
+
+  use Oban.Worker,
+    queue: :notifications,
+    max_attempts: 3
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    case enabled?() do
+      true -> post_to_discord(args)
+      false -> Logger.info("[Discord] Agent feedback worker disabled, skipping notification")
+    end
+  end
+
+  defp enabled? do
+    config()[:enabled] == true
+  end
+
+  defp post_to_discord(args) when is_map(args) do
+    with {:ok, webhook_url} <- webhook_url() do
+      post_to_discord(webhook_url, args)
+    end
+  end
+
+  defp post_to_discord(webhook_url, args) when is_binary(webhook_url) and is_map(args) do
+    body = %{
+      embeds: [
+        %{
+          title: "Agent Feedback",
+          color: color(args["outcome"]),
+          fields: fields(args),
+          timestamp: DateTime.utc_now() |> DateTime.to_iso8601()
+        }
+      ]
+    }
+
+    case Req.post(webhook_url, [json: body] ++ req_options()) do
+      {:ok, %Req.Response{status: status}} when status in 200..299 ->
+        Logger.info("[Discord] Posted agent feedback for task #{args["task_id"]}")
+        :ok
+
+      {:ok, %Req.Response{status: status, body: resp_body}} ->
+        Logger.warning(
+          "[Discord] Agent feedback webhook returned #{status}: #{inspect(resp_body)}"
+        )
+
+        {:error, "Discord webhook returned #{status}"}
+
+      {:error, reason} ->
+        Logger.error("[Discord] Agent feedback webhook request failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp webhook_url do
+    case config()[:webhook_url] do
+      webhook_url when is_binary(webhook_url) -> {:ok, webhook_url}
+      _missing -> {:error, "Discord agent feedback webhook URL is not configured"}
+    end
+  end
+
+  defp req_options do
+    config()[:req_options] || []
+  end
+
+  defp config do
+    Application.get_env(:frontman_server, __MODULE__, [])
+  end
+
+  defp fields(args) do
+    [
+      %{name: "Outcome", value: value(args["outcome"]), inline: true},
+      %{name: "Framework", value: value(args["framework"]), inline: true},
+      %{name: "Task", value: value(args["task_title"]), inline: false},
+      %{name: "Message", value: value(args["message"]), inline: false},
+      %{name: "Task ID", value: value(args["task_id"]), inline: false}
+    ]
+  end
+
+  defp value(nil), do: "—"
+  defp value(""), do: "—"
+  defp value(value) when is_binary(value), do: String.slice(value, 0, 1000)
+  defp value(value), do: value |> inspect() |> String.slice(0, 1000)
+
+  defp color("completed"), do: 0x57F287
+  defp color("stuck"), do: 0xFEE75C
+  defp color("failed"), do: 0xED4245
+  defp color("feature_request"), do: 0x5865F2
+  defp color(_outcome), do: 0x99AAB5
+end

--- a/apps/frontman_server/lib/frontman_server/workers/sync_resend_contact.ex
+++ b/apps/frontman_server/lib/frontman_server/workers/sync_resend_contact.ex
@@ -44,7 +44,7 @@ defmodule FrontmanServer.Workers.SyncResendContact do
   end
 
   defp enabled? do
-    Application.get_env(:frontman_server, __MODULE__)[:enabled] == true
+    config()[:enabled] == true
   end
 
   defp post_contact(%User{email: email, name: name}) do
@@ -74,7 +74,11 @@ defmodule FrontmanServer.Workers.SyncResendContact do
   end
 
   defp req_options do
-    Application.get_env(:frontman_server, :sync_resend_contact_req_options, [])
+    config()[:req_options] || []
+  end
+
+  defp config do
+    Application.get_env(:frontman_server, __MODULE__, [])
   end
 
   defp first_name(nil), do: nil

--- a/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
@@ -1,0 +1,51 @@
+defmodule FrontmanServer.Tools.AgentFeedbackTest do
+  use FrontmanServer.DataCase, async: true
+  use Oban.Testing, repo: FrontmanServer.Repo
+
+  import FrontmanServer.Test.Fixtures.Accounts
+  import FrontmanServer.Test.Fixtures.Tasks
+
+  alias FrontmanServer.Tasks
+  alias FrontmanServer.Tools.AgentFeedback
+  alias FrontmanServer.Tools.Backend.Context
+  alias FrontmanServer.Workers.SendAgentFeedbackToDiscord
+  alias ModelContextProtocol, as: MCP
+
+  test "enqueues feedback for Discord" do
+    scope = user_scope_fixture()
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
+    {:ok, task} = Tasks.get_task(scope, task_id)
+
+    result =
+      AgentFeedback.execute(
+        %{
+          "outcome" => "feature_request",
+          "message" => "Need better route context. The route tool did not explain dynamic params."
+        },
+        %Context{task: task}
+      )
+
+    refute MCP.error?(result)
+
+    assert_enqueued(
+      worker: SendAgentFeedbackToDiscord,
+      args: %{
+        task_id: task.id,
+        framework: "nextjs",
+        task_title: task.short_desc,
+        outcome: "feature_request",
+        message: "Need better route context. The route tool did not explain dynamic params."
+      }
+    )
+  end
+
+  test "rejects invalid outcome" do
+    scope = user_scope_fixture()
+    task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
+    {:ok, task} = Tasks.get_task(scope, task_id)
+
+    result = AgentFeedback.execute(%{"outcome" => "bad", "message" => "x"}, %Context{task: task})
+
+    assert MCP.error?(result)
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -8,6 +8,7 @@ defmodule FrontmanServer.ToolsTest do
   alias FrontmanServer.Tasks.Interaction.ToolResult
   alias FrontmanServer.Tasks.InteractionSchema
   alias FrontmanServer.Tools
+  alias FrontmanServer.Tools.AgentFeedback
   alias FrontmanServer.Tools.Backend.Context
   alias FrontmanServer.Tools.GetToolResult
   alias FrontmanServer.Tools.TodoWrite
@@ -37,6 +38,7 @@ defmodule FrontmanServer.ToolsTest do
     test "tools expose expected access levels" do
       by_name = Map.new(Tools.backend_tools(), &{&1.name, &1.access})
 
+      assert by_name["agent_feedback"] == :write
       assert by_name["get_tool_result"] == :read
       assert by_name["web_fetch"] == :read
       assert by_name["todo_write"] == :write
@@ -46,6 +48,7 @@ defmodule FrontmanServer.ToolsTest do
   describe "find_tool/1" do
     test "finds registered tools" do
       for {tool_name, module} <- [
+            {"agent_feedback", AgentFeedback},
             {"todo_write", TodoWrite},
             {"get_tool_result", GetToolResult},
             {"web_fetch", WebFetch}

--- a/apps/frontman_server/test/frontman_server/workers/notify_discord_new_user_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/notify_discord_new_user_test.exs
@@ -6,12 +6,16 @@ defmodule FrontmanServer.Workers.NotifyDiscordNewUserTest do
   alias FrontmanServer.Workers.NotifyDiscordNewUser
 
   setup do
-    Application.put_env(:frontman_server, :notify_discord_req_options,
-      plug: {Req.Test, :discord_webhook}
+    original_config = Application.get_env(:frontman_server, NotifyDiscordNewUser, [])
+
+    Application.put_env(
+      :frontman_server,
+      NotifyDiscordNewUser,
+      Keyword.put(original_config, :req_options, plug: {Req.Test, :discord_webhook})
     )
 
     on_exit(fn ->
-      Application.delete_env(:frontman_server, :notify_discord_req_options)
+      Application.put_env(:frontman_server, NotifyDiscordNewUser, original_config)
     end)
 
     :ok

--- a/apps/frontman_server/test/frontman_server/workers/send_agent_feedback_to_discord_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/send_agent_feedback_to_discord_test.exs
@@ -1,0 +1,69 @@
+defmodule FrontmanServer.Workers.SendAgentFeedbackToDiscordTest do
+  use FrontmanServer.DataCase, async: true
+  use Oban.Testing, repo: FrontmanServer.Repo
+
+  alias FrontmanServer.Workers.SendAgentFeedbackToDiscord
+
+  setup do
+    original_config = Application.get_env(:frontman_server, SendAgentFeedbackToDiscord, [])
+
+    Application.put_env(
+      :frontman_server,
+      SendAgentFeedbackToDiscord,
+      Keyword.put(original_config, :req_options, plug: {Req.Test, :agent_feedback_webhook})
+    )
+
+    on_exit(fn ->
+      Application.put_env(:frontman_server, SendAgentFeedbackToDiscord, original_config)
+    end)
+
+    :ok
+  end
+
+  test "posts agent feedback embed to the configured Discord webhook" do
+    Req.Test.stub(:agent_feedback_webhook, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
+
+      [embed] = payload["embeds"]
+      assert embed["title"] == "Agent Feedback"
+      assert embed["color"] == 0xFEE75C
+
+      fields = Map.new(embed["fields"], &{&1["name"], &1["value"]})
+      assert fields["Outcome"] == "stuck"
+      assert fields["Framework"] == "nextjs"
+      assert fields["Task"] == "Fix checkout button"
+
+      assert fields["Message"] ==
+               "Could not inspect server actions. Missing server action context."
+
+      assert fields["Task ID"] == "task-1"
+
+      Req.Test.json(conn, %{ok: true})
+    end)
+
+    assert :ok =
+             perform_job(SendAgentFeedbackToDiscord, %{
+               task_id: "task-1",
+               framework: "nextjs",
+               task_title: "Fix checkout button",
+               outcome: "stuck",
+               message: "Could not inspect server actions. Missing server action context."
+             })
+  end
+
+  test "returns error tuple on non-2xx response" do
+    Req.Test.stub(:agent_feedback_webhook, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(429, Jason.encode!(%{"message" => "rate limited"}))
+    end)
+
+    assert {:error, _reason} =
+             perform_job(SendAgentFeedbackToDiscord, %{
+               task_id: "task-1",
+               outcome: "failed",
+               message: "Failed"
+             })
+  end
+end

--- a/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
+++ b/apps/frontman_server/test/frontman_server/workers/sync_resend_contact_test.exs
@@ -6,12 +6,16 @@ defmodule FrontmanServer.Workers.SyncResendContactTest do
   alias FrontmanServer.Workers.SyncResendContact
 
   setup do
-    Application.put_env(:frontman_server, :sync_resend_contact_req_options,
-      plug: {Req.Test, :resend}
+    original_config = Application.get_env(:frontman_server, SyncResendContact, [])
+
+    Application.put_env(
+      :frontman_server,
+      SyncResendContact,
+      Keyword.put(original_config, :req_options, plug: {Req.Test, :resend})
     )
 
     on_exit(fn ->
-      Application.delete_env(:frontman_server, :sync_resend_contact_req_options)
+      Application.put_env(:frontman_server, SyncResendContact, original_config)
     end)
 
     :ok

--- a/apps/marketing/src/components/scripts/LocalScripts.astro
+++ b/apps/marketing/src/components/scripts/LocalScripts.astro
@@ -2,7 +2,7 @@
 	function initNavigation() {
 		const menuItems = document.querySelectorAll('.header__menu-item')
 		menuItems.forEach((menuItem) => {
-			const submenu = menuItem.querySelector('.header__submenu')
+			const submenu = menuItem.querySelector('.header__submenu, .header__mega-menu')
 			const link = menuItem.querySelector('.header__menu-link')
 
 			if (submenu && link) {
@@ -28,7 +28,7 @@
 			const target = event.target
 
 			menuItems.forEach((menuItem) => {
-				const submenu = menuItem.querySelector('.header__submenu')
+				const submenu = menuItem.querySelector('.header__submenu, .header__mega-menu')
 				if (submenu && !menuItem.contains(target)) {
 					menuItem.classList.remove('open')
 					const link = menuItem.querySelector('.header__menu-link')
@@ -63,7 +63,7 @@
 					const isSubmenuParent =
 						window.matchMedia('(max-width: 1023px)').matches
 						&& link.classList.contains('header__menu-link')
-						&& parentMenuItem?.querySelector('.header__submenu')
+						&& parentMenuItem?.querySelector('.header__submenu, .header__mega-menu')
 
 					if (isSubmenuParent) return
 					closeMobileMenu()

--- a/apps/marketing/src/components/ui/NavigationBar.astro
+++ b/apps/marketing/src/components/ui/NavigationBar.astro
@@ -3,12 +3,11 @@
 import { Icon } from 'astro-icon/components'
 
 import { navigationBarData } from '../../config/navigationBar'
-const { logo, navItems } = navigationBarData
-const filteredNavItems = navItems.filter((item) => item.name !== 'Changelog' && item.name !== 'FAQ')
+const { logo, navItems, navActions } = navigationBarData
 
 const path = new URL(Astro.request.url).pathname
-function isActivePath(currentPath: string): boolean {
-	return path === currentPath || path === `${currentPath}/`
+function isActivePath(currentPath: string | undefined): boolean {
+	return currentPath !== undefined && (path === currentPath || path === `${currentPath}/`)
 }
 ---
 
@@ -35,16 +34,16 @@ function isActivePath(currentPath: string): boolean {
 
 			<ul class="header__menu">
 				{
-					filteredNavItems.map((item) => (
+					navItems.map((item) => (
 						<li class="header__menu-item">
-							{!item.submenu ? (
+							{!item.submenu && !item.megaMenu ? (
 								<a
 									href={item.link}
 									class={`header__menu-link ${isActivePath(item.link) ? 'active' : ''}`}
 								>
 									{item.name}
 								</a>
-							) : (
+							) : item.link ? (
 								<a
 									href={item.link}
 									aria-haspopup="true"
@@ -54,6 +53,11 @@ function isActivePath(currentPath: string): boolean {
 									{item.name}
 									<Icon name="chevron-down" class="header__menu-chevron" aria-hidden="true" />
 								</a>
+							) : (
+								<button type="button" aria-expanded="false" class="header__menu-link">
+									{item.name}
+									<Icon name="chevron-down" class="header__menu-chevron" aria-hidden="true" />
+								</button>
 							)}
 							{item.submenu && (
 								<ul class="header__submenu">
@@ -69,6 +73,28 @@ function isActivePath(currentPath: string): boolean {
 									))}
 								</ul>
 							)}
+							{item.megaMenu && (
+								<div class="header__mega-menu">
+									{item.megaMenu.columns.map((column) => (
+										<section class="header__mega-menu-column">
+											<h2 class="header__mega-menu-label">{column.label}</h2>
+											<ul class="header__mega-menu-list">
+												{column.items.map((subItem) => (
+													<li class="header__mega-menu-item">
+														<a
+															href={subItem.link}
+															class={`header__mega-menu-link ${isActivePath(subItem.link) ? 'active' : ''}`}
+														>
+															{subItem.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</section>
+									))}
+									<aside class="header__mega-menu-feature" aria-label="Featured content"></aside>
+								</div>
+							)}
 						</li>
 					))
 				}
@@ -78,7 +104,11 @@ function isActivePath(currentPath: string): boolean {
 				<a href="https://github.com/frontman-ai/frontman" target="_blank" rel="noopener noreferrer" class="header__github-link" aria-label="Frontman GitHub repository" data-ga-event="click_star_github" data-ga-category="conversion" data-ga-label="nav">
 					<Icon name="github-icon" class="header__github-icon" aria-hidden="true" />
 				</a>
-				<a href="/#install" class="header__cta">Try it now</a>
+				{navActions.map((action) => (
+					<a href={action.link} class="header__cta">
+						{action.name}
+					</a>
+				))}
 			</div>
 		</nav>
 	</div>
@@ -201,6 +231,49 @@ function isActivePath(currentPath: string): boolean {
 		box-shadow: 0 12px 32px -4px rgba(0, 0, 0, 0.5);
 		list-style: none;
 	}
+	.header__mega-menu {
+		display: none;
+		list-style: none;
+	}
+	.header__mega-menu-column {
+		min-width: 0;
+	}
+	.header__mega-menu-label {
+		margin: 0 0 12px;
+		color: rgb(255 255 255 / 0.45);
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 18px;
+	}
+	.header__mega-menu-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+	.header__mega-menu-item {
+		list-style: none;
+	}
+	.header__mega-menu-link {
+		display: flex;
+		align-items: center;
+		border-radius: 8px;
+		padding: 8px 10px;
+		color: rgb(255 255 255 / 0.7);
+		font-size: 14px;
+		font-weight: 400;
+		line-height: 20px;
+		text-decoration: none;
+	}
+	.header__mega-menu-link:hover,
+	.header__mega-menu-link.active {
+		color: white;
+		background: rgb(255 255 255 / 0.08);
+	}
+	.header__mega-menu-feature {
+		min-height: 100%;
+		border-left: 1px solid rgb(255 255 255 / 0.1);
+	}
+
 	@media (min-width: 1024px) {
 		.header__submenu::before {
 			content: '';
@@ -210,13 +283,30 @@ function isActivePath(currentPath: string): boolean {
 			right: 0;
 			height: 4px;
 		}
+		.header__mega-menu::before {
+			content: '';
+			position: absolute;
+			top: -16px;
+			left: 0;
+			right: 0;
+			height: 16px;
+		}
 	}
 	@media (max-width: 1023px) {
-		.header__menu-item:hover > .header__submenu {
+		.header__menu-item:hover > .header__submenu,
+		.header__menu-item:hover > .header__mega-menu {
 			display: none;
 		}
 		.header__menu-item.open > .header__submenu {
 			display: block;
+		}
+		.header__menu-item.open > .header__mega-menu {
+			display: grid;
+		gap: 24px;
+		padding: 12px 16px 0;
+		}
+		.header__mega-menu-feature {
+			display: none;
 		}
 		.header__menu-item.open > .header__menu-link .header__menu-chevron {
 			transform: rotate(180deg);
@@ -227,8 +317,25 @@ function isActivePath(currentPath: string): boolean {
 		.header__menu-item:focus-within > .header__submenu {
 			display: block;
 		}
-		.header__submenu {
-			transform: translateY(4px);
+		.header__menu-item:hover > .header__mega-menu,
+		.header__menu-item:focus-within > .header__mega-menu {
+			display: grid;
+		}
+		.header__mega-menu {
+			position: fixed;
+			top: 70px;
+			left: 50%;
+			grid-template-columns: repeat(3, minmax(140px, 1fr)) minmax(180px, 1.2fr);
+			gap: 20px;
+			width: min(1000px, calc(100vw - 48px));
+			padding: 24px;
+			transform: translateX(-50%);
+			background: rgba(20, 20, 20, 0.95);
+			backdrop-filter: blur(16px);
+			-webkit-backdrop-filter: blur(16px);
+			border: 1px solid rgba(255, 255, 255, 0.1);
+			border-radius: 12px;
+			box-shadow: 0 12px 32px -4px rgba(0, 0, 0, 0.5);
 		}
 	}
 

--- a/apps/marketing/src/config/navigationBar.ts
+++ b/apps/marketing/src/config/navigationBar.ts
@@ -9,10 +9,20 @@ export interface NavSubItem {
 	link: string
 }
 
+export interface NavMenuColumn {
+	label: string
+	items: NavSubItem[]
+}
+
+export interface NavMegaMenu {
+	columns: NavMenuColumn[]
+}
+
 export interface NavItem {
 	name: string
-	link: string
+	link?: string
 	submenu?: NavSubItem[]
+	megaMenu?: NavMegaMenu
 }
 
 export interface NavAction {
@@ -35,9 +45,30 @@ export const navigationBarData: NavData = {
 		text: 'Frontman'
 	},
 	navItems: [
-		{ name: 'WordPress', link: '/wordpress/' },
-		{ name: 'Marketing Teams', link: '/marketing-teams/' },
-		{ name: 'Docs', link: '/docs/' },
+		{
+			name: 'Product',
+			megaMenu: {
+				columns: [
+					{
+						label: 'Website builder',
+						items: [
+							{ name: 'WordPress', link: '/wordpress/' },
+							{ name: 'Next.js', link: '/docs/integrations/nextjs/' },
+							{ name: 'Astro', link: '/docs/integrations/astro/' },
+							{ name: 'Vite', link: '/docs/integrations/vite/' }
+						]
+					},
+					{
+						label: 'Use cases',
+						items: [
+							{ name: 'Marketing teams', link: '/marketing-teams/' },
+							{ name: 'Designers', link: '/use-cases/designers/' },
+							{ name: 'Frontend developers', link: '/use-cases/frontend-developers/' }
+						]
+					}
+				]
+			}
+		},
 		{
 			name: 'Compare',
 			link: '/vs/',
@@ -51,19 +82,14 @@ export const navigationBarData: NavData = {
 			]
 		},
 		{
-			name: 'Integrations',
-			link: '/integrations/',
+			name: 'Resources',
 			submenu: [
-				{ name: 'All integrations', link: '/integrations/' },
-				{ name: 'WordPress', link: '/wordpress/' },
-				{ name: 'Next.js', link: '/docs/integrations/nextjs/' },
-				{ name: 'Astro', link: '/docs/integrations/astro/' },
-				{ name: 'Vite', link: '/docs/integrations/vite/' }
+				{ name: 'Documentation', link: '/docs/' },
+				{ name: 'Blog', link: '/blog/' },
+				{ name: 'Changelog', link: '/changelog/' },
+				{ name: 'FAQ', link: '/faq/' }
 			]
-		},
-		{ name: 'Changelog', link: '/changelog/' },
-		{ name: 'Blog', link: '/blog/' },
-		{ name: 'FAQ', link: '/faq/' }
+		}
 	],
 	navActions: [{ name: 'Try it now', link: '/#install', style: 'white', size: 'lg' }]
 }

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -213,6 +213,9 @@ let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSign
       switch await Protocol.sendInitialize(~channel, ~state, ~clientConfig) {
       | Error(e) =>
         Log.error(`ACP initialize failed: ${e}`)
+        channel->Channel.off(~event=#config_options_updated)
+        cleanupChannel(channel)
+        Socket.disconnect(socket)
         Error(ConnectionFailed(e))
       | Ok(result) =>
         Sentry.addBreadcrumb(~category=#acp, ~message="ACP initialized successfully")

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -3,17 +3,19 @@ module Client = FrontmanClient__ACP__Client
 module Channel = FrontmanClient__Phoenix__Channel
 module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 module Constants = FrontmanClient__Transport__Constants
+module Decoders = FrontmanClient__Decoders
 module Log = FrontmanLogs.Logs.Make({
   let component = #ACP
 })
 
 let requestTimeoutMs = 120000
 
-let handlePushReply = (~state: ref<Client.state>, payload: JSON.t): unit => {
+let pushReplyMessageSchema: S.t<JSON.t> = S.object(s => s.field("acp:message", S.json))
+
+let parsePushReply = payload => {
   payload
-  ->JSON.Decode.object
-  ->Option.flatMap(reply => reply->Dict.get("acp:message"))
-  ->Option.forEach(message => state := Client.handleResponse(state.contents, message))
+  ->Decoders.parseSchema(pushReplyMessageSchema)
+  ->Result.mapError(error => `Invalid ACP push reply envelope: ${error}`)
 }
 
 let sendRequest = (
@@ -55,8 +57,15 @@ let sendRequest = (
       )
 
     let payload = request->JsonRpc.Request.toJson
-    let push = channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)
-    push.receive(~status="ok", ~callback=reply => handlePushReply(~state, reply))->ignore
+    let push = channel->Channel.push(~event=Constants.acpMessageEvent, ~payload, ~timeout=timeoutMs)
+    push.receive(~status="ok", ~callback=reply => {
+      switch parsePushReply(reply) {
+      | Ok(message) => state := Client.handleResponse(state.contents, message)
+      | Error(error) =>
+        state := state.contents->Client.reduce(Client.ResponseReceived(id))
+        pending.reject(error)
+      }
+    })->ignore
   })
 }
 

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -9,6 +9,13 @@ module Log = FrontmanLogs.Logs.Make({
 
 let requestTimeoutMs = 120000
 
+let handlePushReply = (~state: ref<Client.state>, payload: JSON.t): unit => {
+  payload
+  ->JSON.Decode.object
+  ->Option.flatMap(reply => reply->Dict.get("acp:message"))
+  ->Option.forEach(message => state := Client.handleResponse(state.contents, message))
+}
+
 let sendRequest = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
@@ -48,7 +55,8 @@ let sendRequest = (
       )
 
     let payload = request->JsonRpc.Request.toJson
-    channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)->ignore
+    let push = channel->Channel.push(~event=Constants.acpMessageEvent, ~payload)
+    push.receive(~status="ok", ~callback=reply => handlePushReply(~state, reply))->ignore
   })
 }
 

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -402,6 +402,34 @@ describe("ACP Protocol sendRequest", _t => {
     t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
   })
 
+  testAsync("rejects malformed Phoenix push reply envelopes immediately", async t => {
+    Vi.useFakeTimers()->ignore
+    let channel = %raw(`{
+      push(_event, _payload) {
+        return {
+          receive(status, callback) {
+            if (status === "ok") {
+              callback({});
+            }
+            return this;
+          }
+        };
+      }
+    }`)
+    let state = ref(Client.initialState)
+    let result = await Protocol.sendRequest(
+      ~channel,
+      ~state,
+      ~method="session/prompt",
+      ~params=None,
+      ~timeoutMs=10,
+      ~parseResult=_ => Ok("unused"),
+    )
+
+    t->expect(result->Result.isError)->Expect.toEqual(true)
+    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+  })
+
   testAsync("times out and removes pending request when no response arrives", async t => {
     Vi.useFakeTimers()->ignore
     let transport = makeLoadTransport([], loadResult)

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -373,6 +373,35 @@ describe("ACP Client parseInitializeResult", _t => {
 })
 
 describe("ACP Protocol sendRequest", _t => {
+  testAsync("resolves Phoenix push reply envelopes", async t => {
+    Vi.useFakeTimers()->ignore
+    let channel = %raw(`{
+      push(_event, payload) {
+        return {
+          receive(status, callback) {
+            if (status === "ok") {
+              callback({"acp:message": {jsonrpc: "2.0", id: payload.id, result: "accepted"}});
+            }
+            return this;
+          }
+        };
+      }
+    }`)
+    let state = ref(Client.initialState)
+    let result = await Protocol.sendRequest(
+      ~channel,
+      ~state,
+      ~method="session/prompt",
+      ~params=None,
+      ~timeoutMs=10,
+      ~parseResult=json =>
+        json->JSON.Decode.string->Option.mapOr(Error("Expected string"), value => Ok(value)),
+    )
+
+    t->expect(result)->Expect.toEqual(Ok("accepted"))
+    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+  })
+
   testAsync("times out and removes pending request when no response arrives", async t => {
     Vi.useFakeTimers()->ignore
     let transport = makeLoadTransport([], loadResult)


### PR DESCRIPTION
## Summary
- handle ACP JSON-RPC responses returned in Phoenix push reply envelopes
- disconnect and leave the channel when initialize fails or times out
- add client coverage for push reply handling

Addresses review feedback from #1619.

## Checks
- make rescript-build
- cd libs/frontman-client && yarn vitest run test/FrontmanClient__ACP__Client.test.res.mjs