### PR TITLE
Fix fflate security advisory

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10980,9 +10980,9 @@ __metadata:
   linkType: hard
 
 "fflate@npm:^0.7.3":
-  version: 0.7.4
-  resolution: "fflate@npm:0.7.4"
-  checksum: 10c0/5e749eb3a6ed61a0f6c55756abf9f4258f06f60505db689e22d18503dd252ca5af656d32668e4b7b20714adf8b313febf695d23863a8352f23e325baee0f672d
+  version: 0.7.5
+  resolution: "fflate@npm:0.7.5"
+  checksum: 10c0/dd49302136bbe63d5e26a1e2ce7f2c9ff73a2c7eb591af433a20a4fd840e4914c7cad863945162067ec87dd871baa9250b755d06650f59c86b2d72dde4042f58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary\n- bump transitive fflate lockfile resolution from 0.7.4 to 0.7.5\n- unblocks Dependabot security update for GHSA advisory\n\n## Test\n- pre-commit source-comments hook passed\n- pre-push reanalyze hook skipped: no matching push files