### PR TITLE
Persist canonical tool calls before every execution

### DIFF
--- a/.changeset/canonical-tool-calls.md
+++ b/.changeset/canonical-tool-calls.md
@@ -1,0 +1,7 @@
+---
+"frontman": patch
+---
+
+Persist every declared tool call before execution, including backend calls and calls with invalid arguments. Replay and recovery now use canonical call records instead of reconstructing them from response metadata.
+
+This release requires a maintenance cutover. Stop old server writers before the history backfill runs. See `apps/frontman_server/README.md` for the rollout requirements.

--- a/apps/frontman_server/README.md
+++ b/apps/frontman_server/README.md
@@ -13,6 +13,29 @@ Ready to run in production? Please [check our deployment guides](https://hexdocs
 
 * Boundary contract policy: [`BOUNDARY_CONTRACT_POLICY.md`](./BOUNDARY_CONTRACT_POLICY.md)
 
+## Tool-call persistence
+
+Every agent response and its declared `ToolCall` rows commit in one transaction.
+Backend, client, unavailable, and malformed calls use the same lifecycle: declaration, call, result.
+Response metadata retains the original arguments for LLM history. Call rows contain normalized arguments, or `nil` for invalid input.
+
+`execution_target` is `nil` until execution starts. Client executors register before they publish `tool_call_started` with the `:mcp` target.
+A recorded call alone does not send a client request. Reconnect dispatches only unresolved calls with the `:mcp` target.
+History replay reads call rows directly. It does not reconstruct calls from response metadata.
+
+### One-time migration rollout
+
+CAUTION: Stop old server writers before migration `20260907000000`. Old releases can create declaration-only histories after the backfill.
+The normal blue/green deployment runs migrations before it stops the old slot. This migration requires a maintenance cutover instead.
+
+1. Stop both old server slots before the migration starts.
+2. Run the migration with the new release.
+3. Start the new release before you restore traffic.
+
+The migration preserves existing calls and results. It inserts missing calls and preserves the relative order of existing rows.
+Duplicate existing call IDs within a task and turn stop the migration. The migration does not delete conflicting records.
+Rollback retains backfilled records. After an older release writes new history, repeat the backfill before you restore the new release.
+
 ## Learn more
 
 * Official website: https://www.phoenixframework.org/

--- a/apps/frontman_server/lib/agent_client_protocol/history.ex
+++ b/apps/frontman_server/lib/agent_client_protocol/history.ex
@@ -27,84 +27,35 @@ defmodule AgentClientProtocol.History do
     {rows, agent_ids} = TaskHistory.attributed_rows!(history)
     Agents.resolve_catalog!(active_agents, agent_ids)
 
-    standalone_tool_call_ids =
-      for %{
-            row: %InteractionSchema{
-              turn_number: turn_number,
-              data: %Interaction.ToolCall{tool_call_id: id}
-            }
-          } <- rows,
-          into: MapSet.new(),
-          do: {turn_number, id}
-
-    notifications =
-      Enum.flat_map(rows, &encode_row(&1, session_id, standalone_tool_call_ids))
+    notifications = Enum.flat_map(rows, &encode_row(&1, session_id))
 
     {:ok, %{notifications: notifications}}
   end
 
-  def encode_row(context, session_id), do: encode_row(context, session_id, MapSet.new())
-
   defp encode_row(
-         %{
-           row: %InteractionSchema{
-             turn_number: turn_number,
-             data: %Interaction.AgentResponse{} = response
-           },
-           turn_row: turn_row,
-           agent_id: agent_id,
-           response_ordinal: ordinal
-         },
-         session_id,
-         standalone_tool_call_ids
+         %{row: %InteractionSchema{data: %Interaction.AgentResponse{} = response}} = context,
+         session_id
        ) do
-    content_notifications =
-      case response.content do
-        content when content in [nil, ""] ->
-          []
+    case response.content do
+      content when content in [nil, ""] ->
+        []
 
-        content when is_binary(content) ->
-          [
-            ACP.build_agent_message_chunk_notification(
-              session_id,
-              content,
-              response.timestamp,
-              ACP.agent_message_id(turn_row.id, ordinal),
-              agent_id
-            )
-          ]
-      end
-
-    tool_call_notifications =
-      response.metadata
-      |> Map.get("tool_calls")
-      |> Interaction.to_swarm_tool_calls()
-      |> Enum.reject(&MapSet.member?(standalone_tool_call_ids, {turn_number, &1.id}))
-      |> Enum.map(fn tool_call ->
-        arguments =
-          case Interaction.ToolCall.attrs(tool_call) do
-            {:ok, %{arguments: arguments}} -> arguments
-            {:error, {:invalid_tool_arguments, _message}} -> nil
-          end
-
-        ACP.tool_call_create(
-          session_id,
-          tool_call.id,
-          tool_call.name,
-          "other",
-          response.timestamp,
-          ACP.tool_call_status_pending(),
-          arguments
-        )
-      end)
-
-    content_notifications ++ tool_call_notifications
+      content when is_binary(content) ->
+        [
+          ACP.build_agent_message_chunk_notification(
+            session_id,
+            content,
+            response.timestamp,
+            ACP.agent_message_id(context.turn_row.id, context.response_ordinal),
+            context.agent_id
+          )
+        ]
+    end
   end
 
   defp encode_row(
          %{row: %InteractionSchema{data: data, type: type} = row} = context,
-         session_id,
-         _standalone_tool_call_ids
+         session_id
        ) do
     case data do
       %Interaction.UserMessage{} = message ->

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -255,31 +255,49 @@ defmodule FrontmanServer.Tasks do
   end
 
   defp record_interaction_row(%TaskSchema{} = task, attrs) do
-    Repo.transact(fn ->
-      with {:ok, schema} <-
-             task
-             |> Ecto.build_assoc(:interaction_rows)
-             |> InteractionSchema.changeset(attrs)
-             |> Repo.insert(),
-           {1, _} <-
-             TaskSchema
-             |> TaskSchema.by_id(task.id)
-             |> Repo.update_all(set: [updated_at: DateTime.utc_now(:second)]) do
-        {:ok, schema}
-      else
-        {:error, reason} -> {:error, reason}
-        {0, _} -> {:error, :not_found}
-      end
-    end)
-    |> case do
-      {:ok, %InteractionSchema{} = interaction_schema} ->
-        broadcast_task(task.id, {:interaction, interaction_schema})
-        {:ok, interaction_schema}
+    entries = Enum.with_index([attrs | declared_tool_calls(attrs)])
 
-      {:error, reason} ->
+    entries
+    |> Enum.reduce(Ecto.Multi.new(), fn {attrs, index}, multi ->
+      changeset =
+        task
+        |> Ecto.build_assoc(:interaction_rows)
+        |> InteractionSchema.changeset(attrs)
+
+      Ecto.Multi.insert(multi, index, changeset)
+    end)
+    |> Ecto.Multi.update_all(:task, TaskSchema.by_id(task.id),
+      set: [updated_at: DateTime.utc_now(:second)]
+    )
+    |> Repo.transaction()
+    |> case do
+      {:ok, rows} ->
+        Enum.each(entries, fn {_attrs, index} ->
+          broadcast_task(task.id, {:interaction, Map.fetch!(rows, index)})
+        end)
+
+        {:ok, Map.fetch!(rows, 0)}
+
+      {:error, _operation, reason, _changes} ->
         {:error, reason}
     end
   end
+
+  defp declared_tool_calls(%{type: :agent_response, data: data, turn_number: turn_number}) do
+    data.metadata
+    |> Map.get("tool_calls")
+    |> Interaction.to_swarm_tool_calls()
+    |> Enum.map(fn call ->
+      %{
+        id: Ecto.UUID.generate(),
+        type: :tool_call,
+        data: Interaction.ToolCall.attrs(call),
+        turn_number: turn_number
+      }
+    end)
+  end
+
+  defp declared_tool_calls(_attrs), do: []
 
   defp topic(task_id), do: "task:#{task_id}"
 
@@ -472,7 +490,12 @@ defmodule FrontmanServer.Tasks do
     )
   end
 
-  defp keeps_turn_open_after_restart?(%Interaction.ToolCall{tool_name: "question"}), do: true
+  defp keeps_turn_open_after_restart?(%Interaction.ToolCall{
+         tool_name: "question",
+         execution_target: :mcp
+       }),
+       do: true
+
   defp keeps_turn_open_after_restart?(%Interaction.ToolCall{}), do: false
 
   @doc """
@@ -756,6 +779,10 @@ defmodule FrontmanServer.Tasks do
     with {:ok, task_schema} <- get_task(scope, task_id) do
       {type, attrs} = build_execution_outcome(outcome)
 
+      task_id
+      |> unresolved_tool_calls_for_turn(turn_number)
+      |> Enum.each(&interrupt_tool_call(scope, task_id, turn_number, &1, "Execution ended"))
+
       record_interaction(task_schema, type, attrs, turn_number)
     end
   end
@@ -800,12 +827,33 @@ defmodule FrontmanServer.Tasks do
      }}
   end
 
-  @doc "Records a client-handled tool request in the given turn."
-  def request_client_tool(scope, task_id, turn_number, %SwarmAi.ToolCall{} = tool_call_data)
-      when is_integer(turn_number) and turn_number > 0 do
-    with {:ok, schema} <- get_task(scope, task_id),
-         {:ok, attrs} <- Interaction.ToolCall.attrs(tool_call_data) do
-      record_interaction(schema, :tool_call, attrs, turn_number)
+  @doc "Starts a persisted tool attempt. Only a started MCP call may be dispatched to a client."
+  def start_tool_call(%Scope{} = scope, task_id, turn_number, tool_call_id, execution_target)
+      when is_integer(turn_number) and turn_number > 0 and
+             execution_target in [:backend, :mcp] do
+    with {:ok, _task} <- get_task(scope, task_id),
+         %InteractionSchema{data: %Interaction.ToolCall{arguments: arguments}} = row
+         when is_map(arguments) <-
+           InteractionSchema.for_task(task_id)
+           |> InteractionSchema.for_turn(turn_number)
+           |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
+           |> InteractionSchema.unresolved_tool_calls()
+           |> Repo.one(),
+         {:ok, updated} <-
+           row
+           |> Ecto.Changeset.change(data: %{row.data | execution_target: execution_target})
+           |> Repo.update() do
+      broadcast_task(task_id, {:tool_call_started, turn_number, updated.data})
+      {:ok, updated.data}
+    else
+      %InteractionSchema{data: %Interaction.ToolCall{arguments: nil}} ->
+        {:error, :invalid_tool_arguments}
+
+      nil ->
+        {:error, :not_pending}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -828,12 +876,12 @@ defmodule FrontmanServer.Tasks do
       )
       when is_list(opts) do
     with {:ok, schema} <- get_task(scope, task_id) do
-      turn_number = tool_result_turn_number(task_id, tool_call_id, opts)
+      call = tool_call_row!(task_id, tool_call_id, opts)
       attrs = Interaction.ToolResult.attrs(tool_call_data, result)
 
       schema
-      |> record_interaction(:tool_result, attrs, turn_number)
-      |> resolve_recorded_tool_result(task_id, turn_number, tool_call_id)
+      |> record_interaction(:tool_result, attrs, call.turn_number)
+      |> resolve_recorded_tool_result(task_id, call.turn_number, tool_call_id)
     end
   end
 
@@ -869,21 +917,18 @@ defmodule FrontmanServer.Tasks do
     {:ok, interaction, Execution.notify_tool_result(task_id, interaction)}
   end
 
-  defp tool_result_turn_number(task_id, tool_call_id, opts) do
+  defp tool_call_row!(task_id, tool_call_id, opts) do
+    query =
+      InteractionSchema.for_task(task_id)
+      |> InteractionSchema.of_type(:tool_call)
+      |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
+
     case Keyword.fetch(opts, :turn_number) do
       {:ok, turn_number} when is_integer(turn_number) and turn_number > 0 ->
-        turn_number
+        query |> InteractionSchema.for_turn(turn_number) |> Repo.one!()
 
       :error ->
-        InteractionSchema.for_task(task_id)
-        |> InteractionSchema.of_type(:tool_call)
-        |> InteractionSchema.data_equals("tool_call_id", tool_call_id)
-        |> Repo.one()
-        |> case do
-          %InteractionSchema{turn_number: turn_number}
-          when is_integer(turn_number) and turn_number > 0 ->
-            turn_number
-        end
+        Repo.one!(query)
     end
   end
 
@@ -902,15 +947,7 @@ defmodule FrontmanServer.Tasks do
           {:ok, :no_active_turn}
 
         turn_number ->
-          tool_calls =
-            InteractionSchema.for_task(task_id)
-            |> InteractionSchema.for_turn(turn_number)
-            |> InteractionSchema.unresolved_tool_calls()
-            |> InteractionSchema.ordered()
-            |> Repo.all()
-            |> Enum.map(& &1.data)
-
-          {:ok, turn_number, tool_calls}
+          {:ok, turn_number, unresolved_tool_calls_for_turn(task_id, turn_number)}
       end
     end
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -101,7 +101,15 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     SentryContext.set_task_scope_context(scope, task_id)
 
     result =
-      execute_backend_tool(scope, module, tool_call, task_id, turn_number)
+      case start_tool_call(scope, task_id, turn_number, tool_call, :backend) do
+        {:ok, arguments} ->
+          {:ok, task} = Tasks.get_task_with_history(scope, task_id)
+          context = %Backend.Context{task: task}
+          do_run_backend_tool(scope, module, arguments, context, tool_call, task_id, turn_number)
+
+        {:error, result} ->
+          result
+      end
 
     to_swarm_tool_result(tool_call, result)
   end
@@ -136,7 +144,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
     Logger.info("ToolExecutor: Routing to MCP tool #{tool_call.name}")
 
     register_mcp_tool(task_id, tool_call)
-    publish_mcp_tool_call(scope, task_id, turn_number, tool_call)
+    start_tool_call(scope, task_id, turn_number, tool_call, :mcp)
     :ok
   end
 
@@ -216,62 +224,27 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   defp tool_registry_key(task_id, tool_call_id), do: {:tool_call, task_id, tool_call_id}
 
-  defp publish_mcp_tool_call(%Scope{} = scope, task_id, turn_number, tool_call) do
-    case Tasks.request_client_tool(scope, task_id, turn_number, tool_call) do
-      {:ok, _interaction} ->
-        :ok
+  defp start_tool_call(scope, task_id, turn_number, tool_call, target) do
+    case Tasks.start_tool_call(scope, task_id, turn_number, tool_call.id, target) do
+      {:ok, call} ->
+        {:ok, call.arguments}
 
-      {:error, {:invalid_tool_arguments, _message}} ->
+      {:error, :invalid_tool_arguments} ->
         Logger.error("Tool argument parse failure", tool_parse_metadata(tool_call, task_id))
 
-        persist_error_tool_result(
-          scope,
-          task_id,
-          turn_number,
-          tool_call,
-          "Failed to parse arguments for tool"
-        )
+        result =
+          persist_error_tool_result(
+            scope,
+            task_id,
+            turn_number,
+            tool_call,
+            "Failed to parse arguments for tool"
+          )
+
+        {:error, result}
 
       {:error, reason} ->
-        Logger.error(
-          "ToolExecutor: Failed to publish MCP tool call #{tool_call.id}: #{inspect(reason)}"
-        )
-
-        raise "Failed to publish MCP tool call: #{inspect(reason)}"
-    end
-  end
-
-  defp execute_backend_tool(scope, module, tool_call, task_id, turn_number) do
-    Logger.debug("ToolExecutor: Executing backend tool #{tool_call.name}")
-    {:ok, task} = Tasks.get_task_with_history(scope, task_id)
-    tool_call = SwarmAi.ToolCall.strip_null_arguments(tool_call)
-
-    context = %Backend.Context{
-      task: task
-    }
-
-    case SwarmAi.ToolCall.parse_arguments(tool_call) do
-      {:error, _message} ->
-        Logger.error("Tool argument parse failure", tool_parse_metadata(tool_call, task_id))
-
-        persist_error_tool_result(
-          scope,
-          task_id,
-          turn_number,
-          tool_call,
-          "Failed to parse arguments for tool"
-        )
-
-      {:ok, args} ->
-        do_run_backend_tool(
-          scope,
-          module,
-          args,
-          context,
-          tool_call,
-          task_id,
-          turn_number
-        )
+        raise "Failed to start tool call: #{inspect(reason)}"
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -836,7 +836,9 @@ defmodule FrontmanServer.Tasks.Interaction do
 
   defmodule ToolCall do
     @moduledoc """
-    Represents an LLM requesting a tool execution.
+    The canonical execution attempt for a tool declared by an agent response.
+    A nil execution target means execution has not started. Malformed arguments
+    are retained in the response; their execution attempt has nil arguments.
     """
 
     use Ecto.Schema
@@ -845,6 +847,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :tool_call_id, :string
       field :tool_name, :string
       field :arguments, :map
+      field :execution_target, Ecto.Enum, values: [:backend, :mcp]
       field :timestamp, :utc_datetime_usec
     end
 
@@ -854,25 +857,20 @@ defmodule FrontmanServer.Tasks.Interaction do
         :tool_call_id,
         :tool_name,
         :arguments,
+        :execution_target,
         :timestamp
       ])
+      |> Ecto.Changeset.validate_required([:tool_call_id, :tool_name])
     end
 
-    def attrs(%SwarmAi.ToolCall{} = tc) do
-      tc = SwarmAi.ToolCall.strip_null_arguments(tc)
+    def attrs(%SwarmAi.ToolCall{} = call) do
+      arguments =
+        case SwarmAi.ToolCall.parse_arguments(call) do
+          {:ok, arguments} -> SwarmAi.SchemaTransformer.strip_nulls(arguments)
+          {:error, _message} -> nil
+        end
 
-      case SwarmAi.ToolCall.parse_arguments(tc) do
-        {:ok, arguments} ->
-          {:ok,
-           %{
-             tool_call_id: tc.id,
-             tool_name: tc.name,
-             arguments: arguments
-           }}
-
-        {:error, message} ->
-          {:error, {:invalid_tool_arguments, message}}
-      end
+      %{tool_call_id: call.id, tool_name: call.name, arguments: arguments}
     end
   end
 

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction_schema.ex
@@ -138,6 +138,10 @@ defmodule FrontmanServer.Tasks.InteractionSchema do
       name: @tool_result_unique_constraint,
       message: "duplicate tool result for this tool_call_id"
     )
+    |> unique_constraint([:task_id, :data],
+      name: :interactions_tool_call_turn_uniqueness,
+      message: "duplicate tool call for this tool_call_id"
+    )
   end
 
   defp generate_sequence do

--- a/apps/frontman_server/lib/frontman_server/tools.ex
+++ b/apps/frontman_server/lib/frontman_server/tools.ex
@@ -35,19 +35,6 @@ defmodule FrontmanServer.Tools do
     end
   end
 
-  @doc """
-  Returns the execution target for a tool.
-
-  Backend tools are executed server-side by ToolExecutor.
-  MCP tools are routed to the browser client for execution.
-  """
-  def execution_target(tool_name) do
-    case find_tool(tool_name) do
-      {:ok, _module} -> :backend
-      :not_found -> :mcp
-    end
-  end
-
   def todo_mutation?(tool_name), do: tool_name in @todo_mutations
 
   def mcp_tools(mcp_tools, :all), do: Enum.filter(mcp_tools, & &1.visible_to_agent)

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -204,6 +204,10 @@ defmodule FrontmanServerWeb.TaskChannel do
     handle_interaction(interaction, turn_number, socket)
   end
 
+  def handle_info({:tool_call_started, turn_number, tool_call}, socket) do
+    {:noreply, redispatch_unresolved_tool_call(socket, tool_call, turn_number)}
+  end
+
   def handle_info({:message_unqueued, message_id}, socket) when is_binary(message_id) do
     notification = ACP.build_message_unqueued_notification(socket.assigns.task_id, message_id)
     push(socket, @acp_message, notification)
@@ -275,13 +279,10 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     push(socket, @acp_message, notification)
 
-    case Tools.execution_target(tool_call.tool_name) do
-      :backend ->
-        {:noreply, socket}
+    socket =
+      assign(socket, :announced_tool_calls, MapSet.put(announced, tool_call.tool_call_id))
 
-      :mcp ->
-        route_to_mcp(tool_call, socket)
-    end
+    {:noreply, socket}
   end
 
   defp handle_interaction(%Tasks.Interaction.ToolResult{} = tool_result, _turn_number, socket) do
@@ -402,13 +403,14 @@ defmodule FrontmanServerWeb.TaskChannel do
     end
   end
 
-  defp open_tool_call(socket, tool_call_id) do
-    with {:ok, _turn_number, tool_calls} when is_list(tool_calls) <-
+  defp open_tool_call(socket, tool_call_id, expected_turn \\ nil) do
+    with {:ok, turn_number, tool_calls}
+         when is_list(tool_calls) and expected_turn in [nil, turn_number] <-
            Tasks.get_active_turn_unresolved_tool_calls(
              socket.assigns.scope,
              socket.assigns.task_id
            ),
-         %Tasks.Interaction.ToolCall{} = tool_call <-
+         %Tasks.Interaction.ToolCall{execution_target: :mcp} = tool_call <-
            Enum.find(tool_calls, &(&1.tool_call_id == tool_call_id)) do
       {:ok, tool_call}
     else
@@ -1077,16 +1079,28 @@ defmodule FrontmanServerWeb.TaskChannel do
 
   defp redispatch_unresolved_tool_calls(socket), do: socket
 
-  defp redispatch_unresolved_tool_call(socket, tool_call, turn_number) do
+  defp redispatch_unresolved_tool_call(
+         socket,
+         %Tasks.Interaction.ToolCall{execution_target: :mcp} = tool_call,
+         turn_number
+       ) do
     case mcp_tool_request_pending?(socket, tool_call.tool_call_id) do
       true ->
         socket
 
       false ->
-        {:noreply, socket} = handle_interaction(tool_call, turn_number, socket)
-        socket
+        case open_tool_call(socket, tool_call.tool_call_id, turn_number) do
+          {:ok, call} ->
+            {:noreply, socket} = route_to_mcp(call, socket)
+            socket
+
+          :error ->
+            socket
+        end
     end
   end
+
+  defp redispatch_unresolved_tool_call(socket, _call, _turn_number), do: socket
 
   defp mcp_tool_request_pending?(socket, tool_call_id) do
     socket.assigns.pending_mcp_tool_requests

--- a/apps/frontman_server/priv/repo/migrations/20260907000000_canonicalize_tool_calls.exs
+++ b/apps/frontman_server/priv/repo/migrations/20260907000000_canonicalize_tool_calls.exs
@@ -1,0 +1,126 @@
+defmodule FrontmanServer.Repo.Migrations.CanonicalizeToolCalls do
+  @moduledoc "Backfills canonical calls without application dependencies or changes to original row order."
+  use Ecto.Migration
+
+  def up do
+    execute("LOCK TABLE interactions IN SHARE ROW EXCLUSIVE MODE")
+
+    execute("""
+    UPDATE interactions
+    SET data = data || '{"execution_target":"mcp"}'::jsonb
+    WHERE type = 'tool_call' AND NOT data ? 'execution_target'
+    """)
+
+    create_argument_functions()
+    backfill_calls()
+    reorder_history()
+
+    create unique_index(:interactions, [:task_id, :turn_number, "(data->>'tool_call_id')"],
+             where: "type = 'tool_call'",
+             name: :interactions_tool_call_turn_uniqueness
+           )
+  end
+
+  def down do
+    drop index(:interactions, [:task_id, :turn_number, "(data->>'tool_call_id')"],
+           name: :interactions_tool_call_turn_uniqueness
+         )
+  end
+
+  defp create_argument_functions do
+    execute("""
+    CREATE OR REPLACE FUNCTION pg_temp.strip_tool_nulls(value jsonb) RETURNS jsonb
+    LANGUAGE sql IMMUTABLE AS $$
+      SELECT CASE WHEN jsonb_typeof(value) = 'object' THEN
+        coalesce((SELECT jsonb_object_agg(key, pg_temp.strip_tool_nulls(v))
+                  FROM jsonb_each(value) AS fields(key, v) WHERE v <> 'null'::jsonb), '{}')
+      ELSE value END
+    $$
+    """)
+
+    execute("""
+    CREATE OR REPLACE FUNCTION pg_temp.tool_arguments(value jsonb) RETURNS jsonb
+    LANGUAGE plpgsql IMMUTABLE AS $$
+    BEGIN
+      IF jsonb_typeof(value) = 'string' THEN
+        IF value #>> '{}' ~ '^[[:space:]]*$' THEN RETURN '{}'::jsonb; END IF;
+        BEGIN
+          value := (value #>> '{}')::jsonb;
+        EXCEPTION WHEN invalid_text_representation THEN
+          RETURN 'null'::jsonb;
+        END;
+      END IF;
+      IF jsonb_typeof(value) = 'object' THEN RETURN pg_temp.strip_tool_nulls(value); END IF;
+      RETURN 'null'::jsonb;
+    END $$
+    """)
+  end
+
+  defp backfill_calls do
+    execute("""
+    CREATE TEMP TABLE canonical_tool_call_backfill ON COMMIT DROP AS
+    WITH declarations AS (
+      SELECT response.id AS anchor_id, response.task_id, response.turn_number,
+             response.sequence, response.inserted_at, response.data->>'timestamp' AS timestamp,
+             entry->>'id' AS call_id,
+             coalesce(entry->>'name', entry#>>'{function,name}') AS name,
+             pg_temp.tool_arguments(coalesce(entry->'arguments', entry#>'{function,arguments}')) AS arguments,
+             ordinal, 0 AS priority
+      FROM interactions response
+      CROSS JOIN LATERAL jsonb_array_elements(
+        coalesce(nullif(response.data#>'{metadata,tool_calls}', 'null'::jsonb), '[]'::jsonb)
+      ) WITH ORDINALITY AS calls(entry, ordinal)
+      WHERE response.type = 'agent_response'
+      UNION ALL
+      SELECT result.id, result.task_id, result.turn_number, result.sequence, result.inserted_at,
+             result.data->>'timestamp', result.data->>'tool_call_id', result.data->>'tool_name',
+             'null'::jsonb, -1, 1
+      FROM interactions result WHERE result.type = 'tool_result'
+    ), missing AS (
+      SELECT DISTINCT ON (task_id, turn_number, call_id) * FROM declarations declaration
+      WHERE NOT EXISTS (
+        SELECT 1 FROM interactions call
+        WHERE call.type = 'tool_call' AND call.task_id = declaration.task_id
+          AND call.turn_number = declaration.turn_number AND call.data->>'tool_call_id' = declaration.call_id
+      )
+      ORDER BY task_id, turn_number, call_id, priority, sequence, inserted_at, anchor_id, ordinal
+    )
+    SELECT gen_random_uuid() AS id, *, jsonb_build_object(
+      '__type__', 'tool_call', 'tool_call_id', call_id, 'tool_name', name, 'arguments', arguments,
+      'execution_target', NULL,
+      'timestamp', coalesce(timestamp, to_char(inserted_at, 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'))
+    ) AS data FROM missing
+    """)
+
+    execute("""
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM canonical_tool_call_backfill
+                 WHERE call_id IS NULL OR call_id = '' OR name IS NULL OR name = '' OR turn_number IS NULL) THEN
+        RAISE EXCEPTION 'Cannot backfill tool calls without identity, name, or turn';
+      END IF;
+    END $$
+    """)
+
+    execute("""
+    INSERT INTO interactions (id, task_id, turn_number, type, data, sequence, inserted_at)
+    SELECT id, task_id, turn_number, 'tool_call', data || jsonb_build_object('id', id::text), sequence, inserted_at
+    FROM canonical_tool_call_backfill
+    """)
+  end
+
+  defp reorder_history do
+    execute("""
+    WITH ordered AS (
+      SELECT interaction.id, row_number() OVER (
+        PARTITION BY interaction.task_id
+        ORDER BY anchor.sequence, anchor.inserted_at, anchor.id, coalesce(backfill.ordinal, 0), interaction.id
+      ) AS sequence
+      FROM interactions interaction
+      LEFT JOIN canonical_tool_call_backfill backfill ON backfill.id = interaction.id
+      JOIN interactions anchor ON anchor.id = coalesce(backfill.anchor_id, interaction.id)
+      WHERE interaction.task_id IN (SELECT task_id FROM canonical_tool_call_backfill)
+    )
+    UPDATE interactions SET sequence = ordered.sequence FROM ordered WHERE interactions.id = ordered.id
+    """)
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tasks/canonical_tool_calls_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/canonical_tool_calls_test.exs
@@ -1,0 +1,372 @@
+defmodule FrontmanServer.Tasks.CanonicalToolCallsTest do
+  use FrontmanServer.DataCase, async: false
+
+  import FrontmanServer.Test.Fixtures.Accounts
+  import FrontmanServer.Test.Fixtures.Tasks
+
+  alias AgentClientProtocol.History, as: ACPHistory
+  alias Ecto.Migration.Runner
+  alias FrontmanServer.Agents
+  alias FrontmanServer.Repo
+  alias FrontmanServer.Repo.Migrations.CanonicalizeToolCalls
+  alias FrontmanServer.Tasks
+  alias FrontmanServer.Tasks.Execution.ToolExecutor
+  alias FrontmanServer.Tasks.{History, Interaction, InteractionSchema}
+  alias FrontmanServer.Tools
+
+  setup do
+    scope = user_scope_fixture()
+    task_id = task_fixture(scope).id
+    turn_number = start_turn_fixture(scope, task_id)
+    Phoenix.PubSub.subscribe(FrontmanServer.PubSub, task_topic(task_id))
+    %{scope: scope, task_id: task_id, turn_number: turn_number}
+  end
+
+  test "response persistence creates every call and normalizes arguments once", context do
+    calls = [
+      call("valid", "todo_write", ~s({"todos":[],"optional":null,"nested":{"optional":null}})),
+      call("blank", "question", " \n "),
+      call("invalid", "question", "{invalid"),
+      call("array", "question", "[]")
+    ]
+
+    response = %SwarmAi.LLM.Response{content: "Working", tool_calls: calls}
+    timestamp = ~U[2026-09-01 12:00:00.000000Z]
+
+    assert :ok =
+             Tasks.handle_swarm_event(
+               context.scope,
+               context.task_id,
+               context.turn_number,
+               {:response, %{timestamp: timestamp}, response}
+             )
+
+    [response_row | call_rows] = execution_rows(context.task_id)
+    assert response_row.type == :agent_response
+    assert response_row.data.timestamp == timestamp
+    assert Enum.map(call_rows, & &1.data.tool_call_id) == Enum.map(calls, & &1.id)
+
+    assert Enum.map(call_rows, & &1.data.arguments) == [
+             %{"todos" => [], "nested" => %{}},
+             %{},
+             nil,
+             nil
+           ]
+
+    assert Enum.all?(call_rows, &is_nil(&1.data.execution_target))
+
+    assert Enum.map(response_row.data.metadata["tool_calls"], & &1["arguments"]) ==
+             Enum.map(calls, & &1.arguments)
+
+    refute_receive {:tool_call_started, _, _}
+
+    assert {:ok, history} = History.new(all_rows(context.task_id))
+
+    assert {:ok, replay} =
+             ACPHistory.build(history, context.task_id, Agents.list_agents(context.scope))
+
+    creates =
+      Enum.filter(
+        replay.notifications,
+        &(get_in(&1, ["params", "update", "sessionUpdate"]) == "tool_call")
+      )
+
+    assert length(creates) == 4
+    refute Map.has_key?(get_in(List.last(creates), ["params", "update"]), "rawInput")
+  end
+
+  test "duplicate declarations roll back the response and every call without broadcasting",
+       context do
+    declaration = call("duplicate", "todo_write", "{}")
+
+    assert {:error, %Ecto.Changeset{}} =
+             declare_tool_calls_fixture(context.scope, context.task_id, context.turn_number, [
+               declaration,
+               declaration
+             ])
+
+    assert execution_rows(context.task_id) == []
+    refute_receive {:interaction, _}
+  end
+
+  test "call IDs are unique within a turn, not across turns", context do
+    declaration = call("reused", "todo_write", "{}")
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, [declaration])
+
+    assert {:error, %Ecto.Changeset{}} =
+             declare_tool_calls_fixture(context.scope, context.task_id, 1, [declaration])
+
+    assert {:ok, _} =
+             Tasks.record_execution_outcome(context.scope, context.task_id, 1, :completed)
+
+    assert 2 = start_turn_fixture(context.scope, context.task_id)
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 2, [declaration])
+
+    assert [1, 2] =
+             all_rows(context.task_id)
+             |> Enum.filter(&(&1.type == :tool_call))
+             |> Enum.map(& &1.turn_number)
+  end
+
+  @tag :capture_log
+  test "malformed backend and client calls both persist a call followed by its error", context do
+    backend = call("backend", "todo_write", "{invalid")
+    client = call("client", "question", "[]")
+    calls = [backend, client]
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, calls)
+
+    assert {:ok, results} =
+             ToolExecutor.execute(context.scope, %{
+               task_id: context.task_id,
+               turn_number: 1,
+               tool_calls: calls,
+               task_supervisor: SwarmAi.Runtime.task_supervisor_name(FrontmanServer.AgentRuntime),
+               backend_tool_modules: [Tools.TodoWrite],
+               mcp_tool_defs: [
+                 %Tools.MCP{
+                   name: "question",
+                   description: "Question",
+                   input_schema: %{},
+                   timeout_ms: 1_000,
+                   on_timeout: :error
+                 }
+               ],
+               execution_mode: :serial
+             })
+
+    assert Enum.all?(results, & &1.is_error)
+
+    assert [:agent_response, :tool_call, :tool_call, :tool_result, :tool_result] =
+             Enum.map(execution_rows(context.task_id), & &1.type)
+
+    for result <- results do
+      assert [%{text: "Failed to parse arguments for tool"}] = result.content
+    end
+
+    refute_receive {:tool_call_started, _, _}
+  end
+
+  test "restart closes declared but undispatched questions as well as backend calls", context do
+    declarations = [call("backend", "todo_write", "{}"), call("question", "question", "{}")]
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, declarations)
+
+    assert :ok =
+             Tasks.handle_swarm_event(context.scope, context.task_id, 1, {:terminated, :shutdown})
+
+    assert {:ok, :no_active_turn} =
+             Tasks.get_active_turn_unresolved_tool_calls(context.scope, context.task_id)
+
+    assert [:agent_response, :tool_call, :tool_call, :tool_result, :tool_result, :agent_error] =
+             Enum.map(execution_rows(context.task_id), & &1.type)
+  end
+
+  test "resolved calls cannot start again", context do
+    declaration = call("resolved", "todo_write", "{}")
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, [declaration])
+
+    assert {:ok, _, _} =
+             Tasks.resolve_tool_request(
+               context.scope,
+               context.task_id,
+               declaration,
+               ModelContextProtocol.tool_result_text("done"),
+               turn_number: 1
+             )
+
+    assert {:error, :not_pending} =
+             Tasks.start_tool_call(context.scope, context.task_id, 1, declaration.id, :backend)
+
+    refute_receive {:tool_call_started, _, _}
+  end
+
+  test "results cannot be recorded without a canonical call", context do
+    assert_raise Ecto.NoResultsError, fn ->
+      Tasks.resolve_tool_request(
+        context.scope,
+        context.task_id,
+        %{id: "missing", name: "todo_write"},
+        ModelContextProtocol.tool_result_text("done"),
+        turn_number: 1
+      )
+    end
+
+    assert execution_rows(context.task_id) == []
+  end
+
+  test "backfill preserves standalone calls and inserts missing calls in declaration order",
+       context do
+    calls = [
+      call("existing", "question", "{}"),
+      call("valid", "todo_write", ~s({"todos":[],"drop":null})),
+      call("invalid", "question", "{invalid")
+    ]
+
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, calls)
+    assert {:ok, _} = Tasks.start_tool_call(context.scope, context.task_id, 1, "existing", :mcp)
+
+    for call <- calls do
+      assert {:ok, _, _} =
+               Tasks.resolve_tool_request(
+                 context.scope,
+                 context.task_id,
+                 call,
+                 ModelContextProtocol.tool_result_text("done"),
+                 turn_number: 1
+               )
+    end
+
+    assert {:ok, _} =
+             Tasks.record_execution_outcome(context.scope, context.task_id, 1, :completed)
+
+    original_rows = all_rows(context.task_id)
+
+    existing =
+      Enum.find(
+        original_rows,
+        &match?(%InteractionSchema{data: %Interaction.ToolCall{tool_call_id: "existing"}}, &1)
+      )
+
+    task_id = Ecto.UUID.dump!(context.task_id)
+
+    Repo.query!(
+      "DELETE FROM interactions WHERE task_id = $1 AND type = 'tool_call' AND data->>'tool_call_id' <> 'existing'",
+      [task_id]
+    )
+
+    Repo.query!("UPDATE interactions SET data = data - 'execution_target' WHERE id = $1", [
+      Ecto.UUID.dump!(existing.id)
+    ])
+
+    retained_ids = Enum.map(all_rows(context.task_id), & &1.id)
+    run_migration(:down)
+    run_migration(:up)
+
+    rows = all_rows(context.task_id)
+    assert {:ok, _} = History.new(rows)
+    assert (Enum.map(rows, & &1.id) -- Enum.map(original_rows, & &1.id)) |> length() == 2
+    assert Enum.find(rows, &(&1.id == existing.id)).data.execution_target == :mcp
+
+    assert ["valid", "invalid", "existing"] =
+             rows |> Enum.filter(&(&1.type == :tool_call)) |> Enum.map(& &1.data.tool_call_id)
+
+    assert [
+             %Interaction.ToolCall{arguments: %{"todos" => []}, execution_target: nil},
+             %Interaction.ToolCall{arguments: nil, execution_target: nil}
+           ] =
+             rows
+             |> Enum.filter(&(&1.type == :tool_call and &1.id != existing.id))
+             |> Enum.map(& &1.data)
+
+    assert Enum.filter(Enum.map(rows, & &1.id), &(&1 in retained_ids)) == retained_ids
+  end
+
+  test "backfill scopes IDs by turn and accepts legacy argument formats", context do
+    assert {:ok, _} =
+             declare_tool_calls_fixture(context.scope, context.task_id, 1, [
+               call("shared", "question", "{}")
+             ])
+
+    assert {:ok, _} =
+             Tasks.record_execution_outcome(context.scope, context.task_id, 1, :completed)
+
+    assert 2 = start_turn_fixture(context.scope, context.task_id)
+    arguments = %{"drop" => nil, "nested" => %{"drop" => nil}, "array" => [%{"keep" => nil}]}
+
+    assert {:ok, _} =
+             Tasks.agent_replied(context.scope, context.task_id, 2, nil, %{
+               "tool_calls" => [
+                 %{
+                   "id" => "shared",
+                   "function" => %{"name" => "question", "arguments" => " \n "}
+                 },
+                 %{
+                   "id" => "nested",
+                   "function" => %{"name" => "question", "arguments" => arguments}
+                 },
+                 %{"id" => "array", "name" => "question", "arguments" => "[]"}
+               ]
+             })
+
+    Repo.query!(
+      "DELETE FROM interactions WHERE task_id = $1 AND turn_number = 2 AND type = 'tool_call'",
+      [Ecto.UUID.dump!(context.task_id)]
+    )
+
+    run_migration(:down)
+    run_migration(:up)
+    rows = all_rows(context.task_id)
+    assert {:ok, _} = History.new(rows)
+    calls = Enum.filter(rows, &(&1.type == :tool_call))
+
+    assert Enum.map(calls, &{&1.turn_number, &1.data.tool_call_id}) == [
+             {1, "shared"},
+             {2, "shared"},
+             {2, "nested"},
+             {2, "array"}
+           ]
+
+    assert Enum.map(calls, & &1.data.arguments) == [
+             %{},
+             %{},
+             %{"nested" => %{}, "array" => [%{"keep" => nil}]},
+             nil
+           ]
+  end
+
+  test "backfill gives legacy result-only records a call before the result", context do
+    declaration = call("orphan", "todo_write", "{}")
+    assert {:ok, _} = declare_tool_calls_fixture(context.scope, context.task_id, 1, [declaration])
+
+    assert {:ok, result, _} =
+             Tasks.resolve_tool_request(
+               context.scope,
+               context.task_id,
+               declaration,
+               ModelContextProtocol.tool_result_text("done"),
+               turn_number: 1
+             )
+
+    Repo.query!(
+      "DELETE FROM interactions WHERE task_id = $1 AND type IN ('agent_response', 'tool_call')",
+      [Ecto.UUID.dump!(context.task_id)]
+    )
+
+    run_migration(:down)
+    run_migration(:up)
+
+    assert [
+             %InteractionSchema{
+               data: %Interaction.ToolCall{
+                 tool_call_id: "orphan",
+                 arguments: nil,
+                 execution_target: nil
+               }
+             },
+             %InteractionSchema{data: ^result}
+           ] = execution_rows(context.task_id)
+  end
+
+  defp run_migration(direction) do
+    Code.require_file("priv/repo/migrations/20260907000000_canonicalize_tool_calls.exs")
+
+    assert :ok =
+             Runner.run(
+               Repo,
+               Repo.config(),
+               0,
+               CanonicalizeToolCalls,
+               :forward,
+               direction,
+               direction,
+               log: false
+             )
+  end
+
+  defp call(id, name, arguments), do: %SwarmAi.ToolCall{id: id, name: name, arguments: arguments}
+
+  defp all_rows(task_id),
+    do: task_id |> InteractionSchema.for_task() |> InteractionSchema.ordered() |> Repo.all()
+
+  defp execution_rows(task_id),
+    do: Enum.reject(all_rows(task_id), &(&1.type in [:user_message, :turn_started]))
+end

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_broadcast_test.exs
@@ -59,7 +59,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
 
       assert length(tool_call_broadcasts) == 1,
              "Expected exactly 1 tool call broadcast, got #{length(tool_call_broadcasts)}. " <>
-               "This indicates Tasks.request_client_tool is being called multiple times."
+               "Each declaration must create exactly one persisted tool call."
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
@@ -135,7 +135,10 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
       {:ok, task_id: task_id, scope: scope}
     end
 
-    test "agent is registered before interaction is broadcast", %{task_id: task_id, scope: scope} do
+    test "executor is registered before a client call is ready to dispatch", %{
+      task_id: task_id,
+      scope: scope
+    } do
       mcp_tool_call = swarm_tool_call("mcp_tool")
       expected_id = mcp_tool_call.id
 
@@ -154,10 +157,12 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
       {:ok, _, _} =
         submit_user_message_and_run(scope, task_id, execution_request, user_content("Call tool"))
 
-      assert_receive_interaction(
-        %Tasks.Interaction.ToolCall{tool_call_id: ^expected_id},
-        _turn_number
-      )
+      assert_receive {:tool_call_started, _turn_number,
+                      %Tasks.Interaction.ToolCall{
+                        tool_call_id: ^expected_id,
+                        execution_target: :mcp
+                      }},
+                     5_000
 
       registered =
         case Registry.lookup(FrontmanServer.ProcessRegistry, {:tool_call, task_id, expected_id}) do
@@ -166,7 +171,7 @@ defmodule FrontmanServer.Tasks.Execution.MCPToolBroadcastTest do
         end
 
       assert registered,
-             "Agent not registered when tool call broadcast - race condition exists"
+             "Executor must be registered before client dispatch"
 
       assert :ok = Tasks.cancel_execution(scope, task_id)
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
@@ -41,6 +41,7 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
       turn_number = latest_turn_number(task_id)
 
       tool_call = swarm_tool_call("take_screenshot", ~s({"selector": "#main"}))
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call])
 
       ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tool_call)
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -44,6 +44,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
           })
         )
 
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call])
+
       todo_write_module = Enum.find(Tools.backend_tool_modules(), &(&1.name() == "todo_write"))
 
       result =
@@ -89,6 +91,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
     } do
       secret = "frontman-secret-1445"
       tool_call = swarm_tool_call("todo_write", ~s({"secret":"#{secret}"))
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call])
 
       todo_write_module = Enum.find(Tools.backend_tool_modules(), &(&1.name() == "todo_write"))
 
@@ -135,6 +138,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       turn_number: turn_number
     } do
       tool_call = swarm_tool_call("todo_write", Jason.encode!(%{"todos" => []}))
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call])
 
       todo_write_module = Enum.find(Tools.backend_tool_modules(), &(&1.name() == "todo_write"))
 
@@ -166,6 +170,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
     } do
       secret = "frontman-mcp-secret-1445"
       tool_call = swarm_tool_call("take_screenshot", ~s(["#{secret}"]))
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call])
 
       assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tool_call)
       assert_receive {:tool_result, _, [%{text: "Failed to parse arguments for tool"}], true}
@@ -185,6 +190,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
       turn_number: turn_number
     } do
       tc = %SwarmAi.ToolCall{id: "tc-deadline-1", name: "todo_write", arguments: "{}"}
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tc])
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :triggered)
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -47,6 +47,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
       turn_number: turn_number
     } do
       tc = %SwarmAi.ToolCall{id: "tc-to-2", name: "some_tool", arguments: "{}"}
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tc])
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :error, tc, :cancelled)
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
@@ -65,6 +66,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         arguments: "{}"
       }
 
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tc])
       ToolExecutor.handle_timeout(scope, task_id, turn_number, :pause_agent, tc, :cancelled)
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
@@ -93,6 +95,9 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
           arguments: "{}"
         }
 
+        {:ok, _} =
+          declare_tool_calls_fixture(scope, task_id, turn_number, [available, unavailable])
+
         assert {:ok, results} =
                  ToolExecutor.execute(scope, %{
                    task_id: task_id,
@@ -118,10 +123,12 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         assert [%Interaction.ToolResult{is_error: false}] = tool_results(task, available.id)
         assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, unavailable.id)
 
-        refute Enum.any?(Tasks.interactions(task), fn
-                 %Interaction.ToolCall{tool_call_id: id} -> id == unavailable.id
-                 _interaction -> false
-               end)
+        recorded = Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolCall{}, &1))
+
+        assert Enum.find(recorded, &(&1.tool_call_id == available.id)).execution_target ==
+                 :backend
+
+        assert Enum.find(recorded, &(&1.tool_call_id == unavailable.id)).execution_target == nil
       end
     end
 
@@ -136,6 +143,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         arguments: "{}"
       }
 
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tc])
       assert :ok = ToolExecutor.start_mcp_tool(scope, task_id, turn_number, tc)
 
       assert_raise RuntimeError,
@@ -162,6 +170,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         arguments: "{}"
       }
 
+      {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [tc])
+
       assert {:ok, [%SwarmAi.ToolResult{is_error: true}]} =
                ToolExecutor.execute(scope, %{
                  task_id: task_id,
@@ -176,10 +186,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
 
-      refute Enum.any?(Tasks.interactions(task), fn
-               %Interaction.ToolCall{tool_call_id: tool_call_id} -> tool_call_id == tc.id
-               _interaction -> false
-             end)
+      assert [%Interaction.ToolCall{execution_target: nil}] =
+               Enum.filter(Tasks.interactions(task), &match?(%Interaction.ToolCall{}, &1))
 
       assert [%Interaction.ToolResult{is_error: true}] = tool_results(task, tc.id)
     end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -1249,7 +1249,10 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       interactions = Tasks.interactions(task)
-      refute Enum.any?(interactions, &match?(%Interaction.ToolCall{tool_call_id: ^tc_id}, &1))
+
+      assert [%Interaction.ToolCall{execution_target: nil}] =
+               Enum.filter(interactions, &match?(%Interaction.ToolCall{tool_call_id: ^tc_id}, &1))
+
       assert Enum.any?(interactions, &match?(%Interaction.ToolResult{tool_call_id: ^tc_id}, &1))
     end
   end

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -49,7 +49,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         ]
       }
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_write"},
@@ -95,7 +95,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         ]
       }
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_write"},
@@ -103,7 +103,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c2", name: "todo_write"},
@@ -139,7 +139,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         ]
       }
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_write"},
@@ -147,7 +147,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c2", name: "todo_write"},
@@ -166,7 +166,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
       scope: scope,
       turn_number: turn_number
     } do
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_write"},
@@ -183,7 +183,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
       scope: scope,
       turn_number: turn_number
     } do
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_add"},
@@ -191,7 +191,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         turn_number: turn_number
       )
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c2", name: "todo_update"},
@@ -221,7 +221,7 @@ defmodule FrontmanServer.Tasks.TodosTest do
         "updated_at" => DateTime.to_iso8601(DateTime.utc_now())
       }
 
-      Tasks.resolve_tool_request(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "loaded-task", name: "todo_write"},

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -70,6 +70,8 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
         task_id = task_fixture(scope).id
         turn_number = start_turn_fixture(scope, task_id)
         parent = self()
+        call = %SwarmAi.ToolCall{id: "call_dedup", name: "some_tool", arguments: "{}"}
+        {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [call])
 
         tasks =
           for result <- ["result1", "result2"] do
@@ -117,12 +119,15 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
   end
 
   defp start_executor(scope, task_id, turn_number, tool_call_id) do
+    call = %SwarmAi.ToolCall{id: tool_call_id, name: "some_tool", arguments: "{}"}
+    {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [call])
+
     Task.async(fn ->
       Sandbox.unboxed_run(Repo, fn ->
         ToolExecutor.execute(scope, %{
           task_id: task_id,
           turn_number: turn_number,
-          tool_calls: [%SwarmAi.ToolCall{id: tool_call_id, name: "some_tool", arguments: "{}"}],
+          tool_calls: [call],
           task_supervisor: SwarmAi.Runtime.task_supervisor_name(FrontmanServer.AgentRuntime),
           backend_tool_modules: [],
           mcp_tool_defs: [mcp_tool_def()],

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -69,7 +69,11 @@ defmodule FrontmanServer.TasksTest do
       assert {:ok, :no_active_turn} = Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
 
       assert 1 = start_turn_fixture(scope, task_id)
-      insert_interaction_row(task_id, Interaction.ToolCall, 1, %{"tool_call_id" => "call_1"})
+
+      insert_interaction_row(task_id, Interaction.ToolCall, 1, %{
+        "tool_call_id" => "call_1",
+        "tool_name" => "test_tool"
+      })
 
       assert {:ok, 1, [%Interaction.ToolCall{tool_call_id: "call_1"}]} =
                Tasks.get_active_turn_unresolved_tool_calls(scope, task_id)
@@ -235,21 +239,12 @@ defmodule FrontmanServer.TasksTest do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
 
-      {:ok, _tool_call} =
-        Tasks.request_client_tool(
-          scope,
-          task_id,
-          turn_number,
-          named_swarm_tool_call("question_1", "question")
-        )
-
-      {:ok, _tool_call} =
-        Tasks.request_client_tool(
-          scope,
-          task_id,
-          turn_number,
-          named_swarm_tool_call("read_1", "read_file")
-        )
+      for call <- [
+            named_swarm_tool_call("question_1", "question"),
+            named_swarm_tool_call("read_1", "read_file")
+          ] do
+        {:ok, _} = start_client_tool_fixture(scope, task_id, turn_number, call)
+      end
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:terminated, :shutdown})
 
@@ -280,21 +275,12 @@ defmodule FrontmanServer.TasksTest do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
 
-      {:ok, _tool_call} =
-        Tasks.request_client_tool(
-          scope,
-          task_id,
-          turn_number,
-          named_swarm_tool_call("question_1", "question")
-        )
-
-      {:ok, _tool_call} =
-        Tasks.request_client_tool(
-          scope,
-          task_id,
-          turn_number,
-          named_swarm_tool_call("read_1", "read_file")
-        )
+      for call <- [
+            named_swarm_tool_call("question_1", "question"),
+            named_swarm_tool_call("read_1", "read_file")
+          ] do
+        {:ok, _} = start_client_tool_fixture(scope, task_id, turn_number, call)
+      end
 
       Tasks.handle_swarm_event(scope, task_id, turn_number, {:cancelled, :user})
 
@@ -729,7 +715,7 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s({"expression": "2+2"})
       }
 
-      {:ok, _} = Tasks.request_client_tool(scope, task_id, turn_number, tc)
+      {:ok, _} = Tasks.start_tool_call(scope, task_id, turn_number, tc.id, :mcp)
 
       untrusted_result = %{
         "content" => [
@@ -801,7 +787,7 @@ defmodule FrontmanServer.TasksTest do
     end
   end
 
-  describe "request_client_tool/3" do
+  describe "start_tool_call/5" do
     test "creates tool call interaction", %{scope: scope} do
       task_id = task_fixture(scope).id
       turn_number = start_turn_fixture(scope, task_id)
@@ -812,7 +798,7 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s({"expression": "1 + 1"})
       }
 
-      {:ok, interaction} = Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+      {:ok, interaction} = start_client_tool_fixture(scope, task_id, turn_number, tool_call)
 
       assert interaction.tool_name == "calculator"
       assert interaction.tool_call_id == "call_123"
@@ -830,7 +816,7 @@ defmodule FrontmanServer.TasksTest do
       }
 
       assert {:ok, interaction} =
-               Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+               start_client_tool_fixture(scope, task_id, turn_number, tool_call)
 
       assert interaction.arguments == %{}
     end
@@ -844,10 +830,10 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s({"expression":)
       }
 
-      assert {:error, {:invalid_tool_arguments, reason}} =
-               Tasks.request_client_tool(scope, task_id, 1, tool_call)
+      turn_number = start_turn_fixture(scope, task_id)
 
-      assert reason =~ "unexpected end of input"
+      assert {:error, :invalid_tool_arguments} =
+               start_client_tool_fixture(scope, task_id, turn_number, tool_call)
     end
 
     test "returns an error for non-object tool call arguments", %{scope: scope} do
@@ -859,10 +845,10 @@ defmodule FrontmanServer.TasksTest do
         arguments: ~s(["not", "object"])
       }
 
-      assert {:error, {:invalid_tool_arguments, reason}} =
-               Tasks.request_client_tool(scope, task_id, 1, tool_call)
+      turn_number = start_turn_fixture(scope, task_id)
 
-      assert reason =~ "expected JSON object"
+      assert {:error, :invalid_tool_arguments} =
+               start_client_tool_fixture(scope, task_id, turn_number, tool_call)
     end
 
     test "returns error for non-existent task", %{scope: scope} do
@@ -870,7 +856,7 @@ defmodule FrontmanServer.TasksTest do
       tool_call = %SwarmAi.ToolCall{id: "call_123", name: "test", arguments: "{}"}
 
       assert {:error, :not_found} =
-               Tasks.request_client_tool(scope, nonexistent_id, 1, tool_call)
+               Tasks.start_tool_call(scope, nonexistent_id, 1, tool_call.id, :mcp)
     end
   end
 
@@ -885,9 +871,10 @@ defmodule FrontmanServer.TasksTest do
 
       turn_number = latest_turn_number(task_id)
 
-      {:ok, _} = Tasks.agent_replied(scope, task_id, turn_number, "response1")
+      tool_call_data = %SwarmAi.ToolCall{id: "tc_1", name: "test_tool", arguments: "{}"}
 
-      tool_call_data = %{id: "tc_1", name: "test_tool"}
+      {:ok, _} =
+        declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call_data], "response1")
 
       {:ok, _, _} =
         resolve_tool(
@@ -900,7 +887,7 @@ defmodule FrontmanServer.TasksTest do
 
       sequences = db_sequences(task_id)
 
-      assert length(sequences) == 4
+      assert length(sequences) == 5
       assert sequences == Enum.sort(sequences)
       assert sequences == Enum.uniq(sequences)
       assert Enum.all?(sequences, &(&1 > 0))
@@ -974,7 +961,7 @@ defmodule FrontmanServer.TasksTest do
   end
 
   defp test_interaction_attrs(Interaction.ToolCall, data) do
-    {:ok, attrs} =
+    attrs =
       Interaction.ToolCall.attrs(%SwarmAi.ToolCall{
         id: Map.get(data, "tool_call_id", Ecto.UUID.generate()),
         name: Map.get(data, "tool_name", "question"),
@@ -1319,12 +1306,12 @@ defmodule FrontmanServer.TasksTest do
         ]
       }
 
-      resolve_tool(
+      tool_result_fixture(
         scope,
         task_id,
         %{id: "c1", name: "todo_write"},
         %{"content" => [], "structuredContent" => write_result},
-        turn_number
+        turn_number: turn_number
       )
 
       {:ok, todos} = Tasks.list_todos(scope, task_id)
@@ -1354,12 +1341,12 @@ defmodule FrontmanServer.TasksTest do
         ]
       }
 
-      resolve_tool(
+      tool_result_fixture(
         scope,
         task_a,
         %{id: "c1", name: "todo_write"},
         %{"content" => [], "structuredContent" => write_result},
-        turn_number
+        turn_number: turn_number
       )
 
       {:ok, todos_a} = Tasks.list_todos(scope, task_a)

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -64,24 +64,6 @@ defmodule FrontmanServer.ToolsTest do
     end
   end
 
-  describe "execution_target/1" do
-    test "returns :backend for backend tools" do
-      Tools.backend_tools()
-      |> Enum.each(fn tool ->
-        assert Tools.execution_target(tool.name) == :backend,
-               "Expected #{tool.name} to target :backend"
-      end)
-    end
-
-    test "returns :mcp for non-backend tools" do
-      assert Tools.execution_target("read_file") == :mcp
-      assert Tools.execution_target("screenshot") == :mcp
-      assert Tools.execution_target("unknown_tool") == :mcp
-      assert Tools.execution_target("question") == :mcp
-      assert Tools.execution_target("") == :mcp
-    end
-  end
-
   describe "todo_mutation?/1" do
     test "returns true for todo_write" do
       assert Tools.todo_mutation?("todo_write")
@@ -220,7 +202,7 @@ defmodule FrontmanServer.ToolsTest do
       }
 
       {:ok, interaction, :no_executor} =
-        Tasks.resolve_tool_request(
+        tool_result_fixture(
           scope,
           task_id,
           %{id: "tc-read", name: "read_file"},

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -793,7 +793,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       {:ok, socket: socket, task_id: task_id}
     end
 
-    test "channel receives tool call interactions via PubSub broadcast", %{
+    test "recorded tool calls are displayed without dispatching them", %{
       socket: _socket,
       task_id: task_id
     } do
@@ -806,10 +806,11 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         interaction_event(tool_call, 1)
       )
 
-      assert_push("mcp:message", %{
-        "method" => "tools/call",
-        "params" => %{"name" => "testTool"}
+      assert_push("acp:message", %{
+        "params" => %{"update" => %{"sessionUpdate" => "tool_call", "title" => "testTool"}}
       })
+
+      refute_push("mcp:message", %{"method" => "tools/call"})
     end
 
     test "channel does NOT receive broadcasts to different topics", %{
@@ -827,7 +828,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         interaction_event(tool_call, 1)
       )
 
-      refute_push("mcp:message", %{"params" => %{"name" => "otherTool"}})
+      refute_push("acp:message", %{"params" => %{"update" => %{"title" => "otherTool"}}})
 
       tool_call2 = %{
         tool_call
@@ -841,9 +842,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
         interaction_event(tool_call2, 1)
       )
 
-      assert_push("mcp:message", %{
-        "method" => "tools/call",
-        "params" => %{"name" => "ownTool"}
+      assert_push("acp:message", %{
+        "params" => %{"update" => %{"sessionUpdate" => "tool_call", "title" => "ownTool"}}
       })
     end
 

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -78,7 +78,7 @@ defmodule AgentClientProtocol.HistoryTest do
     assert tool_result["toolCallId"] == "call"
   end
 
-  test "replays embedded-only calls without malformed raw input" do
+  test "replays canonical calls without malformed raw input" do
     rows = [
       row("turn-row", 1, turn("turn-id", [])),
       row(
@@ -91,6 +91,8 @@ defmodule AgentClientProtocol.HistoryTest do
           ]
         })
       ),
+      row("valid-tool", 1, tool_call("valid-call", "todo_write", %{"todos" => []})),
+      row("invalid-tool", 1, tool_call("call", "todo_write", nil)),
       row(
         "tool-result",
         1,

--- a/apps/frontman_server/test/support/fixtures/tasks.ex
+++ b/apps/frontman_server/test/support/fixtures/tasks.ex
@@ -79,19 +79,38 @@ defmodule FrontmanServer.Test.Fixtures.Tasks do
       arguments: Jason.encode!(tool_call.arguments)
     }
 
-    Tasks.request_client_tool(scope, task_id, turn_number, swarm_tool_call)
+    persist_response_tool_call_fixture(scope, task_id, turn_number, nil, swarm_tool_call)
   end
 
   @doc "Persist an agent response and its matching client-handled tool call."
   def persist_response_tool_call_fixture(scope, task_id, turn_number, content, tool_call) do
+    {:ok, _response} =
+      declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call], content)
+
+    Tasks.start_tool_call(scope, task_id, turn_number, tool_call.id, :mcp)
+  end
+
+  def declare_tool_calls_fixture(scope, task_id, turn_number, tool_calls, content \\ nil) do
     metadata = %{
-      "tool_calls" => [
-        %{"id" => tool_call.id, "name" => tool_call.name, "arguments" => tool_call.arguments}
-      ]
+      "tool_calls" =>
+        Enum.map(tool_calls, fn call ->
+          %{"id" => call.id, "name" => call.name, "arguments" => call.arguments}
+        end)
     }
 
-    {:ok, _response} = Tasks.agent_replied(scope, task_id, turn_number, content, metadata)
-    Tasks.request_client_tool(scope, task_id, turn_number, tool_call)
+    Tasks.agent_replied(scope, task_id, turn_number, content, metadata)
+  end
+
+  def tool_result_fixture(scope, task_id, call, result, turn_number: turn_number) do
+    declaration = %SwarmAi.ToolCall{id: call.id, name: call.name, arguments: "{}"}
+    {:ok, _} = declare_tool_calls_fixture(scope, task_id, turn_number, [declaration])
+    Tasks.resolve_tool_request(scope, task_id, call, result, turn_number: turn_number)
+  end
+
+  def start_client_tool_fixture(scope, task_id, turn_number, tool_call) do
+    with {:ok, _response} <- declare_tool_calls_fixture(scope, task_id, turn_number, [tool_call]) do
+      Tasks.start_tool_call(scope, task_id, turn_number, tool_call.id, :mcp)
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Prerequisite for `refactor/wait-server`, implemented directly on `main`. No commits from the wait-server branch are included.

Every backend, client, unavailable, and malformed tool call now follows the same persistence model:

```text
AgentResponse(tool declaration) → ToolCall → ToolResult(success or error)
```

- Insert responses and all declared calls in one transaction, before execution. Enforce call identity by task, turn, and call ID.
- Normalize arguments at persistence. Keep original arguments in response metadata. Invalid arguments produce a canonical call with `nil` input, followed by an execution error.
- Separate recording a call from starting it. Persist the execution target when execution starts. Register client executors before publishing the dispatch-ready event.
- Dispatch only unresolved calls that started on the MCP target. Recording a call does not start it, including later calls in serial execution.
- Read canonical call rows for ACP replay and unresolved-call queries. Delete embedded-call reconstruction, replay deduplication, duplicate argument parsing, and name-based target inference.
- Backfill missing historical calls while preserving existing records and their relative order. Preserve existing client dispatches. Backfill legacy result-only records before their results.
- Preserve main's timeout/pause policies. This PR does not include the interactive-wait redesign.

## Deployment blocker — draft

**The first rollout requires a maintenance cutover. Do not merge into the normal blue/green deployment without coordinating it.**

`infra/production/deploy.sh` runs migrations before it stops the old slot. An old server can therefore write declaration-only history after this backfill. A database lock during the migration does not prevent those later writes.

Stop old writers before the migration. Start the new release before restoring traffic. Rollout and rollback requirements are documented in `apps/frontman_server/README.md`. This PR does not change deployment policy or run any production migration.

## Size

Runtime code in `apps/frontman_server/lib`: **175 added, 211 deleted — 36 fewer lines**.

The complete PR grows because it includes the data migration, regression tests, documentation, and a changeset. The line reduction is in runtime code, not the complete diff.

## Verification

```bash
MIX_TEST_DB_SUFFIX=_canonical_tool_calls make -C apps/frontman_server format precommit strict-compile
make check-source-comments
```

- 897 server tests passed.
- Development and test compilation passed with warnings as errors.
- Formatting and strict Credo passed.
- Source-comment checks and their 30 tests passed.
- Git commit hooks passed without bypasses.

New coverage includes transaction rollback, per-turn identity, malformed backend/client calls, resolved-call start rejection, restart before dispatch, canonical result requirements, replay, historical ordering, legacy argument formats, and result-only backfill.

The original `refactor/wait-server` worktree remains unchanged.
