### PR TITLE
Add Pi to the mise development toolchain

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,7 @@ mkcert="1.4.4"
 "npm:@biomejs/biome"="latest"
 "npm:typescript-language-server" = "latest"
 lefthook="latest"
+pi = "latest"
 
 [env]
 MIX_OS_DEPS_COMPILE_PARTITION_COUNT = "1"


### PR DESCRIPTION
## Summary
Add `pi = "latest"` to the shared mise tool list.

## Validation
- Source-comment and whitespace checks passed.
- No application code changed. Tool installation was not run.

Chore-only change: no changelog entry.