### PR TITLE
Remove timeout-driven pauses for interactive tools

### DIFF
--- a/.changeset/clarify-task-history-loading.md
+++ b/.changeset/clarify-task-history-loading.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Separate lightweight task metadata lookup from explicit task history loading.

--- a/.changeset/cuddly-friends-report.md
+++ b/.changeset/cuddly-friends-report.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/client": patch
+---
+
+Allow cancellation of a pending question even when the client shows the agent as idle.

--- a/.changeset/fix-agent-completion-lifecycle.md
+++ b/.changeset/fix-agent-completion-lifecycle.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Keep agent executions registered until terminal events finish so completion checks cannot race persistence. Queued turns wait for the previous worker to exit before they start. Ignore cancellation requests for finishing workers so terminal persistence can complete.

--- a/.changeset/fix-agent-feedback-delivery.md
+++ b/.changeset/fix-agent-feedback-delivery.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Allow agent feedback in read-only sessions. Reject blank messages and enforce the 2,000-character limit. Preserve the full feedback message in Discord.

--- a/.changeset/fix-deploy-drain-rpc-output.md
+++ b/.changeset/fix-deploy-drain-rpc-output.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Print the active execution count during deployment so the old server can stop when its work finishes instead of always waiting five minutes.

--- a/.changeset/fix-runtime-shutdown-events.md
+++ b/.changeset/fix-runtime-shutdown-events.md
@@ -1,5 +1,0 @@
----
-"frontman": patch
----
-
-Report pending agent terminations when the runtime shuts down after supervisor restart failures. This prevents the loss of termination events during registry crash recovery.

--- a/.changeset/many-trees-cheer.md
+++ b/.changeset/many-trees-cheer.md
@@ -1,0 +1,9 @@
+---
+"frontman": patch
+---
+
+Interactive tools now wait without a deadline. Finite tool failures return the same result that the server stores.
+
+Supported shutdown preserves dispatched interactive calls and interrupts other unresolved declarations, including tools that did not run. Historical timeout pauses remain terminal.
+
+Execution admission and reconnect behavior remain unchanged. This change does not guarantee cancellation without a worker or prevent synchronous replay after abrupt process loss.

--- a/.changeset/many-trees-cheer.md
+++ b/.changeset/many-trees-cheer.md
@@ -1,9 +1,0 @@
----
-"frontman": patch
----
-
-Interactive tools now wait without a deadline. Finite tool failures return the same result that the server stores.
-
-Supported shutdown preserves dispatched interactive calls and interrupts other unresolved declarations, including tools that did not run. Historical timeout pauses remain terminal.
-
-Execution admission and reconnect behavior remain unchanged. This change does not guarantee cancellation without a worker or prevent synchronous replay after abrupt process loss.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Instruct agents to write Frontman feedback in English regardless of the session language.
+- Interactive tools now wait without a deadline. Finite tool failures return the same result that the server stores. Supported shutdown preserves dispatched interactive calls and interrupts other unresolved declarations, including tools that did not run. Historical timeout pauses remain terminal. Execution admission and reconnect behavior remain unchanged. This change does not guarantee cancellation without a worker or prevent synchronous replay after abrupt process loss.
+- Report pending agent terminations when the runtime shuts down after supervisor restart failures. This prevents the loss of termination events during registry crash recovery.
+- Print the active execution count during deployment so the old server can stop when its work finishes instead of always waiting five minutes.
+- Allow agent feedback in read-only sessions. Reject blank messages and enforce the 2,000-character limit. Preserve the full feedback message in Discord.
+- Keep agent executions registered until terminal events finish so completion checks cannot race persistence. Queued turns wait for the previous worker to exit before they start. Ignore cancellation requests for finishing workers so terminal persistence can complete.
+
+### Changed
+
+- Separate lightweight task metadata lookup from explicit task history loading.
 
 ## [5.0.0] - 2026-09-04
 

--- a/agent_docs/elixir-style.md
+++ b/agent_docs/elixir-style.md
@@ -16,6 +16,9 @@ Safety > Performance > Developer Experience. All three matter.
   explicit bound. GenServer mailboxes should have backpressure or bounded queues. Use
   `:queue.len/1` checks or `Process.info(self(), :message_queue_len)` guards where needed.
   Timeouts on every `GenServer.call`, every `Task.await`, every `Req` request. No unbounded waits.
+  Exception: dispatched `Interactive` tools may await human input without a deadline. Their
+  parked execution retains history in memory and remains cancellable. Operation, transport,
+  and control-plane timeouts remain finite; recovery of browser tools requires a connection.
 
 - **Guard clauses are your assertions.** Use `when` guards liberally in function heads to assert
   pre-conditions at the boundary. They crash on violation — exactly what we want.

--- a/apps/frontman_server/README.md
+++ b/apps/frontman_server/README.md
@@ -13,6 +13,20 @@ Ready to run in production? Please [check our deployment guides](https://hexdocs
 
 * Boundary contract policy: [`BOUNDARY_CONTRACT_POLICY.md`](./BOUNDARY_CONTRACT_POLICY.md)
 
+## Interactive tool waits
+
+`Interactive` MCP tools have no execution deadline. The parked executor retains conversation history in memory and remains cancellable through the existing runtime.
+`Synchronous` tools keep finite deadlines. Transport, provider, and control-plane timeouts remain unchanged.
+
+Each dispatched call stores its execution mode. Supported shutdown preserves dispatched interactive calls and records interruption results for other unresolved declarations.
+This includes declared serial tools that did not run. Recovery still requires a connected browser for browser tools.
+Historical `AgentPaused` records remain terminal.
+
+Execution admission, retries, cancellation, and reconnect decisions retain their existing APIs.
+Cancellation without a live worker and concurrent continuation admission remain unresolved.
+Reconnect still redispatches unresolved synchronous calls. Abrupt process loss can therefore repeat external writes.
+The client still supports one pending question form.
+
 ## Learn more
 
 * Official website: https://www.phoenixframework.org/

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -82,9 +82,11 @@ defmodule AgentClientProtocol.History do
       |> Enum.reject(&MapSet.member?(standalone_tool_call_ids, {turn_number, &1.id}))
       |> Enum.map(fn tool_call ->
         arguments =
-          case Interaction.ToolCall.attrs(tool_call) do
-            {:ok, %{arguments: arguments}} -> arguments
-            {:error, {:invalid_tool_arguments, _message}} -> nil
+          case tool_call
+               |> SwarmAi.ToolCall.strip_null_arguments()
+               |> SwarmAi.ToolCall.parse_arguments() do
+            {:ok, arguments} -> arguments
+            {:error, _message} -> nil
           end
 
         ACP.tool_call_create(

--- a/apps/frontman_server/lib/frontman_server/observability/console_handler.ex
+++ b/apps/frontman_server/lib/frontman_server/observability/console_handler.ex
@@ -166,7 +166,6 @@ defmodule FrontmanServer.Observability.ConsoleHandler do
   defp format_status(:ok), do: "✓"
   defp format_status(:completed), do: "✓"
   defp format_status({:failed, _reason}), do: "✗"
-  defp format_status({:paused, _reason}), do: "⏸"
   defp format_status(:error), do: "✗"
   defp format_status(status), do: inspect(status)
 end

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -255,22 +255,7 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp record_interaction_row(%TaskSchema{} = task, attrs) do
-    Repo.transact(fn ->
-      with {:ok, schema} <-
-             task
-             |> Ecto.build_assoc(:interaction_rows)
-             |> InteractionSchema.changeset(attrs)
-             |> Repo.insert(),
-           {1, _} <-
-             TaskSchema
-             |> TaskSchema.by_id(task.id)
-             |> Repo.update_all(set: [updated_at: DateTime.utc_now(:second)]) do
-        {:ok, schema}
-      else
-        {:error, reason} -> {:error, reason}
-        {0, _} -> {:error, :not_found}
-      end
-    end)
+    Repo.transact(fn -> insert_interaction_row(task, attrs) end)
     |> case do
       {:ok, %InteractionSchema{} = interaction_schema} ->
         broadcast_task(task.id, {:interaction, interaction_schema})
@@ -278,6 +263,23 @@ defmodule FrontmanServer.Tasks do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp insert_interaction_row(task, attrs) do
+    with {:ok, schema} <-
+           task
+           |> Ecto.build_assoc(:interaction_rows)
+           |> InteractionSchema.changeset(attrs)
+           |> Repo.insert(),
+         {1, _} <-
+           TaskSchema
+           |> TaskSchema.by_id(task.id)
+           |> Repo.update_all(set: [updated_at: DateTime.utc_now(:second)]) do
+      {:ok, schema}
+    else
+      {:error, reason} -> {:error, reason}
+      {0, _} -> {:error, :not_found}
     end
   end
 
@@ -360,58 +362,15 @@ defmodule FrontmanServer.Tasks do
     persist_execution_outcome(scope, task_id, turn_number, {:crashed, message})
   end
 
-  defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:cancelled, _}) do
-    task_id
-    |> unresolved_tool_calls_for_turn(turn_number)
-    |> Enum.each(&interrupt_tool_call(scope, task_id, turn_number, &1, "Interrupted by user"))
-
-    persist_execution_outcome(scope, task_id, turn_number, :cancelled)
-  end
-
-  defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {:terminated, _}) do
-    Logger.info("Execution terminated by supervisor for task #{task_id}")
-
-    unresolved_tool_calls = unresolved_tool_calls_for_turn(task_id, turn_number)
-
-    {interactive_tool_calls, interrupted_tool_calls} =
-      Enum.split_with(unresolved_tool_calls, &keeps_turn_open_after_restart?/1)
-
-    Enum.each(
-      interrupted_tool_calls,
-      &interrupt_tool_call(scope, task_id, turn_number, &1, "Interrupted by restart")
-    )
-
-    case interactive_tool_calls do
-      [] ->
-        persist_execution_outcome(scope, task_id, turn_number, :terminated)
-
-      [_ | _] ->
-        :ok
-    end
-  end
-
-  defp persist_swarm_event(
-         %Scope{} = scope,
-         task_id,
-         turn_number,
-         {:paused, {:timeout, tool_call_id, tool_name, timeout_ms}}
-       ) do
-    reason = "Tool #{tool_name} timed out after #{timeout_ms}ms (on_timeout: :pause_agent)"
-
-    resolve_tool_request(
-      scope,
-      task_id,
-      %{id: tool_call_id, name: tool_name},
-      ModelContextProtocol.tool_result_error(reason),
-      turn_number: turn_number
-    )
-
-    persist_execution_outcome(
-      scope,
-      task_id,
-      turn_number,
-      {:paused_for_tool_timeout, tool_name, timeout_ms}
-    )
+  defp persist_swarm_event(%Scope{} = scope, task_id, turn_number, {kind, _})
+       when kind in [:cancelled, :terminated] do
+    Repo.transact(fn ->
+      case get_task_by_id_for_update(scope, task_id) do
+        %TaskSchema{} = task -> interrupt_turn(task, turn_number, kind)
+        nil -> {:error, :not_found}
+      end
+    end)
+    |> publish_interruption(task_id)
   end
 
   defp persist_swarm_event(%Scope{}, _task_id, _turn_number, {:chunk, _, _}), do: :ok
@@ -447,33 +406,77 @@ defmodule FrontmanServer.Tasks do
 
   defp broadcast_swarm_event(_task_id, _turn_number, _event), do: :ok
 
-  defp unresolved_tool_calls_for_turn(task_id, turn_number) do
-    InteractionSchema.for_task(task_id)
-    |> InteractionSchema.for_turn(turn_number)
-    |> InteractionSchema.unresolved_tool_calls()
-    |> InteractionSchema.ordered()
-    |> Repo.all()
-    |> Enum.map(& &1.data)
+  defp interrupt_turn(task, turn_number, kind) do
+    {:ok, history} = History.new(load_interaction_rows(task.id))
+
+    case History.active_turn_number(history) do
+      ^turn_number when is_integer(turn_number) ->
+        {preserved, interrupted} =
+          history.rows
+          |> History.unresolved_tool_calls(turn_number)
+          |> Enum.split_with(&(kind == :terminated and keeps_turn_open_after_restart?(&1)))
+
+        reason =
+          case kind do
+            :cancelled -> "Interrupted by user"
+            :terminated -> "Interrupted by restart"
+          end
+
+        results =
+          Enum.map(interrupted, fn {call, _dispatch} ->
+            {:ok, {row, true}} =
+              store_tool_result(
+                task,
+                turn_number,
+                call,
+                ModelContextProtocol.tool_result_error(reason)
+              )
+
+            row
+          end)
+
+        case preserved do
+          [] ->
+            {type, attrs} = build_execution_outcome(kind)
+
+            {:ok, terminal} =
+              insert_interaction_row(task, %{
+                id: Ecto.UUID.generate(),
+                type: type,
+                data: attrs,
+                turn_number: turn_number
+              })
+
+            {:ok, results ++ [terminal]}
+
+          [_ | _] ->
+            {:ok, results}
+        end
+
+      _inactive ->
+        {:ok, []}
+    end
   end
 
-  defp interrupt_tool_call(
-         scope,
-         task_id,
-         turn_number,
-         %Interaction.ToolCall{} = tool_call,
-         reason
-       ) do
-    resolve_tool_request(
-      scope,
-      task_id,
-      %{id: tool_call.tool_call_id, name: tool_call.tool_name},
-      ModelContextProtocol.tool_result_error(reason),
-      turn_number: turn_number
-    )
+  defp publish_interruption({:ok, rows}, task_id) do
+    Enum.each(rows, fn row ->
+      broadcast_task(task_id, {:interaction, row})
+
+      case row.data do
+        %Interaction.ToolResult{} = result -> Execution.notify_tool_result(task_id, result)
+        _terminal -> :ok
+      end
+    end)
+
+    :ok
   end
 
-  defp keeps_turn_open_after_restart?(%Interaction.ToolCall{tool_name: "question"}), do: true
-  defp keeps_turn_open_after_restart?(%Interaction.ToolCall{}), do: false
+  defp publish_interruption({:error, reason}, _task_id), do: {:error, reason}
+
+  defp keeps_turn_open_after_restart?({_tool_call, nil}), do: false
+
+  defp keeps_turn_open_after_restart?({_tool_call, %Interaction.ToolCall{} = dispatch}),
+    do: Interaction.ToolCall.execution_mode(dispatch) == :interactive
 
   @doc """
   Accepts a user prompt into session history.
@@ -779,14 +782,6 @@ defmodule FrontmanServer.Tasks do
 
       {:crashed, error} ->
         turn_error(error, "crashed")
-
-      {:paused_for_tool_timeout, tool, timeout} ->
-        {:agent_paused,
-         %{
-           reason: "Tool #{tool} timed out after #{timeout}ms (on_timeout: :pause_agent)",
-           tool_name: tool,
-           timeout_ms: timeout
-         }}
     end
   end
 
@@ -801,10 +796,17 @@ defmodule FrontmanServer.Tasks do
   end
 
   @doc "Records a client-handled tool request in the given turn."
-  def request_client_tool(scope, task_id, turn_number, %SwarmAi.ToolCall{} = tool_call_data)
-      when is_integer(turn_number) and turn_number > 0 do
+  def request_client_tool(
+        %Scope{} = scope,
+        task_id,
+        turn_number,
+        %SwarmAi.ToolCall{} = tool_call_data,
+        execution_mode
+      )
+      when is_integer(turn_number) and turn_number > 0 and
+             execution_mode in [:synchronous, :interactive] do
     with {:ok, schema} <- get_task(scope, task_id),
-         {:ok, attrs} <- Interaction.ToolCall.attrs(tool_call_data) do
+         {:ok, attrs} <- Interaction.ToolCall.attrs(tool_call_data, execution_mode) do
       record_interaction(schema, :tool_call, attrs, turn_number)
     end
   end
@@ -827,47 +829,65 @@ defmodule FrontmanServer.Tasks do
         opts \\ []
       )
       when is_list(opts) do
-    with {:ok, schema} <- get_task(scope, task_id) do
-      turn_number = tool_result_turn_number(task_id, tool_call_id, opts)
-      attrs = Interaction.ToolResult.attrs(tool_call_data, result)
+    Repo.transact(fn ->
+      case get_task_by_id_for_update(scope, task_id) do
+        %TaskSchema{} = task ->
+          turn_number = tool_result_turn_number(task_id, tool_call_id, opts)
+          store_tool_result(task, turn_number, tool_call_data, result)
 
-      schema
-      |> record_interaction(:tool_result, attrs, turn_number)
-      |> resolve_recorded_tool_result(task_id, turn_number, tool_call_id)
+        nil ->
+          {:error, :not_found}
+      end
+    end)
+    |> case do
+      {:ok, {row, inserted?}} ->
+        status = publish_tool_result(task_id, row, inserted?)
+        {:ok, row.data, status}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp resolve_recorded_tool_result({:ok, interaction}, task_id, _turn_number, _tool_call_id) do
-    notify_recorded_tool_result(interaction, task_id)
-  end
+  defp store_tool_result(task, turn_number, tool_call, result) do
+    existing =
+      InteractionSchema.for_task(task.id)
+      |> InteractionSchema.for_turn(turn_number)
+      |> InteractionSchema.of_type(:tool_result)
+      |> InteractionSchema.data_equals("tool_call_id", tool_call.id)
+      |> Repo.one()
 
-  defp resolve_recorded_tool_result(
-         {:error, %Ecto.Changeset{} = changeset},
-         task_id,
-         turn_number,
-         tool_call_id
-       ) do
-    case InteractionSchema.duplicate_tool_result?(changeset) do
-      true ->
-        interaction =
-          InteractionSchema
-          |> InteractionSchema.for_task(task_id)
-          |> InteractionSchema.for_turn(turn_number)
-          |> InteractionSchema.of_type(:tool_result)
-          |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
-          |> Repo.one!()
-          |> Map.fetch!(:data)
+    case existing do
+      %InteractionSchema{} = row ->
+        {:ok, {row, false}}
 
-        notify_recorded_tool_result(interaction, task_id)
+      nil ->
+        {:ok, history} = History.new(load_interaction_rows(task.id))
 
-      false ->
-        {:error, changeset}
+        attrs = %{
+          id: Ecto.UUID.generate(),
+          type: :tool_result,
+          data: Interaction.ToolResult.attrs(tool_call, result),
+          turn_number: turn_number
+        }
+
+        with ^turn_number <- History.active_turn_number(history),
+             {:ok, row} <- insert_interaction_row(task, attrs) do
+          {:ok, {row, true}}
+        else
+          {:error, reason} -> {:error, reason}
+          _inactive -> {:error, :not_running}
+        end
     end
   end
 
-  defp notify_recorded_tool_result(interaction, task_id) do
-    {:ok, interaction, Execution.notify_tool_result(task_id, interaction)}
+  defp publish_tool_result(task_id, row, true) do
+    broadcast_task(task_id, {:interaction, row})
+    Execution.notify_tool_result(task_id, row.data)
   end
+
+  defp publish_tool_result(task_id, row, false),
+    do: Execution.notify_tool_result(task_id, row.data)
 
   defp tool_result_turn_number(task_id, tool_call_id, opts) do
     case Keyword.fetch(opts, :turn_number) do

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -922,13 +922,13 @@ defmodule FrontmanServer.Tasks do
           {:ok, :no_active_turn}
 
         turn_number ->
+          dispatches = MapSet.new(History.unresolved_tool_calls(rows, turn_number), &elem(&1, 1))
+
           tool_calls =
-            InteractionSchema.for_task(task_id)
-            |> InteractionSchema.for_turn(turn_number)
-            |> InteractionSchema.unresolved_tool_calls()
-            |> InteractionSchema.ordered()
-            |> Repo.all()
+            rows
+            |> Enum.filter(&(&1.turn_number == turn_number))
             |> Enum.map(& &1.data)
+            |> Enum.filter(&MapSet.member?(dispatches, &1))
 
           {:ok, turn_number, tool_calls}
       end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -55,10 +55,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
         %ToolExecution.Sync{
           tool_call: tool_call,
           timeout_ms: module.timeout_ms(),
-          on_timeout_policy: module.on_timeout(),
           run: {__MODULE__, :run_backend_tool, [scope, module, task_id, turn_number]},
-          on_timeout:
-            {__MODULE__, :handle_timeout, [scope, task_id, turn_number, module.on_timeout()]}
+          on_error: {__MODULE__, :handle_error, [scope, task_id, turn_number]}
         }
     end
   end
@@ -77,10 +75,9 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
         %ToolExecution.Await{
           tool_call: tool_call,
           timeout_ms: tool_def.timeout_ms,
-          on_timeout_policy: tool_def.on_timeout,
-          start: {__MODULE__, :start_mcp_tool, [scope, task_id, turn_number]},
-          on_timeout:
-            {__MODULE__, :handle_timeout, [scope, task_id, turn_number, tool_def.on_timeout]}
+          start:
+            {__MODULE__, :start_mcp_tool, [scope, task_id, turn_number, tool_def.execution_mode]},
+          on_error: {__MODULE__, :handle_error, [scope, task_id, turn_number]}
         }
     end
   end
@@ -89,9 +86,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     %ToolExecution.Sync{
       tool_call: tool_call,
       timeout_ms: 5_000,
-      on_timeout_policy: :error,
       run: {__MODULE__, :reject_unavailable_tool, [scope, task_id, turn_number]},
-      on_timeout: {__MODULE__, :handle_timeout, [scope, task_id, turn_number, :error]}
+      on_error: {__MODULE__, :handle_error, [scope, task_id, turn_number]}
     }
   end
 
@@ -129,59 +125,44 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   end
 
   @doc false
-  def start_mcp_tool(%Scope{} = scope, task_id, turn_number, tool_call)
+  def start_mcp_tool(%Scope{} = scope, task_id, turn_number, execution_mode, tool_call)
       when is_integer(turn_number) and turn_number > 0 do
     SentryContext.set_task_scope_context(scope, task_id)
 
     Logger.info("ToolExecutor: Routing to MCP tool #{tool_call.name}")
 
     register_mcp_tool(task_id, tool_call)
-    publish_mcp_tool_call(scope, task_id, turn_number, tool_call)
+    publish_mcp_tool_call(scope, task_id, turn_number, tool_call, execution_mode)
     :ok
   end
 
   @doc false
-  def handle_timeout(%Scope{} = scope, task_id, turn_number, :error, tool_call, :triggered)
+  def handle_error(%Scope{} = scope, task_id, turn_number, reason, tool_call)
       when is_integer(turn_number) and turn_number > 0 do
     SentryContext.set_task_scope_context(scope, task_id)
 
-    timeout_msg =
-      "Tool #{tool_call.name} timed out. Execution may still be in progress; " <>
-        "do not blindly retry mutations."
+    {error_type, message} =
+      case reason do
+        :timeout ->
+          {"tool_timeout",
+           "Tool #{tool_call.name} timed out. Execution may still be in progress; " <>
+             "do not blindly retry mutations."}
+
+        {:crashed, exit_reason} ->
+          {"tool_crash", "Tool #{tool_call.name} crashed: #{inspect(exit_reason)}"}
+      end
 
     metadata = [
-      error_type: "tool_timeout",
+      error_type: error_type,
       tool_name: tool_call.name,
       tool_call_id: tool_call.id,
       task_id: task_id
     ]
 
-    Logger.error("Backend tool timeout", metadata)
+    Logger.error("Tool execution failed", metadata)
 
-    result = persist_error_tool_result(scope, task_id, turn_number, tool_call, timeout_msg)
+    result = persist_error_tool_result(scope, task_id, turn_number, tool_call, message)
     to_swarm_tool_result(tool_call, result)
-  end
-
-  def handle_timeout(%Scope{} = scope, task_id, turn_number, :error, tool_call, :cancelled)
-      when is_integer(turn_number) and turn_number > 0 do
-    cancel_msg = "Tool #{tool_call.name} cancelled (sibling tool paused agent)"
-    Logger.info("ToolExecutor: #{cancel_msg}")
-
-    persist_error_tool_result(scope, task_id, turn_number, tool_call, cancel_msg)
-    :ok
-  end
-
-  def handle_timeout(_scope, _task_id, turn_number, :pause_agent, _tool_call, :triggered)
-      when is_integer(turn_number) and turn_number > 0 do
-    :ok
-  end
-
-  def handle_timeout(%Scope{} = scope, task_id, turn_number, :pause_agent, tool_call, :cancelled)
-      when is_integer(turn_number) and turn_number > 0 do
-    cancel_msg = "Tool #{tool_call.name} cancelled (sibling tool paused agent)"
-
-    persist_error_tool_result(scope, task_id, turn_number, tool_call, cancel_msg)
-    :ok
   end
 
   defp to_swarm_tool_result(tool_call, %{"content" => content} = result) do
@@ -218,8 +199,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   defp tool_registry_key(task_id, tool_call_id), do: {:tool_call, task_id, tool_call_id}
 
-  defp publish_mcp_tool_call(%Scope{} = scope, task_id, turn_number, tool_call) do
-    case Tasks.request_client_tool(scope, task_id, turn_number, tool_call) do
+  defp publish_mcp_tool_call(%Scope{} = scope, task_id, turn_number, tool_call, execution_mode) do
+    case Tasks.request_client_tool(scope, task_id, turn_number, tool_call, execution_mode) do
       {:ok, _interaction} ->
         :ok
 
@@ -321,18 +302,17 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     end
 
     persist_tool_result(scope, task_id, turn_number, tool_call, result)
-    result
   end
 
   defp handle_backend_outcome(
-         {:returned, result},
+         {:returned, _invalid},
          scope,
          tool_call,
          task_id,
          turn_number
        ) do
     Logger.error("Incorrect tool result")
-    persist_tool_result(scope, task_id, turn_number, tool_call, result)
+    persist_error_tool_result(scope, task_id, turn_number, tool_call, "Invalid tool result")
   end
 
   defp handle_backend_outcome({:crashed, reason}, scope, tool_call, task_id, turn_number) do
@@ -356,9 +336,9 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
   end
 
   defp persist_tool_result(scope, task_id, turn_number, tool_call, result) do
-    {:ok, _interaction, _executor_status} =
+    {:ok, interaction, _status} =
       Tasks.resolve_tool_request(scope, task_id, tool_call, result, turn_number: turn_number)
 
-    result
+    interaction.result
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tasks/history.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/history.ex
@@ -77,6 +77,36 @@ defmodule FrontmanServer.Tasks.History do
     end)
   end
 
+  @doc "Unresolved declarations paired with their dispatch snapshot, if dispatch occurred."
+  def unresolved_tool_calls(rows, turn_number) do
+    rows = Enum.filter(rows, &(&1.turn_number == turn_number))
+
+    dispatches =
+      for %{data: %Interaction.ToolCall{} = call} <- rows,
+          into: %{},
+          do: {call.tool_call_id, call}
+
+    resolved =
+      for %{data: %Interaction.ToolResult{} = result} <- rows,
+          into: MapSet.new(),
+          do: result.tool_call_id
+
+    rows
+    |> Enum.flat_map(fn
+      %{data: %Interaction.AgentResponse{metadata: metadata}} ->
+        Interaction.to_swarm_tool_calls(metadata["tool_calls"])
+
+      %{data: %Interaction.ToolCall{} = call} ->
+        [%{id: call.tool_call_id, name: call.tool_name}]
+
+      _row ->
+        []
+    end)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.reject(&MapSet.member?(resolved, &1.id))
+    |> Enum.map(&{&1, Map.get(dispatches, &1.id)})
+  end
+
   def active_turn_number(%__MODULE__{active_turn: active_turn}), do: active_turn
   def active_turn_context(%__MODULE__{} = history), do: turn_context(history, history.active_turn)
 

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -809,9 +809,8 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defmodule AgentPaused do
     @moduledoc """
-    Recorded when the agent loop is paused due to a tool timeout with
-    `on_timeout: :pause_agent`. Stored as an interaction so reconnecting
-    clients and the debug-task tool can see why the agent stopped.
+    Historical terminal outcome for timeout-driven pauses.
+    Retained for replay; interactive waits no longer produce this event.
     """
 
     use Ecto.Schema
@@ -845,6 +844,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :tool_call_id, :string
       field :tool_name, :string
       field :arguments, :map
+      field :execution_mode, Ecto.Enum, values: [:synchronous, :interactive]
       field :timestamp, :utc_datetime_usec
     end
 
@@ -854,11 +854,19 @@ defmodule FrontmanServer.Tasks.Interaction do
         :tool_call_id,
         :tool_name,
         :arguments,
+        :execution_mode,
         :timestamp
       ])
+      |> Ecto.Changeset.validate_required([:execution_mode])
     end
 
-    def attrs(%SwarmAi.ToolCall{} = tc) do
+    @doc "Historical rows lack a mode snapshot. Only legacy question calls recover as interactive."
+    def execution_mode(%__MODULE__{execution_mode: nil, tool_name: "question"}), do: :interactive
+    def execution_mode(%__MODULE__{execution_mode: nil}), do: :synchronous
+    def execution_mode(%__MODULE__{execution_mode: mode}), do: mode
+
+    def attrs(%SwarmAi.ToolCall{} = tc, execution_mode)
+        when execution_mode in [:synchronous, :interactive] do
       tc = SwarmAi.ToolCall.strip_null_arguments(tc)
 
       case SwarmAi.ToolCall.parse_arguments(tc) do
@@ -867,7 +875,8 @@ defmodule FrontmanServer.Tasks.Interaction do
            %{
              tool_call_id: tc.id,
              tool_name: tc.name,
-             arguments: arguments
+             arguments: arguments,
+             execution_mode: execution_mode
            }}
 
         {:error, message} ->

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -97,15 +97,6 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
     from(i in query, select: fragment("?->>?", i.data, ^field), limit: ^limit)
   end
 
-  def duplicate_tool_result?(%Ecto.Changeset{} = changeset) do
-    Enum.any?(changeset.errors, fn {_field, {_message, metadata}} ->
-      case {Keyword.fetch(metadata, :constraint), Keyword.fetch(metadata, :constraint_name)} do
-        {{:ok, :unique}, {:ok, name}} -> name == Atom.to_string(@tool_result_unique_constraint)
-        _other_constraint -> false
-      end
-    end)
-  end
-
   def unresolved_tool_calls(query \\ __MODULE__) do
     from(i in query,
       left_join: r in __MODULE__,

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -97,16 +97,6 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
     from(i in query, select: fragment("?->>?", i.data, ^field), limit: ^limit)
   end
 
-  def unresolved_tool_calls(query \\ __MODULE__) do
-    from(i in query,
-      left_join: r in __MODULE__,
-      on:
-        r.task_id == i.task_id and r.turn_number == i.turn_number and r.type == :tool_result and
-          fragment("?->>'tool_call_id'", r.data) == fragment("?->>'tool_call_id'", i.data),
-      where: i.type == :tool_call and is_nil(r.id)
-    )
-  end
-
   def to_json_map(%__MODULE__{type: type, data: data}) when is_struct(data) do
     data
     |> Interaction.to_json_map()

--- a/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
@@ -62,9 +62,6 @@ defmodule FrontmanServer.Tools.AgentFeedback do
   def timeout_ms, do: 30_000
 
   @impl true
-  def on_timeout, do: :error
-
-  @impl true
   def execute(args, %Context{task: task}) do
     with {:ok, outcome} <- validate_outcome(args["outcome"]),
          {:ok, message} <- validate_required_string(args["message"], "message") do

--- a/apps/frontman_server/lib/frontman_server/tools/backend.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/backend.ex
@@ -29,7 +29,6 @@ defmodule FrontmanServer.Tools.Backend do
   @callback access() :: access()
   @callback parameter_schema() :: map()
   @callback timeout_ms() :: pos_integer()
-  @callback on_timeout() :: :error | :pause_agent
   @callback execute(args :: map(), context :: %Context{}) :: result()
 
   def to_swarm_tool(module) do
@@ -37,9 +36,7 @@ defmodule FrontmanServer.Tools.Backend do
       name: module.name(),
       description: module.description(),
       access: module.access(),
-      parameter_schema: module.parameter_schema(),
-      timeout_ms: module.timeout_ms(),
-      on_timeout: module.on_timeout()
+      parameter_schema: module.parameter_schema()
     )
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
@@ -56,9 +56,6 @@ defmodule FrontmanServer.Tools.GetToolResult do
   def timeout_ms, do: 30_000
 
   @impl true
-  def on_timeout, do: :error
-
-  @impl true
   def execute(args, %Context{task: %{interaction_rows: rows}}) do
     case Map.get(args, "tool_call_id") do
       tool_call_id when is_binary(tool_call_id) ->

--- a/apps/frontman_server/lib/frontman_server/tools/mcp.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/mcp.ex
@@ -9,7 +9,7 @@ defmodule FrontmanServer.Tools.MCP do
   Utilities for MCP tools from external clients.
   """
 
-  @enforce_keys [:name, :description, :input_schema, :timeout_ms, :on_timeout]
+  @enforce_keys [:name, :description, :input_schema, :timeout_ms, :execution_mode]
   defstruct name: nil,
             description: nil,
             input_schema: nil,
@@ -17,15 +17,14 @@ defmodule FrontmanServer.Tools.MCP do
             access: :read_write,
             visible_to_agent: true,
             timeout_ms: nil,
-            on_timeout: nil
+            execution_mode: nil
 
   @default_timeout_ms 600_000
-  @default_on_timeout :error
   @tool_metadata_extension "ai.frontman/tool-metadata"
 
   def from_map(tool) when is_map(tool) do
     metadata = get_in(tool, ["_meta", @tool_metadata_extension]) || %{}
-    {timeout_ms, on_timeout} = timeout_policy(metadata["executionMode"])
+    execution_mode = parse_execution_mode(metadata["executionMode"])
 
     %__MODULE__{
       name: tool["name"],
@@ -34,13 +33,16 @@ defmodule FrontmanServer.Tools.MCP do
       output_schema: tool["outputSchema"],
       access: parse_access(metadata["access"]),
       visible_to_agent: Map.get(metadata, "visibleToAgent", true),
-      timeout_ms: timeout_ms,
-      on_timeout: on_timeout
+      timeout_ms: deadline(execution_mode),
+      execution_mode: execution_mode
     }
   end
 
-  defp timeout_policy("Interactive"), do: {120_000, :pause_agent}
-  defp timeout_policy(_), do: {@default_timeout_ms, @default_on_timeout}
+  defp parse_execution_mode("Interactive"), do: :interactive
+  defp parse_execution_mode(mode) when mode in [nil, "Synchronous"], do: :synchronous
+
+  defp deadline(:interactive), do: :infinity
+  defp deadline(:synchronous), do: @default_timeout_ms
 
   defp parse_access("read"), do: :read
   defp parse_access("write"), do: :write
@@ -62,9 +64,7 @@ defmodule FrontmanServer.Tools.MCP do
       name: tool.name,
       description: tool.description,
       access: tool.access,
-      parameter_schema: tool.input_schema,
-      timeout_ms: tool.timeout_ms,
-      on_timeout: tool.on_timeout
+      parameter_schema: tool.input_schema
     )
   end
 end

--- a/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
@@ -103,9 +103,6 @@ defmodule FrontmanServer.Tools.TodoWrite do
   def timeout_ms, do: 30_000
 
   @impl true
-  def on_timeout, do: :error
-
-  @impl true
   def execute(args, _context) do
     raw_todos = Map.get(args, "todos", [])
 

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -90,9 +90,6 @@ defmodule FrontmanServer.Tools.WebFetch do
   def timeout_ms, do: 60_000
 
   @impl true
-  def on_timeout, do: :error
-
-  @impl true
   def execute(args, _context) do
     offset = clamp(Map.get(args, "offset", 0), 0, :infinity)
     limit = clamp(Map.get(args, "limit", 500), 1, 2000)

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -245,7 +245,7 @@ defmodule FrontmanServerWeb.TaskChannel do
     {:noreply, assign(socket, :active_turn, context)}
   end
 
-  defp handle_interaction(%Tasks.Interaction.ToolCall{} = tool_call, _turn_number, socket) do
+  defp dispatch_tool_call(tool_call, socket) do
     task_id = socket.assigns.task_id
 
     announced = socket.assigns[:announced_tool_calls] || MapSet.new()
@@ -281,6 +281,13 @@ defmodule FrontmanServerWeb.TaskChannel do
 
       :mcp ->
         route_to_mcp(tool_call, socket)
+    end
+  end
+
+  defp handle_interaction(%Tasks.Interaction.ToolCall{} = tool_call, _turn_number, socket) do
+    case open_tool_call(socket, tool_call.tool_call_id) do
+      {:ok, pending} -> dispatch_tool_call(pending, socket)
+      :error -> {:noreply, socket}
     end
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/llm_client_test.exs
@@ -40,9 +40,7 @@ defmodule FrontmanServer.Tasks.Execution.LLMClientTest do
             "path" => %{"type" => "string"}
           },
           "required" => ["path"]
-        },
-        timeout_ms: 60_000,
-        on_timeout: :error
+        }
       }
 
       {:ok, tool: tool}

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -39,8 +39,8 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
         name: "some_mcp_tool",
         description: "A test MCP tool",
         input_schema: %{},
-        timeout_ms: 60_000,
-        on_timeout: :pause_agent
+        timeout_ms: :infinity,
+        execution_mode: :interactive
       }
 
       expect_llm_responses([{:tool_calls, [mcp_tool_call], "Done!"}])
@@ -143,8 +143,8 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
         name: "mcp_tool",
         description: "A test MCP tool",
         input_schema: %{},
-        timeout_ms: 60_000,
-        on_timeout: :pause_agent
+        timeout_ms: :infinity,
+        execution_mode: :interactive
       }
 
       expect_llm_responses([{:tool_calls, [mcp_tool_call], "Done!"}])

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
@@ -42,7 +42,7 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
 
       tool_call = swarm_tool_call("take_screenshot", ~s({"selector": "#main"}))
 
-      ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tool_call)
+      ToolExecutor.start_mcp_tool(scope, task_id, turn_number, :synchronous, tool_call)
 
       assert_push(
         "mcp:message",
@@ -71,7 +71,7 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
         name: "take_screenshot",
         description: "Take a screenshot",
         input_schema: %{},
-        on_timeout: :pause_agent,
+        execution_mode: :interactive,
         timeout_ms: 60_000
       }
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -167,7 +167,9 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       secret = "frontman-mcp-secret-1445"
       tool_call = swarm_tool_call("take_screenshot", ~s(["#{secret}"]))
 
-      assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tool_call)
+      assert :ok =
+               ToolExecutor.start_mcp_tool(scope, task_id, turn_number, :synchronous, tool_call)
+
       assert_receive {:tool_result, _, [%{text: "Failed to parse arguments for tool"}], true}
 
       assert [report] = Sentry.Test.pop_sentry_reports()
@@ -177,7 +179,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
     end
   end
 
-  describe "handle_timeout/5 — :error policy Sentry reporting" do
+  describe "handle_error/5 — finite deadline Sentry reporting" do
     @tag :capture_log
     test "persists error ToolResult and reports to Sentry", %{
       task_id: task_id,
@@ -185,7 +187,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       turn_number: turn_number
     } do
       tc = %SwarmAi.ToolCall{id: "tc-deadline-1", name: "todo_write", arguments: "{}"}
-      ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :triggered)
+      ToolExecutor.handle_error(scope, task_id, turn_number, :timeout, tc)
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
@@ -204,25 +206,6 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       assert [report] = timeout_reports
       assert report.tags[:user_id] == scope.user.id
       assert report.tags[:task_id] == task_id
-    end
-
-    test "handle_timeout(:triggered) is a no-op for :pause_agent policy", %{
-      task_id: task_id,
-      scope: scope,
-      turn_number: turn_number
-    } do
-      tc = %SwarmAi.ToolCall{id: "tc-pause-1", name: "some_mcp_tool", arguments: "{}"}
-      ToolExecutor.handle_timeout(scope, task_id, turn_number, :pause_agent, tc, :triggered)
-
-      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
-
-      tool_result =
-        Enum.find(Tasks.interactions(task), fn
-          %Interaction.ToolResult{tool_call_id: "tc-pause-1"} -> true
-          _ -> false
-        end)
-
-      assert tool_result == nil
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -8,27 +8,25 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
   alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tools.Backend
+  alias FrontmanServer.Tools.MCP
   alias SwarmAi.Message.ContentPart
 
-  defmodule PauseOnTimeoutTool do
+  defmodule FiniteTool do
     @behaviour Backend
 
-    def name, do: "pause_on_timeout_tool"
-    def description, do: "Declares on_timeout: :pause_agent"
+    def name, do: "finite_tool"
+    def description, do: "A finite backend operation"
     def access, do: :read
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 30_000
-    def on_timeout, do: :pause_agent
-
+    def execute(%{"invalid" => true}, _context), do: %{"unexpected" => "shape"}
     def execute(_args, _context), do: ModelContextProtocol.tool_result_text("done")
   end
 
   setup do
     scope = user_scope_fixture()
-    task_id = task_fixture(scope).id
+    task_id = task_with_active_turn_fixture(scope).id
     Phoenix.PubSub.subscribe(FrontmanServer.PubSub, task_topic(task_id))
-    {:ok, _message} = user_message_fixture(scope, task_id, user_content("test turn"))
-
     {:ok, scope: scope, task_id: task_id, turn_number: latest_turn_number(task_id)}
   end
 
@@ -39,56 +37,112 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     end)
   end
 
-  describe "handle_timeout/5 — cancelled tools" do
+  describe "canonical backend results" do
     @tag :capture_log
-    test "persists error ToolResult for :error policy", %{
-      scope: scope,
-      task_id: task_id,
-      turn_number: turn_number
-    } do
-      tc = %SwarmAi.ToolCall{id: "tc-to-2", name: "some_tool", arguments: "{}"}
-      ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :cancelled)
+    test "completion and timeout return the persisted winner in either ordering", context do
+      %{scope: scope, task_id: task_id, turn_number: turn_number} = context
 
-      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
-      assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
-    end
+      for first <- [:completion, :timeout] do
+        tc = %SwarmAi.ToolCall{id: "race_#{first}", name: FiniteTool.name(), arguments: "{}"}
 
-    @tag :capture_log
-    test "persists ToolResult for :pause_agent policy", %{
-      scope: scope,
-      task_id: task_id,
-      turn_number: turn_number
-    } do
-      tc = %SwarmAi.ToolCall{
-        id: "tc_#{System.unique_integer([:positive])}",
-        name: PauseOnTimeoutTool.name(),
-        arguments: "{}"
-      }
+        complete = fn ->
+          ToolExecutor.run_backend_tool(scope, FiniteTool, task_id, turn_number, tc)
+        end
 
-      ToolExecutor.handle_timeout(scope, task_id, turn_number, :pause_agent, tc, :cancelled)
+        timeout = fn -> ToolExecutor.handle_error(scope, task_id, turn_number, :timeout, tc) end
 
-      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
-      assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
+        {winner, loser} =
+          case first do
+            :completion -> {complete.(), timeout.()}
+            :timeout -> {timeout.(), complete.()}
+          end
+
+        assert winner == loser
+        assert winner.is_error == (first == :timeout)
+        {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+        assert [stored] = tool_results(task, tc.id)
+        assert stored.is_error == winner.is_error
+        assert ModelContextProtocol.extract_content_text(stored.result) == hd(winner.content).text
+      end
     end
   end
 
-  describe "execute/2" do
-    test "runs available and unavailable tools in serial and parallel", %{
-      scope: scope,
-      task_id: task_id,
-      turn_number: turn_number
-    } do
-      for mode <- [:serial, :parallel] do
-        suffix = Atom.to_string(mode)
+  @tag :capture_log
+  test "a malformed backend return becomes a canonical error", context do
+    %{scope: scope, task_id: task_id, turn_number: turn_number} = context
 
+    call = %SwarmAi.ToolCall{
+      id: "malformed_result",
+      name: FiniteTool.name(),
+      arguments: ~s({"invalid":true})
+    }
+
+    assert %SwarmAi.ToolResult{is_error: true, content: [%{text: "Invalid tool result"}]} =
+             ToolExecutor.run_backend_tool(scope, FiniteTool, task_id, turn_number, call)
+
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+
+    assert [
+             %Interaction.ToolResult{
+               is_error: true,
+               result: %{"content" => [%{"text" => "Invalid tool result"}]}
+             }
+           ] = tool_results(task, call.id)
+  end
+
+  test "Sync DOWN after a committed success returns that same success", context do
+    %{scope: scope, task_id: task_id, turn_number: turn_number} = context
+    call = %SwarmAi.ToolCall{id: "committed_then_down", name: "finite_tool", arguments: "{}"}
+
+    execution = %SwarmAi.ToolExecution.Sync{
+      tool_call: call,
+      timeout_ms: 1_000,
+      run: {__MODULE__, :persist_then_exit, [scope, task_id, turn_number]},
+      on_error: {ToolExecutor, :handle_error, [scope, task_id, turn_number]}
+    }
+
+    assert {:ok, [%SwarmAi.ToolResult{is_error: false, content: [%{text: "committed"}]}]} =
+             SwarmAi.ParallelExecutor.run(
+               [execution],
+               SwarmAi.Runtime.task_supervisor_name(FrontmanServer.AgentRuntime)
+             )
+
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+
+    assert [
+             %Interaction.ToolResult{
+               is_error: false,
+               result: %{"content" => [%{"text" => "committed"}]}
+             }
+           ] = tool_results(task, call.id)
+  end
+
+  def persist_then_exit(scope, task_id, turn_number, call) do
+    {:ok, _, _} =
+      Tasks.resolve_tool_request(
+        scope,
+        task_id,
+        call,
+        ModelContextProtocol.tool_result_text("committed"),
+        turn_number: turn_number
+      )
+
+    Process.exit(self(), :kill)
+  end
+
+  describe "execute/2" do
+    test "runs available and unavailable tools in serial and parallel", context do
+      %{scope: scope, task_id: task_id, turn_number: turn_number} = context
+
+      for mode <- [:serial, :parallel] do
         available = %SwarmAi.ToolCall{
-          id: "available_#{suffix}",
-          name: PauseOnTimeoutTool.name(),
+          id: "available_#{mode}",
+          name: FiniteTool.name(),
           arguments: "{}"
         }
 
         unavailable = %SwarmAi.ToolCall{
-          id: "unavailable_#{suffix}",
+          id: "unavailable_#{mode}",
           name: "filtered_tool",
           arguments: "{}"
         }
@@ -100,67 +154,45 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
                    tool_calls: [available, unavailable],
                    task_supervisor:
                      SwarmAi.Runtime.task_supervisor_name(FrontmanServer.AgentRuntime),
-                   backend_tool_modules: [PauseOnTimeoutTool],
+                   backend_tool_modules: [FiniteTool],
                    mcp_tool_defs: [],
                    execution_mode: mode
                  })
 
-        assert %SwarmAi.ToolResult{is_error: false, content: [%ContentPart{text: "done"}]} =
-                 Enum.find(results, &(&1.id == available.id))
-
-        assert %SwarmAi.ToolResult{is_error: true, content: [%ContentPart{text: message}]} =
-                 Enum.find(results, &(&1.id == unavailable.id))
+        assert [
+                 %SwarmAi.ToolResult{is_error: false, content: [%ContentPart{text: "done"}]},
+                 %SwarmAi.ToolResult{is_error: true, content: [%ContentPart{text: message}]}
+               ] = results
 
         assert message =~ "filtered_tool"
         assert message =~ "unavailable"
-
         {:ok, task} = Tasks.get_task_with_history(scope, task_id)
         assert [%Interaction.ToolResult{is_error: false}] = tool_results(task, available.id)
         assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, unavailable.id)
-
-        refute Enum.any?(Tasks.interactions(task), fn
-                 %Interaction.ToolCall{tool_call_id: id} -> id == unavailable.id
-                 _interaction -> false
-               end)
+        refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.ToolCall{}, &1))
       end
     end
 
-    test "raises when an MCP tool executor registration unexpectedly collides", %{
-      scope: scope,
-      task_id: task_id,
-      turn_number: turn_number
-    } do
-      tc = %SwarmAi.ToolCall{
-        id: "tc_collision_#{System.unique_integer([:positive])}",
-        name: "some_tool",
-        arguments: "{}"
-      }
+    test "registers before publishing and rejects a duplicate waiter", context do
+      %{scope: scope, task_id: task_id, turn_number: turn_number} = context
+      tc = %SwarmAi.ToolCall{id: "collision", name: "approval", arguments: "{}"}
+      assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, :interactive, tc)
+      assert_receive {:interaction, %{data: %Interaction.ToolCall{execution_mode: :interactive}}}
 
-      assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tc)
+      assert [{_, %{caller_pid: caller}}] =
+               Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, task_id, tc.id})
 
-      assert_raise RuntimeError,
-                   ~r/Duplicate MCP tool executor registration/,
-                   fn -> ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tc) end
+      assert caller == self()
+
+      assert_raise RuntimeError, ~r/Duplicate MCP tool executor registration/, fn ->
+        ToolExecutor.start_mcp_tool(scope, task_id, turn_number, :interactive, tc)
+      end
     end
 
-    test "rejects a filtered backend tool even when an MCP tool has the same name", %{
-      scope: scope,
-      task_id: task_id,
-      turn_number: turn_number
-    } do
-      todo_write_mcp_def = %FrontmanServer.Tools.MCP{
-        name: "todo_write",
-        description: "Colliding browser tool",
-        input_schema: %{},
-        on_timeout: :error,
-        timeout_ms: 60_000
-      }
-
-      tc = %SwarmAi.ToolCall{
-        id: "tc_#{System.unique_integer([:positive])}",
-        name: "todo_write",
-        arguments: "{}"
-      }
+    test "rejects a filtered backend even when an MCP tool has the same name", context do
+      %{scope: scope, task_id: task_id, turn_number: turn_number} = context
+      tool = MCP.from_map(%{"name" => "todo_write"})
+      tc = %SwarmAi.ToolCall{id: "collision_backend", name: "todo_write", arguments: "{}"}
 
       assert {:ok, [%SwarmAi.ToolResult{is_error: true}]} =
                ToolExecutor.execute(scope, %{
@@ -170,17 +202,12 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
                  task_supervisor:
                    SwarmAi.Runtime.task_supervisor_name(FrontmanServer.AgentRuntime),
                  backend_tool_modules: [],
-                 mcp_tool_defs: [todo_write_mcp_def],
+                 mcp_tool_defs: [tool],
                  execution_mode: :serial
                })
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
-
-      refute Enum.any?(Tasks.interactions(task), fn
-               %Interaction.ToolCall{tool_call_id: tool_call_id} -> tool_call_id == tc.id
-               _interaction -> false
-             end)
-
+      refute Enum.any?(Tasks.interactions(task), &match?(%Interaction.ToolCall{}, &1))
       assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end
   end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -46,22 +46,6 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   @endpoint FrontmanServerWeb.Endpoint
   @acp_message AgentClientProtocol.event_acp_message()
 
-  defp short_timeout_question_mcp_tool_defs do
-    [
-      %MCP{
-        name: "question",
-        description: "Ask the user a question",
-        input_schema: %{
-          "type" => "object",
-          "properties" => %{"questions" => %{"type" => "array"}}
-        },
-        visible_to_agent: true,
-        timeout_ms: 200,
-        on_timeout: :pause_agent
-      }
-    ]
-  end
-
   defp error_timeout_mcp_tool_defs do
     [
       %MCP{
@@ -73,7 +57,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
         },
         visible_to_agent: true,
         timeout_ms: 100,
-        on_timeout: :error
+        execution_mode: :synchronous
       }
     ]
   end
@@ -1075,49 +1059,112 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     end
   end
 
-  describe "interactive tool timeout — ToolResult DB persistence" do
-    setup [:setup_sandbox, :setup_user, :setup_task]
+  describe "interactive waits and serial recovery" do
+    setup [:setup_sandbox, :setup_user]
 
-    test "ToolResult is persisted in DB when question tool times out", %{
-      task_id: task_id,
-      scope: scope
-    } do
-      question_tc_id = "tc_timeout_#{System.unique_integer([:positive])}"
-      question_tc = tool_call("question", question_args(), id: question_tc_id)
+    test "shutdown preserves approval, interrupts the undispatched write, and resumes the same turn",
+         %{scope: scope} do
+      task_id = task_with_pubsub_fixture(scope, framework: "wordpress").id
+      approval = tool_call("approval", %{}, id: "approval_serial")
+      write = tool_call("write_file", %{}, id: "write_serial")
 
-      expect_llm_responses([{:tool_calls, [question_tc], "done"}])
+      tools =
+        MCP.from_maps([
+          %{
+            "name" => "approval",
+            "_meta" => %{"ai.frontman/tool-metadata" => %{"executionMode" => "Interactive"}}
+          },
+          %{"name" => "write_file"}
+        ])
 
-      {:ok, _, _} =
-        submit_user_message(scope, task_id, user_content("Ask me"),
-          mcp_tools: short_timeout_question_mcp_tool_defs()
+      parent = self()
+      expect_llm_responses([{:tool_calls, [approval, write], "Approve first"}])
+
+      expect(LLMProviderMock, :stream_text, fn model, messages, _opts ->
+        send(parent, {:resumed_messages, model, messages})
+        ReqLLMResponses.response("Recovered")
+      end)
+
+      {:ok, _, 1} =
+        submit_user_message(scope, task_id, user_content("Do the change"), mcp_tools: tools)
+
+      assert_receive_interaction(
+        %Interaction.ToolCall{tool_name: "approval", execution_mode: :interactive},
+        1
+      )
+
+      refute_receive {:interaction, %{data: %Interaction.ToolCall{tool_name: "write_file"}}}, 250
+      {:ok, waiting} = Tasks.get_task_with_history(scope, task_id)
+      refute Enum.any?(Tasks.interactions(waiting), &match?(%Interaction.ToolResult{}, &1))
+      refute Enum.any?(Tasks.interactions(waiting), &match?(%Interaction.AgentPaused{}, &1))
+
+      [{worker, _}] = SwarmAi.Runtime.Registry.lookup(FrontmanServer.AgentRuntime, task_id)
+
+      assert :ok =
+               DynamicSupervisor.terminate_child(
+                 SwarmAi.Runtime.execution_supervisor_name(FrontmanServer.AgentRuntime),
+                 worker
+               )
+
+      assert_receive_interaction(
+        %Interaction.ToolResult{tool_name: "write_file", is_error: true},
+        1
+      )
+
+      refute_receive {:interaction, %{data: %Interaction.AgentError{}}}, 50
+      {:ok, pending} = Tasks.get_task_with_history(scope, task_id)
+
+      assert [%Interaction.ToolCall{tool_name: "approval"}] =
+               Enum.filter(Tasks.interactions(pending), &match?(%Interaction.ToolCall{}, &1))
+
+      assert {:ok, 1, [%Interaction.ToolCall{tool_name: "approval"}]} =
+               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+
+      {:ok, _} =
+        Tasks.submit_user_message(
+          scope,
+          Map.merge(execution_request_fixture(), %{
+            task_id: task_id,
+            message_id: Ecto.UUID.generate(),
+            message: user_content("Queued next turn")
+          })
         )
 
-      assert_receive_interaction(%Interaction.AgentPaused{}, _turn_number)
+      assert {:ok, _, _} =
+               Tasks.resolve_tool_request(
+                 scope,
+                 task_id,
+                 approval,
+                 ModelContextProtocol.tool_result_text("yes")
+               )
 
-      {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+      assert :ok =
+               Tasks.resume_execution(
+                 scope,
+                 task_id,
+                 execution_request_fixture(model: "missing:connection-model", mcp_tools: tools)
+               )
 
-      tool_results =
-        Enum.filter(Tasks.interactions(task), fn
-          %Interaction.ToolResult{tool_call_id: ^question_tc_id} -> true
-          _ -> false
-        end)
+      assert_receive {:resumed_messages, %LLMDB.Model{id: "openai/gpt-5.5"}, messages}, 1_000
+      results = Enum.filter(messages, &(&1.role == :tool))
+      assert Enum.map(results, & &1.tool_call_id) == [write.id, approval.id]
 
-      assert length(tool_results) == 1,
-             "Expected exactly 1 ToolResult for the timed-out ToolCall, got #{length(tool_results)} — double-persist bug"
+      assert Enum.map(results, &extract_content_text(&1.content)) == [
+               "Interrupted by restart",
+               "yes"
+             ]
 
-      [tool_result] = tool_results
-      %{"content" => [%{"text" => result_text}], "isError" => true} = tool_result.result
-      assert tool_result.is_error == true
-
-      assert result_text =~ "on_timeout: :pause_agent",
-             "Expected ToolResult message to come from loop pause handling (includes policy name), got: #{inspect(tool_result.result)}"
+      refute Enum.any?(messages, &(extract_content_text(&1.content) =~ "Queued next turn"))
+      assert_receive_interaction(%Interaction.AgentCompleted{}, 1)
+      assert length(turn_started_rows(task_id)) == 1
+      refute_receive {:interaction, %{data: %Interaction.ToolCall{tool_name: "write_file"}}}, 50
     end
   end
 
-  describe "MCP tool timeout with on_timeout: :error" do
+  describe "finite synchronous MCP deadline" do
     setup [:setup_sandbox, :setup_user, :setup_task]
 
-    test "ToolResult is persisted in DB when MCP tool times out (on_timeout: :error)", %{
+    test "ToolResult is persisted in DB when a synchronous MCP tool times out", %{
       task_id: task_id,
       scope: scope
     } do
@@ -1155,7 +1202,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     end
   end
 
-  describe "interactive tool timeout — client notification" do
+  describe "historical pause — client notification" do
     setup [:setup_sandbox, :setup_user, :setup_task_only, :setup_channel]
 
     test "session/update is pushed to client when agent pauses", %{
@@ -1256,7 +1303,6 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     def access, do: :write
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 5_000
-    def on_timeout, do: :error
     def execute(_args, _ctx), do: raise("boom")
   end
 
@@ -1268,7 +1314,6 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
     def access, do: :write
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 100
-    def on_timeout, do: :error
     def execute(_args, _ctx), do: Process.sleep(:infinity)
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_schema_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_schema_test.exs
@@ -150,11 +150,25 @@ defmodule FrontmanServer.Tasks.InteractionSchemaTest do
     end
   end
 
+  test "new dispatch writes require a supported execution mode", %{task: task} do
+    call = tool_call("mode_validation", "approval")
+    refute interaction_changeset(task, call, 1).valid?
+
+    for mode <- [:synchronous, :interactive] do
+      assert interaction_changeset(task, %{call | execution_mode: mode}, 1).valid?
+    end
+
+    refute interaction_changeset(task, %{call | execution_mode: :unsupported}, 1).valid?
+  end
+
   describe "JSON encoding" do
     test "encodes persisted interaction type from the row", %{task: task} do
       row =
         task
-        |> interaction_changeset(tool_call("call_1", "read_file"), 1)
+        |> interaction_changeset(
+          %{tool_call("call_1", "read_file") | execution_mode: :synchronous},
+          1
+        )
         |> Ecto.Changeset.apply_changes()
 
       decoded = row |> Jason.encode!() |> Jason.decode!()

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -116,6 +116,58 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
     end)
   end
 
+  test "an answer concurrent with cancellation cleanup preserves one result and a closed turn" do
+    Sandbox.unboxed_run(Repo, fn ->
+      scope = user_scope_fixture()
+
+      try do
+        task_id = task_fixture(scope).id
+        turn_number = start_turn_fixture(scope, task_id)
+        call = %SwarmAi.ToolCall{id: "cancel_race", name: "approval", arguments: "{}"}
+        {:ok, _} = Tasks.request_client_tool(scope, task_id, turn_number, call, :interactive)
+        parent = self()
+
+        operations = [
+          fn -> Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user}) end,
+          fn -> Tasks.resolve_tool_request(scope, task_id, call, MCP.tool_result_text("yes")) end
+        ]
+
+        tasks =
+          Enum.map(operations, fn operation ->
+            Task.async(fn ->
+              Sandbox.unboxed_run(Repo, fn ->
+                send(parent, {:ready, self()})
+
+                receive do
+                  :go -> operation.()
+                after
+                  1_000 -> raise "cancellation race barrier timed out"
+                end
+              end)
+            end)
+          end)
+
+        assert_receive {:ready, _}, 1_000
+        assert_receive {:ready, _}, 1_000
+        Enum.each(tasks, &send(&1.pid, :go))
+        assert [:ok, {:ok, winner, :no_executor}] = Enum.map(tasks, &Task.await(&1, 1_000))
+
+        assert {:ok, ^winner, :no_executor} =
+                 Tasks.resolve_tool_request(scope, task_id, call, MCP.tool_result_text("late"))
+
+        assert {:ok, :no_active_turn} =
+                 Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+
+        {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+
+        assert [^winner] =
+                 Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
+      after
+        Repo.delete!(Scope.user(scope))
+      end
+    end)
+  end
+
   defp start_executor(scope, task_id, turn_number, tool_call_id) do
     Task.async(fn ->
       Sandbox.unboxed_run(Repo, fn ->
@@ -138,7 +190,7 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
       description: "Some client tool",
       input_schema: %{},
       timeout_ms: 1_000,
-      on_timeout: :error
+      execution_mode: :synchronous
     }
   end
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -231,7 +231,7 @@ defmodule FrontmanServer.TasksTest do
   end
 
   describe "terminated execution recovery" do
-    test "interrupts non-question tools but keeps pending questions open", %{scope: scope} do
+    test "interrupts synchronous tools but keeps persisted interactive mode open", %{scope: scope} do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
 
@@ -240,7 +240,8 @@ defmodule FrontmanServer.TasksTest do
           scope,
           task_id,
           turn_number,
-          named_swarm_tool_call("question_1", "question")
+          named_swarm_tool_call("question_1", "approval"),
+          :interactive
         )
 
       {:ok, _tool_call} =
@@ -248,7 +249,8 @@ defmodule FrontmanServer.TasksTest do
           scope,
           task_id,
           turn_number,
-          named_swarm_tool_call("read_1", "read_file")
+          named_swarm_tool_call("read_1", "read_file"),
+          :synchronous
         )
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
@@ -275,6 +277,67 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
+  test "historical question mode is recovered after the real JSON load path", %{scope: scope} do
+    task_id = task_fixture(scope).id
+    turn_number = start_turn_fixture(scope, task_id)
+
+    {:ok, _} =
+      Tasks.request_client_tool(
+        scope,
+        task_id,
+        turn_number,
+        named_swarm_tool_call("legacy_question", "question"),
+        :interactive
+      )
+
+    Repo.query!(
+      "UPDATE interactions SET data = data - 'execution_mode' WHERE task_id = $1 AND type = 'tool_call'",
+      [Ecto.UUID.dump!(task_id)]
+    )
+
+    {:ok, ^turn_number, [loaded]} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+    assert loaded.execution_mode == nil
+    assert Interaction.ToolCall.execution_mode(loaded) == :interactive
+
+    assert Interaction.ToolCall.execution_mode(%Interaction.ToolCall{tool_name: "write_file"}) ==
+             :synchronous
+
+    assert :ok = Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
+    assert {:ok, ^turn_number, [_]} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+  end
+
+  test "cancellation cleanup closes undispatched declarations and preserves its canonical result",
+       %{scope: scope} do
+    task_id = task_fixture(scope).id
+    turn_number = start_turn_fixture(scope, task_id)
+    approval = named_swarm_tool_call("approval_pending", "approval")
+    write = named_swarm_tool_call("write_not_dispatched", "write_file")
+
+    {:ok, _} =
+      Tasks.agent_replied(scope, task_id, turn_number, nil, %{
+        "tool_calls" => Enum.map([approval, write], &Map.take(&1, [:id, :name, :arguments]))
+      })
+
+    {:ok, _} = Tasks.request_client_tool(scope, task_id, turn_number, approval, :interactive)
+
+    assert :ok = Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
+    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+    results = Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolResult{}, &1))
+    assert Enum.map(results, & &1.tool_call_id) == [approval.id, write.id]
+    assert Enum.all?(results, & &1.is_error)
+
+    assert [%Interaction.ToolCall{tool_name: "approval"}] =
+             Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolCall{}, &1))
+
+    assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+
+    assert {:ok, winner, :no_executor} =
+             Tasks.resolve_tool_request(scope, task_id, approval, MCP.tool_result_text("yes"))
+
+    assert winner == hd(results)
+    assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+  end
+
   describe "cancelled execution" do
     test "records interrupted results for every unresolved tool call", %{scope: scope} do
       task_id = task_fixture(scope).id
@@ -285,7 +348,8 @@ defmodule FrontmanServer.TasksTest do
           scope,
           task_id,
           turn_number,
-          named_swarm_tool_call("question_1", "question")
+          named_swarm_tool_call("question_1", "question"),
+          :interactive
         )
 
       {:ok, _tool_call} =
@@ -293,10 +357,11 @@ defmodule FrontmanServer.TasksTest do
           scope,
           task_id,
           turn_number,
-          named_swarm_tool_call("read_1", "read_file")
+          named_swarm_tool_call("read_1", "read_file"),
+          :synchronous
         )
 
-      Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
+      assert :ok = Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       interactions = Tasks.interactions(task)
@@ -729,7 +794,7 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s({"expression": "2+2"})
       }
 
-      {:ok, _} = Tasks.request_client_tool(scope, task_id, turn_number, tc)
+      {:ok, _} = Tasks.request_client_tool(scope, task_id, turn_number, tc, :synchronous)
 
       untrusted_result = %{
         "content" => [
@@ -801,7 +866,7 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
-  describe "request_client_tool/3" do
+  describe "request_client_tool/5" do
     test "creates tool call interaction", %{scope: scope} do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
@@ -812,7 +877,8 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s({"expression": "1 + 1"})
       }
 
-      {:ok, interaction} = Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+      {:ok, interaction} =
+        Tasks.request_client_tool(scope, task_id, turn_number, tool_call, :synchronous)
 
       assert interaction.tool_name == "calculator"
       assert interaction.tool_call_id == "call_123"
@@ -830,7 +896,7 @@ defmodule FrontmanServer.TasksTest do
       }
 
       assert {:ok, interaction} =
-               Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+               Tasks.request_client_tool(scope, task_id, turn_number, tool_call, :synchronous)
 
       assert interaction.arguments == %{}
     end
@@ -845,7 +911,7 @@ defmodule FrontmanServer.TasksTest do
       }
 
       assert {:error, {:invalid_tool_arguments, reason}} =
-               Tasks.request_client_tool(scope, task_id, 1, tool_call)
+               Tasks.request_client_tool(scope, task_id, 1, tool_call, :synchronous)
 
       assert reason =~ "unexpected end of input"
     end
@@ -860,7 +926,7 @@ defmodule FrontmanServer.TasksTest do
       }
 
       assert {:error, {:invalid_tool_arguments, reason}} =
-               Tasks.request_client_tool(scope, task_id, 1, tool_call)
+               Tasks.request_client_tool(scope, task_id, 1, tool_call, :synchronous)
 
       assert reason =~ "expected JSON object"
     end
@@ -870,7 +936,7 @@ defmodule FrontmanServer.TasksTest do
       tool_call = %SwarmAi.ToolCall{id: "call_123", name: "test", arguments: "{}"}
 
       assert {:error, :not_found} =
-               Tasks.request_client_tool(scope, nonexistent_id, 1, tool_call)
+               Tasks.request_client_tool(scope, nonexistent_id, 1, tool_call, :synchronous)
     end
   end
 
@@ -975,11 +1041,14 @@ defmodule FrontmanServer.TasksTest do
 
   defp test_interaction_attrs(Interaction.ToolCall, data) do
     {:ok, attrs} =
-      Interaction.ToolCall.attrs(%SwarmAi.ToolCall{
-        id: Map.get(data, "tool_call_id", Ecto.UUID.generate()),
-        name: Map.get(data, "tool_name", "question"),
-        arguments: Jason.encode!(Map.get(data, "arguments", %{}))
-      })
+      Interaction.ToolCall.attrs(
+        %SwarmAi.ToolCall{
+          id: Map.get(data, "tool_call_id", Ecto.UUID.generate()),
+          name: Map.get(data, "tool_name", "question"),
+          arguments: Jason.encode!(Map.get(data, "arguments", %{}))
+        },
+        :interactive
+      )
 
     {:tool_call, attrs}
   end
@@ -1012,6 +1081,8 @@ defmodule FrontmanServer.TasksTest do
          timestamp: Interaction.now(),
          retried_error_id: Map.fetch!(data, "retried_error_id")
        }}
+
+  defp test_interaction_attrs(:agent_paused, attrs), do: {:agent_paused, attrs}
 
   defp test_interaction_attrs(Interaction.AgentCompleted, _data),
     do: {:agent_completed, %{id: Ecto.UUID.generate(), timestamp: Interaction.now(), result: nil}}
@@ -1376,13 +1447,11 @@ defmodule FrontmanServer.TasksTest do
       {:ok, %TaskSchema{id: ^task_id}} = Tasks.create_task(scope, task_id, "nextjs")
       turn_number = start_turn_fixture(scope, task_id)
 
-      {:ok, _interaction} =
-        Tasks.record_execution_outcome(
-          scope,
-          task_id,
-          turn_number,
-          {:paused_for_tool_timeout, "question", 120_000}
-        )
+      insert_interaction_row(task_id, :agent_paused, turn_number, %{
+        tool_name: "question",
+        timeout_ms: 120_000,
+        reason: "Historical timeout"
+      })
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
@@ -1390,6 +1459,7 @@ defmodule FrontmanServer.TasksTest do
       assert paused != nil
       assert paused.tool_name == "question"
       assert paused.timeout_ms == 120_000
+      assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end
 
     test "to_swarm_messages/1 succeeds when interactions include AgentPaused", %{scope: scope} do
@@ -1401,13 +1471,11 @@ defmodule FrontmanServer.TasksTest do
 
       turn_number = latest_turn_number(task_id)
 
-      {:ok, _} =
-        Tasks.record_execution_outcome(
-          scope,
-          task_id,
-          turn_number,
-          {:paused_for_tool_timeout, "question", 120_000}
-        )
+      insert_interaction_row(task_id, :agent_paused, turn_number, %{
+        tool_name: "question",
+        timeout_ms: 120_000,
+        reason: "Historical timeout"
+      })
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -63,18 +63,26 @@ defmodule FrontmanServer.TasksTest do
   end
 
   describe "get_active_turn_unresolved_tool_calls/2" do
-    test "returns unresolved tool calls only for the active turn", %{scope: scope} do
+    test "returns only unresolved dispatched calls in dispatch order", %{scope: scope} do
       task_id = task_fixture(scope).id
 
       assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
 
       assert 1 = start_turn_fixture(scope, task_id)
-      insert_interaction_row(task_id, Interaction.ToolCall, 1, %{"tool_call_id" => "call_1"})
 
-      assert {:ok, 1, [%Interaction.ToolCall{tool_call_id: "call_1"}]} =
-               Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+      calls =
+        for id <- ~w(call_3 call_2 call_1), do: %{id: id, name: "read_file", arguments: "{}"}
+
+      {:ok, _} = Tasks.agent_replied(scope, task_id, 1, nil, %{"tool_calls" => calls})
+
+      insert_interaction_row(task_id, Interaction.ToolCall, 1, %{"tool_call_id" => "call_1"})
+      insert_interaction_row(task_id, Interaction.ToolCall, 1, %{"tool_call_id" => "call_2"})
+
+      assert {:ok, 1, calls} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+      assert Enum.map(calls, & &1.tool_call_id) == ["call_1", "call_2"]
 
       insert_interaction_row(task_id, Interaction.ToolResult, 1, %{"tool_call_id" => "call_1"})
+      insert_interaction_row(task_id, Interaction.ToolResult, 1, %{"tool_call_id" => "call_2"})
 
       assert {:ok, 1, []} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
     end

--- a/apps/frontman_server/test/frontman_server/tools/backend_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/backend_test.exs
@@ -15,7 +15,6 @@ defmodule FrontmanServer.Tools.BackendTest do
     def access, do: :read
     def parameter_schema, do: %{}
     def timeout_ms, do: 45_000
-    def on_timeout, do: :error
     def execute(_args, _ctx), do: ModelContextProtocol.tool_result_text("done")
   end
 
@@ -27,8 +26,8 @@ defmodule FrontmanServer.Tools.BackendTest do
       assert tool.description == "A fake tool for testing"
       assert tool.access == :read
       assert tool.parameter_schema == %{}
-      assert tool.timeout_ms == 45_000
-      assert tool.on_timeout == :error
+      refute Map.has_key?(tool, :timeout_ms)
+      refute Map.has_key?(tool, :on_timeout)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server/tools/mcp_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/mcp_test.exs
@@ -20,7 +20,7 @@ defmodule FrontmanServer.Tools.MCPTest do
       assert tool.access == :read_write
       assert tool.output_schema == output_schema
       assert tool.timeout_ms == 600_000
-      assert tool.on_timeout == :error
+      assert tool.execution_mode == :synchronous
     end
 
     test "parses access from wire format" do
@@ -42,7 +42,7 @@ defmodule FrontmanServer.Tools.MCPTest do
       end
     end
 
-    test "applies pause_agent policy for executionMode: Interactive" do
+    test "interactive tools have no deadline" do
       tool =
         MCP.from_map(%{
           "name" => "question",
@@ -53,8 +53,19 @@ defmodule FrontmanServer.Tools.MCPTest do
           }
         })
 
-      assert tool.timeout_ms == 120_000
-      assert tool.on_timeout == :pause_agent
+      assert tool.timeout_ms == :infinity
+      assert tool.execution_mode == :interactive
+    end
+  end
+
+  test "rejects unsupported declared execution modes" do
+    for mode <- ["interactive", "Unknown", 1, false] do
+      assert_raise FunctionClauseError, fn ->
+        MCP.from_map(%{
+          "name" => "approval",
+          "_meta" => %{"ai.frontman/tool-metadata" => %{"executionMode" => mode}}
+        })
+      end
     end
   end
 
@@ -73,7 +84,7 @@ defmodule FrontmanServer.Tools.MCPTest do
       assert swarm_tool.access == :read
     end
 
-    test "passes pause_agent policy through to swarm tool for interactive tools" do
+    test "model-facing tools carry no operational deadline" do
       mcp_tool =
         MCP.from_map(%{
           "name" => "question",
@@ -86,8 +97,8 @@ defmodule FrontmanServer.Tools.MCPTest do
 
       [swarm_tool] = MCP.to_swarm_tools([mcp_tool])
 
-      assert swarm_tool.timeout_ms == 120_000
-      assert swarm_tool.on_timeout == :pause_agent
+      refute Map.has_key?(swarm_tool, :timeout_ms)
+      refute Map.has_key?(swarm_tool, :on_timeout)
     end
   end
 end

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -793,18 +793,36 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       {:ok, socket: socket, task_id: task_id}
     end
 
+    test "a delayed synchronous dispatch cannot execute after cancellation", %{
+      scope: scope,
+      task_id: task_id,
+      socket: socket
+    } do
+      :ok = :sys.suspend(socket.channel_pid)
+      turn_number = start_turn_fixture(scope, task_id)
+      call = tool_call("delayed_mutation", "write_file")
+      {:ok, _} = persist_tool_call_fixture(scope, task_id, turn_number, call)
+      assert :ok = Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
+      :ok = :sys.resume(socket.channel_pid)
+      :sys.get_state(socket.channel_pid)
+
+      refute_push("mcp:message", %{
+        "method" => "tools/call",
+        "params" => %{"name" => "write_file"}
+      })
+
+      assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
+    end
+
     test "channel receives tool call interactions via PubSub broadcast", %{
       socket: _socket,
+      scope: scope,
       task_id: task_id
     } do
       tool_call =
         tool_call("call_pubsub_#{:rand.uniform(1_000_000)}", "testTool", %{"key" => "value"})
 
-      Phoenix.PubSub.broadcast(
-        FrontmanServer.PubSub,
-        task_topic(task_id),
-        interaction_event(tool_call, 1)
-      )
+      persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call)
 
       assert_push("mcp:message", %{
         "method" => "tools/call",
@@ -814,6 +832,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "channel does NOT receive broadcasts to different topics", %{
       socket: _socket,
+      scope: scope,
       task_id: task_id
     } do
       different_topic = "task:different_#{:rand.uniform(1_000_000)}"
@@ -835,11 +854,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
           tool_name: "ownTool"
       }
 
-      Phoenix.PubSub.broadcast(
-        FrontmanServer.PubSub,
-        task_topic(task_id),
-        interaction_event(tool_call2, 1)
-      )
+      persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tool_call2)
 
       assert_push("mcp:message", %{
         "method" => "tools/call",
@@ -1700,7 +1715,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "deduplicates tool_call_create when interaction arrives after tool_call", %{
       socket: socket,
-      task_id: _task_id
+      scope: scope,
+      task_id: task_id
     } do
       tool_call_id = "call_dedup_#{:rand.uniform(1_000_000)}"
       activate_turn(socket, "turn-1")
@@ -1720,7 +1736,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       tc =
         tool_call(tool_call_id, "write_file", %{"target_file" => "test.txt", "content" => "hello"})
 
-      send(socket.channel_pid, interaction_event(tc, 1))
+      persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tc)
       :sys.get_state(socket.channel_pid)
 
       assert_push("acp:message", %{
@@ -1748,13 +1764,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
 
     test "sends tool_call_create for interactions without prior tool_call", %{
       socket: socket,
+      scope: scope,
       task_id: task_id
     } do
       tool_call_id = "call_no_start_#{:rand.uniform(1_000_000)}"
 
       tc = tool_call(tool_call_id, "take_screenshot")
 
-      send(socket.channel_pid, interaction_event(tc, 1))
+      persist_tool_call_fixture(scope, task_id, start_turn_fixture(scope, task_id), tc)
       :sys.get_state(socket.channel_pid)
 
       assert_push("acp:message", %{
@@ -1788,7 +1805,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       turn_number = latest_turn_number(task_id)
 
       {:ok, _tool_call} =
-        persist_response_tool_call_fixture(scope, task_id, turn_number, "", tool_call)
+        persist_response_tool_call_fixture(
+          scope,
+          task_id,
+          turn_number,
+          "",
+          tool_call,
+          :interactive
+        )
 
       {:ok, task_id: task_id, scope: scope, tool_call_id: tool_call_id}
     end
@@ -1873,7 +1897,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       turn_number = latest_turn_number(task_id)
 
       {:ok, _tool_call} =
-        persist_response_tool_call_fixture(scope, task_id, turn_number, "", second_tool_call)
+        persist_response_tool_call_fixture(
+          scope,
+          task_id,
+          turn_number,
+          "",
+          second_tool_call,
+          :interactive
+        )
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
       expect_resumed_model()
@@ -1990,7 +2021,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       first_turn_number = latest_turn_number(task_id)
 
       {:ok, _tool_call} =
-        persist_response_tool_call_fixture(scope, task_id, first_turn_number, "", first_tc)
+        persist_response_tool_call_fixture(
+          scope,
+          task_id,
+          first_turn_number,
+          "",
+          first_tc,
+          :interactive
+        )
 
       Tasks.resolve_tool_request(
         scope,
@@ -2006,7 +2044,14 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       second_turn_number = latest_turn_number(task_id)
 
       {:ok, _tool_call} =
-        persist_response_tool_call_fixture(scope, task_id, second_turn_number, "", second_tc)
+        persist_response_tool_call_fixture(
+          scope,
+          task_id,
+          second_turn_number,
+          "",
+          second_tc,
+          :interactive
+        )
 
       {:ok, _reply, socket} =
         UserSocket

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -79,11 +79,24 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
       arguments: Jason.encode!(tool_call.arguments)
     }
 
-    Tasks.request_client_tool(scope, task_id, turn_number, swarm_tool_call)
+    Tasks.request_client_tool(
+      scope,
+      task_id,
+      turn_number,
+      swarm_tool_call,
+      Interaction.ToolCall.execution_mode(tool_call)
+    )
   end
 
   @doc "Persist an agent response and its matching client-handled tool call."
-  def persist_response_tool_call_fixture(scope, task_id, turn_number, content, tool_call) do
+  def persist_response_tool_call_fixture(
+        scope,
+        task_id,
+        turn_number,
+        content,
+        tool_call,
+        execution_mode \\ :synchronous
+      ) do
     metadata = %{
       "tool_calls" => [
         %{"id" => tool_call.id, "name" => tool_call.name, "arguments" => tool_call.arguments}
@@ -91,7 +104,7 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
     }
 
     {:ok, _response} = Tasks.agent_replied(scope, task_id, turn_number, content, metadata)
-    Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+    Tasks.request_client_tool(scope, task_id, turn_number, tool_call, execution_mode)
   end
 
   @doc """

--- a/apps/swarm_ai/CHANGELOG.md
+++ b/apps/swarm_ai/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the `swarm_ai` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Breaking changes
+
+- Remove `timeout_ms` and `on_timeout` from `SwarmAi.Tool`. Put deadlines and error callbacks on execution descriptors instead.
+- Remove `on_timeout_policy` from `ToolExecution.Sync` and `ToolExecution.Await`.
+- Replace the descriptor `on_timeout` MFA with `on_error`. It receives appended arguments `[reason, tool_call]`, where `reason` is `:timeout` or `{:crashed, exit_reason}`. Return the canonical `SwarmAi.ToolResult`, not `:ok`.
+- Tool batches return `{:ok, results}`. Remove timeout halt results, `Loop.pause/2`, and paused loop statuses and events.
+- Remove the unused overall `Loop.Config.timeout_ms`. Keep `step_timeout_ms` for LLM protocol implementations.
+
+These changes require a breaking package release. The package version remains unchanged pending maintainer coordination. Do not publish these changes as a patch release.
+
+### Added
+
+- `Await.timeout_ms` accepts `:infinity`. Interactive waits create no timer and remain cancellable. The parked executor retains its history in memory.
+
+### Fixed
+
+- Finite timeouts and Sync crashes consume the error callback's canonical result instead of constructing a separate local error.
+- A Sync success persisted before a crash remains the canonical result after the task dies.
+- Finite Sync timeouts kill and monitor the affected task before the error callback runs. Timeout results no longer cancel sibling tools.
+
+### Retained limits
+
+- Cancelling an executor does not terminate its existing Sync tasks under the runtime-global task supervisor. This pre-existing ownership limit remains unchanged.
+
 ## [1.0.0] - 2026-06-08
 
 ### Removed

--- a/apps/swarm_ai/README.md
+++ b/apps/swarm_ai/README.md
@@ -3,100 +3,83 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/swarm_ai.svg)](https://hex.pm/packages/swarm_ai)
 [![Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/swarm_ai)
 
-A functional AI agent execution framework for Elixir with protocol-based LLM and tool integration.
-
-SwarmAi implements a **functional core / imperative shell** architecture: a pure state machine produces effects (instructions for side effects) which are interpreted by an execution layer. This makes agent logic deterministic and testable while keeping I/O at the edges.
+SwarmAi runs supervised AI loops in Elixir. A pure state machine produces effects. The executor handles LLM calls and tool execution.
 
 ## Installation
 
-Add `swarm_ai` to your list of dependencies in `mix.exs`:
+Add the published package to `mix.exs`:
 
 ```elixir
-def deps do
-  [
-    {:swarm_ai, "~> 0.1.0"}
-  ]
-end
+{:swarm_ai, "~> 1.0"}
 ```
+
+The examples below describe the unreleased source API. The timeout changes break compatibility with previous releases. See [CHANGELOG.md](CHANGELOG.md).
 
 ## Quick Start
 
-### Define an Agent and Run
-
-Agents own lifecycle identity and execution data. `id/1` must return a stable string.
+Add a runtime to the supervision tree:
 
 ```elixir
-defmodule MyAgent do
-  defstruct [:id, :messages, :tool_executor, context: %{}, model: "gpt-4o"]
-
-  defimpl SwarmAi.Agent do
-    def id(%{id: id}) when is_binary(id), do: id
-    def messages(agent), do: agent.messages
-    def context(agent), do: agent.context
-    def tool_executor(agent), do: agent.tool_executor
-    def system_prompt(_agent), do: "You are a helpful assistant."
-    def llm(agent), do: MyLLMClient.new(agent.model)
-  end
-end
+children = [{SwarmAi, name: MyApp.AgentRuntime}]
 ```
 
-### Supervised Execution
+Create a loop with complete input messages, an LLM client, a tool callback, and an event callback:
 
 ```elixir
-children = [
-  {SwarmAi,
-   name: MyApp.AgentRuntime,
-   event_dispatcher: {MyApp.SwarmDispatcher, :dispatch, []}}
-]
+loop = SwarmAi.Loop.new(%{
+  task_id: task_id,
+  turn_number: 1,
+  messages: [SwarmAi.Message.user("Analyze this code")],
+  llm: MyLLMClient.new("my-model"),
+  execute_tools: &MyTools.execute/2,
+  dispatch_event: &MyEvents.dispatch/1
+})
 
-agent = %MyAgent{
-  id: task_id,
-  messages: "Analyze this code",
-  context: %{task_id: task_id},
-  tool_executor: %{build: &build_tool_executions/1, execution_mode: :parallel}
+{:ok, pid} = SwarmAi.run(MyApp.AgentRuntime, loop)
+SwarmAi.running?(MyApp.AgentRuntime, loop.task_id)
+SwarmAi.cancel(MyApp.AgentRuntime, loop.task_id)
+```
+
+The LLM client implements `SwarmAi.LLM.stream/3`. The tool callback accepts tool calls and a task supervisor. It returns `{:ok, results}`.
+
+## Tool Execution
+
+`SwarmAi.Tool` contains only the name, description, access mode, and parameter schema for the LLM. Execution descriptors own deadlines and error callbacks.
+
+```elixir
+%SwarmAi.ToolExecution.Await{
+  tool_call: tool_call,
+  timeout_ms: :infinity,
+  start: {MyTools, :request_answer, [context]},
+  on_error: {MyTools, :persist_error, [context]}
 }
-
-{:ok, pid} = SwarmAi.run(MyApp.AgentRuntime, agent)
-
-SwarmAi.running?(MyApp.AgentRuntime, SwarmAi.Agent.id(agent))
-SwarmAi.cancel(MyApp.AgentRuntime, SwarmAi.Agent.id(agent))
 ```
 
-## Architecture
+The `start` MFA receives one appended argument: `tool_call`. This callback runs in the executor process. It registers delivery before publishing the request.
 
-```
-┌──────────────────────────────────────────────────┐
-│            SwarmAi Public API                     │
-│  Supervised runs, cancellation, execution events  │
-└────────────────────────┬─────────────────────────┘
-                         │ produces/consumes
-                         ▼
-┌──────────────────────────────────────────────────┐
-│        Executor + Loop (Functional Core)          │
-│  State machine for agent execution,               │
-│  returns {loop, effects} tuples, no side effects  │
-└──────────────────────────────────────────────────┘
-```
+The answer arrives as `{:tool_result, tool_call_id, content, is_error}`. With `:infinity`, no timer exists and the error callback does not run for a deadline.
 
-### Key Concepts
+The `on_error` MFA receives two appended arguments: `reason` and `tool_call`. The reason is `:timeout` or `{:crashed, exit_reason}`.
 
-- **Agent Protocol** - Define stable string identity, messages, dispatcher context, tool executor, system prompt, and LLM config
-- **LLM Protocol** - Bring your own LLM client by implementing `SwarmAi.LLM` (streaming interface)
-- **Effect System** - Pure functions produce effects (`{:call_llm, ...}`, `{:execute_tool, ...}`) instead of performing I/O directly
-- **Tool Execution** - Tools are pure data structures; execution is delegated to the agent's `tool_executor`
-- **Telemetry** - Built-in `:telemetry` events for runs, steps, LLM calls, and tool executions
+The error callback returns the canonical `SwarmAi.ToolResult` selected by application persistence. It does not return `:ok`. A stored success can win over a timeout or crash.
 
-## Telemetry Events
+`Sync` descriptors require a positive millisecond deadline and a `run` MFA. The executor kills and monitors the timed-out Sync task before the error callback runs.
 
-SwarmAi emits telemetry under the `[:swarm_ai, ...]` prefix:
+`ParallelExecutor.run/2` returns results in call order. `run_serial/2` also preserves dispatch order. An interactive wait blocks subsequent serial calls, but not parallel siblings.
 
-| Event | Description |
-|-------|-------------|
-| `[:swarm_ai, :run, :start\|:stop\|:exception]` | Full agent run lifecycle |
-| `[:swarm_ai, :step, :start\|:stop]` | Individual step within a run |
-| `[:swarm_ai, :llm, :call, :start\|:stop\|:exception]` | LLM API calls |
-| `[:swarm_ai, :tool, :execute, :start\|:stop\|:exception]` | Tool executions |
+Human waits are an explicit exception to bounded execution. A parked executor retains its history in memory without polling or calling the LLM.
+
+Cancellation terminates the parked executor and removes its registration. Existing Sync tasks use the runtime-global task supervisor and can outlive executor cancellation. This release does not change that ownership.
+
+## Telemetry
+
+| Event | Scope |
+|-------|-------|
+| `[:swarm_ai, :run, :start\|:stop\|:exception]` | Loop execution |
+| `[:swarm_ai, :step, :start\|:stop]` | One LLM step |
+| `[:swarm_ai, :llm, :call, :start\|:stop\|:exception]` | LLM call |
+| `[:swarm_ai, :tool, :execute, :start\|:stop\|:exception]` | Tool execution |
 
 ## License
 
-Apache-2.0 - see the LICENSE file for details.
+Apache-2.0. See [LICENSE](LICENSE).

--- a/apps/swarm_ai/lib/swarm_ai/executor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/executor.ex
@@ -72,7 +72,7 @@ defmodule SwarmAi.Executor do
 
     Enum.each(tool_calls, &emit_tool_start(loop_id, step, &1))
 
-    executor_result =
+    {:ok, results} =
       try do
         loop.execute_tools.(tool_calls, task_supervisor)
       rescue
@@ -81,28 +81,16 @@ defmodule SwarmAi.Executor do
           reraise e, __STACKTRACE__
       end
 
-    case executor_result do
-      {:halt, halt_reason} ->
-        Telemetry.step_stop(loop.id, loop.current_step)
-        Loop.pause(loop, halt_reason)
+    Enum.zip(tool_calls, results)
+    |> Enum.each(fn {tc, result} -> emit_tool_stop(loop_id, step, tc, result) end)
 
-      {:ok, results} ->
-        Enum.zip(tool_calls, results)
-        |> Enum.each(fn {tc, result} -> emit_tool_stop(loop_id, step, tc, result) end)
+    {new_effects, updated_loop} =
+      Enum.flat_map_reduce(results, loop, fn result, loop_acc ->
+        {l, e} = Loop.handle_tool_result(loop_acc, result)
+        {e, l}
+      end)
 
-        {new_effects, updated_loop} =
-          Enum.flat_map_reduce(results, loop, fn result, loop_acc ->
-            {l, e} = Loop.handle_tool_result(loop_acc, result)
-            {e, l}
-          end)
-
-        run_effects(
-          updated_loop,
-          new_effects ++ rest,
-          task_supervisor,
-          steps_left
-        )
-    end
+    run_effects(updated_loop, new_effects ++ rest, task_supervisor, steps_left)
   end
 
   defp execute_llm_call(loop, llm, messages) do

--- a/apps/swarm_ai/lib/swarm_ai/loop.ex
+++ b/apps/swarm_ai/lib/swarm_ai/loop.ex
@@ -10,7 +10,6 @@ defmodule SwarmAi.Loop do
   - No more tool calls (LLM responds without requesting tools)
   - Max steps reached
   - LLM returns an error
-  - Tool execution pauses the loop
   """
 
   alias SwarmAi.Effect
@@ -30,7 +29,6 @@ defmodule SwarmAi.Loop do
           | :waiting_for_tools
           | :completed
           | {:failed, term()}
-          | {:paused, term()}
 
   @type response_event_metadata :: %{ordinal: non_neg_integer(), timestamp: DateTime.t()}
 
@@ -40,13 +38,12 @@ defmodule SwarmAi.Loop do
           | {:tool_call, ToolCall.t()}
           | :completed
           | {:failed, term()}
-          | {:paused, term()}
           | {:cancelled, nil}
           | {:terminated, term()}
           | {:crashed, %{message: String.t()}}
 
   @type execute_tools ::
-          ([ToolCall.t()], pid() | atom() -> {:ok, [ToolResult.t()]} | {:halt, term()})
+          ([ToolCall.t()], pid() | atom() -> {:ok, [ToolResult.t()]})
 
   typedstruct do
     field(:id, String.t(), enforce: true)
@@ -106,13 +103,6 @@ defmodule SwarmAi.Loop do
   """
   def fail(%__MODULE__{} = loop, reason) do
     %{loop | status: {:failed, reason}}
-  end
-
-  @doc """
-  Pauses the loop with the given reason.
-  """
-  def pause(%__MODULE__{} = loop, reason) do
-    %{loop | status: {:paused, reason}}
   end
 
   @doc """

--- a/apps/swarm_ai/lib/swarm_ai/loop/config.ex
+++ b/apps/swarm_ai/lib/swarm_ai/loop/config.ex
@@ -5,14 +5,12 @@ defmodule SwarmAi.Loop.Config do
   ## Fields
 
   - `:max_steps` - maximum number of LLM call steps before stopping (default: `400`)
-  - `:timeout_ms` - overall loop timeout in milliseconds (default: `300_000` / 5 minutes)
   - `:step_timeout_ms` - per-step timeout in milliseconds (default: `60_000` / 1 minute)
   """
   use TypedStruct
 
   typedstruct do
     field(:max_steps, non_neg_integer(), default: 400)
-    field(:timeout_ms, non_neg_integer(), default: 300_000)
     field(:step_timeout_ms, non_neg_integer(), default: 60_000)
   end
 end

--- a/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
+++ b/apps/swarm_ai/lib/swarm_ai/parallel_executor.ex
@@ -5,36 +5,29 @@ defmodule SwarmAi.ParallelExecutor do
   Accepts a list of `ToolExecution.t()` structs. PE is the sole execution
   authority — executors build descriptions, PE runs them.
 
-  - `Sync` executions are spawned as supervised tasks.
+  - `Sync` executions are spawned as supervised tasks with finite deadlines.
   - `Await` executions call their start MFA in PE's own process, then wait
     for `{:tool_result, tool_call_id, content, is_error}` in PE's receive loop.
+    An infinite deadline creates no timer, so human input can arrive later.
+  - Finite deadlines and Sync crashes return the error callback's canonical `ToolResult`.
 
-  Timeout callbacks return `ToolResult.t()` for triggered `:error` deadlines;
-  return values for pauses and sibling cancellations are ignored.
-
-  ## Return values
-
-  - `{:ok, [ToolResult.t()]}` — all tools completed; results in original call order
-  - `{:halt, {:timeout, tool_call_id, tool_name, timeout_ms}}` — a deadline fired
-    for a tool with `on_timeout: :pause_agent`; all remaining tasks cancelled;
-    first deadline wins
+  Returns `{:ok, [ToolResult.t()]}` with results in original call order.
   """
 
   alias SwarmAi.{ToolCall, ToolExecution, ToolResult}
 
-  @type halt_reason :: {:timeout, String.t(), String.t(), pos_integer()}
-  @type result :: {:ok, [ToolResult.t()]} | {:halt, halt_reason()}
+  @type result :: {:ok, [ToolResult.t()]}
 
   @typep sync_entry :: %{
            kind: :sync,
            exec: ToolExecution.Sync.t(),
            timer: reference(),
-           pid: pid()
+           task: Task.t()
          }
   @typep await_entry :: %{
            kind: :await,
            exec: ToolExecution.Await.t(),
-           timer: reference()
+           timer: reference() | nil
          }
   @typep pending_entry :: sync_entry() | await_entry()
   @typep results_map :: %{ToolCall.id() => ToolResult.t()}
@@ -47,13 +40,9 @@ defmodule SwarmAi.ParallelExecutor do
   @spec run([ToolExecution.t()], pid() | atom()) :: result()
   def run(executions, task_supervisor) do
     {pending, awaiting} = spawn_all(executions, task_supervisor)
-
     tool_calls = Enum.map(executions, & &1.tool_call)
-
-    case collect_results(pending, awaiting, %{}, task_supervisor) do
-      {:ok, results_map} -> {:ok, finalize(tool_calls, results_map)}
-      {:halt, _} = halt -> halt
-    end
+    results_map = collect_results(pending, awaiting, %{})
+    {:ok, finalize(tool_calls, results_map)}
   end
 
   @doc """
@@ -61,16 +50,13 @@ defmodule SwarmAi.ParallelExecutor do
   """
   @spec run_serial([ToolExecution.t()], pid() | atom()) :: result()
   def run_serial(executions, task_supervisor) do
-    Enum.reduce_while(executions, {:ok, []}, fn exec, {:ok, results} ->
-      case run([exec], task_supervisor) do
-        {:ok, [result]} -> {:cont, {:ok, [result | results]}}
-        {:halt, _reason} = halt -> {:halt, halt}
-      end
-    end)
-    |> case do
-      {:ok, results} -> {:ok, Enum.reverse(results)}
-      {:halt, _reason} = halt -> halt
-    end
+    results =
+      Enum.map(executions, fn exec ->
+        {:ok, [result]} = run([exec], task_supervisor)
+        result
+      end)
+
+    {:ok, results}
   end
 
   @spec spawn_all([ToolExecution.t()], pid() | atom()) :: {pending(), awaiting()}
@@ -79,140 +65,105 @@ defmodule SwarmAi.ParallelExecutor do
       case exec do
         %ToolExecution.Sync{} ->
           task = spawn_sync(exec, task_supervisor)
-          timer = Process.send_after(self(), {:deadline, task.ref}, exec.timeout_ms)
-          entry = %{kind: :sync, exec: exec, timer: timer, pid: task.pid}
+          timer = start_timer(task.ref, exec.timeout_ms)
+          entry = %{kind: :sync, exec: exec, timer: timer, task: task}
           {Map.put(pending, task.ref, entry), awaiting}
 
         %ToolExecution.Await{} ->
           ref = make_ref()
           {mod, fun, args} = exec.start
           apply(mod, fun, args ++ [exec.tool_call])
-          timer = Process.send_after(self(), {:deadline, ref}, exec.timeout_ms)
+          timer = start_timer(ref, exec.timeout_ms)
           entry = %{kind: :await, exec: exec, timer: timer}
           {Map.put(pending, ref, entry), Map.put(awaiting, exec.tool_call.id, ref)}
       end
     end)
   end
 
-  @spec collect_results(pending(), awaiting(), results_map(), pid() | atom()) ::
-          {:ok, results_map()} | {:halt, halt_reason()}
-  defp collect_results(pending, _awaiting, results, _task_supervisor) when pending == %{} do
-    {:ok, results}
+  defp start_timer(_ref, :infinity), do: nil
+
+  defp start_timer(ref, timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
+    Process.send_after(self(), {:deadline, ref}, timeout_ms)
   end
 
-  defp collect_results(pending, awaiting, results, task_supervisor) do
+  defp cancel_timer(nil), do: :ok
+  defp cancel_timer(timer), do: Process.cancel_timer(timer)
+
+  @spec collect_results(pending(), awaiting(), results_map()) :: results_map()
+  defp collect_results(pending, _awaiting, results) when pending == %{}, do: results
+
+  defp collect_results(pending, awaiting, results) do
     receive do
       {ref, result} when is_map_key(pending, ref) ->
         Process.demonitor(ref, [:flush])
         %{timer: timer, exec: exec} = Map.fetch!(pending, ref)
-        Process.cancel_timer(timer)
+        cancel_timer(timer)
 
         collect_results(
           Map.delete(pending, ref),
           awaiting,
-          Map.put(results, exec.tool_call.id, result),
-          task_supervisor
+          Map.put(results, exec.tool_call.id, result)
         )
 
       {:DOWN, ref, :process, _pid, reason} when is_map_key(pending, ref) ->
         %{timer: timer, exec: exec} = Map.fetch!(pending, ref)
-        Process.cancel_timer(timer)
+        cancel_timer(timer)
 
-        error_result =
-          ToolResult.make(exec.tool_call.id, "Tool crashed: #{inspect(reason)}", true)
+        error_result = error_result(exec, {:crashed, reason})
 
         collect_results(
           Map.delete(pending, ref),
           awaiting,
-          Map.put(results, exec.tool_call.id, error_result),
-          task_supervisor
+          Map.put(results, exec.tool_call.id, error_result)
         )
 
       {:tool_result, key, content, is_error} when is_map_key(awaiting, key) ->
         ref = Map.fetch!(awaiting, key)
         %{exec: exec, timer: timer} = Map.fetch!(pending, ref)
-        Process.cancel_timer(timer)
+        cancel_timer(timer)
 
         result = ToolResult.make(exec.tool_call.id, content, is_error)
 
         collect_results(
           Map.delete(pending, ref),
           Map.delete(awaiting, key),
-          Map.put(results, exec.tool_call.id, result),
-          task_supervisor
+          Map.put(results, exec.tool_call.id, result)
         )
 
       {:deadline, ref} when is_map_key(pending, ref) ->
-        handle_deadline(pending, awaiting, results, ref, task_supervisor)
+        handle_deadline(pending, awaiting, results, ref)
     end
   end
 
-  @spec handle_deadline(pending(), awaiting(), results_map(), reference(), pid() | atom()) ::
-          {:ok, results_map()} | {:halt, halt_reason()}
-  defp handle_deadline(pending, awaiting, results, ref, task_supervisor) do
-    %{kind: kind, exec: exec} = Map.fetch!(pending, ref)
+  @spec handle_deadline(pending(), awaiting(), results_map(), reference()) :: results_map()
+  defp handle_deadline(pending, awaiting, results, ref) do
+    entry = Map.fetch!(pending, ref)
+    exec = entry.exec
 
-    {mod, fun, args} = exec.on_timeout
-
-    error_result = apply(mod, fun, args ++ [exec.tool_call, :triggered])
-
-    awaiting =
-      case kind do
-        :sync ->
-          %{pid: pid} = Map.fetch!(pending, ref)
-          Task.Supervisor.terminate_child(task_supervisor, pid)
-
-          receive do
-            {:DOWN, ^ref, :process, _, _} -> :ok
-          end
-
-          awaiting
-
-        :await ->
-          Map.delete(awaiting, exec.tool_call.id)
-      end
-
-    case exec.on_timeout_policy do
-      :error ->
-        collect_results(
-          Map.delete(pending, ref),
-          awaiting,
-          Map.put(results, exec.tool_call.id, error_result),
-          task_supervisor
-        )
-
-      :pause_agent ->
-        cancel_remaining(Map.delete(pending, ref), awaiting, task_supervisor)
-        {:halt, {:timeout, exec.tool_call.id, exec.tool_call.name, exec.timeout_ms}}
+    case entry do
+      %{kind: :sync, task: task} -> Task.shutdown(task, :brutal_kill)
+      %{kind: :await} -> :ok
     end
+
+    result = error_result(exec, :timeout)
+
+    collect_results(
+      Map.delete(pending, ref),
+      Map.delete(awaiting, exec.tool_call.id),
+      Map.put(results, exec.tool_call.id, result)
+    )
   end
 
-  @spec cancel_remaining(pending(), awaiting(), pid() | atom()) :: :ok
-  defp cancel_remaining(pending, awaiting, task_supervisor) do
-    Enum.each(pending, fn {ref, entry} ->
-      %{kind: kind, exec: exec, timer: timer} = entry
-      Process.cancel_timer(timer)
-
-      {mod, fun, args} = exec.on_timeout
-      apply(mod, fun, args ++ [exec.tool_call, :cancelled])
-
-      case kind do
-        :sync ->
-          Task.Supervisor.terminate_child(task_supervisor, entry.pid)
-
-          receive do
-            {:DOWN, ^ref, :process, _, _} -> :ok
-          end
-
-        :await ->
-          _ = Map.delete(awaiting, exec.tool_call.id)
-          :ok
-      end
-    end)
+  defp error_result(exec, reason) do
+    {mod, fun, args} = exec.on_error
+    %ToolResult{id: id} = result = apply(mod, fun, args ++ [reason, exec.tool_call])
+    true = id == exec.tool_call.id
+    result
   end
 
   @spec spawn_sync(ToolExecution.Sync.t(), pid() | atom()) :: Task.t()
-  defp spawn_sync(exec, task_supervisor) do
+  defp spawn_sync(%{timeout_ms: timeout_ms} = exec, task_supervisor)
+       when is_integer(timeout_ms) and timeout_ms > 0 do
     Task.Supervisor.async_nolink(task_supervisor, fn ->
       {mod, fun, args} = exec.run
       apply(mod, fun, args ++ [exec.tool_call])

--- a/apps/swarm_ai/lib/swarm_ai/spec.md
+++ b/apps/swarm_ai/lib/swarm_ai/spec.md
@@ -31,18 +31,9 @@ The `swarm_ai` package implements a **functional core, imperative shell** archit
 
 ## Core Components
 
-### Agent Protocol (`agent.ex`)
+### Public Runtime API (`swarm_ai.ex`)
 
-Defines runnable agent data via the `SwarmAi.Agent` protocol:
-
-| Function | Purpose |
-|----------|---------|
-| `id/1` | Returns stable string identity for lifecycle operations |
-| `messages/1` | Returns input messages for this run |
-| `context/1` | Returns dispatcher-only app context |
-| `tool_executor/1` | Returns tool execution builder and mode |
-| `system_prompt/1` | Returns the system prompt string |
-| `llm/1` | Returns the LLM client configuration |
+`SwarmAi.run/2` accepts a `Loop` with task identity, messages, an LLM client, and tool and event callbacks.
 
 ### Loop State Machine (`loop.ex`, `loop/`)
 
@@ -51,8 +42,8 @@ The `SwarmAi.Loop` struct tracks execution state:
 | Field | Purpose |
 |-------|---------|
 | `id` | UUIDv7-based unique identifier |
-| `agent` | The agent being run |
-| `status` | `:ready`, `:running`, `:waiting_for_tools`, `:completed`, `:failed`, `:paused`, `:max_steps` |
+| `task_id`, `turn_number` | Task and turn identity |
+| `status` | `:ready`, `:running`, `:waiting_for_tools`, `:completed`, `{:failed, reason}` |
 | `steps` | History of all execution steps |
 
 **Status Transitions:**
@@ -66,7 +57,7 @@ The `SwarmAi.Loop` struct tracks execution state:
 Pure functional module that produces effects without performing side effects:
 
 ```elixir
-{loop, effects} = Runner.start(loop, messages)
+{loop, effects} = Loop.execute(loop)
 ```
 
 ### Effect System (`effect.ex`)
@@ -115,19 +106,26 @@ Tools are pure data structures describing interfaces:
 Tool.new(
   name: "search",
   description: "Search the web",
-  parameter_schema: %{"query" => %{"type" => "string"}},
-  timeout_ms: 30_000,
-  on_timeout: :error
+  access: :read,
+  parameter_schema: %{"query" => %{"type" => "string"}}
 )
 ```
 
-Agents return execution descriptors for SwarmAi to run:
-```elixir
-@type tool_executor :: %{
-  build: ([ToolCall.t()] -> [ToolExecution.t()]),
-  execution_mode: :parallel | :serial
-}
-```
+The loop's `execute_tools` callback accepts tool calls and a task supervisor. It builds descriptors and calls `ParallelExecutor.run/2` or `run_serial/2`.
+
+Both return `{:ok, results}` in original call order. Serial execution waits for each result before dispatching the next call.
+
+- `Sync` has a positive `timeout_ms`, a `run` MFA, and an `on_error` MFA.
+- `Await` has a positive `timeout_ms` or `:infinity`, a `start` MFA, and an `on_error` MFA.
+- The `run` and `start` MFAs receive one appended `tool_call` argument.
+- The `on_error` MFA receives appended arguments `[reason, tool_call]`. The reason is `:timeout` or `{:crashed, exit_reason}`.
+- The error callback returns the canonical `ToolResult` selected by application persistence. A stored success can win over a timeout or crash.
+- A finite Sync deadline kills and monitors the task before the error callback runs. No late task return can replace that callback result.
+- An infinite Await creates no timer. The executor waits for `{:tool_result, tool_call_id, content, is_error}` without polling.
+
+Interactive human input is an explicit exception to bounded execution. The parked worker retains loop history in memory. It remains registered and cancellable.
+
+Cancellation terminates the executor, not its existing Sync tasks under the runtime-global task supervisor. This pre-existing ownership limit is outside the timeout change.
 
 ### Telemetry (`telemetry.ex`, `telemetry/events.ex`)
 
@@ -143,7 +141,7 @@ Telemetry hierarchy:
 
 ## Execution Flow
 
-1. **Entry**: `SwarmAi.run/2` starts supervised execution; `SwarmAi.Executor.run/3` creates a loop and calls `Runner.start/2`
+1. **Entry**: `SwarmAi.run/2` starts supervised execution. `SwarmAi.Executor.run/2` calls `Loop.execute/1`.
 2. **LLM Call**: `{:call_llm, ...}` effect triggers actual API call
 3. **Response**: `Runner.handle_llm_response/2` produces effects based on tool calls
 4. **Tool Execution**: `{:execute_tool, ...}` effects invoke the tool executor
@@ -156,7 +154,6 @@ Telemetry hierarchy:
 
 | File | Purpose |
 |------|---------|
-| `agent.ex` | Agent protocol definition |
 | `executor.ex` | Runtime side-effect interpreter |
 | `loop.ex` | Loop struct and state transitions |
 | `loop/runner.ex` | Pure functional effect producer |
@@ -179,5 +176,4 @@ Telemetry hierarchy:
 
 From `loop/config.ex`:
 - `max_steps`: 400
-- `timeout_ms`: 300,000 (5 minutes)
 - `step_timeout_ms`: 60,000 (1 minute)

--- a/apps/swarm_ai/lib/swarm_ai/telemetry.ex
+++ b/apps/swarm_ai/lib/swarm_ai/telemetry.ex
@@ -359,7 +359,6 @@ defmodule SwarmAi.Telemetry do
   defp format_status(:ok), do: "✓"
   defp format_status(:completed), do: "✓"
   defp format_status({:failed, _reason}), do: "✗"
-  defp format_status({:paused, _reason}), do: "⏸"
   defp format_status(:error), do: "✗"
   defp format_status(:failed), do: "✗"
   defp format_status(status), do: inspect(status)

--- a/apps/swarm_ai/lib/swarm_ai/testing.ex
+++ b/apps/swarm_ai/lib/swarm_ai/testing.ex
@@ -322,9 +322,8 @@ defmodule SwarmAi.Testing do
           %SwarmAi.ToolExecution.Sync{
             tool_call: tc,
             timeout_ms: 5_000,
-            on_timeout_policy: :error,
             run: {__MODULE__, :default_tool_run, []},
-            on_timeout: {__MODULE__, :default_tool_timeout, []}
+            on_error: {__MODULE__, :default_tool_error, []}
           }
         end)
 
@@ -337,9 +336,13 @@ defmodule SwarmAi.Testing do
   def default_tool_run(tool_call), do: SwarmAi.ToolResult.make(tool_call.id, "done", false)
 
   @doc false
-  @spec default_tool_timeout(SwarmAi.ToolCall.t(), term()) :: SwarmAi.ToolResult.t()
-  def default_tool_timeout(tool_call, _reason),
+  @spec default_tool_error(:timeout | {:crashed, term()}, SwarmAi.ToolCall.t()) ::
+          SwarmAi.ToolResult.t()
+  def default_tool_error(:timeout, tool_call),
     do: SwarmAi.ToolResult.make(tool_call.id, "Tool timed out", true)
+
+  def default_tool_error({:crashed, reason}, tool_call),
+    do: SwarmAi.ToolResult.make(tool_call.id, "Tool crashed: #{inspect(reason)}", true)
 
   @doc """
   Creates a mock LLM with the given response.

--- a/apps/swarm_ai/lib/swarm_ai/tool.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool.ex
@@ -2,17 +2,9 @@ defmodule SwarmAi.Tool do
   @moduledoc """
   Tool definition for LLM consumption.
 
-  This is pure data describing a tool's interface and execution policy for LLM
-  consumption. Callers provide loop tool execution separately.
-
-  Both `timeout_ms` and `on_timeout` are required. There are no defaults —
-  every tool must explicitly declare its execution policy. Missing either
-  field raises at construction time.
-
-  `on_timeout` semantics:
-  - `:error` — return an error ToolResult to the LLM, agent continues
-  - `:pause_agent` — halt the execution loop cleanly; the caller persists context
-    and restarts on the next user message
+  This is pure data describing a tool's interface for LLM consumption.
+  Callers provide execution deadlines and error callbacks on execution descriptors,
+  not on these model-facing declarations.
   """
   use TypedStruct
 
@@ -21,14 +13,12 @@ defmodule SwarmAi.Tool do
     field(:description, String.t())
     field(:access, :read | :write | :read_write)
     field(:parameter_schema, map())
-    field(:timeout_ms, pos_integer())
-    field(:on_timeout, :error | :pause_agent)
   end
 
   @doc """
   Creates a new tool definition.
 
-  All five fields are required. Raises `ArgumentError` if any is missing
+  All four fields are required. Raises `ArgumentError` if any is missing
   or `KeyError` if an unknown key is provided.
 
   ## Example
@@ -37,9 +27,7 @@ defmodule SwarmAi.Tool do
         name: "question",
         description: "Ask the user a question",
         access: :write,
-        parameter_schema: %{},
-        timeout_ms: 120_000,
-        on_timeout: :pause_agent
+        parameter_schema: %{}
       )
   """
   @spec new(keyword()) :: t()

--- a/apps/swarm_ai/lib/swarm_ai/tool_execution.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_execution.ex
@@ -4,8 +4,7 @@ defmodule SwarmAi.ToolExecution do
 
   Executors return a list of these structs — PE pattern-matches on the struct
   type to decide whether to spawn a task (Sync) or register in its own receive
-  loop (Await). This makes the executor contract explicit and gives PE full
-  ownership of execution lifecycle.
+  loop (Await). PE runs the descriptors and collects their results.
   """
 
   @type t :: SwarmAi.ToolExecution.Sync.t() | SwarmAi.ToolExecution.Await.t()

--- a/apps/swarm_ai/lib/swarm_ai/tool_execution/await.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_execution/await.ex
@@ -8,7 +8,12 @@ defmodule SwarmAi.ToolExecution.Await do
 
   Then waits for `{:tool_result, tool_call_id, content, is_error}` in its
   receive loop. No separate task is spawned — PE's receive loop IS the
-  waiting mechanism.
+  waiting mechanism. `timeout_ms: :infinity` creates no timer. This is the
+  explicit exception to bounded execution for interactive human input; the
+  parked executor retains its history in memory and remains cancellable.
+
+  For a finite deadline, PE calls the `on_error` MFA with appended arguments
+  `[:timeout, tool_call]`. The callback must return the canonical `ToolResult.t()`.
   """
 
   use TypedStruct
@@ -17,11 +22,10 @@ defmodule SwarmAi.ToolExecution.Await do
 
   typedstruct enforce: true do
     field(:tool_call, ToolCall.t())
-    field(:timeout_ms, pos_integer())
-    field(:on_timeout_policy, :error | :pause_agent)
+    field(:timeout_ms, pos_integer() | :infinity)
 
     field(:start, {module(), atom(), list()})
 
-    field(:on_timeout, {module(), atom(), list()})
+    field(:on_error, {module(), atom(), list()})
   end
 end

--- a/apps/swarm_ai/lib/swarm_ai/tool_execution/sync.ex
+++ b/apps/swarm_ai/lib/swarm_ai/tool_execution/sync.ex
@@ -6,7 +6,11 @@ defmodule SwarmAi.ToolExecution.Sync do
 
       apply(mod, fun, args ++ [tool_call]) :: ToolResult.t()
 
-  The task may block as long as needed. PE kills it on deadline.
+  PE kills and awaits termination of the task on deadline, then calls the
+  `on_error` MFA with appended arguments `[:timeout, tool_call]`.
+  A task crash calls the same MFA with `[{:crashed, exit_reason}, tool_call]`.
+  The callback must return the canonical `ToolResult.t()`, including any
+  persistence race winner.
   """
 
   use TypedStruct
@@ -16,10 +20,9 @@ defmodule SwarmAi.ToolExecution.Sync do
   typedstruct enforce: true do
     field(:tool_call, ToolCall.t())
     field(:timeout_ms, pos_integer())
-    field(:on_timeout_policy, :error | :pause_agent)
 
     field(:run, {module(), atom(), list()})
 
-    field(:on_timeout, {module(), atom(), list()})
+    field(:on_error, {module(), atom(), list()})
   end
 end

--- a/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/loop/runner_test.exs
@@ -7,7 +7,7 @@ defmodule SwarmAi.Loop.RunnerTest do
   alias SwarmAi.Loop.{Config, Runner, Step}
 
   setup do
-    config = %Config{max_steps: 10, timeout_ms: 60_000, step_timeout_ms: 120_000}
+    config = %Config{max_steps: 10, step_timeout_ms: 120_000}
     loop = test_execution(mock_llm("test"), "TestBot", config: config)
 
     %{loop: loop}

--- a/apps/swarm_ai/test/swarm_ai/parallel_executor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/parallel_executor_test.exs
@@ -3,333 +3,301 @@ defmodule SwarmAi.ParallelExecutorTest do
 
   alias SwarmAi.{Message.ContentPart, ParallelExecutor, ToolCall, ToolExecution, ToolResult}
 
-  def run_instant(content, tool_call) do
-    ToolResult.make(tool_call.id, content, false)
-  end
+  def run_instant(content, tool_call), do: ToolResult.make(tool_call.id, content, false)
 
   def run_slow(delay_ms, content, tool_call) do
     Process.sleep(delay_ms)
-    ToolResult.make(tool_call.id, content, false)
+    run_instant(content, tool_call)
   end
 
-  def run_error(content, tool_call) do
-    ToolResult.make(tool_call.id, content, true)
+  def run_crash(_tool_call), do: raise("boom")
+
+  def record_error(test_pid, reason, tool_call) do
+    send(test_pid, {:error_called, tool_call.id, reason})
+    SwarmAi.Testing.default_tool_error(reason, tool_call)
   end
 
-  def run_crash(_tool_call) do
-    raise "boom"
-  end
-
-  defdelegate noop_timeout(tc, reason), to: SwarmAi.Testing, as: :default_tool_timeout
-
-  def record_timeout(test_pid, tool_call, reason) do
-    send(test_pid, {:timeout_called, tool_call.id, reason})
-    noop_timeout(tool_call, reason)
-  end
-
-  def start_await_soon(result_content, tool_call) do
-    pe_pid = self()
-    key = tool_call.id
-
-    spawn(fn ->
-      Process.sleep(10)
-      send(pe_pid, {:tool_result, key, result_content, false})
-    end)
-
+  def start_await(test_pid, tool_call) do
+    send(test_pid, {:await_started, tool_call.id, self()})
     :ok
   end
 
-  defp make_tc(id, name), do: %ToolCall{id: id, name: name, arguments: "{}"}
+  def start_await_soon(content, tool_call) do
+    Process.send_after(self(), {:tool_result, tool_call.id, content, false}, 10)
+    :ok
+  end
 
-  defp sync_exec(tc, opts \\ []) do
-    timeout_ms = Keyword.get(opts, :timeout_ms, 5_000)
-    policy = Keyword.get(opts, :policy, :error)
-    content = Keyword.get(opts, :content, "done:#{tc.name}")
+  def start_await_immediate(tool_call) do
+    send(self(), {:tool_result, tool_call.id, "immediate", false})
+    :ok
+  end
 
+  def start_await_gate(test_pid, tool_call) do
+    start_await(test_pid, tool_call)
+
+    receive do
+      :start -> :ok
+    after
+      1_000 -> raise "Await start gate was not released"
+    end
+  end
+
+  def store_then_wait(table, test_pid, tool_call) do
+    :ets.insert(table, {:worker, self()})
+    result = ToolResult.make(tool_call.id, "stored success", false)
+    true = :ets.insert_new(table, {tool_call.id, result})
+    send(test_pid, {:sync_started, self()})
+
+    receive do
+      :return -> result
+    after
+      5_000 -> raise "Sync gate was not released or killed"
+    end
+  end
+
+  def store_then_crash(table, tool_call) do
+    result = ToolResult.make(tool_call.id, "stored success", false)
+    true = :ets.insert_new(table, {tool_call.id, result})
+    exit(:crashed_after_persistence)
+  end
+
+  def canonical_error(table, test_pid, reason, tool_call) do
+    case :ets.lookup(table, :worker) do
+      [{:worker, pid}] ->
+        false = Process.alive?(pid)
+        send(pid, :return)
+
+      [] ->
+        :ok
+    end
+
+    :ets.insert_new(table, {tool_call.id, SwarmAi.Testing.default_tool_error(reason, tool_call)})
+    [{_, result}] = :ets.lookup(table, tool_call.id)
+    send(test_pid, {:error_called, tool_call.id, reason})
+    result
+  end
+
+  defp make_tc(id), do: %ToolCall{id: id, name: id, arguments: "{}"}
+
+  defp sync_exec(id) do
     %ToolExecution.Sync{
-      tool_call: tc,
-      timeout_ms: timeout_ms,
-      on_timeout_policy: policy,
-      run: {__MODULE__, :run_instant, [content]},
-      on_timeout: {__MODULE__, :noop_timeout, []}
+      tool_call: make_tc(id),
+      timeout_ms: 5_000,
+      run: {__MODULE__, :run_instant, ["done:#{id}"]},
+      on_error: {SwarmAi.Testing, :default_tool_error, []}
     }
   end
 
-  defp await_exec(tc, opts) do
-    timeout_ms = Keyword.get(opts, :timeout_ms, 5_000)
-    policy = Keyword.get(opts, :policy, :error)
-    content = Keyword.get(opts, :content, "await:#{tc.name}")
-
+  defp await_exec(id, timeout_ms \\ :infinity) do
     %ToolExecution.Await{
-      tool_call: tc,
+      tool_call: make_tc(id),
       timeout_ms: timeout_ms,
-      on_timeout_policy: policy,
-      start: {__MODULE__, :start_await_soon, [content]},
-      on_timeout: {__MODULE__, :noop_timeout, []}
+      start: {__MODULE__, :start_await, [self()]},
+      on_error: {__MODULE__, :record_error, [self()]}
     }
   end
 
-  defp start_sup do
-    {:ok, sup} = Task.Supervisor.start_link()
-    sup
-  end
-
+  defp start_sup, do: start_supervised!(Task.Supervisor)
   defp content_text(%ToolResult{content: content}), do: ContentPart.extract_text(content)
 
-  describe "run/2 — Sync normal completion" do
-    test "returns {:ok, results} for a single Sync tool" do
-      sup = start_sup()
-      tc = make_tc("id1", "t1")
-
-      assert {:ok, [%ToolResult{id: "id1"} = r]} =
-               ParallelExecutor.run([sync_exec(tc)], sup)
-
-      assert content_text(r) == "done:t1"
-    end
-
-    test "returns results in original order for concurrent Sync tools" do
-      sup = start_sup()
-      slow_tc = make_tc("slow1", "slow")
-      fast_tc = make_tc("fast1", "fast")
-
-      slow = %ToolExecution.Sync{
-        tool_call: slow_tc,
-        timeout_ms: 5_000,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_slow, [50, "slow"]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      fast = sync_exec(fast_tc, content: "fast")
-
-      {:ok, [r1, r2]} = ParallelExecutor.run([slow, fast], sup)
-
-      assert r1.id == "slow1"
-      assert r2.id == "fast1"
-    end
+  test "returns results for empty batches" do
+    sup = start_sup()
+    assert ParallelExecutor.run([], sup) == {:ok, []}
+    assert ParallelExecutor.run_serial([], sup) == {:ok, []}
   end
 
-  describe "run/2 — Await normal completion" do
-    test "returns {:ok, results} for a single Await tool" do
-      sup = start_sup()
-      tc = make_tc("id1", "mcp1")
-
-      assert {:ok, [%ToolResult{id: "id1"} = r]} =
-               ParallelExecutor.run([await_exec(tc, content: "await result")], sup)
-
-      assert content_text(r) == "await result"
-    end
-
-    test "Await error result propagates is_error flag" do
-      sup = start_sup()
-      tc = make_tc("id1", "mcp1")
-      pe_pid = self()
-
-      exec = %ToolExecution.Await{
-        tool_call: tc,
-        timeout_ms: 5_000,
-        on_timeout_policy: :error,
-        start: {__MODULE__, :start_await_error, [pe_pid]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      {:ok, [result]} = ParallelExecutor.run([exec], sup)
-      assert result.is_error == true
-      assert content_text(result) == "mcp error"
-    end
+  test "Sync normal completion and original order despite out-of-order completion" do
+    slow = %{sync_exec("slow") | run: {__MODULE__, :run_slow, [50, "slow"]}}
+    assert {:ok, [first, second]} = ParallelExecutor.run([slow, sync_exec("fast")], start_sup())
+    assert first.id == "slow"
+    assert content_text(first) == "slow"
+    assert second.id == "fast"
+    assert content_text(second) == "done:fast"
   end
 
-  describe "run/2 — on_timeout: :error" do
-    test "timed-out Sync tool returns error ToolResult, agent continues" do
-      sup = start_sup()
-      tc = make_tc("id1", "slow")
+  test "infinite Await accepts a later answer without a deadline" do
+    exec = %{await_exec("human") | start: {__MODULE__, :start_await_soon, ["answer"]}}
 
-      exec = %ToolExecution.Sync{
-        tool_call: tc,
-        timeout_ms: 10,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_slow, [500, "too late"]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      {:ok, [result]} = ParallelExecutor.run([exec], sup)
-      assert result.is_error == true
-      assert result == noop_timeout(tc, :triggered)
-    end
-
-    test "timed-out Await tool returns error ToolResult, agent continues" do
-      sup = start_sup()
-      tc = make_tc("id1", "mcp_slow")
-
-      exec = %ToolExecution.Await{
-        tool_call: tc,
-        timeout_ms: 10,
-        on_timeout_policy: :error,
-        start: {__MODULE__, :start_await_never, []},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      {:ok, [result]} = ParallelExecutor.run([exec], sup)
-      assert result.is_error == true
-      assert result == noop_timeout(tc, :triggered)
-    end
+    assert {:ok, [%ToolResult{id: "human", is_error: false}]} =
+             ParallelExecutor.run([exec], start_sup())
   end
 
-  describe "run/2 — on_timeout: :pause_agent" do
-    test "Sync pause_agent timeout halts with correct reason" do
-      sup = start_sup()
-      tc = make_tc("id1", "interactive")
-
-      exec = %ToolExecution.Sync{
-        tool_call: tc,
-        timeout_ms: 10,
-        on_timeout_policy: :pause_agent,
-        run: {__MODULE__, :run_slow, [500, "never"]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      assert {:halt, {:timeout, "id1", "interactive", 10}} =
-               ParallelExecutor.run([exec], sup)
-    end
-
-    test "Await pause_agent timeout halts with correct reason" do
-      sup = start_sup()
-      tc = make_tc("id1", "mcp_interactive")
-
-      exec = %ToolExecution.Await{
-        tool_call: tc,
-        timeout_ms: 10,
-        on_timeout_policy: :pause_agent,
-        start: {__MODULE__, :start_await_never, []},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      assert {:halt, {:timeout, "id1", "mcp_interactive", 10}} =
-               ParallelExecutor.run([exec], sup)
-    end
-
-    test "mixed batch: one pauses, others are cancelled, returns halt" do
-      sup = start_sup()
-      tc1 = make_tc("id1", "interactive")
-      tc2 = make_tc("id2", "normal")
-
-      pause_exec = %ToolExecution.Sync{
-        tool_call: tc1,
-        timeout_ms: 20,
-        on_timeout_policy: :pause_agent,
-        run: {__MODULE__, :run_slow, [500, "never"]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      normal_exec = %ToolExecution.Sync{
-        tool_call: tc2,
-        timeout_ms: 5_000,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_slow, [500, "never"]},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
-
-      assert {:halt, {:timeout, "id1", "interactive", 20}} =
-               ParallelExecutor.run([pause_exec, normal_exec], sup)
-    end
-
-    test "two pause_agent tools with same timeout: exactly one halt returned" do
-      sup = start_sup()
-      tc1 = make_tc("id1", "a")
-      tc2 = make_tc("id2", "b")
-
-      make_pause = fn tc ->
-        %ToolExecution.Sync{
-          tool_call: tc,
-          timeout_ms: 10,
-          on_timeout_policy: :pause_agent,
-          run: {__MODULE__, :run_slow, [500, "never"]},
-          on_timeout: {__MODULE__, :noop_timeout, []}
-        }
-      end
-
-      result = ParallelExecutor.run([make_pause.(tc1), make_pause.(tc2)], sup)
-      assert {:halt, {:timeout, _id, _name, 10}} = result
-    end
+  test "Await error result propagates its content and error flag" do
+    sup = start_sup()
+    exec = await_exec("human")
+    task = Task.async(fn -> ParallelExecutor.run([exec], sup) end)
+    assert_receive {:await_started, "human", pid}
+    send(pid, {:tool_result, "human", "client error", true})
+    assert {:ok, [result]} = Task.await(task)
+    assert result.is_error
+    assert content_text(result) == "client error"
   end
 
-  describe "run/2 — Sync task crash" do
-    test "crashing Sync tool produces error ToolResult, agent continues" do
-      sup = start_sup()
-      tc = make_tc("id1", "crasher")
+  test "infinite Await survives a finite Sync sibling deadline and keeps batch order" do
+    sup = start_sup()
+    human = await_exec("human")
 
-      exec = %ToolExecution.Sync{
-        tool_call: tc,
-        timeout_ms: 5_000,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_crash, []},
-        on_timeout: {__MODULE__, :noop_timeout, []}
-      }
+    slow = %{
+      sync_exec("slow")
+      | timeout_ms: 20,
+        run: {__MODULE__, :run_slow, [5_000, "too late"]},
+        on_error: {__MODULE__, :record_error, [self()]}
+    }
 
-      {:ok, [result]} = ParallelExecutor.run([exec], sup)
-      assert result.is_error == true
-      assert content_text(result) =~ "crashed"
-    end
+    task = Task.async(fn -> ParallelExecutor.run([human, slow, sync_exec("fast")], sup) end)
+    assert_receive {:await_started, "human", pid}
+    assert_receive {:error_called, "slow", :timeout}, 1_000
+    assert Task.yield(task, 50) == nil
+    refute_receive {:error_called, "human", _}, 0
+    assert Task.Supervisor.children(sup) == []
+
+    send(pid, {:tool_result, "human", "answer", false})
+    assert {:ok, [answer, error, fast]} = Task.await(task)
+    assert {answer.id, content_text(answer), answer.is_error} == {"human", "answer", false}
+    assert {error.id, error.is_error} == {"slow", true}
+    assert fast.id == "fast"
   end
 
-  describe "run/2 — on_timeout callback" do
-    test "calls on_timeout(:triggered) before terminating a timed-out :error Sync tool" do
-      sup = start_sup()
-      test_pid = self()
-      tc = make_tc("id1", "slow")
-
-      exec = %ToolExecution.Sync{
-        tool_call: tc,
-        timeout_ms: 10,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_slow, [500, "too late"]},
-        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
-      }
-
-      ParallelExecutor.run([exec], sup)
-      assert_receive {:timeout_called, "id1", :triggered}, 1_000
-    end
-
-    test "calls on_timeout(:triggered) for the pausing tool and on_timeout(:cancelled) for siblings" do
-      sup = start_sup()
-      test_pid = self()
-      tc1 = make_tc("id1", "interactive")
-      tc2 = make_tc("id2", "normal")
-
-      pause_exec = %ToolExecution.Sync{
-        tool_call: tc1,
-        timeout_ms: 10,
-        on_timeout_policy: :pause_agent,
-        run: {__MODULE__, :run_slow, [500, "never"]},
-        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
-      }
-
-      normal_exec = %ToolExecution.Sync{
-        tool_call: tc2,
-        timeout_ms: 5_000,
-        on_timeout_policy: :error,
-        run: {__MODULE__, :run_slow, [500, "never"]},
-        on_timeout: {__MODULE__, :record_timeout, [test_pid]}
-      }
-
-      ParallelExecutor.run([pause_exec, normal_exec], sup)
-
-      calls =
-        for _ <- 1..2 do
-          assert_receive {:timeout_called, id, reason}, 1_000
-          {id, reason}
-        end
-
-      assert {:triggered, :cancelled} ==
-               {calls |> Enum.find_value(fn {id, r} -> id == "id1" && r end),
-                calls |> Enum.find_value(fn {id, r} -> id == "id2" && r end)}
-    end
+  test "serial interactive call blocks later dispatch until answered" do
+    sup = start_sup()
+    executions = [await_exec("first"), await_exec("second")]
+    task = Task.async(fn -> ParallelExecutor.run_serial(executions, sup) end)
+    assert_receive {:await_started, "first", pid}
+    refute_receive {:await_started, "second", _}, 50
+    send(pid, {:tool_result, "first", "first answer", false})
+    assert_receive {:await_started, "second", ^pid}
+    send(pid, {:tool_result, "second", "second answer", false})
+    assert {:ok, results} = Task.await(task)
+    assert Enum.map(results, & &1.id) == ["first", "second"]
   end
 
-  def start_await_error(pe_pid, tool_call) do
-    spawn(fn -> send(pe_pid, {:tool_result, tool_call.id, "mcp error", true}) end)
-    :ok
+  test "parallel Await results keep original order" do
+    sup = start_sup()
+    executions = [await_exec("first"), await_exec("second")]
+    task = Task.async(fn -> ParallelExecutor.run(executions, sup) end)
+    assert_receive {:await_started, "first", pid}
+    assert_receive {:await_started, "second", ^pid}
+    send(pid, {:tool_result, "second", "second answer", false})
+    assert Task.yield(task, 20) == nil
+    send(pid, {:tool_result, "first", "first answer", false})
+    assert {:ok, results} = Task.await(task)
+    assert Enum.map(results, & &1.id) == ["first", "second"]
   end
 
-  def start_await_never(_tool_call), do: :ok
+  test "crashing Sync tool persists an error without cancelling siblings" do
+    table = :ets.new(:canonical_results, [:public, :set])
+
+    crash = %{
+      sync_exec("crash")
+      | run: {__MODULE__, :run_crash, []},
+        on_error: {__MODULE__, :canonical_error, [table, self()]}
+    }
+
+    assert {:ok, [error, success]} = ParallelExecutor.run([crash, sync_exec("ok")], start_sup())
+    assert error.is_error
+    assert content_text(error) =~ "crashed"
+    assert [{"crash", ^error}] = :ets.lookup(table, "crash")
+    assert_receive {:error_called, "crash", {:crashed, {%RuntimeError{message: "boom"}, _}}}
+    refute success.is_error
+  end
+
+  test "finite Await deadline returns callback result" do
+    assert {:ok, [result]} = ParallelExecutor.run([await_exec("finite", 10)], start_sup())
+    assert result == SwarmAi.Testing.default_tool_error(:timeout, make_tc("finite"))
+    assert_receive {:error_called, "finite", :timeout}
+    refute_receive {:error_called, "finite", _}, 20
+  end
+
+  test "Sync is dead before timeout persistence and its stored success wins" do
+    sup = start_sup()
+    table = :ets.new(:canonical_results, [:public, :set])
+
+    exec = %{
+      sync_exec("sync")
+      | timeout_ms: 100,
+        run: {__MODULE__, :store_then_wait, [table, self()]},
+        on_error: {__MODULE__, :canonical_error, [table, self()]}
+    }
+
+    task = Task.async(fn -> ParallelExecutor.run([exec], sup) end)
+    assert_receive {:sync_started, pid}
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 1_000
+    assert_receive {:error_called, "sync", :timeout}
+    assert {:ok, [result]} = Task.await(task)
+    assert [{"sync", ^result}] = :ets.lookup(table, "sync")
+    refute result.is_error
+    assert content_text(result) == "stored success"
+    assert Task.Supervisor.children(sup) == []
+  end
+
+  test "Sync success persisted before a crash remains the canonical result" do
+    table = :ets.new(:canonical_results, [:public, :set])
+
+    exec = %{
+      sync_exec("sync")
+      | run: {__MODULE__, :store_then_crash, [table]},
+        on_error: {__MODULE__, :canonical_error, [table, self()]}
+    }
+
+    assert {:ok, [result]} = ParallelExecutor.run([exec], start_sup())
+    assert [{"sync", ^result}] = :ets.lookup(table, "sync")
+    refute result.is_error
+    assert_receive {:error_called, "sync", {:crashed, :crashed_after_persistence}}
+    refute_receive {:error_called, "sync", _}, 20
+  end
+
+  test "Await answer stored before deadline wins even when delivery is delayed" do
+    sup = start_sup()
+    table = :ets.new(:canonical_results, [:public, :set])
+    winner = ToolResult.make("human", "stored answer", false)
+    :ets.insert(table, {"human", winner})
+
+    exec = %{
+      await_exec("human", 10)
+      | on_error: {__MODULE__, :canonical_error, [table, self()]}
+    }
+
+    assert {:ok, [^winner]} = ParallelExecutor.run([exec], sup)
+  end
+
+  test "timeout stored first wins and late answers cannot override it" do
+    sup = start_sup()
+    table = :ets.new(:canonical_results, [:public, :set])
+
+    finite = %{
+      await_exec("finite", 10)
+      | on_error: {__MODULE__, :canonical_error, [table, self()]}
+    }
+
+    executions = [finite, await_exec("human")]
+    task = Task.async(fn -> ParallelExecutor.run(executions, sup) end)
+    assert_receive {:await_started, "human", pid}
+    assert_receive {:error_called, "finite", :timeout}, 1_000
+    late = ToolResult.make("finite", "late answer", false)
+    refute :ets.insert_new(table, {"finite", late})
+    send(pid, {:tool_result, "finite", late.content, late.is_error})
+    send(pid, {:tool_result, "human", "answer", false})
+    assert {:ok, [result, _]} = Task.await(task)
+    assert [{"finite", ^result}] = :ets.lookup(table, "finite")
+    assert result.is_error
+    refute_receive {:error_called, "finite", _}, 20
+  end
+
+  test "a queued stale deadline cannot overwrite a completed result" do
+    sup = start_sup()
+    first = %{await_exec("first", 10) | start: {__MODULE__, :start_await_immediate, []}}
+    second = %{await_exec("second") | start: {__MODULE__, :start_await_gate, [self()]}}
+    task = Task.async(fn -> ParallelExecutor.run([first, second], sup) end)
+    assert_receive {:await_started, "second", pid}
+    Process.sleep(30)
+    {:messages, messages} = Process.info(pid, :messages)
+    assert Enum.any?(messages, &match?({:deadline, _}, &1))
+    send(pid, :start)
+    send(pid, {:tool_result, "second", "answer", false})
+    assert {:ok, [first_result, _]} = Task.await(task)
+    assert content_text(first_result) == "immediate"
+    refute first_result.is_error
+    refute_receive {:error_called, "first", _}, 20
+  end
 end

--- a/apps/swarm_ai/test/swarm_ai/parallel_tool_execution_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/parallel_tool_execution_test.exs
@@ -17,7 +17,11 @@ defmodule SwarmAi.ParallelToolExecutionTest do
 
   def run_instant(tool_call), do: ToolResult.make(tool_call.id, "OK", false)
   def run_crash(_tool_call), do: raise("boom")
-  defdelegate noop_timeout(tc, reason), to: SwarmAi.Testing, as: :default_tool_timeout
+
+  def start_await(test_pid, tool_call) do
+    send(test_pid, {:await_started, tool_call.id, self()})
+    :ok
+  end
 
   def run_serial_gate(test_pid, tool_call) do
     send(test_pid, {:serial_started, tool_call.name, self()})
@@ -69,9 +73,8 @@ defmodule SwarmAi.ParallelToolExecutionTest do
           %ToolExecution.Sync{
             tool_call: tc,
             timeout_ms: 5_000,
-            on_timeout_policy: :error,
             run: {__MODULE__, :run_rendezvous, [coordinator]},
-            on_timeout: {__MODULE__, :noop_timeout, []}
+            on_error: {SwarmAi.Testing, :default_tool_error, []}
           }
         end)
         |> SwarmAi.ParallelExecutor.run(task_supervisor)
@@ -109,9 +112,8 @@ defmodule SwarmAi.ParallelToolExecutionTest do
           %ToolExecution.Sync{
             tool_call: tc,
             timeout_ms: 5_000,
-            on_timeout_policy: :error,
             run: run_mfa,
-            on_timeout: {__MODULE__, :noop_timeout, []}
+            on_error: {SwarmAi.Testing, :default_tool_error, []}
           }
         end)
         |> SwarmAi.ParallelExecutor.run(task_supervisor)
@@ -143,9 +145,8 @@ defmodule SwarmAi.ParallelToolExecutionTest do
           %ToolExecution.Sync{
             tool_call: tc,
             timeout_ms: 5_000,
-            on_timeout_policy: :error,
             run: {__MODULE__, :run_serial_gate, [test_pid]},
-            on_timeout: {__MODULE__, :noop_timeout, []}
+            on_error: {SwarmAi.Testing, :default_tool_error, []}
           }
         end)
         |> SwarmAi.ParallelExecutor.run_serial(task_supervisor)
@@ -164,6 +165,33 @@ defmodule SwarmAi.ParallelToolExecutionTest do
       await_exit(pid)
       assert_receive {:test_event, "task-serial", :completed}, 2_000
     end
+  end
+
+  test "a delayed interactive answer continues the same loop to completion" do
+    runtime = start_runtime!()
+    test_pid = self()
+    llm = tool_then_complete_llm([tool_call("approval", %{}, id: "human")], "done")
+
+    execute_tools = fn tool_calls, task_supervisor ->
+      Enum.map(tool_calls, fn tool_call ->
+        %ToolExecution.Await{
+          tool_call: tool_call,
+          timeout_ms: :infinity,
+          start: {__MODULE__, :start_await, [test_pid]},
+          on_error: {SwarmAi.Testing, :default_tool_error, []}
+        }
+      end)
+      |> SwarmAi.ParallelExecutor.run(task_supervisor)
+    end
+
+    {:ok, pid} = run_execution(runtime, "task-human", llm, execute_tools: execute_tools)
+    assert_receive {:await_started, "human", ^pid}
+    refute_receive {:test_event, "task-human", :completed}, 50
+    assert SwarmAi.running?(runtime, "task-human")
+    send(pid, {:tool_result, "human", "approved", false})
+    await_exit(pid)
+    assert_receive {:test_event, "task-human", :completed}
+    refute_receive {:test_event, "task-human", {:failed, _}}, 0
   end
 
   defp start_runtime! do

--- a/apps/swarm_ai/test/swarm_ai/tool_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/tool_test.exs
@@ -4,60 +4,36 @@ defmodule SwarmAi.ToolTest do
   alias SwarmAi.Tool
 
   describe "new/1" do
-    test "creates a tool with all required fields" do
+    test "creates a model-facing declaration without operational fields" do
       tool =
         Tool.new(
           name: "my_tool",
           description: "Does something",
           access: :read,
-          parameter_schema: %{},
-          timeout_ms: 30_000,
-          on_timeout: :error
+          parameter_schema: %{}
         )
 
       assert tool.name == "my_tool"
       assert tool.description == "Does something"
       assert tool.access == :read
       assert tool.parameter_schema == %{}
-      assert tool.timeout_ms == 30_000
-      assert tool.on_timeout == :error
+      refute Map.has_key?(tool, :timeout_ms)
+      refute Map.has_key?(tool, :on_timeout)
     end
 
-    test "raises on missing timeout_ms" do
+    test "raises on missing required declaration fields" do
       assert_raise ArgumentError, fn ->
-        Tool.new(
-          name: "t",
-          description: "d",
-          access: :read,
-          parameter_schema: %{},
-          on_timeout: :error
-        )
+        Tool.new(name: "t", description: "d", access: :read)
       end
     end
 
-    test "raises on missing on_timeout" do
-      assert_raise ArgumentError, fn ->
-        Tool.new(
-          name: "t",
-          description: "d",
-          access: :read,
-          parameter_schema: %{},
-          timeout_ms: 5_000
-        )
-      end
-    end
-
-    test "raises on unknown key" do
-      assert_raise KeyError, fn ->
-        Tool.new(
-          name: "t",
-          description: "d",
-          access: :read,
-          parameter_schema: %{},
-          timeout_ms: 5_000,
-          on_timeout: :error,
-          extra: "nope"
-        )
+    test "rejects operational timeout fields and unknown keys" do
+      for key <- [:timeout_ms, :on_timeout, :extra] do
+        assert_raise KeyError, fn ->
+          Tool.new(
+            [name: "t", description: "d", access: :read, parameter_schema: %{}] ++ [{key, 5_000}]
+          )
+        end
       end
     end
   end

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -64,7 +64,7 @@ defmodule SwarmAiTest do
       assert {:ok, next_pid} = Task.await(next_run, 2_000)
       await_exit(next_pid)
       assert_receive {:test_event, "task-handoff", :completed}
-      refute SwarmAi.running?(runtime, "task-handoff")
+      assert_unregistered(runtime, "task-handoff")
     end
 
     test "prevents duplicate execution for same key" do
@@ -241,6 +241,24 @@ defmodule SwarmAiTest do
 
   defp run_agent(runtime, id, llm, opts \\ []) do
     SwarmAi.run(runtime, agent(id, llm, opts))
+  end
+
+  defp assert_unregistered(
+         runtime,
+         task_id,
+         deadline \\ System.monotonic_time(:millisecond) + 2_000
+       ) do
+    case SwarmAi.running?(runtime, task_id) do
+      false ->
+        :ok
+
+      true ->
+        assert System.monotonic_time(:millisecond) < deadline,
+               "Registry did not remove the exited execution for #{task_id}"
+
+        :erlang.yield()
+        assert_unregistered(runtime, task_id, deadline)
+    end
   end
 
   defp await_exit(pid) do

--- a/apps/swarm_ai/test/swarm_ai_test.exs
+++ b/apps/swarm_ai/test/swarm_ai_test.exs
@@ -1,14 +1,12 @@
 defmodule SwarmAiTest do
   use SwarmAi.Testing, async: true
 
-  alias SwarmAi.{ToolExecution, ToolResult}
+  alias SwarmAi.ToolExecution
 
-  def slow_run(tool_call) do
-    Process.sleep(500)
-    ToolResult.make(tool_call.id, "never", false)
+  def start_await(test_pid, tool_call) do
+    send(test_pid, {:await_started, tool_call.id, self()})
+    :ok
   end
-
-  defdelegate noop_timeout(tc, reason), to: SwarmAi.Testing, as: :default_tool_timeout
 
   describe "run/2" do
     test "remains running while dispatching the terminal event" do
@@ -183,50 +181,37 @@ defmodule SwarmAiTest do
     end
   end
 
-  describe "pause_agent" do
-    test "pause_agent tool timeout returns :paused result, no :failed event" do
-      runtime = start_runtime!()
+  test "cancelling an infinite Await terminates the parked worker and unregisters" do
+    runtime = start_runtime!()
+    test_pid = self()
 
-      execute_tools = fn tool_calls, task_supervisor ->
-        executions =
-          Enum.map(tool_calls, fn tool_call ->
-            %ToolExecution.Sync{
-              tool_call: tool_call,
-              timeout_ms: 10,
-              on_timeout_policy: :pause_agent,
-              run: {__MODULE__, :slow_run, []},
-              on_timeout: {__MODULE__, :noop_timeout, []}
-            }
-          end)
-
-        SwarmAi.ParallelExecutor.run(executions, task_supervisor)
-      end
-
-      llm = %MockLLM{
-        response: fn ->
-          {:ok,
-           %SwarmAi.LLM.Response{
-             content: nil,
-             tool_calls: [%SwarmAi.ToolCall{id: "tc1", name: "test_tool", arguments: "{}"}],
-             usage: %{input_tokens: 10, output_tokens: 5},
-             raw: nil
-           }}
-        end
-      }
-
-      {:ok, pid} =
-        run_agent(runtime, "task-pause", llm, execute_tools: execute_tools)
-
-      await_exit(pid)
-
-      assert_receive {:test_event, "task-pause", {:paused, {:timeout, "tc1", "test_tool", 10}}},
-                     200
-
-      refute_receive {:test_event, "task-pause", :completed}, 200
-      refute_receive {:test_event, "task-pause", {:failed, _}}, 0
-      refute_receive {:test_event, "task-pause", {:crashed, _}}, 0
-      refute SwarmAi.running?(runtime, "task-pause")
+    execute_tools = fn tool_calls, task_supervisor ->
+      Enum.map(tool_calls, fn tool_call ->
+        %ToolExecution.Await{
+          tool_call: tool_call,
+          timeout_ms: :infinity,
+          start: {__MODULE__, :start_await, [test_pid]},
+          on_error: {SwarmAi.Testing, :default_tool_error, []}
+        }
+      end)
+      |> SwarmAi.ParallelExecutor.run(task_supervisor)
     end
+
+    llm = tool_then_complete_llm([tool_call("approval", %{}, id: "tc1")], "done")
+    {:ok, pid} = run_agent(runtime, "task-wait", llm, execute_tools: execute_tools)
+    assert_receive {:await_started, "tc1", ^pid}
+    assert SwarmAi.running?(runtime, "task-wait")
+    refute_receive {:test_event, "task-wait", :completed}, 50
+
+    assert :ok = SwarmAi.cancel(runtime, "task-wait")
+    await_exit(pid)
+    assert_receive {:test_event, "task-wait", {:cancelled, nil}}
+    refute SwarmAi.running?(runtime, "task-wait")
+    assert SwarmAi.active_count(runtime) == 0
+    send(pid, {:tool_result, "tc1", "late answer", false})
+    refute_receive {:test_event, "task-wait", :completed}, 20
+    refute_receive {:test_event, "task-wait", {:failed, _}}, 0
+    refute_receive {:test_event, "task-wait", {:crashed, _}}, 0
   end
 
   defp start_runtime! do

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -1023,9 +1023,9 @@ let next = (task: Task.t, action: action): (Task.t, array<effect>) => {
     )
 
   | (Task.Loaded(data), CancelTurn) =>
-    if !data.isAgentRunning {
-      (task, [])
-    } else {
+    switch data.isAgentRunning || data.pendingQuestion->Option.isSome {
+    | false => (task, [])
+    | true =>
       let completed = Lens.completeStreamingMessage(task)
       let withCancelledTools = Lens.updateMessages(completed, store =>
         MessageStore.map(store, msg =>

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -875,6 +875,166 @@ describe("Task - QuestionReceived on freshly loaded task (reconnect scenario)", 
   })
 })
 
+describe("Task - Interactive wait contract", () => {
+  let questions: array<Client__Question__Types.questionItem> = [
+    {
+      question: "Pick one",
+      header: "Test",
+      options: [{label: "A", description: "Option A"}],
+      multiple: None,
+    },
+  ]
+
+  let runEffects = (effects, ~delegate=_ => failwith("Unexpected delegated effect")) =>
+    effects->Array.forEach(effect =>
+      TaskReducer.handleEffect(
+        effect,
+        ~dispatch=_ => failwith("Unexpected dispatched action"),
+        ~delegate,
+      )
+    )
+
+  afterEach(() => Vi.useRealTimers()->ignore)
+
+  [
+    ("selected option", TaskReducer.QuestionOptionToggled({questionIndex: 0, label: "A"}), "A"),
+    (
+      "custom text",
+      TaskReducer.QuestionCustomTextChanged({questionIndex: 0, text: "My own answer"}),
+      "My own answer",
+    ),
+  ]->Array.forEach(((label, answerAction, answer)) => {
+    testAsync(
+      `waiting preserves the question and resolves ${label} once without draining prompts`,
+      async t => {
+        Vi.useFakeTimers()->ignore
+        let resolutions = ref([])
+        let rejections = ref([])
+        let (running, _) = TaskReducer.next(TestHelpers.makeLoadedTask(), ExecutionStateRunning)
+        let (waiting, effects) = TaskReducer.next(
+          running,
+          QuestionReceived({
+            questions,
+            toolCallId: "durable-question-1",
+            resolveOk: json => resolutions := Array.concat(resolutions.contents, [json]),
+            resolveError: error => rejections := Array.concat(rejections.contents, [error]),
+          }),
+        )
+        runEffects(effects)
+        let (answered, effects) = TaskReducer.next(waiting, answerAction)
+        runEffects(effects)
+        let (queued, sendEffects) = TaskReducer.next(
+          answered,
+          AddUserMessage({
+            id: testUserMessageId,
+            content: [Client__Task__Types.UserContentPart.Text({text: "Next turn, not an answer"})],
+            annotations: [],
+            agentId: "executor-id",
+          }),
+        )
+        switch sendEffects->Array.get(0) {
+        | Some(SendMessage({text})) => t->expect(text)->Expect.toBe("Next turn, not an answer")
+        | _ => failwith("Expected ordinary prompt, not a question result")
+        }
+        let accepted = TestHelpers.acceptUserMessage(
+          queued,
+          ~id=testUserMessageId->UserMessageId.toString,
+          ~text="Next turn, not an answer",
+        )
+        let _ = await Vi.advanceTimersByTimeAsync(600_001)
+        let pending = TaskReducer.Selectors.pendingQuestion(accepted)->Option.getOrThrow
+        t->expect(pending.toolCallId)->Expect.toBe("durable-question-1")
+        t->expect(resolutions.contents)->Expect.toEqual([])
+        t->expect(rejections.contents)->Expect.toEqual([])
+        t->expect(TaskReducer.Selectors.turnError(accepted))->Expect.toEqual(None)
+
+        let (submitted, effects) = TaskReducer.next(accepted, QuestionSubmitted)
+        runEffects(effects)
+        let (duplicate, effects) = TaskReducer.next(submitted, QuestionSubmitted)
+        runEffects(effects)
+        t->expect(duplicate)->Expect.toEqual(submitted)
+        t->expect(effects)->Expect.toEqual([])
+        t->expect(TaskReducer.Selectors.pendingQuestion(submitted))->Expect.toEqual(None)
+        t
+        ->expect(resolutions.contents)
+        ->Expect.toEqual([
+          JSON.parseOrThrow(
+            `{"answers":[{"question":"Pick one","answer":["${answer}"]}],"skippedAll":false,"cancelled":false}`,
+          ),
+        ])
+        t->expect(rejections.contents)->Expect.toEqual([])
+        t
+        ->expect(TestHelpers.getQueuedUserMessages(submitted))
+        ->Expect.toEqual(TestHelpers.getQueuedUserMessages(accepted))
+        t->expect(TestHelpers.getMessages(submitted))->Expect.toEqual([])
+      },
+    )
+  })
+
+  [TaskReducer.CancelTurn, TaskReducer.QuestionCancelled]->Array.forEach(action => {
+    test(
+      `${TaskReducer.actionToString(action)} cancels a pending question when not running`,
+      t => {
+        let resolutions = ref([])
+        let rejections = ref([])
+        let commands = ref([])
+        let (waiting, _) = TaskReducer.next(
+          TestHelpers.makeLoadedTask(),
+          QuestionReceived({
+            questions,
+            toolCallId: "durable-question-1",
+            resolveOk: json => resolutions := Array.concat(resolutions.contents, [json]),
+            resolveError: error => rejections := Array.concat(rejections.contents, [error]),
+          }),
+        )
+        t->expect(TaskReducer.Selectors.isAgentRunning(waiting))->Expect.toEqual(Some(false))
+        let (cancelled, effects) = TaskReducer.next(waiting, action)
+        runEffects(
+          effects,
+          ~delegate=command => commands := Array.concat(commands.contents, [command]),
+        )
+        t->expect(commands.contents)->Expect.toEqual([TaskReducer.NeedSessionCommand(ACP.Cancel)])
+        t->expect(rejections.contents)->Expect.toEqual(["Cancelled by user"])
+        t->expect(TaskReducer.Selectors.pendingQuestion(cancelled))->Expect.toEqual(None)
+        t->expect(TaskReducer.Selectors.isAgentRunning(cancelled))->Expect.toEqual(Some(false))
+        let (lateAnswer, effects) = TaskReducer.next(cancelled, QuestionSubmitted)
+        runEffects(effects)
+        t->expect(lateAnswer)->Expect.toEqual(cancelled)
+        t->expect(effects)->Expect.toEqual([])
+        t->expect(resolutions.contents)->Expect.toEqual([])
+      },
+    )
+  })
+
+  test("historical requires_action replays without reopening the turn", t => {
+    let (history, _) = TaskReducer.next(
+      TestHelpers.makeLoadingTask(),
+      TextDeltaReceived({
+        messageId: "old-message",
+        text: "Old paused turn",
+        agentId: "executor-id",
+      }),
+    )
+    let (paused, effects) = TaskReducer.next(history, ExecutionStateRequiresAction)
+    t->expect(effects)->Expect.toEqual([])
+    let (loaded, effects) = TaskReducer.next(paused, LoadComplete)
+    t->expect(TaskReducer.Selectors.isAgentRunning(loaded))->Expect.toEqual(Some(false))
+    t->expect(TaskReducer.Selectors.pendingQuestion(loaded))->Expect.toEqual(None)
+    t->expect(effects)->Expect.toEqual([])
+    t
+    ->expect(TestHelpers.getMessages(loaded))
+    ->Expect.toEqual([
+      Message.Assistant(
+        Completed({
+          id: "old-message",
+          content: [Client__Task__Types.AssistantContentPart.Text({text: "Old paused turn"})],
+          agentId: "executor-id",
+        }),
+      ),
+    ])
+  })
+})
+
 describe("Task - QuestionPerQuestionSkipped", () => {
   test("skipping a non-last question advances currentStep without submitting", t => {
     let task = TestHelpers.makeLoadedTask()

--- a/libs/client/test/Client__Task.test.res
+++ b/libs/client/test/Client__Task.test.res
@@ -894,8 +894,6 @@ describe("Task - Interactive wait contract", () => {
       )
     )
 
-  afterEach(() => Vi.useRealTimers()->ignore)
-
   [
     ("selected option", TaskReducer.QuestionOptionToggled({questionIndex: 0, label: "A"}), "A"),
     (
@@ -904,10 +902,9 @@ describe("Task - Interactive wait contract", () => {
       "My own answer",
     ),
   ]->Array.forEach(((label, answerAction, answer)) => {
-    testAsync(
-      `waiting preserves the question and resolves ${label} once without draining prompts`,
-      async t => {
-        Vi.useFakeTimers()->ignore
+    test(
+      `queued prompts preserve the question and resolve ${label} once without draining prompts`,
+      t => {
         let resolutions = ref([])
         let rejections = ref([])
         let (running, _) = TaskReducer.next(TestHelpers.makeLoadedTask(), ExecutionStateRunning)
@@ -941,7 +938,6 @@ describe("Task - Interactive wait contract", () => {
           ~id=testUserMessageId->UserMessageId.toString,
           ~text="Next turn, not an answer",
         )
-        let _ = await Vi.advanceTimersByTimeAsync(600_001)
         let pending = TaskReducer.Selectors.pendingQuestion(accepted)->Option.getOrThrow
         t->expect(pending.toolCallId)->Expect.toBe("durable-question-1")
         t->expect(resolutions.contents)->Expect.toEqual([])


### PR DESCRIPTION
## Summary
- Let interactive tools wait indefinitely without timeout-generated failures or sibling cancellation.
- Remove duplicate timeout policy fields and return canonical persisted results after completion, timeout, or task crash.
- Persist execution mode for supported shutdown recovery, including interruption of declared-but-undispatched calls.
- Allow pending-question cancellation when the client appears idle; preserve historical pause records.

## Scope
This is the reviewed timeout/recovery subset, not the full continuation architecture refactor. Admission consolidation was withheld after independent review found lock-order and handoff races. Existing admission APIs and runtime behavior remain unchanged.

Still deferred: cancellation without a live worker, concurrent admission fencing, and safe replay after abrupt process loss. Parked executors retain history in memory. Swarm descriptor API changes are documented as breaking.

## Verification
- Server: 895 tests passed; strict compilation, check, and precommit passed.
- Swarm: 124 tests passed; check passed.
- Client: 428 tests; frontman-client: 88 tests; protocol: 12 tests passed.
- ReScript build passed.
- Independent reviewer repeated integrated server and Swarm checks.
- A pre-existing handoff-test synchronization race was corrected with a bounded Registry-cleanup wait; 20 varied-seed focused runs passed.
- Production source: 348 lines added, 405 removed (net reduction of 57).

Includes changesets. All work was implemented in isolated worktrees and independently reviewed.
