### PR TITLE
Fix WordPress v4 relay compatibility

### DIFF
--- a/.changeset/fix-wordpress-relay-compat.md
+++ b/.changeset/fix-wordpress-relay-compat.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-protocol": patch
+---
+
+Keep WordPress v4 installations working with the hosted client by normalizing relay protocol 1.0 tool catalogs. Report project-context connection failures to Sentry and show the failure instead of an endless loading state.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -122,7 +122,7 @@ module ExecutePlanAction = {
 
 @react.component
 let make = (~onConfigureProvider: unit => unit) => {
-  let {session, createSession} = Client__FrontmanProvider.useFrontman()
+  let {session, createSession, connectionState} = Client__FrontmanProvider.useFrontman()
 
   let messages = Client__State.useSelector(Client__State.Selectors.messages)
   let isAgentRunning = Client__State.useSelector(Client__State.Selectors.isAgentRunning)
@@ -403,9 +403,13 @@ let make = (~onConfigureProvider: unit => unit) => {
     <Client__UpdateBanner />
     <ScrollContainer className="flex-grow overflow-x-hidden">
       <ScrollContainer.ContentWrapper>
-        {switch hasActiveACPSession {
-        | true => React.null
-        | false =>
+        {switch (hasActiveACPSession, connectionState) {
+        | (true, _) => React.null
+        | (false, Error(message)) =>
+          <div role="alert" className="py-3 px-4 text-[13px] text-red-400">
+            {React.string(`Could not load project context: ${message}`)}
+          </div>
+        | (false, Connecting | LoggingOut | Connected | SessionActive(_) | Disconnected) =>
           <div className="flex items-center gap-2 py-3 px-4 text-[13px] text-zinc-400">
             <span className="shimmer-text"> {React.string("Loading project context...")} </span>
           </div>

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -375,7 +375,10 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
 
   | ({relay: RelayConnecting}, RelayConnectError(message)) => (
       {...state, relay: RelayError(message)},
-      [TrackAnalytics(RelayConnectionCompleted(Failure(relayFailureReason(message))))],
+      [
+        LogError(`Project context connection failed: ${message}`),
+        TrackAnalytics(RelayConnectionCompleted(Failure(relayFailureReason(message)))),
+      ],
     )
 
   | ({session: SessionCreating(expectedSessionId)}, SessionCreateSuccess(sess))
@@ -495,7 +498,6 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
     )
 
   | (_, SessionCreateError(_)) => (state, [LogInfo("Stale session create result ignored")])
-
   }
 }
 

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -297,6 +297,7 @@ describe("Connection Reducer", () => {
             let (nextState, effects) = Reducer.reduce(state, RelayConnectError(message))
 
             t->expect(nextState.relay)->Expect.toEqual(Reducer.RelayError(message))
+            t->expect(effectKinds(effects))->Expect.toContain(#logError)
             t
             ->expect(trackedRelayOutcomes(effects))
             ->Expect.toEqual([Client__Analytics.Failure(reason)])

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -33,43 +33,54 @@ let isConnected = (relay: t): bool => {
 
 let getState = (relay: t): relayState => relay.state.contents
 
-let normalizeLegacyTool = (tool: Types.legacyRemoteTool): Types.remoteTool => {
-  let metadata = dict{
-    "access": tool.access
-    ->Option.getOr(FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite)
-    ->S.decodeOrThrow(
-      ~from=FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.accessSchema,
-      ~to=S.json->S.noValidation(true),
-    ),
-    "visibleToAgent": JSON.Encode.bool(tool.visibleToAgent),
-  }
-  let definition = dict{
-    "name": JSON.Encode.string(tool.name),
-    "description": JSON.Encode.string(tool.description),
-    "inputSchema": tool.inputSchema,
-    "_meta": JSON.Encode.object(dict{"ai.frontman/tool-metadata": JSON.Encode.object(metadata)}),
-  }
-  tool.outputSchema->Option.forEach(outputSchema =>
-    definition->Dict.set("outputSchema", outputSchema)
-  )
-  JSON.Encode.object(definition)
-}
-
 let parseToolsResponse = (json: JSON.t): result<Types.toolsResponse, string> => {
-  switch json->Decoders.parseSchema(Types.toolsResponseSchema) {
-  | Ok(data) => Ok(data)
-  | Error(currentError) =>
-    switch json->Decoders.parseSchema(Types.legacyToolsResponseSchema) {
-    | Ok(data) =>
-      Ok({
-        tools: data.tools->Array.map(normalizeLegacyTool),
-        serverInfo: data.serverInfo,
-        protocolVersion: Types.protocolVersion,
-      })
-    | Error(legacyError) =>
-      Error(`Current protocol: ${currentError}; legacy protocol: ${legacyError}`)
+  let normalizeLegacyTool = (tool: Types.legacyRemoteTool): Types.remoteTool => {
+    let metadata = dict{
+      "access": tool.access
+      ->Option.getOr(FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite)
+      ->S.decodeOrThrow(
+        ~from=FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.accessSchema,
+        ~to=S.json->S.noValidation(true),
+      ),
+      "visibleToAgent": JSON.Encode.bool(tool.visibleToAgent),
     }
+    let definition = dict{
+      "name": JSON.Encode.string(tool.name),
+      "description": JSON.Encode.string(tool.description),
+      "inputSchema": tool.inputSchema,
+      "_meta": JSON.Encode.object(dict{"ai.frontman/tool-metadata": JSON.Encode.object(metadata)}),
+    }
+    tool.outputSchema->Option.forEach(outputSchema =>
+      definition->Dict.set("outputSchema", outputSchema)
+    )
+    JSON.Encode.object(definition)
   }
+  let protocolVersionSchema = S.object(s => s.field("protocolVersion", S.string))
+
+  json
+  ->Decoders.parseSchema(protocolVersionSchema)
+  ->Result.mapError(error => `Invalid protocol version: ${error}`)
+  ->Result.flatMap(protocolVersion =>
+    switch protocolVersion {
+    | "2.0" =>
+      json
+      ->Decoders.parseSchema(Types.toolsResponseSchema)
+      ->Result.mapError(error => `Relay protocol 2.0: ${error}`)
+    | "1.0" =>
+      json
+      ->Decoders.parseSchema(Types.legacyToolsResponseSchema)
+      ->Result.map(data => {
+        let normalized: Types.toolsResponse = {
+          tools: data.tools->Array.map(normalizeLegacyTool),
+          serverInfo: data.serverInfo,
+          protocolVersion: Types.protocolVersion,
+        }
+        normalized
+      })
+      ->Result.mapError(error => `Relay protocol 1.0: ${error}`)
+    | unsupported => Error(`Unsupported relay protocol version: ${unsupported}`)
+    }
+  )
 }
 
 let connect = async (relay: t, ~signal: option<WebAPI.EventTypes.abortSignal>=?): result<

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -33,6 +33,45 @@ let isConnected = (relay: t): bool => {
 
 let getState = (relay: t): relayState => relay.state.contents
 
+let normalizeLegacyTool = (tool: Types.legacyRemoteTool): Types.remoteTool => {
+  let metadata = dict{
+    "access": tool.access
+    ->Option.getOr(FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.ReadWrite)
+    ->S.decodeOrThrow(
+      ~from=FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool.accessSchema,
+      ~to=S.json->S.noValidation(true),
+    ),
+    "visibleToAgent": JSON.Encode.bool(tool.visibleToAgent),
+  }
+  let definition = dict{
+    "name": JSON.Encode.string(tool.name),
+    "description": JSON.Encode.string(tool.description),
+    "inputSchema": tool.inputSchema,
+    "_meta": JSON.Encode.object(dict{"ai.frontman/tool-metadata": JSON.Encode.object(metadata)}),
+  }
+  tool.outputSchema->Option.forEach(outputSchema =>
+    definition->Dict.set("outputSchema", outputSchema)
+  )
+  JSON.Encode.object(definition)
+}
+
+let parseToolsResponse = (json: JSON.t): result<Types.toolsResponse, string> => {
+  switch json->Decoders.parseSchema(Types.toolsResponseSchema) {
+  | Ok(data) => Ok(data)
+  | Error(currentError) =>
+    switch json->Decoders.parseSchema(Types.legacyToolsResponseSchema) {
+    | Ok(data) =>
+      Ok({
+        tools: data.tools->Array.map(normalizeLegacyTool),
+        serverInfo: data.serverInfo,
+        protocolVersion: Types.protocolVersion,
+      })
+    | Error(legacyError) =>
+      Error(`Current protocol: ${currentError}; legacy protocol: ${legacyError}`)
+    }
+  }
+}
+
 let connect = async (relay: t, ~signal: option<WebAPI.EventTypes.abortSignal>=?): result<
   unit,
   string,
@@ -54,7 +93,7 @@ let connect = async (relay: t, ~signal: option<WebAPI.EventTypes.abortSignal>=?)
       Error(msg)
     | true =>
       let json = await response->WebAPI.Response.json
-      switch json->Decoders.parseSchema(Types.toolsResponseSchema) {
+      switch json->parseToolsResponse {
       | Ok(data) =>
         relay.state := Connected({tools: data.tools, serverInfo: data.serverInfo})
         Ok()

--- a/libs/frontman-client/test/FrontmanClient__Relay.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Relay.test.res
@@ -12,6 +12,37 @@ describe("Relay.connect", _t => {
     ->Expect.toThrow
   })
 
+  test("normalizes WordPress relay v1 responses", t => {
+    let json = JSON.parseOrThrow(`{
+      "tools":[{
+        "name":"wp_list_posts",
+        "description":"List posts",
+        "access":"read",
+        "inputSchema":{"type":"object"},
+        "visibleToAgent":true
+      }],
+      "serverInfo":{"name":"frontman-wordpress","version":"4.0.0"},
+      "protocolVersion":"1.0"
+    }`)
+    let response = json->Relay.parseToolsResponse->Result.getOrThrow
+
+    t->expect(response.protocolVersion)->Expect.toBe("2.0")
+    t
+    ->expect(response.tools->Array.get(0)->Option.map(jsonString))
+    ->Expect.toEqual(
+      Some(
+        JSON.stringify(
+          JSON.parseOrThrow(`{
+            "name":"wp_list_posts",
+            "description":"List posts",
+            "inputSchema":{"type":"object"},
+            "_meta":{"ai.frontman/tool-metadata":{"access":"read","visibleToAgent":true}}
+          }`),
+        ),
+      ),
+    )
+  })
+
   test("requires relay v2 tool metadata shape", t => {
     let legacy = JSON.parseOrThrow(`{
       "tools":[{"name":"hidden","inputSchema":{"type":"object"},"access":"read","visibleToAgent":false}],

--- a/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
+++ b/libs/frontman-protocol/src/FrontmanProtocol__Relay.res
@@ -1,8 +1,19 @@
 module MCP = FrontmanProtocol__MCP
 
 let protocolVersion = "2.0"
+let legacyProtocolVersion = "1.0"
 
 type remoteTool = JSON.t
+
+@schema
+type legacyRemoteTool = {
+  name: string,
+  description: string,
+  access: option<FrontmanProtocol__Tool.access>,
+  inputSchema: JSON.t,
+  outputSchema: option<JSON.t>,
+  visibleToAgent: bool,
+}
 
 let relayToolMetadataSchema = S.object(s => {
   s.field("visibleToAgent", S.bool)->ignore
@@ -47,6 +58,13 @@ let toolsResponseSchema = S.object(s => {
   serverInfo: s.field("serverInfo", MCP.infoSchema),
   protocolVersion: s.field("protocolVersion", S.literal(protocolVersion)),
 })
+
+@schema
+type legacyToolsResponse = {
+  tools: array<legacyRemoteTool>,
+  serverInfo: MCP.info,
+  protocolVersion: @s.matches(S.literal(legacyProtocolVersion)) string,
+}
 
 @schema
 type toolCallRequest = {


### PR DESCRIPTION
## Summary
- accept and normalize WordPress relay protocol 1.0 catalogs in the hosted client
- report project-context connection failures to Sentry
- replace the endless loading state with a visible connection error

## Verification
- `make -C libs/frontman-client test`
- `make -C libs/client test`
- `make -C libs/client build-standalone`
- manually loaded the fixed standalone bundle on a WordPress v4 site and confirmed project context connects successfully

No production service restart is required; merging deploys the corrected hosted client.