### PR TITLE
Keep agent executions registered through completion

### DIFF
--- a/.changeset/fix-agent-completion-lifecycle.md
+++ b/.changeset/fix-agent-completion-lifecycle.md
@@ -2,4 +2,4 @@
 "frontman": patch
 ---
 
-Keep agent executions registered until terminal events finish so completion checks cannot race persistence.
+Keep agent executions registered until terminal events finish so completion checks cannot race persistence. Queued turns wait for the previous worker to exit before they start.

--- a/.changeset/fix-agent-completion-lifecycle.md
+++ b/.changeset/fix-agent-completion-lifecycle.md
@@ -2,4 +2,4 @@
 "frontman": patch
 ---
 
-Keep agent executions registered until terminal events finish so completion checks cannot race persistence. Queued turns wait for the previous worker to exit before they start.
+Keep agent executions registered until terminal events finish so completion checks cannot race persistence. Queued turns wait for the previous worker to exit before they start. Ignore cancellation requests for finishing workers so terminal persistence can complete.

--- a/.changeset/fix-agent-completion-lifecycle.md
+++ b/.changeset/fix-agent-completion-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Keep agent executions registered until terminal events finish so completion checks cannot race persistence.

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -431,6 +431,8 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert [turn_started] = turn_started_rows(task_id)
       assert turn_started.data.agent_id == "test-planner"
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
+      refute_running_eventually(task_id)
     end
 
     test "accepts follow-up while running and drains it next", %{
@@ -1045,6 +1047,9 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
         worker: GenerateTitle,
         args: %{task_id: task_id, user_prompt_text: "Use this prompt"}
       )
+
+      assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
+      refute_running_eventually(task_id)
     end
 
     test "second message does not enqueue an additional title generation job", %{

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -2245,6 +2245,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
                  &1
                )
              )
+
+      assert_state_update_running_then_idle(task_id)
     end
 
     test "non-retryable error pushes error notification without retryAt", %{

--- a/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
@@ -30,12 +30,7 @@ defmodule SwarmAi.ExecutionWorker do
   def handle_continue(:run, %__MODULE__{loop: loop, runtime: runtime} = state) do
     task_supervisor = SwarmAi.Runtime.task_supervisor_name(runtime)
 
-    final_loop =
-      try do
-        SwarmAi.Executor.run(loop, task_supervisor)
-      after
-        SwarmAi.Runtime.Registry.unregister(runtime, loop.task_id)
-      end
+    final_loop = SwarmAi.Executor.run(loop, task_supervisor)
 
     try do
       final_loop.dispatch_event.(final_loop.status)

--- a/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
+++ b/apps/swarm_ai/lib/swarm_ai/execution_worker.ex
@@ -31,6 +31,7 @@ defmodule SwarmAi.ExecutionWorker do
     task_supervisor = SwarmAi.Runtime.task_supervisor_name(runtime)
 
     final_loop = SwarmAi.Executor.run(loop, task_supervisor)
+    :ok = SwarmAi.Runtime.Registry.mark_finishing(runtime, loop.task_id)
 
     try do
       final_loop.dispatch_event.(final_loop.status)

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -52,6 +52,9 @@ defmodule SwarmAi.Runtime do
   @spec cancel(atom(), String.t()) :: :ok | {:error, :not_running}
   def cancel(runtime, task_id) when is_atom(runtime) and is_binary(task_id) do
     case SwarmAi.Runtime.Registry.lookup(runtime, task_id) do
+      [{_pid, :finishing}] ->
+        :ok
+
       [{pid, _}] ->
         Logger.info("Cancelling execution for #{inspect(task_id)}")
         Process.exit(pid, :cancelled)

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -21,9 +21,11 @@ defmodule SwarmAi.Runtime do
   @spec run(atom(), SwarmAi.Loop.t()) ::
           {:ok, pid()} | {:error, :already_running | {:start_failed, term()}}
   def run(runtime, %SwarmAi.Loop{} = loop) when is_atom(runtime) do
-    case GenServer.call(runtime, {:run, loop}, 5_000) do
-      {:error, {:start_failed, {:exit, reason}}} -> exit(reason)
-      result -> result
+    with :ok <- await_finishing_execution(runtime, loop.task_id) do
+      case GenServer.call(runtime, {:run, loop}, 5_000) do
+        {:error, {:start_failed, {:exit, reason}}} -> exit(reason)
+        result -> result
+      end
     end
   end
 
@@ -109,6 +111,27 @@ defmodule SwarmAi.Runtime do
       {%SwarmAi.Loop{} = loop, monitors} ->
         SwarmAi.TerminalEvent.emit(loop, reason)
         {:noreply, %{state | monitors: monitors}}
+    end
+  end
+
+  defp await_finishing_execution(runtime, task_id) do
+    case SwarmAi.Runtime.Registry.lookup(runtime, task_id) do
+      [{pid, :finishing}] ->
+        ref = Process.monitor(pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+        after
+          5_000 ->
+            Process.demonitor(ref, [:flush])
+            {:error, {:start_failed, :finishing_timeout}}
+        end
+
+      [{_pid, _running}] ->
+        :ok
+
+      [] ->
+        :ok
     end
   end
 

--- a/apps/swarm_ai/lib/swarm_ai/runtime/registry.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime/registry.ex
@@ -15,10 +15,10 @@ defmodule SwarmAi.Runtime.Registry do
     Registry.lookup(name(runtime), task_id)
   end
 
-  def unregister(runtime, task_id) when is_atom(runtime) and is_binary(task_id) do
-    Registry.unregister(name(runtime), task_id)
-  catch
-    :exit, {:noproc, _} -> :ok
-    :exit, :noproc -> :ok
+  def mark_finishing(runtime, task_id) when is_atom(runtime) and is_binary(task_id) do
+    {:finishing, _previous} =
+      Registry.update_value(name(runtime), task_id, fn _ -> :finishing end)
+
+    :ok
   end
 end

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -27,6 +27,48 @@ defmodule SwarmAiTest do
       assert_receive {:completed, true}
     end
 
+    test "hands off to the next execution after terminal dispatch finishes" do
+      runtime = start_runtime!()
+      test_pid = self()
+
+      dispatch = fn
+        :completed ->
+          send(test_pid, {:completion_broadcast, self()})
+
+          receive do
+            :finish_persistence -> :ok
+          after
+            2_000 -> raise "Terminal persistence was not released"
+          end
+
+        _event ->
+          :ok
+      end
+
+      {:ok, pid} =
+        run_agent(runtime, "task-handoff", %MockLLM{response: "done"}, dispatch_event: dispatch)
+
+      assert_receive {:completion_broadcast, ^pid}
+
+      next_loop = agent("task-handoff", %MockLLM{response: "follow-up"}, [])
+
+      next_run =
+        Task.async(fn ->
+          send(test_pid, :starting_next_turn)
+          SwarmAi.run(runtime, next_loop)
+        end)
+
+      assert_receive :starting_next_turn
+      assert Task.yield(next_run, 50) == nil
+      assert SwarmAi.running?(runtime, "task-handoff")
+
+      send(pid, :finish_persistence)
+      assert {:ok, next_pid} = Task.await(next_run, 2_000)
+      await_exit(next_pid)
+      assert_receive {:test_event, "task-handoff", :completed}
+      refute SwarmAi.running?(runtime, "task-handoff")
+    end
+
     test "prevents duplicate execution for same key" do
       runtime = start_runtime!()
       llm = %MockLLM{response: "slow", delay_ms: 500}

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -11,7 +11,7 @@ defmodule SwarmAiTest do
   def noop_timeout(_tool_call, _reason), do: :ok
 
   describe "run/2" do
-    test "unregisters before dispatching the terminal event" do
+    test "remains running while dispatching the terminal event" do
       runtime = start_runtime!()
       test_pid = self()
 
@@ -24,7 +24,7 @@ defmodule SwarmAiTest do
         run_agent(runtime, "task-handoff", %MockLLM{response: "done"}, dispatch_event: dispatch)
 
       await_exit(pid)
-      assert_receive {:completed, false}
+      assert_receive {:completed, true}
     end
 
     test "prevents duplicate execution for same key" do

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -137,6 +137,46 @@ defmodule SwarmAiTest do
       refute SwarmAi.running?(runtime, "task-c")
     end
 
+    test "does not interrupt terminal dispatch or emit a second terminal event" do
+      runtime = start_runtime!()
+      test_pid = self()
+
+      dispatch = fn
+        :completed ->
+          send(test_pid, {:completion_started, self()})
+
+          receive do
+            :finish_persistence ->
+              send(test_pid, :completion_persisted)
+              :ok
+          after
+            2_000 -> raise "Terminal persistence was not released"
+          end
+
+        event ->
+          send(test_pid, {:execution_event, event})
+          :ok
+      end
+
+      {:ok, pid} =
+        run_agent(runtime, "task-finishing", %MockLLM{response: "done"}, dispatch_event: dispatch)
+
+      assert_receive {:completion_started, ^pid}
+      ref = Process.monitor(pid)
+      assert :ok = SwarmAi.cancel(runtime, "task-finishing")
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 50
+      assert SwarmAi.running?(runtime, "task-finishing")
+
+      send(pid, :finish_persistence)
+      assert_receive :completion_persisted
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+      assert SwarmAi.active_count(runtime) == 0
+      refute_receive {:execution_event, {:cancelled, _}}, 50
+      refute_receive {:execution_event, {:crashed, _}}, 0
+      refute_receive {:execution_event, {:terminated, _}}, 0
+      refute_receive {:completion_started, _}, 0
+    end
+
     test "returns error when not running" do
       runtime = start_runtime!()
       assert SwarmAi.cancel(runtime, "nope") == {:error, :not_running}


### PR DESCRIPTION
## Summary

- keep execution workers registered until the OTP process exits instead of unregistering before terminal-event persistence
- make execution and retry tests wait for their existing terminal lifecycle events
- prevent SQL sandbox owners from being stopped while execution persistence is still active

## Verification

- `apps/swarm_ai`: 121 passed
- `apps/frontman_server` full suite: 889 passed
- execution integration suite: 40 passed with zero DBConnection ownership errors
- channel suite repeated three times: 70 passed each run

The remaining Postgrex `client exited` logs come from Phoenix terminating channel processes during checkout; this PR fixes the separate ownership violation where application-supervised execution workers outlived a test sandbox owner.