### PR TITLE
Add provider-neutral WordPress SEO tools for Yoast

### DIFF
--- a/.changeset/add-wordpress-seo-tools.md
+++ b/.changeset/add-wordpress-seo-tools.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Add two provider-neutral WordPress SEO tools for reading and updating Yoast SEO Free 28.4 title and description overrides. Limit the route to tested versions, supported content types, permissions, and installations without detected SEO-plugin conflicts.

--- a/.github/workflows/wordpress-compatibility.yml
+++ b/.github/workflows/wordpress-compatibility.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   wordpress-runtime:
-    name: WordPress ${{ matrix.wordpress }} / PHP ${{ matrix.php }}
+    name: WordPress ${{ matrix.wordpress }} / PHP ${{ matrix.php }} / Yoast ${{ matrix.yoast }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -37,6 +37,12 @@ jobs:
             php: "7.4"
           - wordpress: "7.0.2"
             php: "8.4"
+          - wordpress: "7.0.2"
+            php: "7.4"
+            yoast: "28.4"
+          - wordpress: "7.0.2"
+            php: "8.4"
+            yoast: "28.4"
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -53,4 +59,5 @@ jobs:
         env:
           WORDPRESS_VERSION: ${{ matrix.wordpress }}
           PHP_VERSION: ${{ matrix.php }}
+          YOAST_VERSION: ${{ matrix.yoast }}
         run: bash scripts/test-wordpress-plugin-runtime.sh

--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,7 @@ test-wordpress-core-tools:
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/WooCommerceToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/MutationSnapshotsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/PluginDependenciesTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SeoToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/RouterTest.php
 
 test-wordpress-runtime:

--- a/libs/frontman-wordpress/frontman.php
+++ b/libs/frontman-wordpress/frontman.php
@@ -62,6 +62,7 @@ require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-options.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-templates.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-widgets.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-cache.php';
+require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-seo.php';
 
 /**
  * Main plugin bootstrap.
@@ -76,6 +77,10 @@ function frontman_init(): void {
 	( new Frontman_Tool_Templates() )->register( $tools );
 	( new Frontman_Tool_Widgets() )->register( $tools );
 	( new Frontman_Tool_Cache() )->register( $tools );
+
+	if ( Frontman_Tool_Seo::is_available() ) {
+		( new Frontman_Tool_Seo() )->register( $tools );
+	}
 
 	if ( Frontman_Plugin_Dependencies::is_available( 'elementor/elementor.php', '\Elementor\Plugin' ) ) {
 		require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-elementor-data.php';

--- a/libs/frontman-wordpress/includes/class-frontman-router.php
+++ b/libs/frontman-wordpress/includes/class-frontman-router.php
@@ -285,8 +285,15 @@ class Frontman_Router {
 			return [];
 		}
 
-		$raw  = wp_check_invalid_utf8( $raw, true );
 		$data = json_decode( $raw, true );
+		if ( ! is_array( $data ) ) {
+			$raw  = wp_check_invalid_utf8( $raw, true );
+			$data = json_decode( $raw, true );
+			if ( is_array( $data ) && isset( $data['name'] ) && is_string( $data['name'] )
+				&& in_array( sanitize_key( $data['name'] ), [ 'wp_read_seo', 'wp_update_seo' ], true ) ) {
+				return [];
+			}
+		}
 		return is_array( $data ) ? $this->sanitize_json_body( $data ) : [];
 	}
 
@@ -358,7 +365,6 @@ class Frontman_Router {
 		$body      = $this->read_json_body();
 		$name      = sanitize_key( $body['name'] ?? '' );
 		$raw_input = $body['arguments'] ?? $body['input'] ?? [];
-		$input     = is_array( $raw_input ) ? $this->tools->sanitize_input( $name, $raw_input ) : [];
 
 		if ( empty( $name ) ) {
 			$this->send_sse_tool_result( Frontman_Tools::error_result( 'Missing tool name' ) );
@@ -367,6 +373,7 @@ class Frontman_Router {
 
 		if ( $this->tools->is_wp_tool( $name ) ) {
 			try {
+				$input  = is_array( $raw_input ) ? $this->tools->sanitize_input( $name, $raw_input ) : [];
 				$result = $this->tools->call( $name, $input );
 				$this->send_sse_tool_result( $result );
 			} catch ( \Throwable $e ) {

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -156,6 +156,10 @@ class Frontman_Tools {
 			return $this->sanitize_untyped_array( $input, $name );
 		}
 
+		if ( class_exists( 'Frontman_Tool_Seo' ) && in_array( $name, [ 'wp_read_seo', 'wp_update_seo' ], true ) ) {
+			return Frontman_Tool_Seo::validate_input( $name, $input );
+		}
+
 		$sanitized = $this->sanitize_value_for_schema( $input, $tool->input_schema, $name, '', $tool->preserve_input_strings );
 		return is_array( $sanitized ) ? $sanitized : [];
 	}

--- a/libs/frontman-wordpress/readme.txt
+++ b/libs/frontman-wordpress/readme.txt
@@ -51,6 +51,7 @@ Use Frontman to:
 * Update WooCommerce products and other supported store data
 * Change navigation menus, templates, template parts, and supported widgets
 * Update Additional CSS and allowlisted site settings
+* Read or update supported SEO title and description overrides when a tested provider is available
 * Inspect a page and explain which supported WordPress structure can control it
 
 == How Frontman Works ==
@@ -61,6 +62,16 @@ Frontman then uses WordPress, Elementor, or WooCommerce tools that match the req
 
 Frontman works with WordPress content and structures that its current tools support. Custom themes, custom plugins, hosting controls, and unsupported page builders can require a different workflow.
 
+== Optional SEO Tools ==
+
+`wp_read_seo` reads stored SEO title and description overrides. `wp_update_seo` updates one or both overrides. Yoast SEO Free 28.4 is an optional dependency that Frontman does not install.
+
+The route requires WordPress 6.9 or later. Tests cover WordPress 7.0.2 with PHP 7.4 and 8.4. Premium and active Rank Math, All in One SEO, or The SEO Framework disable these tools. Frontman cannot detect every custom SEO owner.
+
+Supported objects are posts, pages, and editable non-attachment custom post types with an admin interface, including authorized drafts and private content. Revisions, autosaves, attachments, and internal WordPress object types are not supported.
+
+Omitted fields stay unchanged. Empty strings clear overrides and restore Yoast templates or defaults, not necessarily empty rendered tags. Results confirm stored overrides, not rendered HTML or search-engine indexing. Yoast expands variables on later requests. External full-page caches and CDNs have separate refresh behavior.
+
 == Safety, Limits, and Data ==
 
 Only WordPress administrators with the `manage_options` capability can access Frontman. The plugin uses WordPress nonces, sanitizes inputs, and restricts option changes to an allowlist.
@@ -70,6 +81,8 @@ Frontman is early-access software. It has not been tested across every theme, pa
 Start on a staging site. Keep a current backup. Review each change before you use it on a production site.
 
 When you submit a request, relevant site content can pass through Frontman AI to your configured model provider. The Third-Party Services section summarizes this data flow.
+
+During an active, user-requested chat task, SEO tool results can include overrides from authorized drafts and private content. Frontman sends these results to the selected AI provider as request context. Frontman also stores the results in task history. This process uses the existing chat request and consent flow.
 
 == Open Source and Support ==
 
@@ -114,7 +127,7 @@ The hosted service processes your prompts, relevant site or store content, tool 
 This plugin and the hosted Frontman service connect to these external services:
 
 **Frontman Client and API**
-The plugin loads its interface from `app.frontman.sh` and connects to `api.frontman.sh`. Frontman processes prompts, relevant site or store content, tool results, and stored task history to run the agent. Stored provider credentials use server-side encryption.
+The plugin loads its interface from `app.frontman.sh` and connects to `api.frontman.sh`. Frontman processes prompts, relevant site or store content, tool results, and stored task history to run the agent. SEO tool results can include stored title and description overrides from authorized drafts and private content. Stored provider credentials use server-side encryption.
 
 * Services: [Client](https://app.frontman.sh), [API](https://api.frontman.sh)
 * Provider: Frontman AI

--- a/libs/frontman-wordpress/tests/SeoToolsTest.php
+++ b/libs/frontman-wordpress/tests/SeoToolsTest.php
@@ -1,0 +1,35 @@
+<?php
+define( 'ABSPATH', sys_get_temp_dir() . '/frontman-seo-tools/' );
+function __( string $message, string $domain = '' ): string { return $message; }
+require_once __DIR__ . '/../includes/class-frontman-tools.php';
+require_once __DIR__ . '/../tools/class-tool-seo.php';
+$seo   = new Frontman_Tool_Seo();
+$tools = new Frontman_Tools();
+$seo->register( $tools );
+$valid = [ 'id' => 7, 'title' => "  Café %%title%% \\ \"quoted\"  ", 'description' => '' ];
+if ( $valid !== $tools->sanitize_input( 'wp_update_seo', $valid ) ) {
+	throw new RuntimeException( 'Valid raw SEO input changed before the handler.' );
+}
+
+$invalid = [
+	[ 'wp_read_seo', [ 'id' => '7' ] ],
+	[ 'wp_read_seo', [ 'id' => 0 ] ],
+	[ 'wp_update_seo', [ 'id' => 7 ] ],
+	[ 'wp_update_seo', [ 'id' => 7, 'title' => null ] ],
+	[ 'wp_update_seo', [ 'id' => 7, 'title' => "bad\xC3\x28" ] ],
+	[ 'wp_update_seo', [ 'id' => 7, 'title' => 'safe', 'meta_key' => '_danger' ] ],
+];
+foreach ( $invalid as [ $name, $input ] ) {
+	try {
+		$tools->sanitize_input( $name, $input );
+		throw new RuntimeException( 'Invalid raw SEO input was accepted.' );
+	} catch ( Frontman_Tool_Error $error ) {
+		continue;
+	}
+}
+try {
+	$seo->read_seo( [ 'id' => '7' ] );
+	throw new RuntimeException( 'Direct SEO input was coerced.' );
+} catch ( Frontman_Tool_Error $error ) {
+	fwrite( STDOUT, "OK (8 assertions)\n" );
+}

--- a/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
+++ b/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
@@ -12,6 +12,16 @@ set_error_handler(
 require '/var/www/html/wp-load.php';
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+$yoast = getenv( 'EXPECTED_YOAST_VERSION' );
+if ( false !== $yoast && '' !== $yoast ) {
+	if ( $yoast !== get_plugin_data( WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php', false, false )['Version'] ) {
+		throw new RuntimeException( 'Installed Yoast version does not match the verified package.' );
+	}
+	$result = activate_plugin( 'wordpress-seo/wp-seo.php' );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( $result->get_error_message() );
+	}
+}
 $result = activate_plugin( 'frontman-agentic-ai-editor/frontman.php' );
 if ( is_wp_error( $result ) ) {
 	throw new RuntimeException( $result->get_error_message() );

--- a/libs/frontman-wordpress/tests/integration/SeoRuntimeFixture.php
+++ b/libs/frontman-wordpress/tests/integration/SeoRuntimeFixture.php
@@ -1,0 +1,42 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+$frontman_seo_test = sanitize_key( wp_unslash( $_SERVER['HTTP_X_FRONTMAN_SEO_TEST'] ?? '' ) );
+add_filter( 'redirect_canonical', static fn( $redirect ) => 'render' === $frontman_seo_test ? false : $redirect );
+add_action( 'init', static function (): void {
+	register_post_type( 'frontman_seo_item', [
+		'public'   => true,
+		'show_ui'  => true,
+		'supports' => [ 'title', 'editor', 'excerpt', 'custom-fields' ],
+	] );
+} );
+add_filter( 'map_meta_cap', static function ( array $caps, string $cap ) use ( $frontman_seo_test ): array {
+	if ( ( 'deny-object' === $frontman_seo_test && 'edit_post' === $cap ) || ( 'deny-meta' === $frontman_seo_test && 'edit_post_meta' === $cap ) ) {
+		return [ 'do_not_allow' ];
+	}
+	return $caps;
+}, PHP_INT_MAX, 2 );
+add_filter( 'wpseo_sanitize_post_meta__yoast_wpseo_title', static function ( string $value ): string {
+	return $value . ' [runtime-filter]';
+} );
+add_filter( 'wpseo_sanitize_post_meta__yoast_wpseo_metadesc', static function ( string $value ) use ( $frontman_seo_test ): string {
+	if ( 'fail-sanitizer' === $frontman_seo_test ) {
+		throw new RuntimeException( 'Injected sanitizer failure.' );
+	}
+	return $value;
+} );
+add_filter( 'update_post_metadata', static function ( $check, int $id, string $key ) use ( $frontman_seo_test ) {
+	if ( 'silent-title' === $frontman_seo_test && '_yoast_wpseo_title' === $key ) {
+		return true;
+	}
+	return 'fail-write' === $frontman_seo_test && '_yoast_wpseo_metadesc' === $key ? false : $check;
+}, PHP_INT_MAX, 3 );
+add_filter( 'get_post_metadata', static function ( $value, int $id, string $key ) use ( $frontman_seo_test ) {
+	global $wpdb;
+	if ( 'fail-read' === $frontman_seo_test && '' === $key
+		&& $wpdb->get_var( $wpdb->prepare( "SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_yoast_wpseo_title'", $id ) ) ) {
+		throw new RuntimeException( 'Injected read-back failure.' );
+	}
+	return $value;
+}, PHP_INT_MAX, 3 );

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -10,6 +10,39 @@ function frontman_runtime_assert( bool $condition, string $message ): void {
 	}
 }
 
+function frontman_runtime_http( string $method, string $path, string $cookie = '', ?string $nonce = null, ?string $body = null, string $test = '' ): array {
+	$headers = [ 'Host: frontman-runtime.example.test' ];
+	$headers[] = '' === $test ? '' : 'X-Frontman-Seo-Test: ' . $test;
+	if ( '' !== $cookie ) {
+		$headers[] = 'Cookie: ' . LOGGED_IN_COOKIE . '=' . $cookie;
+	}
+	if ( null !== $nonce ) {
+		$headers[] = 'X-WP-Nonce: ' . $nonce;
+	}
+	$response = file_get_contents(
+		'http://127.0.0.1' . $path,
+		false,
+		stream_context_create( [ 'http' => [
+			'content' => $body ?? '',
+			'header' => implode( "\r\n", array_filter( $headers ) ) . "\r\nContent-Type: application/json\r\n",
+			'ignore_errors' => true, 'follow_location' => 0,
+			'method' => $method,
+		] ] )
+	);
+	preg_match_all( '/^HTTP\/\S+\s+(\d{3})/m', implode( "\n", $http_response_header ?? [] ), $status );
+	preg_match( '/<title[^>]*>(.*?)<\/title>/is', (string) $response, $title );
+	preg_match( "~<meta\\s+[^>]*name=[\"']description[\"'][^>]*content=([\"'])(.*?)\\1[^>]*>~is", (string) $response, $description );
+	return [ 'body' => (string) $response, 'status' => (int) ( end( $status[1] ) ?: 0 ), 'title' => isset( $title[1] ) ? html_entity_decode( trim( wp_strip_all_tags( $title[1] ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : null, 'description' => isset( $description[2] ) ? html_entity_decode( $description[2], ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : null ];
+}
+function frontman_runtime_tool( string $cookie, ?string $nonce, array $request, ?string $raw = null, string $test = '' ): array {
+	$response = frontman_runtime_http( 'POST', '/index.php/frontman/tools/call', $cookie, $nonce, $raw ?? wp_json_encode( $request ), $test );
+	if ( 200 !== $response['status'] ) {
+		return $response;
+	}
+	frontman_runtime_assert( 1 === preg_match( '/^data: (.+)$/m', $response['body'], $match ), 'Tool response contained no SSE data event.' );
+	return [ 'body' => json_decode( $match[1], true, 512, JSON_THROW_ON_ERROR ), 'status' => 200 ];
+}
+
 $expected_wordpress_version = getenv( 'EXPECTED_WORDPRESS_VERSION' );
 frontman_runtime_assert( false !== $expected_wordpress_version, 'Expected WordPress version was not provided.' );
 frontman_runtime_assert( $expected_wordpress_version === get_bloginfo( 'version' ), 'Runtime WordPress version does not match the requested version.' );
@@ -125,3 +158,104 @@ frontman_runtime_assert( 1 <= count( $menu_tool->list_navigation_menus( [] ) ), 
 $deleted = $menu_tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => true ] );
 frontman_runtime_assert( 'Updated Runtime Navigation' === $deleted['before']['title'], 'Navigation deletion did not preserve its snapshot.' );
 frontman_runtime_assert( null === get_post( $created['id'] ), 'Navigation tool did not permanently delete the post.' );
+$yoast = getenv( 'EXPECTED_YOAST_VERSION' );
+if ( false === $yoast || '' === $yoast ) {
+	frontman_runtime_assert( null === Frontman_Tools::instance()->get( 'wp_read_seo' ), 'SEO tools were registered without Yoast.' );
+	return;
+}
+frontman_runtime_assert( defined( 'WPSEO_VERSION' ) && $yoast === WPSEO_VERSION, 'Loaded Yoast version differs from the verified package.' );
+$runtime_permalink = get_option( 'permalink_structure' );
+$wp_rewrite->set_permalink_structure( '' );
+wp_set_current_user( $admin->ID );
+$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
+$nonce = Frontman_Auth::create_nonce();
+unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+wp_set_current_user( 0 );
+$catalog   = json_decode( frontman_runtime_http( 'GET', '/index.php/frontman/tools', $cookie )['body'], true, 512, JSON_THROW_ON_ERROR );
+$seo_names = array_values( array_filter( array_column( $catalog['tools'], 'name' ), static fn( string $name ): bool => false !== strpos( $name, 'seo' ) || false !== strpos( $name, 'yoast' ) ) );
+frontman_runtime_assert( [ 'wp_read_seo', 'wp_update_seo' ] === $seo_names, 'SEO catalog is not provider-neutral.' );
+$fixtures = [];
+foreach ( [ [ 'post', 'publish' ], [ 'page', 'publish' ], [ 'frontman_seo_item', 'publish' ], [ 'post', 'draft' ], [ 'post', 'private' ] ] as [ $type, $status ] ) {
+	$id = wp_insert_post( [ 'post_type' => $type, 'post_status' => $status, 'post_title' => "Runtime $type $status", 'post_content' => 'Unchanged body' ], true );
+	frontman_runtime_assert( ! is_wp_error( $id ), "Could not create $type/$status SEO fixture." );
+	update_post_meta( $id, '_frontman_runtime_unrelated', 'keep' );
+	$fixtures[] = [ 'id' => $id, 'status' => $status, 'title' => get_the_title( $id ), 'type' => $type ];
+}
+$snapshot = static function ( int $id ) use ( $wpdb ): array {
+	return [
+		'post' => $wpdb->get_row( $wpdb->prepare( "SELECT post_title, post_content, post_status, post_type FROM {$wpdb->posts} WHERE ID = %d", $id ), ARRAY_A ),
+		'unrelated' => $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_frontman_runtime_unrelated'", $id ) ),
+		'options' => $wpdb->get_results( "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name IN ('blogname','blogdescription','wpseo_titles','wpseo_social') ORDER BY option_name", ARRAY_A ),
+		'title' => $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_yoast_wpseo_title'", $id ) ),
+		'description' => $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_yoast_wpseo_metadesc'", $id ) ),
+	];
+};
+$target = $fixtures[0]['id']; $unchanged = $snapshot( $target );
+$valid             = [ 'name' => 'wp_update_seo', 'arguments' => [ 'id' => $target, 'title' => 'Blocked' ] ];
+$subscriber_cookie = wp_generate_auth_cookie( wp_create_user( 'runtime-subscriber', wp_generate_password(), 'runtime-subscriber@example.test' ), time() + HOUR_IN_SECONDS, 'logged_in' );
+$invalid = [
+	frontman_runtime_tool( '', null, $valid ),
+	frontman_runtime_tool( $subscriber_cookie, null, $valid ),
+	frontman_runtime_tool( $cookie, null, $valid ),
+	frontman_runtime_tool( $cookie, 'invalid', $valid ),
+];
+frontman_runtime_assert( [ 401, 403, 403, 403 ] === array_column( $invalid, 'status' ), 'Authentication or nonce checks allowed an SEO mutation.' );
+foreach ( [ [ 'id' => (string) $target, 'title' => 'Bad type' ], [ 'id' => $target, 'title' => 'Bad key', 'meta_key' => '_private' ] ] as $arguments ) {
+	$result = frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_update_seo', 'arguments' => $arguments ] );
+	frontman_runtime_assert( true === $result['body']['isError'], 'Invalid SEO arguments were accepted.' );
+}
+$malformed = frontman_runtime_tool( $cookie, $nonce, [], '{"name":"wp_update_seo","arguments":{"id":' . $target . ',"title":"bad' . "\xC3\x28" . '"}}' );
+frontman_runtime_assert( true === $malformed['body']['isError'], 'Malformed SEO JSON was accepted.' );
+frontman_runtime_assert( $unchanged === $snapshot( $target ), 'Rejected requests changed SQL state.' );
+$failure = [ 'name' => 'wp_update_seo', 'input' => [ 'id' => $target, 'title' => 'Partial', 'description' => 'Description' ] ];
+frontman_runtime_assert( true === frontman_runtime_tool( $cookie, $nonce, $failure, null, 'fail-sanitizer' )['body']['isError'] && $unchanged === $snapshot( $target ), 'Second-field preflight failure wrote state.' );
+$silent = frontman_runtime_tool( $cookie, $nonce, $failure, null, 'silent-title' )['body'];
+frontman_runtime_assert( true === $silent['isError'] && $unchanged === $snapshot( $target ), 'Silent first-write failure wrote state or allowed the next write.' );
+$partial = frontman_runtime_tool( $cookie, $nonce, $failure, null, 'fail-write' )['body']; $partial_state = $snapshot( $target );
+frontman_runtime_assert( true === $partial['isError'] && 'Partial [runtime-filter]' === $partial_state['title'] && null === $partial_state['description'], 'Second-field failure did not preserve only the first write.' );
+frontman_runtime_assert( false !== strpos( $partial['content'][0]['text'], '"before":{"title":"","description":""}' ) && false !== strpos( $partial['content'][0]['text'], '"actualAfter":{"title":"Partial [runtime-filter]","description":""}' ), 'Partial error snapshots are inaccurate.' );
+foreach ( [ 'deny-object', 'deny-meta' ] as $denial ) {
+	$denied = frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_read_seo', 'arguments' => [ 'id' => $target ] ], null, $denial )['body'];
+	frontman_runtime_assert( true === $denied['isError'] && false === strpos( $denied['content'][0]['text'], 'Partial' ) && $partial_state === $snapshot( $target ), 'Denied read disclosed or changed SEO state.' );
+}
+frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_update_seo', 'input' => [ 'id' => $target, 'title' => '' ] ] );
+$read_failure = frontman_runtime_tool( $cookie, $nonce, $failure, null, 'fail-read' )['body']; $read_failure_state = $snapshot( $target );
+frontman_runtime_assert( true === $read_failure['isError'] && 'Partial [runtime-filter]' === $read_failure_state['title'] && null === $read_failure_state['description'], 'Failed first-field read-back allowed the next write: ' . wp_json_encode( $read_failure_state ) );
+frontman_runtime_assert( $unchanged['post'] === $read_failure_state['post'] && $unchanged['unrelated'] === $read_failure_state['unrelated'] && $unchanged['options'] === $read_failure_state['options'], 'Failure paths changed core, unrelated, or option state.' );
+frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_update_seo', 'input' => [ 'id' => $target, 'title' => '' ] ] );
+$safety = static fn( array $state ): array => [ $state['post'], $state['unrelated'], $state['options'] ];
+foreach ( $fixtures as $fixture ) {
+	$id      = $fixture['id'];
+	$request = static fn( array $arguments ): array => frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_update_seo', 'input' => $arguments ] )['body'];
+	$safe    = $safety( $snapshot( $id ) );
+	$read    = frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_read_seo', 'arguments' => [ 'id' => $id ] ] )['body'];
+	$read    = json_decode( $read['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	frontman_runtime_assert( $id === $read['id'] && 'yoast' === $read['provider'] && '' === $read['title'] && '' === $read['description'], 'SEO read contract failed.' );
+	$default = 'publish' === $fixture['status'] ? frontman_runtime_http( 'GET', str_replace( home_url(), '', get_permalink( $id ) ), '', null, null, 'render' ) : null;
+	$updated = json_decode( $request( [ 'id' => $id, 'description' => 'Runtime “Café” \\ path' ] )['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	$updated = json_decode( $request( [ 'id' => $id, 'title' => 'SEO %%title%% — "Café" \\ path' ] )['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	frontman_runtime_assert( 'SEO %%title%% — "Café" \\ path [runtime-filter]' === $updated['after']['title'] && 'Runtime “Café” \\ path' === $updated['after']['description'], 'Title-only update changed the seeded description or skipped custom sanitization.' );
+	$readback = json_decode( frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_read_seo', 'arguments' => [ 'id' => $id ] ] )['body']['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	frontman_runtime_assert( $updated['after'] === [ 'title' => $readback['title'], 'description' => $readback['description'] ], 'Quotes, slashes, or Unicode changed on persisted read-back.' );
+	frontman_runtime_assert( $safe === $safety( $snapshot( $id ) ), 'Successful SEO update changed core, unrelated, or option SQL state.' );
+	$repeat = json_decode( $request( [ 'id' => $id, 'title' => 'SEO %%title%% — "Café" \\ path', 'description' => 'Runtime “Café” \\ path' ] )['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	frontman_runtime_assert( false === $repeat['changed'], 'Repeated SEO update was not idempotent.' );
+	if ( 'publish' === $fixture['status'] ) {
+		$html = frontman_runtime_http( 'GET', str_replace( home_url(), '', get_permalink( $id ) ), '', null, null, 'render' );
+		frontman_runtime_assert( false !== strpos( $html['title'], 'SEO ' . $fixture['title'] . ' — "Café"' ), 'A later request did not render the SEO title tag for ' . $fixture['type'] . '/' . $fixture['status'] . ': ' . var_export( $html['title'], true ) );
+		frontman_runtime_assert( false !== strpos( $html['description'], 'Runtime “Café”' ), 'A later request did not render the SEO description meta tag.' );
+	} else {
+		$restricted = frontman_runtime_http( 'GET', str_replace( home_url(), '', get_permalink( $id ) ), '', null, null, 'render' );
+		frontman_runtime_assert( 404 === $restricted['status'] && false === strpos( $restricted['body'], 'Café' ) && false === strpos( $restricted['body'], '\\ path' ), 'Restricted SEO data rendered anonymously.' );
+	}
+	$cleared = json_decode( $request( [ 'id' => $id, 'title' => '', 'description' => '' ] )['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	$repeat  = json_decode( $request( [ 'id' => $id, 'title' => '', 'description' => '' ] )['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	frontman_runtime_assert( [ 'title' => '', 'description' => '' ] === $cleared['after'] && false === $repeat['changed'], 'SEO clear or repeated clear failed.' );
+	frontman_runtime_assert( $safe === $safety( $snapshot( $id ) ), 'SEO clear changed core, unrelated, or option SQL state.' );
+	if ( 'publish' === $fixture['status'] ) {
+		$default_after_clear = frontman_runtime_http( 'GET', str_replace( home_url(), '', get_permalink( $id ) ), '', null, null, 'render' );
+		frontman_runtime_assert( $default['title'] === $default_after_clear['title'] && null === $default_after_clear['description'], 'Clearing did not restore later rendered defaults: ' . wp_json_encode( [ 'before' => [ $default['title'], $default['description'] ], 'after' => [ $default_after_clear['title'], $default_after_clear['description'] ] ] ) );
+	}
+}
+$wp_rewrite->set_permalink_structure( $runtime_permalink );
+fwrite( STDOUT, "Yoast $yoast HTTP SEO checks passed.\n" );

--- a/libs/frontman-wordpress/tools/class-tool-seo.php
+++ b/libs/frontman-wordpress/tools/class-tool-seo.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Provider-neutral SEO tools for the tested Yoast route.
+ * @package Frontman
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Frontman_Tool_Seo {
+	private const YOAST = 'wordpress-seo/wp-seo.php';
+	private const META = [ 'title' => '_yoast_wpseo_title', 'description' => '_yoast_wpseo_metadesc' ];
+	public function register( Frontman_Tools $tools ): void {
+		$schema = [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [ 'id' => [ 'type' => 'integer', 'description' => 'Post, page, or custom post type ID.' ] ],
+			'required'             => [ 'id' ],
+		];
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_read_seo',
+			'Reads stored SEO title and description overrides for an editable post.',
+			$schema,
+			[ $this, 'read_seo' ],
+			'read'
+		) );
+		$schema['properties'] += [
+			'title'       => [ 'type' => 'string', 'description' => 'SEO title override.' ],
+			'description' => [ 'type' => 'string', 'description' => 'SEO description override.' ],
+		];
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_update_seo',
+			'Updates SEO overrides. Omitted fields stay unchanged; empty strings restore provider defaults.',
+			$schema,
+			[ $this, 'update_seo' ],
+			'read-write'
+		) );
+	}
+	public static function is_available(): bool {
+		global $wp_version;
+		if ( ! Frontman_Plugin_Dependencies::is_available( self::YOAST )
+			|| Frontman_Plugin_Dependencies::is_available( 'wordpress-seo-premium/wp-seo-premium.php' )
+			|| Frontman_Plugin_Dependencies::is_available( 'seo-by-rank-math/rank-math.php', 'RankMath' )
+			|| Frontman_Plugin_Dependencies::is_available( 'all-in-one-seo-pack/all_in_one_seo_pack.php' ) || function_exists( 'aioseo' )
+			|| Frontman_Plugin_Dependencies::is_available( 'all-in-one-seo-pack-pro/all_in_one_seo_pack.php' )
+			|| Frontman_Plugin_Dependencies::is_available( 'autodescription/autodescription.php' ) || defined( 'THE_SEO_FRAMEWORK_VERSION' )
+			|| ! defined( 'WPSEO_VERSION' ) || '28.4' !== WPSEO_VERSION
+			|| ! isset( $wp_version ) || version_compare( (string) $wp_version, '6.9', '<' )
+			|| did_action( 'wpseo_loaded' ) < 1 || ! function_exists( 'sanitize_meta' ) ) {
+			return false;
+		}
+		foreach ( [ 'get_value', 'set_value', 'delete', 'sanitize_post_meta' ] as $method ) {
+			if ( ! is_callable( [ 'WPSEO_Meta', $method ] ) ) {
+				return false;
+			}
+		}
+		$registered = get_registered_meta_keys( 'post' );
+		foreach ( self::META as $meta_key ) {
+			if ( ! is_callable( $registered[ $meta_key ]['sanitize_callback'] ?? null )
+				|| false === has_filter( 'sanitize_post_meta_' . $meta_key, [ 'WPSEO_Meta', 'sanitize_post_meta' ] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+	public static function validate_input( string $tool, array $input ): array {
+		$allowed = 'wp_read_seo' === $tool ? [ 'id' ] : [ 'id', 'title', 'description' ];
+		if ( ! in_array( $tool, [ 'wp_read_seo', 'wp_update_seo' ], true ) || array_diff( array_keys( $input ), $allowed ) ) {
+			throw new Frontman_Tool_Error( __( 'Invalid SEO tool input.', 'frontman-agentic-ai-editor' ) );
+		}
+		if ( ! isset( $input['id'] ) || ! is_int( $input['id'] ) || $input['id'] < 1 ) {
+			throw new Frontman_Tool_Error( __( 'id must be a positive integer.', 'frontman-agentic-ai-editor' ) );
+		}
+		foreach ( [ 'title', 'description' ] as $field ) {
+			if ( array_key_exists( $field, $input ) && ( ! is_string( $input[ $field ] ) || 1 !== preg_match( '//u', $input[ $field ] ) ) ) {
+				throw new Frontman_Tool_Error( __( 'SEO values must be valid UTF-8 strings.', 'frontman-agentic-ai-editor' ) );
+			}
+		}
+		if ( 'wp_update_seo' === $tool && ! array_key_exists( 'title', $input ) && ! array_key_exists( 'description', $input ) ) {
+			throw new Frontman_Tool_Error( __( 'Provide title or description.', 'frontman-agentic-ai-editor' ) );
+		}
+		return $input;
+	}
+	public function read_seo( array $input ): array {
+		$input = self::validate_input( 'wp_read_seo', $input );
+		$this->guard( $input['id'] );
+		return [ 'id' => $input['id'], 'provider' => 'yoast' ] + $this->snapshot( $input['id'] );
+	}
+	public function update_seo( array $input ): array {
+		$input     = self::validate_input( 'wp_update_seo', $input );
+		$post_type = $this->guard( $input['id'] );
+		$before    = $this->snapshot( $input['id'] );
+		$expected  = [];
+		try {
+			foreach ( self::META as $field => $meta_key ) {
+				if ( array_key_exists( $field, $input ) ) {
+					$expected[ $field ] = '' === $input[ $field ] ? '' : sanitize_meta( $meta_key, $input[ $field ], 'post', $post_type );
+					if ( ! is_string( $expected[ $field ] ) || 1 !== preg_match( '//u', $expected[ $field ] ) ) {
+						throw new \UnexpectedValueException();
+					}
+				}
+			}
+		} catch ( \Throwable $error ) {
+			throw new Frontman_Tool_Error( __( 'Yoast could not sanitize the SEO value.', 'frontman-agentic-ai-editor' ) );
+		}
+		$wanted = array_replace( $before, $expected );
+		$after  = $before;
+		foreach ( self::META as $field => $meta_key ) {
+			if ( ! array_key_exists( $field, $expected ) ) {
+				continue;
+			}
+			$key = 'description' === $field ? 'metadesc' : 'title';
+			try {
+				if ( '' === $input[ $field ] ) {
+					\WPSEO_Meta::delete( $key, $input['id'] );
+				} else {
+					\WPSEO_Meta::set_value( $key, $input[ $field ], $input['id'] );
+				}
+				$after = $this->snapshot( $input['id'] );
+			} catch ( \Throwable $error ) {
+				$this->persistence_error( $input['id'], $before, $wanted );
+			}
+			if ( $after[ $field ] !== $expected[ $field ] ) {
+				$this->persistence_error( $input['id'], $before, $wanted );
+			}
+		}
+		try {
+			$after = $this->snapshot( $input['id'] );
+		} catch ( \Throwable $error ) {
+			$this->persistence_error( $input['id'], $before, $wanted );
+		}
+		if ( $after !== $wanted ) {
+			$this->persistence_error( $input['id'], $before, $wanted );
+		}
+		return [
+			'id' => $input['id'], 'provider' => 'yoast',
+			'before' => $before, 'after' => $after, 'changed' => $before !== $after,
+		];
+	}
+	private function guard( int $id ): string {
+		if ( defined( 'WPSEO_VERSION' ) && '28.4' !== WPSEO_VERSION ) {
+			throw new Frontman_Tool_Error( sprintf(
+				/** translators: %s: installed Yoast SEO version. */
+				__( 'Unsupported Yoast SEO version %s; expected 28.4.', 'frontman-agentic-ai-editor' ),
+				(string) WPSEO_VERSION
+			) );
+		}
+		if ( ! self::is_available() ) {
+			throw new Frontman_Tool_Error( __( 'Yoast SEO Free 28.4 is unavailable or conflicts with another SEO plugin.', 'frontman-agentic-ai-editor' ) );
+		}
+		$post = get_post( $id );
+		$type = $post ? get_post_type_object( $post->post_type ) : null;
+		if ( ! $post || wp_is_post_revision( $id ) || wp_is_post_autosave( $id )
+			|| ( ! in_array( $post->post_type, [ 'post', 'page' ], true )
+				&& ( 'attachment' === $post->post_type || ! $type || ! empty( $type->_builtin ) || empty( $type->show_ui ) ) ) ) {
+			throw new Frontman_Tool_Error( __( 'SEO overrides are not available for this object.', 'frontman-agentic-ai-editor' ) );
+		}
+		if ( ! current_user_can( 'edit_post', $id ) ) {
+			throw new Frontman_Tool_Error( __( 'You cannot edit this post.', 'frontman-agentic-ai-editor' ) );
+		}
+		foreach ( self::META as $meta_key ) {
+			if ( ! current_user_can( 'edit_post_meta', $id, $meta_key ) ) {
+				throw new Frontman_Tool_Error( __( 'You cannot edit this post SEO metadata.', 'frontman-agentic-ai-editor' ) );
+			}
+		}
+		return $post->post_type;
+	}
+	private function snapshot( int $id ): array {
+		try {
+			$title       = \WPSEO_Meta::get_value( 'title', $id );
+			$description = \WPSEO_Meta::get_value( 'metadesc', $id );
+		} catch ( \Throwable $error ) {
+			throw new Frontman_Tool_Error( __( 'Yoast could not read the stored SEO overrides.', 'frontman-agentic-ai-editor' ) );
+		}
+		if ( ! is_string( $title ) || ! is_string( $description )
+			|| 1 !== preg_match( '//u', $title ) || 1 !== preg_match( '//u', $description ) ) {
+			throw new Frontman_Tool_Error( __( 'Yoast returned invalid SEO overrides.', 'frontman-agentic-ai-editor' ) );
+		}
+		return [ 'title' => $title, 'description' => $description ];
+	}
+	private function persistence_error( int $id, array $before, array $wanted ): void {
+		try {
+			$actual = $this->snapshot( $id );
+			$status = $actual === $before ? 'failed' : 'partial';
+		} catch ( \Throwable $error ) {
+			$actual = null;
+			$status = 'uncertain';
+		}
+		$state = wp_json_encode( [
+			'id' => $id, 'provider' => 'yoast', 'status' => $status,
+			'before' => $before, 'expectedAfter' => $wanted, 'actualAfter' => $actual,
+		] );
+		throw new Frontman_Tool_Error( __( 'SEO update failed. Update state: ', 'frontman-agentic-ai-editor' ) . $state );
+	}
+}

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -6,6 +6,8 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 RUNTIME="${CONTAINER_RUNTIME:-docker}"
 WORDPRESS_VERSION="${WORDPRESS_VERSION:-7.0.2}"
 PHP_VERSION="${PHP_VERSION:-8.4}"
+YOAST_VERSION="${YOAST_VERSION:-}"
+YOAST_SHA256="93eba5afc65149967a4bb4906bc8fdebf92f4a65ee02bec97f5c01a7e14e7028"
 PLUGIN_VERSION="$(bash "$ROOT_DIR/scripts/validate-wordpress-plugin-release.sh")"
 RUN_ID="frontman-wp-runtime-$$"
 NETWORK="${RUN_ID}-network"
@@ -24,6 +26,16 @@ trap cleanup EXIT
 
 make -C "$ROOT_DIR" package-wordpress-plugin VERSION="$PLUGIN_VERSION" >/dev/null
 curl -fsSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz" -o "$BUILD_DIR/wordpress.tar.gz"
+if [[ -n "$YOAST_VERSION" ]]; then
+  if [[ "$YOAST_VERSION" != "28.4" ]]; then
+    printf 'Unsupported Yoast runtime test version: %s\n' "$YOAST_VERSION" >&2
+    exit 1
+  fi
+  curl -fsSL "https://downloads.wordpress.org/plugin/wordpress-seo.${YOAST_VERSION}.zip" -o "$BUILD_DIR/wordpress-seo.zip"
+  printf '%s  %s\n' "$YOAST_SHA256" "$BUILD_DIR/wordpress-seo.zip" | sha256sum --check --status
+  unzip -q "$BUILD_DIR/wordpress-seo.zip" -d "$BUILD_DIR/yoast"
+  printf 'Verified official Yoast SEO %s package (SHA-256 %s)\n' "$YOAST_VERSION" "$YOAST_SHA256"
+fi
 "$RUNTIME" build \
   --build-arg PHP_VERSION="$PHP_VERSION" \
   -f "$ROOT_DIR/libs/frontman-wordpress/tests/integration/Dockerfile" \
@@ -60,16 +72,25 @@ done
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php" "$WORDPRESS:/tmp/CustomCssRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php" "$WORDPRESS:/tmp/RunWordPressRuntimeTest.php"
+if [[ -n "$YOAST_VERSION" ]]; then
+  "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/mu-plugins /var/www/html/wp-content/plugins/wordpress-seo
+  "$RUNTIME" cp "$BUILD_DIR/yoast/wordpress-seo/." "$WORDPRESS:/var/www/html/wp-content/plugins/wordpress-seo/"
+  "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/SeoRuntimeFixture.php" "$WORDPRESS:/var/www/html/wp-content/mu-plugins/frontman-seo-runtime.php"
+fi
 
 "$RUNTIME" exec "$WORDPRESS" php -r 'define("WP_INSTALLING", true); define("WP_SITEURL", "http://frontman-runtime.example.test"); require "/var/www/html/wp-load.php"; require_once ABSPATH . "wp-admin/includes/upgrade.php"; if (!is_blog_installed()) { wp_install("Frontman Runtime", "admin", "admin@example.test", true, "", "frontman-runtime-password"); }'
 "$RUNTIME" exec "$WORDPRESS" php -r '$db = new mysqli(getenv("WORDPRESS_DB_HOST"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_NAME")); $result = $db->query("SELECT option_value FROM wp_options WHERE option_name = '\''siteurl'\''"); $row = $result ? $result->fetch_row() : false; if (!$row || !$row[0]) { throw new RuntimeException("WordPress installation did not persist a site URL."); }'
-"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/ActivateWordPressPlugin.php
-TEST_OUTPUT="$("$RUNTIME" exec \
+"$RUNTIME" exec -e EXPECTED_YOAST_VERSION="$YOAST_VERSION" "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/ActivateWordPressPlugin.php
+if TEST_OUTPUT="$("$RUNTIME" exec \
   -e EXPECTED_WORDPRESS_VERSION="$WORDPRESS_VERSION" \
+  -e EXPECTED_YOAST_VERSION="$YOAST_VERSION" \
   "$WORDPRESS" \
-  php -d display_errors=1 -d error_reporting=E_ALL /tmp/RunWordPressRuntimeTest.php)"
+  php -d display_errors=1 -d error_reporting=E_ALL /tmp/RunWordPressRuntimeTest.php)"; then
+  TEST_STATUS=0
+else TEST_STATUS=$?
+fi
 printf '%s\n' "$TEST_OUTPUT"
-if [[ "$TEST_OUTPUT" != *"OK (WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
+if [[ "$TEST_STATUS" -ne 0 || "$TEST_OUTPUT" != *"OK (WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
   printf 'WordPress runtime tests did not report successful completion.\n' >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Add exactly two provider-neutral tools: `wp_read_seo` and `wp_update_seo`, initially for Yoast SEO Free 28.4.
- Enforce strict raw input, object/metadata capabilities, deterministic availability and conflict checks, and verified persistence with partial-failure reporting.
- Reuse the existing WordPress runtime fixtures and add the two Yoast compatibility jobs. Document clearing semantics and SEO data disclosure.

**Budget: 487 added lines across 13 files**, including tests, scripts, CI, documentation, and the changeset. Local implementation plans are not included. No Plugin Check harness/CI job or unrelated whole-plugin remediation is included.

Related: #1653

## Verification
- [x] Core PHP suites on PHP 7.4 and 8.4.
- [x] No-Yoast runtime: WordPress 6.0.9 / PHP 7.4, WordPress 7.0.2 / PHP 7.4 and 8.4.
- [x] Yoast 28.4 runtime: WordPress 7.0.2 / PHP 7.4 and 8.4.
- [x] Actual HTTP/SSE authorization, raw validation, sanitizer and persistence failures, omission/clearing, and later-request rendered tags.
- [x] Fresh SQL checks for unchanged state on denials and failures.
- [x] Packaged artifact includes the SEO class and excludes fixtures, Yoast, and checker tooling.
- [x] `git diff --check` and commit/push hooks.

## Manual Plugin Check review
Official Plugin Check 2.1.0 was run manually against the packaged plugin. Its raw report contained **113 errors and 4 warnings**; this is not a clean-checker claim.

The 15 SEO exception-escaping findings were reviewed as JSON/SSE-context false positives: tool errors are encoded into MCP results, not rendered as HTML. No suppressions were added. The 98 existing errors and four warnings were also reviewed: existing exception/SSE encoding contexts, one pre-existing low-severity translator-comment defect, native update-status reads, request-path routing, the documented LiteSpeed hook, and the accurately stated tested WordPress version. No SEO security/privacy blocker was identified. This is targeted feature review, not whole-plugin certification.
