### PR TITLE
Align ACP session model config

### DIFF
--- a/.changeset/align-acp-session-config.md
+++ b/.changeset/align-acp-session-config.md
@@ -3,4 +3,4 @@
 "@frontman-ai/frontman-client": patch
 ---
 
-Align ACP session configuration with agent-owned model state and current config values.
+Restore ACP session startup by making the server own and persist the selected model, returning `currentValue`, and supporting `session/set_config_option`. Keep older clients compatible when they still send model metadata with prompts.

--- a/.changeset/align-acp-session-config.md
+++ b/.changeset/align-acp-session-config.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-protocol": patch
+"@frontman-ai/frontman-client": patch
+---
+
+Align ACP session configuration with agent-owned model state and current config values.

--- a/apps/frontman_server/lib/agent_client_protocol.ex
+++ b/apps/frontman_server/lib/agent_client_protocol.ex
@@ -172,26 +172,47 @@ defmodule AgentClientProtocol do
   This function has no knowledge of provider
   internals; all domain logic is encapsulated in the Providers context.
   """
-  def build_model_config_options(%{groups: groups}) do
-    [
-      %{
-        "type" => "select",
-        "id" => "model",
-        "name" => "Model",
-        "category" => "model",
-        "options" =>
-          Enum.map(groups, fn %{id: id, name: name, options: options} ->
-            %{
-              "group" => id,
-              "name" => name,
-              "options" =>
-                Enum.map(options, fn %{name: display_name, value: value} ->
-                  %{"value" => value, "name" => display_name}
-                end)
-            }
-          end)
-      }
-    ]
+  def build_model_config_options(model_data, current_value \\ nil)
+
+  def build_model_config_options(%{groups: groups}, current_value) do
+    groups = Enum.reject(groups, &(&1.options == []))
+    values = groups |> Enum.flat_map(& &1.options) |> Enum.map(& &1.value)
+
+    case current_config_value(values, current_value) do
+      nil ->
+        []
+
+      selected_value ->
+        [
+          %{
+            "type" => "select",
+            "id" => "model",
+            "name" => "Model",
+            "category" => "model",
+            "currentValue" => selected_value,
+            "options" =>
+              Enum.map(groups, fn %{id: id, name: name, options: options} ->
+                %{
+                  "group" => id,
+                  "name" => name,
+                  "options" =>
+                    Enum.map(options, fn %{name: display_name, value: value} ->
+                      %{"value" => value, "name" => display_name}
+                    end)
+                }
+              end)
+          }
+        ]
+    end
+  end
+
+  defp current_config_value([], _current_value), do: nil
+
+  defp current_config_value([first | _rest] = values, current_value) do
+    case current_value in values do
+      true -> current_value
+      false -> first
+    end
   end
 
   @doc "Encodes the resolved agent catalog for ACP metadata."
@@ -250,6 +271,18 @@ defmodule AgentClientProtocol do
   """
   def build_config_options_updated_payload(config_options) when is_list(config_options) do
     %{"configOptions" => config_options}
+  end
+
+  def build_set_config_option_result(config_options) when is_list(config_options) do
+    %{"configOptions" => config_options}
+  end
+
+  def build_config_option_update_notification(session_id, config_options)
+      when is_list(config_options) do
+    session_update_notification(session_id, %{
+      "sessionUpdate" => "config_option_update",
+      "configOptions" => config_options
+    })
   end
 
   @doc """

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -130,22 +130,30 @@ defmodule FrontmanServer.Tasks do
   @doc """
   Creates a new task and stores it.
 
-  The task_id must be provided by the client.
+  The task ID must be provided by the caller.
   Requires a scope with a user.
   Returns `{:ok, task}` on success.
   """
-  def create_task(scope, task_id, framework) do
-    user_id = Accounts.scope_user_id(scope)
-
-    attrs = %{
-      id: task_id,
-      short_desc: TaskSchema.default_title(),
-      framework: framework,
-      user_id: user_id
-    }
+  def create_task(%Scope{} = scope, %{id: task_id, framework: _framework} = attrs)
+      when is_binary(task_id) do
+    attrs =
+      attrs
+      |> Map.take([:id, :framework, :current_model])
+      |> Map.put(:short_desc, TaskSchema.default_title())
+      |> Map.put(:user_id, Accounts.scope_user_id(scope))
 
     TaskSchema.create_changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc "Stores the agent-owned current model for a task."
+  def set_current_model(%Scope{} = scope, task_id, current_model)
+      when is_binary(task_id) and is_binary(current_model) and current_model != "" do
+    with {:ok, task} <- get_task_by_id(scope, task_id) do
+      task
+      |> TaskSchema.update_changeset(%{current_model: current_model})
+      |> Repo.update()
+    end
   end
 
   defp hydrate_task(%TaskSchema{} = task_schema) do

--- a/apps/frontman_server/lib/frontman_server/tasks/task_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/task_schema.ex
@@ -28,6 +28,7 @@ defmodule FrontmanServer.Tasks.TaskSchema do
   schema "tasks" do
     field(:short_desc, :string)
     field(:framework, Ecto.Enum, values: @framework_values)
+    field(:current_model, :string)
     belongs_to(:user, User)
     has_many(:interaction_rows, InteractionSchema, foreign_key: :task_id)
 
@@ -44,7 +45,7 @@ defmodule FrontmanServer.Tasks.TaskSchema do
   """
   def create_changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, [:id, :short_desc, :framework, :user_id])
+    |> cast(attrs, [:id, :short_desc, :framework, :user_id, :current_model])
     |> validate_required([:id, :short_desc, :framework, :user_id])
     |> unique_constraint(:id, name: :tasks_pkey)
     |> foreign_key_constraint(:user_id)
@@ -55,7 +56,7 @@ defmodule FrontmanServer.Tasks.TaskSchema do
   """
   def update_changeset(task, attrs) do
     task
-    |> cast(attrs, [:short_desc])
+    |> cast(attrs, [:short_desc, :current_model])
     |> validate_required([:short_desc])
   end
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -34,6 +34,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   @acp_title_updated ACP.event_title_updated()
   @acp_method_session_prompt ACP.method_session_prompt()
   @acp_method_session_load ACP.method_session_load()
+  @acp_method_session_set_config_option "session/set_config_option"
   @mcp_init_timeout_ms 30_000
   @impl true
   def join("task:" <> task_id, _params, socket) do
@@ -45,12 +46,19 @@ defmodule FrontmanServerWeb.TaskChannel do
       {:ok, history} = TaskHistory.new(task.interaction_rows)
 
       SentryContext.set_task_scope_context(scope, task_id)
+
+      Phoenix.PubSub.subscribe(
+        FrontmanServer.PubSub,
+        Providers.config_pubsub_topic(scope.user.id)
+      )
+
       {init_state, init_actions} = MCPInitializer.start(task_id, scope, task.framework)
 
       socket =
         socket
         |> assign(:task_id, task_id)
         |> assign(:framework, task.framework)
+        |> assign(:current_model, task.current_model)
         |> assign(:mcp_init_state, init_state)
         |> assign(:mcp_init_timeout_ref, nil)
         |> assign(:mcp_init_timeout_token, nil)
@@ -87,6 +95,9 @@ defmodule FrontmanServerWeb.TaskChannel do
 
       {:ok, {:request, id, @acp_method_session_load, params}} ->
         handle_session_load(id, params, socket)
+
+      {:ok, {:request, id, @acp_method_session_set_config_option, params}} ->
+        handle_set_config_option(id, params, socket)
 
       {:ok, {:request, id, method, _params}} ->
         reply_acp_error(
@@ -224,6 +235,18 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   def handle_info({:task_title_changed, task_id, title}, socket) do
     push(socket, @acp_title_updated, %{"sessionId" => task_id, "title" => title})
+    {:noreply, socket}
+  end
+
+  def handle_info(:config_options_changed, socket) do
+    config_options = current_config_options(socket, socket.assigns[:current_model])
+
+    push(
+      socket,
+      @acp_message,
+      ACP.build_config_option_update_notification(socket.assigns.task_id, config_options)
+    )
+
     {:noreply, socket}
   end
 
@@ -655,11 +678,7 @@ defmodule FrontmanServerWeb.TaskChannel do
           @acp_message,
           JsonRpc.success_response(
             id,
-            ACP.build_session_load_result(
-              scope
-              |> Providers.available_models()
-              |> ACP.build_model_config_options()
-            )
+            ACP.build_session_load_result(current_config_options(socket, task.current_model))
           )
         )
 
@@ -684,29 +703,68 @@ defmodule FrontmanServerWeb.TaskChannel do
     push_acp_error(socket, id, JsonRpc.error_invalid_params(), "Session does not match channel")
   end
 
-  defp process_prompt(id, %{"prompt" => content_blocks, "_meta" => meta}, socket)
-       when is_map(meta) do
+  defp handle_set_config_option(
+         id,
+         %{"sessionId" => task_id, "configId" => "model", "value" => value},
+         %{assigns: %{task_id: task_id}} = socket
+       )
+       when is_binary(value) do
+    case model_value_valid?(socket, value) do
+      true ->
+        {:ok, _task} = Tasks.set_current_model(socket.assigns.scope, task_id, value)
+        config_options = current_config_options(socket, value)
+
+        push(
+          socket,
+          @acp_message,
+          ACP.build_config_option_update_notification(task_id, config_options)
+        )
+
+        {:reply,
+         {:ok,
+          %{
+            @acp_message =>
+              JsonRpc.success_response(id, ACP.build_set_config_option_result(config_options))
+          }}, assign(socket, :current_model, value)}
+
+      false ->
+        reply_invalid_params(socket, id, "Unknown model")
+    end
+  end
+
+  defp handle_set_config_option(id, _params, socket) do
+    reply_invalid_params(socket, id, "Invalid config option")
+  end
+
+  defp process_prompt(id, %{"prompt" => content_blocks} = params, socket) do
+    meta = Map.get(params, "_meta", %{})
+    process_prompt_content(id, content_blocks, meta, socket)
+  end
+
+  defp process_prompt_content(id, content_blocks, meta, socket) when is_map(meta) do
     task_id = socket.assigns.task_id
     scope = socket.assigns.scope
 
-    case parse_client_model(meta["model"]) do
+    case selected_model(socket, meta) do
       {:ok, model} ->
         Logger.info("process_prompt", %{task_id: task_id, model: model})
 
         with {:ok, agent_id} <-
                Agents.resolve_agent_id(scope, meta["agent"] || Agents.default_agent_id(scope)),
+             {:ok, _task} <- Tasks.set_current_model(scope, task_id, model),
              {:ok, _row} <-
                Tasks.submit_user_message(
                  scope,
                  %{
                    task_id: task_id,
-                   message_id: meta["frontman.dev/messageId"],
+                   message_id: prompt_message_id(meta),
                    message: content_blocks,
                    model: model,
                    agent_id: agent_id,
                    selected_server_skill_id: meta["selectedServerSkillId"]
                  }
                ) do
+          socket = assign(socket, :current_model, model)
           wake_runner(socket, meta)
 
           Logger.info("User message accepted for task #{task_id}")
@@ -735,9 +793,12 @@ defmodule FrontmanServerWeb.TaskChannel do
         end
 
       :error ->
-        reply_invalid_params(socket, id, "Model is required")
+        reply_invalid_params(socket, id, "No model is available")
     end
   end
+
+  defp prompt_message_id(%{"frontman.dev/messageId" => message_id}), do: message_id
+  defp prompt_message_id(_meta), do: Ecto.UUID.generate()
 
   defp reply_acp_error(socket, id, code, message) do
     {:reply, {:ok, %{@acp_message => JsonRpc.error_response(id, code, message)}}, socket}
@@ -972,7 +1033,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp execution_context(socket, meta) do
     model =
-      case parse_client_model(meta && meta["model"]) do
+      case selected_model(socket, meta || %{}) do
         {:ok, model} -> model
         :error -> nil
       end
@@ -982,6 +1043,38 @@ defmodule FrontmanServerWeb.TaskChannel do
       mcp_tools: socket.assigns.mcp_tools,
       project_traits: Frameworks.project_traits_from_meta(meta, socket.assigns.framework)
     }
+  end
+
+  defp selected_model(socket, %{"model" => model_ref}) do
+    case parse_client_model(model_ref) do
+      {:ok, model} -> {:ok, model}
+      :error -> current_model(socket)
+    end
+  end
+
+  defp selected_model(socket, _meta), do: current_model(socket)
+
+  defp current_model(%{assigns: %{current_model: model}}) when is_binary(model) and model != "",
+    do: {:ok, model}
+
+  defp current_model(socket) do
+    case current_config_options(socket, nil) do
+      [%{"currentValue" => model} | _rest] -> {:ok, model}
+      [] -> :error
+    end
+  end
+
+  defp current_config_options(socket, current_model) do
+    socket.assigns.scope
+    |> Providers.available_models()
+    |> ACP.build_model_config_options(current_model)
+  end
+
+  defp model_value_valid?(socket, model) do
+    case current_config_options(socket, model) do
+      [%{"currentValue" => ^model} | _rest] -> true
+      _missing -> false
+    end
   end
 
   defp parse_client_model(%{"provider" => "custom", "value" => value}) do

--- a/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
@@ -130,18 +130,20 @@ defmodule FrontmanServerWeb.TasksChannel do
     with :ok <- validate_uuid_format(session_id),
          raw_framework when is_binary(raw_framework) <-
            extract_framework(socket.assigns[:acp_client_info]),
+         config_options = current_config_options(socket),
+         current_model <- current_model_value(config_options),
          {:ok, %Tasks.TaskSchema{id: ^session_id}} <-
-           Tasks.create_task(
-             socket.assigns.scope,
-             session_id,
-             raw_framework
-           ) do
+           Tasks.create_task(socket.assigns.scope, %{
+             id: session_id,
+             framework: raw_framework,
+             current_model: current_model
+           }) do
       push_response(
         socket,
         id,
         ACP.build_session_new_result(
           session_id,
-          current_config_options(socket)
+          config_options
         )
       )
     else
@@ -190,6 +192,9 @@ defmodule FrontmanServerWeb.TasksChannel do
     |> Providers.available_models()
     |> ACP.build_model_config_options()
   end
+
+  defp current_model_value([%{"currentValue" => current_model} | _rest]), do: current_model
+  defp current_model_value([]), do: nil
 
   defp validate_uuid_format(string) do
     case Ecto.UUID.cast(string) do

--- a/apps/frontman_server/priv/repo/migrations/20260904000000_add_current_model_to_tasks.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260904000000_add_current_model_to_tasks.exs
@@ -1,0 +1,9 @@
+defmodule FrontmanServer.Repo.Migrations.AddCurrentModelToTasks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tasks) do
+      add(:current_model, :string)
+    end
+  end
+end

--- a/apps/frontman_server/test/agent_client_protocol_test.exs
+++ b/apps/frontman_server/test/agent_client_protocol_test.exs
@@ -126,12 +126,17 @@ defmodule AgentClientProtocolTest do
       assert Enum.all?(values, &String.starts_with?(&1, "anthropic:"))
     end
 
-    test "does not set currentValue" do
-      data = config_data([])
+    test "sets currentValue" do
+      data =
+        config_data([
+          model_group("anthropic", "Anthropic", [
+            model_option("Claude Sonnet 4.5", "anthropic:claude-sonnet-4-5")
+          ])
+        ])
 
       [option] = ACP.build_model_config_options(data)
 
-      refute Map.has_key?(option, "currentValue")
+      assert option["currentValue"] == "anthropic:claude-sonnet-4-5"
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -28,11 +28,13 @@ defmodule FrontmanServer.TasksTest do
     %{scope: scope}
   end
 
-  describe "create_task/3" do
+  describe "create_task/2" do
     test "creates task with framework", %{scope: scope} do
       task_id = Ecto.UUID.generate()
       framework = "nextjs"
-      {:ok, %TaskSchema{id: ^task_id}} = Tasks.create_task(scope, task_id, framework)
+
+      {:ok, %TaskSchema{id: ^task_id}} =
+        Tasks.create_task(scope, %{id: task_id, framework: framework})
 
       {:ok, task} = Tasks.get_task(scope, task_id)
       assert task.id == task_id
@@ -1372,7 +1374,10 @@ defmodule FrontmanServer.TasksTest do
   describe "record_execution_outcome/4 paused DB round-trip" do
     test "persisted AgentPaused can be loaded back via get_task", %{scope: scope} do
       task_id = Ecto.UUID.generate()
-      {:ok, %TaskSchema{id: ^task_id}} = Tasks.create_task(scope, task_id, "nextjs")
+
+      {:ok, %TaskSchema{id: ^task_id}} =
+        Tasks.create_task(scope, %{id: task_id, framework: "nextjs"})
+
       turn_number = start_turn_fixture(scope, task_id)
 
       {:ok, _interaction} =
@@ -1393,7 +1398,9 @@ defmodule FrontmanServer.TasksTest do
 
     test "to_swarm_messages/1 succeeds when interactions include AgentPaused", %{scope: scope} do
       task_id = Ecto.UUID.generate()
-      {:ok, %TaskSchema{id: ^task_id}} = Tasks.create_task(scope, task_id, "nextjs")
+
+      {:ok, %TaskSchema{id: ^task_id}} =
+        Tasks.create_task(scope, %{id: task_id, framework: "nextjs"})
 
       {:ok, _message} =
         user_message_fixture(scope, task_id, [%{"type" => "text", "text" => "Hi"}])

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -393,6 +393,62 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert response["error"]["message"] =~ "Method not found"
     end
 
+    test "uses the session model without legacy prompt metadata", %{
+      socket: socket,
+      scope: scope,
+      task_id: task_id
+    } do
+      model = "openrouter:google/gemini-3.1-pro-preview"
+
+      config_ref =
+        push(
+          socket,
+          "acp:message",
+          build_acp_request("session/set_config_option", 2, %{
+            "sessionId" => task_id,
+            "configId" => "model",
+            "value" => model
+          })
+        )
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "sessionId" => ^task_id,
+          "update" => %{
+            "sessionUpdate" => "config_option_update",
+            "configOptions" => [%{"currentValue" => ^model}]
+          }
+        }
+      })
+
+      assert_reply(config_ref, :ok, %{
+        "acp:message" => %{"result" => %{"configOptions" => [%{"currentValue" => ^model}]}}
+      })
+
+      message_id = Ecto.UUID.generate()
+
+      prompt_ref =
+        push(
+          socket,
+          "acp:message",
+          build_acp_request("session/prompt", 3, %{
+            "prompt" => [%{"type" => "text", "text" => "Hello"}],
+            "_meta" => %{"frontman.dev/messageId" => message_id}
+          })
+        )
+
+      assert_push("acp:message", %{
+        "params" => %{
+          "sessionId" => ^task_id,
+          "update" => %{"sessionUpdate" => "user_message_chunk", "messageId" => ^message_id}
+        }
+      })
+
+      assert_reply(prompt_ref, :ok, %{"acp:message" => %{"result" => %{}}})
+      assert {:ok, %{current_model: ^model} = task} = Tasks.get_task(scope, task_id)
+      assert [%Interaction.UserMessage{model: ^model}] = Tasks.interactions(task)
+    end
+
     test "forwards prompt model to title generation job", %{
       socket: socket,
       scope: scope,

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -591,7 +591,6 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     end
 
     for {name, message_id, expected_message} <- [
-          {"missing", :missing, "Message ID can't be blank"},
           {"nil", nil, "Message ID can't be blank"},
           {"empty", "", "Message ID can't be blank"},
           {"malformed", "not-a-uuid", "Message ID is invalid"},

--- a/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
@@ -172,13 +172,15 @@ defmodule FrontmanServerWeb.TasksChannelTest do
         "jsonrpc" => "2.0",
         "id" => 2,
         "result" => %{
-          "sessionId" => ^client_session_id
+          "sessionId" => ^client_session_id,
+          "configOptions" => [%{"currentValue" => current_model}]
         }
       })
 
       assert {:ok, task} = FrontmanServer.Tasks.get_task(scope, client_session_id)
       assert task.id == client_session_id
       assert task.framework == :nextjs
+      assert task.current_model == current_model
     end
 
     test "stores framework ID from clientInfo", %{socket: socket, scope: scope} do

--- a/apps/frontman_server/test/support/channel_case.ex
+++ b/apps/frontman_server/test/support/channel_case.ex
@@ -181,7 +181,7 @@ defmodule FrontmanServerWeb.ChannelCase do
       task_id = Ecto.UUID.generate()
 
       {:ok, %FrontmanServer.Tasks.TaskSchema{id: ^task_id}} =
-        FrontmanServer.Tasks.create_task(scope, task_id, framework)
+        FrontmanServer.Tasks.create_task(scope, %{id: task_id, framework: framework})
 
       {:ok, _reply, socket} =
         FrontmanServerWeb.UserSocket

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -39,7 +39,10 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
   def task_fixture(scope, opts \\ []) do
     framework = Keyword.get(opts, :framework, "nextjs")
     task_id = Keyword.get(opts, :task_id, Ecto.UUID.generate())
-    {:ok, %TaskSchema{id: ^task_id} = task} = Tasks.create_task(scope, task_id, framework)
+
+    {:ok, %TaskSchema{id: ^task_id} = task} =
+      Tasks.create_task(scope, %{id: task_id, framework: framework})
+
     task
   end
 

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -495,7 +495,6 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
     )
 
   | (_, SessionCreateError(_)) => (state, [LogInfo("Stale session create result ignored")])
-
   }
 }
 

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -556,7 +556,7 @@ module Selectors = {
     | (AcpSessionActive(_), Some(configOptions)) =>
       switch configOptions->ACP.findConfigOptionByCategory(ACP.Model) {
       | Some(modelConfig) => ACP.sessionConfigOptionFirstOption(modelConfig)->Option.isNone
-      | None => false
+      | None => true
       }
     | _ => false
     }
@@ -1822,42 +1822,32 @@ let next = (state: state, action) => {
     state->setApiKeySaveStatus(provider, Idle)->StateReducer.update
 
   | ConfigOptionsReceived({configOptions}) =>
-    let modelConfigOption =
-      ACP.findConfigOptionByCategory(configOptions, ACP.Model)->Option.getOrThrow(
-        ~message="ConfigOptionsReceived missing model config option",
-      )
+    let modelConfigOption = ACP.findConfigOptionByCategory(configOptions, ACP.Model)
 
-    let firstModelValue =
-      modelConfigOption->ACP.sessionConfigOptionFirstOption->Option.map(option => option.value)
+    let selectedModelValue = switch modelConfigOption {
+    | Some(modelConfigOption) => {
+        let currentModelValue = switch modelConfigOption {
+        | ACP.SelectConfigOption({currentValue}) => Some(currentValue)
+        }
 
-    let modelValueExists = value =>
-      switch modelConfigOption {
-      | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
-        groups->Array.some(group => group.options->Array.some(option => option.value == value))
-      | ACP.SelectConfigOption({options: ACP.Ungrouped(options)}) =>
-        options->Array.some(option => option.value == value)
+        switch state.pendingProviderAutoSelect {
+        | Some(providerId) =>
+          let providerModelValue = switch modelConfigOption {
+          | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
+            groups
+            ->Array.find(g => g.group == providerId)
+            ->Option.flatMap(g => g.options->Array.get(0))
+            ->Option.map(opt => opt.value)
+          | ACP.SelectConfigOption({options: ACP.Ungrouped(_)}) => None
+          }
+          switch providerModelValue {
+          | Some(value) => Some(value)
+          | None => currentModelValue
+          }
+        | None => currentModelValue
+        }
       }
-
-    let currentOrFirstModelValue = switch state.selectedModelValue {
-    | Some(value) if modelValueExists(value) => Some(value)
-    | _ => firstModelValue
-    }
-
-    let selectedModelValue = switch state.pendingProviderAutoSelect {
-    | Some(providerId) =>
-      let providerModelValue = switch modelConfigOption {
-      | ACP.SelectConfigOption({options: ACP.Grouped(groups)}) =>
-        groups
-        ->Array.find(g => g.group == providerId)
-        ->Option.flatMap(g => g.options->Array.get(0))
-        ->Option.map(opt => opt.value)
-      | ACP.SelectConfigOption({options: ACP.Ungrouped(_)}) => None
-      }
-      switch providerModelValue {
-      | Some(value) => Some(value)
-      | None => currentOrFirstModelValue
-      }
-    | None => currentOrFirstModelValue
+    | None => None
     }
     switch (state.selectedModelValue, selectedModelValue) {
     | (Some(current), Some(next)) if current == next => ()

--- a/libs/client/test/Client__ModelsRefresh.test.res
+++ b/libs/client/test/Client__ModelsRefresh.test.res
@@ -46,12 +46,24 @@ module SampleConfig = {
     _meta: None,
   }
 
+  let _firstModelValue = (options: ACP.sessionConfigSelectOptions) => {
+    let option: ACP.sessionConfigSelectOption = switch options {
+    | ACP.Grouped(groups) =>
+      groups
+      ->Array.findMap(group => group.options->Array.get(0))
+      ->Option.getOrThrow
+    | ACP.Ungrouped(options) => options->Array.get(0)->Option.getOrThrow
+    }
+    option.value
+  }
+
   let _makeModelConfigOption = (options: ACP.sessionConfigSelectOptions) => {
     ACP.SelectConfigOption({
       id: "model",
       name: "Model",
       description: None,
       category: Some(ACP.Model),
+      currentValue: _firstModelValue(options),
       options,
       _meta: None,
     })
@@ -102,7 +114,7 @@ module SampleConfig = {
 
   let configWithFireworksOnly = [_makeModelConfigOption(ACP.Grouped([_fireworksGroup]))]
 
-  let configWithNoModels = [_makeModelConfigOption(ACP.Grouped([]))]
+  let configWithNoModels = []
 
   let configWithEmptyFirstGroup = [
     _makeModelConfigOption(ACP.Grouped([{..._anthropicGroup, options: []}, _openrouterGroup])),

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -80,31 +80,35 @@ module TestHelpers = {
   }
 
   let modelConfigOptions = (~models: array<string>) => {
-    [
-      ACP.SelectConfigOption({
-        id: "model",
-        name: "Model",
-        description: None,
-        category: Some(ACP.Model),
-        options: ACP.Grouped([
-          {
-            group: "future_provider",
-            name: "Future Provider",
-            options: models->Array.map(value => {
-              let option: ACP.sessionConfigSelectOption = {
-                value,
-                name: value,
-                description: None,
-                _meta: None,
-              }
-              option
-            }),
-            _meta: None,
-          },
-        ]),
-        _meta: None,
-      }),
-    ]
+    switch models->Array.get(0) {
+    | None => []
+    | Some(_first) => [
+        ACP.SelectConfigOption({
+          id: "model",
+          name: "Model",
+          description: None,
+          category: Some(ACP.Model),
+          currentValue: models->Array.get(0)->Option.getOrThrow,
+          options: ACP.Grouped([
+            {
+              group: "future_provider",
+              name: "Future Provider",
+              options: models->Array.map(value => {
+                let option: ACP.sessionConfigSelectOption = {
+                  value,
+                  name: value,
+                  description: None,
+                  _meta: None,
+                }
+                option
+              }),
+              _meta: None,
+            },
+          ]),
+          _meta: None,
+        }),
+      ]
+    }
   }
 
   let acceptUserMessage = (

--- a/libs/frontman-protocol/schemas/acp/sessionConfigOption.json
+++ b/libs/frontman-protocol/schemas/acp/sessionConfigOption.json
@@ -33,6 +33,9 @@
         }
       ]
     },
+    "currentValue": {
+      "type": "string"
+    },
     "options": {
       "anyOf": [
         {
@@ -107,6 +110,7 @@
     "type",
     "id",
     "name",
+    "currentValue",
     "options"
   ]
 }

--- a/libs/frontman-protocol/schemas/acp/sessionLoadResult.json
+++ b/libs/frontman-protocol/schemas/acp/sessionLoadResult.json
@@ -72,6 +72,9 @@
               }
             ]
           },
+          "currentValue": {
+            "type": "string"
+          },
           "options": {
             "anyOf": [
               {
@@ -146,6 +149,7 @@
           "type",
           "id",
           "name",
+          "currentValue",
           "options"
         ]
       },

--- a/libs/frontman-protocol/schemas/acp/sessionNewResult.json
+++ b/libs/frontman-protocol/schemas/acp/sessionNewResult.json
@@ -75,6 +75,9 @@
               }
             ]
           },
+          "currentValue": {
+            "type": "string"
+          },
           "options": {
             "anyOf": [
               {
@@ -149,6 +152,7 @@
           "type",
           "id",
           "name",
+          "currentValue",
           "options"
         ]
       },

--- a/libs/frontman-protocol/schemas/acp/sessionUpdate.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdate.json
@@ -1460,6 +1460,9 @@
                   }
                 ]
               },
+              "currentValue": {
+                "type": "string"
+              },
               "options": {
                 "anyOf": [
                   {
@@ -1534,6 +1537,7 @@
               "type",
               "id",
               "name",
+              "currentValue",
               "options"
             ]
           },

--- a/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
+++ b/libs/frontman-protocol/schemas/acp/sessionUpdateNotification.json
@@ -1477,6 +1477,9 @@
                           }
                         ]
                       },
+                      "currentValue": {
+                        "type": "string"
+                      },
                       "options": {
                         "anyOf": [
                           {
@@ -1551,6 +1554,7 @@
                       "type",
                       "id",
                       "name",
+                      "currentValue",
                       "options"
                     ]
                   },

--- a/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__ACP.res
@@ -340,6 +340,7 @@ type sessionConfigOption =
       name: string,
       description: option<string>,
       category: option<sessionConfigOptionCategory>,
+      currentValue: sessionConfigValueId,
       options: sessionConfigSelectOptions,
       _meta: option<JSON.t>,
     })
@@ -360,6 +361,7 @@ let sessionConfigOptionSchema = S.union([
       name: s.field("name", S.string),
       description: s.field("description", S.option(S.string)),
       category: s.field("category", S.option(sessionConfigOptionCategorySchema)),
+      currentValue: s.field("currentValue", S.string),
       options: s.field("options", sessionConfigSelectOptionsSchema),
       _meta: s.field("_meta", S.option(S.json)),
     })
@@ -419,6 +421,12 @@ type titleUpdated = {
 type configOptionsUpdated = {configOptions: array<sessionConfigOption>}
 
 let configOptionsUpdatedSchema = S.object(s => {
+  configOptions: s.field("configOptions", S.array(sessionConfigOptionSchema)),
+})
+
+type setConfigOptionResult = {configOptions: array<sessionConfigOption>}
+
+let setConfigOptionResultSchema = S.object(s => {
   configOptions: s.field("configOptions", S.array(sessionConfigOptionSchema)),
 })
 


### PR DESCRIPTION
## Summary
- add currentValue to ACP model config options and generated schemas
- persist task current_model and support session/set_config_option for model changes
- let generic session/prompt use the agent-owned session model instead of requiring _meta.model

Fixes #1289

## Tests
- make rescript-build
- cd libs/client && make test
- cd libs/frontman-protocol && make test
- cd apps/frontman_server && mix test test/agent_client_protocol_test.exs test/protocols/acp_contract_test.exs test/frontman_server_web/channels/tasks_channel_test.exs test/frontman_server_web/channels/task_channel_test.exs
- cd apps/frontman_server && mix compile --warnings-as-errors
