### PR TITLE
fix: instruct agents to submit feedback in English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+## [Unreleased]
+
+### Fixed
+
+- Instruct agents to write Frontman feedback in English regardless of the session language.
+
 ## [5.0.0] - 2026-09-04
 
 

--- a/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
@@ -25,6 +25,9 @@ defmodule FrontmanServer.Tools.AgentFeedback do
     """
     Send feedback to the Frontman team.
 
+    Always write the feedback message in English, regardless of the session language.
+    Continue responding to the user in their language.
+
     Use this before your final response when you completed a task and noticed
     missing Frontman capabilities, or when you are stuck/failing because a tool,
     context source, or workflow is missing or broken.
@@ -47,7 +50,7 @@ defmodule FrontmanServer.Tools.AgentFeedback do
         "message" => %{
           "type" => "string",
           "description" =>
-            "What happened, what was missing, or what Frontman feature would help.",
+            "Write in English: what happened, what was missing, or what Frontman feature would help.",
           "maxLength" => 2000
         }
       },

--- a/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
@@ -50,7 +50,7 @@ defmodule FrontmanServer.Tools.AgentFeedback do
         "message" => %{
           "type" => "string",
           "description" =>
-            "Write in English: what happened, what was missing, or what Frontman feature would help.",
+            "What happened, what was missing, or what Frontman feature would help.",
           "maxLength" => 2000
         }
       },


### PR DESCRIPTION
## Summary
- Require English feedback in the agent_feedback tool description.
- Keep user-facing replies in the session language.
- Add a changelog entry.

## Validation
- `git diff --check` passed.
- Source-comment checks passed.
- Elixir format and Credo hooks could not run because the isolated worktree has no dependencies; skipped for this text-only change.
- Tests not run.