### PR TITLE
Clarify task history loading

### DIFF
--- a/.changeset/clarify-task-history-loading.md
+++ b/.changeset/clarify-task-history-loading.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Separate lightweight task metadata lookup from explicit task history loading.

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -61,7 +61,8 @@ defmodule FrontmanServer.Tasks do
   alias FrontmanServer.Workers.GenerateTitle
   require Logger
 
-  defp get_task_by_id(scope, task_id) do
+  @doc "Gets task metadata by ID without loading its interaction history."
+  def get_task(scope, task_id) do
     case task_id
          |> TaskSchema.by_id_for_user(Accounts.scope_user_id(scope))
          |> Repo.one() do
@@ -97,14 +98,10 @@ defmodule FrontmanServer.Tasks do
     {:ok, tasks}
   end
 
-  @doc """
-  Gets a task by ID. Returns the task with interactions loaded.
-
-  Requires authorization - scope.user.id must match task.user_id.
-  """
-  def get_task(scope, task_id) do
-    with {:ok, schema} <- get_task_by_id(scope, task_id) do
-      {:ok, hydrate_task(schema)}
+  @doc "Gets a task by ID with its interaction history loaded."
+  def get_task_with_history(scope, task_id) do
+    with {:ok, task} <- get_task(scope, task_id) do
+      {:ok, %{task | interaction_rows: load_interaction_rows(task.id)}}
     end
   end
 
@@ -121,7 +118,7 @@ defmodule FrontmanServer.Tasks do
   Cascade deletes configured in migration handle interaction cleanup.
   """
   def delete_task(scope, task_id) do
-    with {:ok, schema} <- get_task_by_id(scope, task_id),
+    with {:ok, schema} <- get_task(scope, task_id),
          {:ok, _} <- Repo.delete(schema) do
       :ok
     end
@@ -146,10 +143,6 @@ defmodule FrontmanServer.Tasks do
 
     TaskSchema.create_changeset(attrs)
     |> Repo.insert()
-  end
-
-  defp hydrate_task(%TaskSchema{} = task_schema) do
-    %{task_schema | interaction_rows: load_interaction_rows(task_schema.id)}
   end
 
   defp load_interaction_rows(task_id) do
@@ -235,7 +228,7 @@ defmodule FrontmanServer.Tasks do
 
   @doc "Stores the discovered project structure summary for a task."
   def add_discovered_project_structure(scope, task_id, summary) do
-    with {:ok, %TaskSchema{} = task} <- get_task_by_id(scope, task_id),
+    with {:ok, %TaskSchema{} = task} <- get_task(scope, task_id),
          false <-
            task.id
            |> InteractionSchema.for_task()
@@ -322,7 +315,7 @@ defmodule FrontmanServer.Tasks do
       |> Interaction.AgentResponse.attrs_from_llm_response()
       |> Map.put(:timestamp, metadata.timestamp)
 
-    with {:ok, task_schema} <- get_task_by_id(scope, task_id),
+    with {:ok, task_schema} <- get_task(scope, task_id),
          {:ok, _interaction} <-
            record_interaction(task_schema, :agent_response, attrs, turn_number) do
       :ok
@@ -505,7 +498,7 @@ defmodule FrontmanServer.Tasks do
          {:ok, user_message_attrs} <-
            Interaction.UserMessage.attrs(content_blocks, model, agent_id),
          user_message_attrs = put_selected_skill(user_message_attrs, selected_skill),
-         {:ok, task_schema} <- get_task_by_id(scope, task_id) do
+         {:ok, task_schema} <- get_task(scope, task_id) do
       record_interaction_row(
         task_schema,
         %{
@@ -747,7 +740,7 @@ defmodule FrontmanServer.Tasks do
 
   def agent_replied(scope, task_id, turn_number, content, metadata \\ %{}, usage \\ nil)
       when is_integer(turn_number) and turn_number > 0 do
-    with {:ok, task_schema} <- get_task_by_id(scope, task_id) do
+    with {:ok, task_schema} <- get_task(scope, task_id) do
       record_interaction(
         task_schema,
         :agent_response,
@@ -760,7 +753,7 @@ defmodule FrontmanServer.Tasks do
   @doc "Records how the given execution ended."
   def record_execution_outcome(scope, task_id, turn_number, outcome)
       when is_integer(turn_number) and turn_number > 0 do
-    with {:ok, task_schema} <- get_task_by_id(scope, task_id) do
+    with {:ok, task_schema} <- get_task(scope, task_id) do
       {type, attrs} = build_execution_outcome(outcome)
 
       record_interaction(task_schema, type, attrs, turn_number)
@@ -810,7 +803,7 @@ defmodule FrontmanServer.Tasks do
   @doc "Records a client-handled tool request in the given turn."
   def request_client_tool(scope, task_id, turn_number, %SwarmAi.ToolCall{} = tool_call_data)
       when is_integer(turn_number) and turn_number > 0 do
-    with {:ok, schema} <- get_task_by_id(scope, task_id),
+    with {:ok, schema} <- get_task(scope, task_id),
          {:ok, attrs} <- Interaction.ToolCall.attrs(tool_call_data) do
       record_interaction(schema, :tool_call, attrs, turn_number)
     end
@@ -834,7 +827,7 @@ defmodule FrontmanServer.Tasks do
         opts \\ []
       )
       when is_list(opts) do
-    with {:ok, schema} <- get_task_by_id(scope, task_id) do
+    with {:ok, schema} <- get_task(scope, task_id) do
       turn_number = tool_result_turn_number(task_id, tool_call_id, opts)
       attrs = Interaction.ToolResult.attrs(tool_call_data, result)
 
@@ -901,7 +894,7 @@ defmodule FrontmanServer.Tasks do
   in the same turn. Completion, error, and pause records stop execution.
   """
   def get_active_turn_unresolved_tool_calls(scope, task_id) do
-    with {:ok, _schema} <- get_task_by_id(scope, task_id),
+    with {:ok, _schema} <- get_task(scope, task_id),
          rows = load_interaction_rows(task_id),
          {:ok, history} <- History.new(rows) do
       case History.active_turn_number(history) do
@@ -924,7 +917,7 @@ defmodule FrontmanServer.Tasks do
 
   @doc "Records a retry request and starts execution."
   def retry_execution(scope, task_id, retried_error_id, execution) do
-    with {:ok, schema} <- get_task_by_id(scope, task_id),
+    with {:ok, schema} <- get_task(scope, task_id),
          rows = load_interaction_rows(task_id),
          {:ok, history} = History.new(rows),
          {:ok, turn_number} <- retry_turn_number(rows, retried_error_id),
@@ -991,7 +984,7 @@ defmodule FrontmanServer.Tasks do
 
   @doc "Resumes execution for the active turn."
   def resume_execution(scope, task_id, execution) do
-    with {:ok, task} <- get_task(scope, task_id),
+    with {:ok, task} <- get_task_with_history(scope, task_id),
          {:ok, history} <- History.new(task.interaction_rows),
          turn_number when is_integer(turn_number) <- History.active_turn_number(history),
          {:ok, agent} <- turn_agent(scope, history, turn_number),
@@ -1021,7 +1014,7 @@ defmodule FrontmanServer.Tasks do
   Verifies the task exists and belongs to the user before cancelling.
   """
   def cancel_execution(scope, task_id) do
-    with {:ok, _schema} <- get_task_by_id(scope, task_id) do
+    with {:ok, _schema} <- get_task(scope, task_id) do
       SwarmAi.cancel(FrontmanServer.AgentRuntime, task_id)
     end
   end
@@ -1105,7 +1098,7 @@ defmodule FrontmanServer.Tasks do
   def apply_title_suggestion(scope, task_id, title) do
     default_title = TaskSchema.default_title()
 
-    with {:ok, %TaskSchema{short_desc: ^default_title} = schema} <- get_task_by_id(scope, task_id),
+    with {:ok, %TaskSchema{short_desc: ^default_title} = schema} <- get_task(scope, task_id),
          {:ok, _updated} <-
            schema
            |> TaskSchema.update_changeset(%{short_desc: title})
@@ -1133,7 +1126,7 @@ defmodule FrontmanServer.Tasks do
 
   @doc "Lists all todos for a task."
   def list_todos(scope, task_id) do
-    with {:ok, task} <- get_task(scope, task_id) do
+    with {:ok, task} <- get_task_with_history(scope, task_id) do
       {:ok, list_todos(task)}
     end
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -243,7 +243,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   defp execute_backend_tool(scope, module, tool_call, task_id, turn_number) do
     Logger.debug("ToolExecutor: Executing backend tool #{tool_call.name}")
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
     tool_call = SwarmAi.ToolCall.strip_null_arguments(tool_call)
 
     context = %Backend.Context{

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -39,7 +39,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   def join("task:" <> task_id, _params, socket) do
     scope = socket.assigns.scope
 
-    with {:ok, task} <- Tasks.get_task(scope, task_id),
+    with {:ok, task} <- Tasks.get_task_with_history(scope, task_id),
          {:ok, _owner} <-
            Registry.register(FrontmanServer.ProcessRegistry, {:task_channel, task_id}, nil) do
       {:ok, history} = TaskHistory.new(task.interaction_rows)
@@ -353,7 +353,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   end
 
   defp load_turn_context!(socket, turn_number) do
-    {:ok, task} = Tasks.get_task(socket.assigns.scope, socket.assigns.task_id)
+    {:ok, task} = Tasks.get_task_with_history(socket.assigns.scope, socket.assigns.task_id)
     {:ok, history} = TaskHistory.new(task.interaction_rows)
     TaskHistory.turn_context(history, turn_number)
   end
@@ -644,7 +644,7 @@ defmodule FrontmanServerWeb.TaskChannel do
     scope = socket.assigns.scope
     Logger.info("ACP session/load request received on session channel for: #{task_id}")
 
-    case Tasks.get_task(scope, task_id) do
+    case Tasks.get_task_with_history(scope, task_id) do
       {:ok, task} ->
         {:ok, history} = TaskHistory.new(task.interaction_rows)
         {:ok, replay} = ACPHistory.build(history, task.id, Agents.list_agents(scope))

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -61,7 +61,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
              "Expected exactly 1 tool call broadcast, got #{length(tool_call_broadcasts)}. " <>
                "This indicates Tasks.request_client_tool is being called multiple times."
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       assert %Tasks.Interaction.AgentResponse{metadata: %{"tool_calls" => [persisted_call]}} =
                Enum.find(

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
@@ -115,7 +115,7 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
 
       assert_receive_interaction(%Tasks.Interaction.AgentCompleted{}, _turn_number, 10_000)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       assert %Interaction.ToolResult{is_error: false} =
                Enum.find(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -187,7 +187,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       tc = %SwarmAi.ToolCall{id: "tc-deadline-1", name: "todo_write", arguments: "{}"}
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :triggered)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_result =
         Enum.find(Tasks.interactions(task), fn
@@ -214,7 +214,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       tc = %SwarmAi.ToolCall{id: "tc-pause-1", name: "some_mcp_tool", arguments: "{}"}
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :pause_agent, tc, :triggered)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_result =
         Enum.find(Tasks.interactions(task), fn

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -49,7 +49,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       tc = %SwarmAi.ToolCall{id: "tc-to-2", name: "some_tool", arguments: "{}"}
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :cancelled)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end
 
@@ -67,7 +67,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
 
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :pause_agent, tc, :cancelled)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end
   end
@@ -114,7 +114,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         assert message =~ "filtered_tool"
         assert message =~ "unavailable"
 
-        {:ok, task} = Tasks.get_task(scope, task_id)
+        {:ok, task} = Tasks.get_task_with_history(scope, task_id)
         assert [%Interaction.ToolResult{is_error: false}] = tool_results(task, available.id)
         assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, unavailable.id)
 
@@ -174,7 +174,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
                  execution_mode: :serial
                })
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       refute Enum.any?(Tasks.interactions(task), fn
                %Interaction.ToolCall{tool_call_id: tool_call_id} -> tool_call_id == tc.id

--- a/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
@@ -101,7 +101,7 @@ defmodule FrontmanServer.Tasks.ExecutionImageHistoryTest do
     assert [%{type: :image, data: ^screenshot}] = image_parts([turn1_tool_message])
     refute content_text([turn1_tool_message]) =~ "data:image"
 
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
     persisted = tool_result!(Tasks.interactions(task), screenshot_tool_call_id)
     assert persisted.result == canonical_result
 
@@ -182,7 +182,7 @@ defmodule FrontmanServer.Tasks.ExecutionImageHistoryTest do
     assert [%{type: :image}] = image_parts([tool_message])
     refute content_text([tool_message]) =~ "data:image"
 
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
     persisted = tool_result!(Tasks.interactions(task), tool_call_id)
 
     assert persisted.result == %{

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -462,7 +462,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       refute_running_eventually(task_id)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       agent_responses =
         Enum.filter(Tasks.interactions(task), &match?(%Interaction.AgentResponse{}, &1))
@@ -694,7 +694,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentError{category: "auth"}, 1)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert [%Interaction.UserMessage{} = persisted_message | _] = Tasks.interactions(task)
 
       assert %Interaction.CurrentPage{title: "Frontman: Visual AI Frontend Editing"} =
@@ -732,7 +732,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       completions =
         Enum.filter(Tasks.interactions(task), &match?(%Interaction.AgentCompleted{}, &1))
@@ -762,7 +762,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
                  execution_request_fixture()
                )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.AgentRetry{}, &1))
     end
@@ -986,7 +986,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_results =
         Enum.filter(Tasks.interactions(task), fn
@@ -1089,7 +1089,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentPaused{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_results =
         Enum.filter(Tasks.interactions(task), fn
@@ -1131,7 +1131,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_call_interaction =
         Enum.find(Tasks.interactions(task), fn
@@ -1242,7 +1242,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
       assert {:ok, []} = Tasks.list_todos(scope, task_id)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       interactions = Tasks.interactions(task)
       refute Enum.any?(interactions, &match?(%Interaction.ToolCall{tool_call_id: ^tc_id}, &1))
       assert Enum.any?(interactions, &match?(%Interaction.ToolResult{tool_call_id: ^tc_id}, &1))
@@ -1363,7 +1363,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentError{kind: "terminated"}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       agent_error =
         Enum.find(Tasks.interactions(task), &match?(%Interaction.AgentError{}, &1))
@@ -1410,7 +1410,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
         }
       })
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       agent_error =
         Enum.find(Tasks.interactions(task), &match?(%Interaction.AgentError{}, &1))
@@ -1457,7 +1457,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
         }
       })
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       agent_error =
         Enum.find(Tasks.interactions(task), &match?(%Interaction.AgentError{}, &1))
@@ -1542,7 +1542,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_result =
         Enum.find(Tasks.interactions(task), fn
@@ -1578,7 +1578,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_result =
         Enum.find(Tasks.interactions(task), fn

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -17,7 +17,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
 
   describe "list_todos/1" do
     test "returns empty map when no interactions", %{task_id: task_id, scope: scope} do
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert %{} = Todos.list_todos(task.interaction_rows)
     end
 
@@ -57,7 +57,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       todos = Todos.list_todos(task.interaction_rows)
       assert map_size(todos) == 2
 
@@ -111,7 +111,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       todos = Todos.list_todos(task.interaction_rows)
       assert map_size(todos) == 1
 
@@ -155,7 +155,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       todos = Todos.list_todos(task.interaction_rows)
       assert map_size(todos) == 1
       assert [%{content: "Good task"}] = Map.values(todos)
@@ -174,7 +174,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert %{} = Todos.list_todos(task.interaction_rows)
     end
 
@@ -199,7 +199,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       todos = Todos.list_todos(task.interaction_rows)
       assert todos == %{}
     end
@@ -229,7 +229,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       assert [%{content: "Reuse loaded history", priority: :high}] = Tasks.list_todos(task)
     end

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -106,7 +106,7 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
         assert %{"content" => [%{"text" => canonical_text}]} = canonical.result
         assert_receive {:tool_result, "call_dedup", [%{text: ^canonical_text}], false}
 
-        {:ok, task} = Tasks.get_task(scope, task_id)
+        {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
         assert [_result] =
                  Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -37,6 +37,7 @@ defmodule FrontmanServer.TasksTest do
       {:ok, task} = Tasks.get_task(scope, task_id)
       assert task.id == task_id
       assert task.framework == :nextjs
+      assert %Ecto.Association.NotLoaded{} = task.interaction_rows
     end
   end
 
@@ -201,7 +202,7 @@ defmodule FrontmanServer.TasksTest do
                  execution_request_fixture(model: "missing:test")
                )
 
-      assert {:ok, loaded_task} = Tasks.get_task(scope, task.id)
+      assert {:ok, loaded_task} = Tasks.get_task_with_history(scope, task.id)
 
       assert %Interaction.TurnStarted{agent_id: "test-frontman"} =
                Enum.find(
@@ -252,7 +253,7 @@ defmodule FrontmanServer.TasksTest do
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.AgentError{}, &1))
 
       assert [
@@ -297,7 +298,7 @@ defmodule FrontmanServer.TasksTest do
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       interactions = Tasks.interactions(task)
 
       assert Enum.any?(interactions, &match?(%Interaction.AgentError{kind: "cancelled"}, &1))
@@ -779,7 +780,7 @@ defmodule FrontmanServer.TasksTest do
                {Interaction.AgentResponse, ^turn_number}
              ] = db_type_turns(task_id)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       messages = Tasks.Interaction.to_swarm_messages(Tasks.interactions(task))
 
       assert length(messages) == 4,
@@ -1383,7 +1384,7 @@ defmodule FrontmanServer.TasksTest do
           {:paused_for_tool_timeout, "question", 120_000}
         )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       paused = Enum.find(Tasks.interactions(task), &match?(%Interaction.AgentPaused{}, &1))
       assert paused != nil
@@ -1408,7 +1409,7 @@ defmodule FrontmanServer.TasksTest do
           {:paused_for_tool_timeout, "question", 120_000}
         )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       messages = Interaction.to_swarm_messages(Tasks.interactions(task))
 

--- a/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
@@ -14,7 +14,7 @@ defmodule FrontmanServer.Tools.AgentFeedbackTest do
   test "enqueues feedback for Discord" do
     scope = user_scope_fixture()
     task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
     result =
       AgentFeedback.execute(
@@ -42,7 +42,7 @@ defmodule FrontmanServer.Tools.AgentFeedbackTest do
   test "rejects invalid outcome" do
     scope = user_scope_fixture()
     task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
     result = AgentFeedback.execute(%{"outcome" => "bad", "message" => "x"}, %Context{task: task})
 

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -18,7 +18,7 @@ defmodule FrontmanServer.ToolsTest do
   setup do
     scope = user_scope_fixture()
     task_id = task_with_active_turn_fixture(scope, framework: "nextjs").id
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
     {:ok, task_id: task_id, task: task, scope: scope, turn_number: latest_turn_number(task_id)}
   end
 
@@ -228,7 +228,7 @@ defmodule FrontmanServer.ToolsTest do
           turn_number: turn_number
         )
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       context = build_context(task)
 
       result = GetToolResult.execute(%{"tool_call_id" => "tc-read"}, context)

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -260,7 +260,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     assert message =~
              "#{reason} for task #{task_id}, tool testTool, call #{tool_call.tool_call_id}"
 
-    {:ok, task} = Tasks.get_task(scope, task_id)
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
     refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
   end
 
@@ -289,7 +289,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     assert_receive {:tool_result, ^tool_call_id,
                     [%SwarmAi.Message.ContentPart{type: :text, text: ^message}], true}
 
-    assert {:ok, task} = Tasks.get_task(scope, task_id)
+    assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
     assert Enum.any?(
              Tasks.interactions(task),
@@ -457,7 +457,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
                  args["user_prompt_text"] == "Hello"
              end)
 
-      assert {:ok, task} = Tasks.get_task(scope, task_id)
+      assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert Enum.any?(task.interaction_rows, &(&1.type == :user_message and &1.id == message_id))
       turn_row = Enum.find(task.interaction_rows, &(&1.type == :turn_started))
       response = Enum.find(Tasks.interactions(task), &match?(%Interaction.AgentResponse{}, &1))
@@ -549,7 +549,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       assert_reply(ref, :ok, %{"acp:message" => %{"result" => %{}}})
 
-      assert {:ok, task} = Tasks.get_task(scope, task_id)
+      assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert [%Interaction.UserMessage{agent_id: "test-planner"}] = Tasks.interactions(task)
     end
 
@@ -574,7 +574,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert response["error"]["code"] == JsonRpc.error_invalid_params()
       assert response["error"]["message"] == "Unknown agent"
 
-      assert {:ok, task} = Tasks.get_task(scope, task_id)
+      assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert Tasks.interactions(task) == []
     end
 
@@ -627,7 +627,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         assert response["error"]["code"] == JsonRpc.error_invalid_params()
         assert response["error"]["message"] == unquote(expected_message)
 
-        assert {:ok, task} = Tasks.get_task(scope, task_id)
+        assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
         assert Tasks.interactions(task) == []
         assert all_enqueued(worker: GenerateTitle) == []
 
@@ -741,7 +741,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert_state_update_idle(task_id)
       assert_state_update_running_then_idle(task_id)
 
-      assert {:ok, task} = Tasks.get_task(socket.assigns.scope, task_id)
+      assert {:ok, task} = Tasks.get_task_with_history(socket.assigns.scope, task_id)
 
       assert [^first_message_id, ^second_message_id] =
                task.interaction_rows
@@ -1802,7 +1802,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       turn_number = latest_turn_number(task_id)
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.AgentError{}, &1))
 
       {:ok, _reply, socket} =
@@ -1848,7 +1848,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       assert_receive {:resumed_model, %LLMDB.Model{id: "openai/gpt-5.5"}}, 1_000
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_results =
         Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
@@ -2096,7 +2096,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       :sys.get_state(socket.channel_pid)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       tool_results =
         Enum.filter(Tasks.interactions(task), &match?(%Tasks.Interaction.ToolResult{}, &1))
@@ -2210,7 +2210,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       retried_error_id = error_interaction.id
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       refute Enum.any?(
                Tasks.interactions(task),
@@ -2228,13 +2228,13 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       send(socket.channel_pid, {:fire_retry, make_ref()})
       :sys.get_state(socket.channel_pid)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.AgentRetry{}, &1))
 
       send(socket.channel_pid, {:fire_retry, retry_state.timer_token})
       :sys.get_state(socket.channel_pid)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       assert Enum.any?(
                Tasks.interactions(task),
@@ -2289,7 +2289,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       :sys.get_state(socket.channel_pid)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       assert Enum.any?(
                Tasks.interactions(task),
@@ -2329,7 +2329,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
       :sys.get_state(socket.channel_pid)
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       refute Enum.any?(
                Tasks.interactions(task),
@@ -2387,7 +2387,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         }
       })
 
-      assert {:ok, task} = Tasks.get_task(scope, task_id)
+      assert {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       refute Enum.any?(task.interaction_rows, &(&1.id == message_id))
     end
 
@@ -2398,7 +2398,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     } do
       start_turn_fixture(scope, task_id, [%{"type" => "text", "text" => "Claimed"}])
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       [%{id: message_id}] =
         Enum.filter(task.interaction_rows, &(&1.type == :user_message))
@@ -2417,7 +2417,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         "params" => %{"update" => %{"sessionUpdate" => "message_unqueued"}}
       })
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert Enum.any?(task.interaction_rows, &(&1.id == message_id))
     end
 
@@ -2467,7 +2467,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         }
       })
 
-      {:ok, task} = Tasks.get_task(scope, task_id)
+      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
       refute Enum.any?(
                Tasks.interactions(task),

--- a/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
@@ -176,7 +176,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
         }
       })
 
-      assert {:ok, task} = FrontmanServer.Tasks.get_task(scope, client_session_id)
+      assert {:ok, task} = FrontmanServer.Tasks.get_task_with_history(scope, client_session_id)
       assert task.id == client_session_id
       assert task.framework == :nextjs
     end
@@ -222,7 +222,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
         "result" => %{"sessionId" => ^client_session_id}
       })
 
-      assert {:ok, task} = FrontmanServer.Tasks.get_task(scope, client_session_id)
+      assert {:ok, task} = FrontmanServer.Tasks.get_task_with_history(scope, client_session_id)
       assert task.id == client_session_id
       assert task.framework == :nextjs
       assert Repo.get!(TaskSchema, client_session_id).framework == :nextjs
@@ -258,7 +258,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
 
       assert_push("acp:message", %{"id" => 2, "result" => %{}})
 
-      assert {:ok, task} = FrontmanServer.Tasks.get_task(scope, client_session_id)
+      assert {:ok, task} = FrontmanServer.Tasks.get_task_with_history(scope, client_session_id)
       assert task.framework == :vite
       assert Repo.get!(TaskSchema, client_session_id).framework == :vite
     end
@@ -462,12 +462,12 @@ defmodule FrontmanServerWeb.TasksChannelTest do
     test "deletes session and returns empty result", %{socket: socket, scope: scope} do
       task_id = task_fixture(scope).id
 
-      assert {:ok, _task} = FrontmanServer.Tasks.get_task(scope, task_id)
+      assert {:ok, _task} = FrontmanServer.Tasks.get_task_with_history(scope, task_id)
 
       ref = push(socket, "delete_session", %{"sessionId" => task_id})
       assert_reply(ref, :ok, %{})
 
-      assert {:error, :not_found} = FrontmanServer.Tasks.get_task(scope, task_id)
+      assert {:error, :not_found} = FrontmanServer.Tasks.get_task_with_history(scope, task_id)
     end
 
     test "only deletes own sessions", %{socket: socket, scope: scope} do
@@ -479,7 +479,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
       ref = push(socket, "delete_session", %{"sessionId" => other_task_id})
       assert_reply(ref, :error, _)
 
-      assert {:ok, _task} = FrontmanServer.Tasks.get_task(other_scope, other_task_id)
+      assert {:ok, _task} = FrontmanServer.Tasks.get_task_with_history(other_scope, other_task_id)
     end
   end
 end


### PR DESCRIPTION
## Summary
- make `get_task/2` the lightweight authorized metadata lookup
- add explicit `get_task_with_history/2` for callers that need interaction rows
- remove the private lookup and hydration helpers

## Validation
- `make -C apps/frontman_server lint`
- `make -C apps/frontman_server test` (889 passed)