### PR TITLE
Review pending marketing release notes

### DIFF
--- a/.changeset/restore-hero-style-wordpress-copy.md
+++ b/.changeset/restore-hero-style-wordpress-copy.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Restore the original homepage hero typography, badge, CTA layout, and video styling while keeping WordPress-focused content and links to other integrations.

--- a/.changeset/restore-installation-layout.md
+++ b/.changeset/restore-installation-layout.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Restore the original framework tabs and three-step installation layout, including copy controls, with WordPress selected by default.

--- a/.changeset/restore-original-marketing-demo.md
+++ b/.changeset/restore-original-marketing-demo.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Restore the original demo video and thumbnail on the homepage and WordPress page, with click-to-play YouTube loading.

--- a/.changeset/wordpress-default-framework-installations.md
+++ b/.changeset/wordpress-default-framework-installations.md
@@ -1,0 +1,5 @@
+---
+"marketing": patch
+---
+
+Keep WordPress as the default while restoring visible Next.js, Astro, and Vite installation options in the homepage, navigation, and integrations directory.


### PR DESCRIPTION
## Summary
Preserve four local marketing changesets:
- Restore homepage hero styling with WordPress-focused copy.
- Restore the framework tabs and three-step installation layout.
- Restore the original demo video and thumbnail.
- Keep WordPress as the default while retaining other framework installation options.

## Merge blocker
This PR contains release notes only. The corresponding marketing implementation is absent from the local diff. Confirm these entries match shipped changes or add the missing implementation before marking this PR ready.

## Validation
Source-comment and whitespace checks passed. No application code changed.