### PR TITLE
Add persistent chat support banner

### DIFF
--- a/.changeset/curvy-worlds-bathe.md
+++ b/.changeset/curvy-worlds-bathe.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Add an always-visible chat banner linking to GitHub stars or WordPress reviews, matching the first-task dialog.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -400,6 +400,7 @@ let make = (~onConfigureProvider: unit => unit) => {
   }
 
   <div className="relative flex flex-col h-full bg-[#130d20] text-zinc-200">
+    <Client__SupportBanner framework={Client__RuntimeConfig.read().framework} />
     <Client__UpdateBanner />
     <ScrollContainer className="flex-grow overflow-x-hidden">
       <ScrollContainer.ContentWrapper>

--- a/libs/client/src/components/frontman/Client__FirstTaskFeedbackDialog.res
+++ b/libs/client/src/components/frontman/Client__FirstTaskFeedbackDialog.res
@@ -7,10 +7,9 @@ let make = () => {
   let open_ = Client__State.useSelector(Client__State.Selectors.showFirstTaskFeedbackDialog)
   let linkCopied = Client__State.useSelector(Client__State.Selectors.firstTaskFeedbackLinkCopied)
   let shareFailed = Client__State.useSelector(Client__State.Selectors.firstTaskFeedbackShareFailed)
-  let (ratingUrl, ratingLabel) = switch Client__RuntimeConfig.read().framework {
-  | Nextjs | Vite | Astro => ("https://github.com/frontman-ai/frontman", "Star us on GitHub")
-  | Wordpress => ("https://wordpress.org/plugins/frontman-agentic-ai-editor/", "Leave a review")
-  }
+  let (ratingUrl, ratingLabel) = Client__SupportBanner.ratingTarget(
+    Client__RuntimeConfig.read().framework,
+  )
 
   <Dialog
     open_

--- a/libs/client/src/components/frontman/Client__SupportBanner.res
+++ b/libs/client/src/components/frontman/Client__SupportBanner.res
@@ -1,0 +1,25 @@
+let ratingTarget = (framework: Client__RuntimeConfig.frameworkId) =>
+  switch framework {
+  | Nextjs | Vite | Astro => ("https://github.com/frontman-ai/frontman", "Star us on GitHub")
+  | Wordpress => ("https://wordpress.org/plugins/frontman-agentic-ai-editor/", "Leave a review")
+  }
+
+@react.component
+let make = (~framework: Client__RuntimeConfig.frameworkId) => {
+  let (href, label) = ratingTarget(framework)
+
+  <div
+    className="shrink-0 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-emerald-400/15 bg-emerald-400/5 px-4 py-2 text-xs"
+  >
+    <span className="text-zinc-300"> {React.string("Enjoying Frontman?")} </span>
+    <a
+      href
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex min-h-6 items-center gap-1.5 rounded-sm font-medium text-emerald-300 underline decoration-emerald-300/40 underline-offset-4 hover:text-emerald-200 hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-emerald-300"
+    >
+      {React.string(label)}
+      <Client__UI__Icons.ExternalLink size=12 ariaHidden=true />
+    </a>
+  </div>
+}

--- a/libs/client/test/Client__SupportBanner.test.res
+++ b/libs/client/test/Client__SupportBanner.test.res
@@ -1,0 +1,20 @@
+open Vitest
+
+@module("react-dom/server")
+external renderToStaticMarkup: React.element => string = "renderToStaticMarkup"
+
+test("support banner uses the shared rating target for every framework", t => {
+  let frameworks: array<Client__RuntimeConfig.frameworkId> = [Nextjs, Vite, Astro, Wordpress]
+  frameworks->Array.forEach(framework => {
+    let html = renderToStaticMarkup(<Client__SupportBanner framework />)
+    let (url, label) = switch framework {
+    | Nextjs | Vite | Astro => ("https://github.com/frontman-ai/frontman", "Star us on GitHub")
+    | Wordpress => ("https://wordpress.org/plugins/frontman-agentic-ai-editor/", "Leave a review")
+    }
+    t->expect(html->String.includes(`href="${url}"`))->Expect.toBe(true)
+    t->expect(html->String.includes(label))->Expect.toBe(true)
+    t->expect(html->String.includes("Enjoying Frontman?"))->Expect.toBe(true)
+    t->expect(html->String.includes("target=\"_blank\""))->Expect.toBe(true)
+    t->expect(html->String.includes("rel=\"noopener noreferrer\""))->Expect.toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a compact, always-visible support banner above the chat conversation.
- Share GitHub star / WordPress review destinations with the first-task dialog.
- Use a subtle emerald accent, keyboard focus styling, and safe external links without animation or overlays.

## Testing
- `make rescript-build`
- `make -C libs/client test` — 424 tests passed
- Pre-commit checks and Reanalyze passed.