### PR TITLE
Redact Astro session driver credentials

### DIFF
--- a/.changeset/metal-terms-rest.md
+++ b/.changeset/metal-terms-rest.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/astro": patch
+---
+
+Redact session driver credentials from the resolved Astro config tool output.

--- a/libs/frontman-astro/src/tools/resolved-astro-config.mjs
+++ b/libs/frontman-astro/src/tools/resolved-astro-config.mjs
@@ -77,10 +77,21 @@ function sanitizeSession(session) {
   if (!isPlainObject(session)) return undefined
 
   const out = {}
-  for (const key of ["driver", "ttl", "cookie"]) {
+  for (const key of ["ttl", "cookie"]) {
     const value = jsonSafe(session[key])
     if (value !== undefined) out[key] = value
   }
+
+  if (typeof session.driver === "string") {
+    out.driver = session.driver
+  } else if (isPlainObject(session.driver)) {
+    const driver = {}
+    const entrypoint = jsonSafe(session.driver.entrypoint)
+    if (entrypoint !== undefined) driver.entrypoint = entrypoint
+    if (session.driver.config !== undefined) driver.config = "redacted"
+    if (Object.keys(driver).length) out.driver = driver
+  }
+
   return Object.keys(out).length ? out : undefined
 }
 

--- a/libs/frontman-astro/test/resolved-astro-config.test.mjs
+++ b/libs/frontman-astro/test/resolved-astro-config.test.mjs
@@ -2,6 +2,39 @@ import { describe, expect, test } from "vitest"
 import { sanitizeResolvedAstroConfig } from "../src/tools/resolved-astro-config.mjs"
 
 describe("sanitizeResolvedAstroConfig", () => {
+  test.each([
+    ["redis", "redis"],
+    [
+      { entrypoint: "unstorage/drivers/redis", config: { url: "redis://user:secret@localhost" } },
+      { entrypoint: "unstorage/drivers/redis", config: "redacted" },
+    ],
+    [
+      { entrypoint: new URL("file:///app/session-driver.mjs"), config: { token: "secret" } },
+      { entrypoint: "file:///app/session-driver.mjs", config: "redacted" },
+    ],
+    [{ entrypoint: "unstorage/drivers/memory" }, { entrypoint: "unstorage/drivers/memory" }],
+  ])("sanitizes session driver %j", (driver, expectedDriver) => {
+    const sanitized = sanitizeResolvedAstroConfig({
+      astroVersion: "7.1.6",
+      buildOutput: "server",
+      config: {
+        session: {
+          driver,
+          options: { password: "secret" },
+          ttl: 3600,
+          cookie: { name: "session", secure: true },
+        },
+      },
+    })
+
+    expect(sanitized.session).toEqual({
+      driver: expectedDriver,
+      ttl: 3600,
+      cookie: { name: "session", secure: true },
+    })
+    expect(JSON.stringify(sanitized)).not.toContain("secret")
+  })
+
   test("redacts image service config and surfaces serialization errors", () => {
     const sanitized = sanitizeResolvedAstroConfig({
       astroVersion: "5.18.0",


### PR DESCRIPTION
## Summary
- Redact session driver configuration from the resolved Astro config tool output.
- Preserve string drivers, driver entrypoints, session TTL, and cookie metadata.
- Add tests for string drivers, object drivers, and URL entrypoints.

## Validation
- Astro suite: 73 tests passed with `make -C libs/frontman-astro -o build test` in the original checkout.
- This test run used existing build artifacts.
- Source-comment and whitespace checks passed.