### PR TITLE
feat(wordpress): support custom post slugs

### DIFF
--- a/.changeset/wordpress-post-slugs.md
+++ b/.changeset/wordpress-post-slugs.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Support optional custom slugs when creating or updating WordPress posts and pages. Use WordPress core sanitization and uniqueness rules, reject non-string slugs before writes, and return the persisted slug in post snapshots.

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -272,6 +272,10 @@ class Frontman_Tools {
 				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 
 			case 'string':
+				if ( 'slug' === $field_name && in_array( $tool_name, [ 'wp_create_post', 'wp_update_post' ], true ) ) {
+					return $value;
+				}
+
 				if ( 'css' === $field_name && 'wp_update_custom_css' === $tool_name && ! is_string( $value ) ) {
 					return $value;
 				}

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -821,6 +821,40 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( 'Created', $created['after']['title'], 'wp_create_post returns created post snapshot as after' );
 		$this->assert_same( $created_content, $created['after']['content'], 'wp_create_post preserves backslashes through WordPress unslashing' );
 
+		$posts_before_slug_tests = serialize( $GLOBALS['frontman_test_posts'] );
+		$registry = new Frontman_Tools();
+		$tool->register( $registry );
+		foreach ( [ 'wp_create_post' => 'create_post', 'wp_update_post' => 'update_post' ] as $name => $handler ) {
+			$this->assert_same( 'string', $registry->get( $name )->input_schema['properties']['slug']['type'], "$name exposes a string slug" );
+			$this->assert_true( ! in_array( 'slug', $registry->get( $name )->input_schema['required'], true ), "$name keeps slug optional" );
+			$input = [ 'id' => 11, 'title' => 'Slug fixture', 'content' => 'Slug content', 'slug' => 'sample-%e6%97%a5-\\path' ];
+			$sanitized = $registry->sanitize_input( $name, $input );
+			$this->assert_same( $input['slug'], $sanitized['slug'], "$name preserves raw slug for core sanitization" );
+			$saved = $tool->$handler( $sanitized );
+			$this->assert_same( $input['slug'], $saved['after']['slug'], "$name passes post_name through the slashing boundary" );
+			$unchanged = $tool->update_post( [ 'id' => $saved['after']['id'], 'excerpt' => 'Metadata only' ] );
+			$this->assert_same( $input['slug'], $unchanged['after']['slug'], 'Omitted slug survives metadata-only edits' );
+			$input['slug'] = '';
+			$this->assert_same( '', $tool->$handler( $registry->sanitize_input( $name, $input ) )['after']['slug'], "$name passes explicit empty slug to core" );
+
+			foreach ( [ null, 123, 1.5, true, false, [], [ 'bad' ], (object) [ 'slug' => 'bad' ] ] as $invalid_slug ) {
+				$input['slug'] = $invalid_slug;
+				$before = serialize( $GLOBALS['frontman_test_posts'] );
+				$this->assert_error_contains(
+					static function() use ( $tool, $handler, $input ) { $tool->$handler( $input ); },
+					'slug must be a string',
+					"$name rejects invalid slugs in direct calls"
+				);
+				$this->assert_tool_error_result_contains(
+					$registry->call( $name, $registry->sanitize_input( $name, $input ) ),
+					'slug must be a string',
+					"$name rejects invalid slugs through the registry"
+				);
+				$this->assert_same( $before, serialize( $GLOBALS['frontman_test_posts'] ), "$name rejects invalid slugs before writes" );
+			}
+		}
+		$GLOBALS['frontman_test_posts'] = unserialize( $posts_before_slug_tests );
+
 		$this->assert_error_contains(
 			static function() use ( $tool ) {
 				$tool->delete_post( [ 'id' => 10, 'force' => true, 'confirm' => false ] );

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -158,6 +158,71 @@ frontman_runtime_assert( 1 <= count( $menu_tool->list_navigation_menus( [] ) ), 
 $deleted = $menu_tool->delete_navigation_menu( [ 'id' => $created['id'], 'confirm' => true ] );
 frontman_runtime_assert( 'Updated Runtime Navigation' === $deleted['before']['title'], 'Navigation deletion did not preserve its snapshot.' );
 frontman_runtime_assert( null === get_post( $created['id'] ), 'Navigation tool did not permanently delete the post.' );
+wp_set_current_user( $admin->ID );
+$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
+$slug_nonce = Frontman_Auth::create_nonce();
+unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+wp_set_current_user( 0 );
+$slug_call = static function ( string $name, array $arguments ) use ( $cookie, $slug_nonce ): array {
+	$response = frontman_runtime_tool( $cookie, $slug_nonce, [ 'name' => $name, 'arguments' => $arguments ] );
+	frontman_runtime_assert( 200 === $response['status'] && false === $response['body']['isError'], 'Slug tool failed: ' . wp_json_encode( $response ) );
+	$data = json_decode( $response['body']['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+	if ( isset( $data['after'] ) ) {
+		clean_post_cache( $data['after']['id'] );
+		frontman_runtime_assert( get_post( $data['after']['id'] )->post_name === $data['after']['slug'], 'Slug snapshot differs from persisted post_name.' );
+	}
+	return $data;
+};
+$slug_fixture = [ 'title' => 'Runtime Slug Fixture', 'content' => 'Unchanged content', 'status' => 'draft', 'slug' => 'sample-delivery-guide' ];
+$slug_created = $slug_call( 'wp_create_post', $slug_fixture );
+$slug_id = $slug_created['id'];
+frontman_runtime_assert( 'sample-delivery-guide' === $slug_created['after']['slug'], 'Custom draft slug was not persisted.' );
+$slug_duplicate = $slug_call( 'wp_create_post', $slug_fixture );
+frontman_runtime_assert( 'sample-delivery-guide' === $slug_duplicate['after']['slug'], 'Draft slugs should not be made unique.' );
+$slug_published = $slug_call( 'wp_update_post', [ 'id' => $slug_id, 'status' => 'publish' ] );
+frontman_runtime_assert( 'sample-delivery-guide-2' === $slug_published['after']['slug'], 'Publication did not resolve the collision with the other draft.' );
+$slug_collision = $slug_call( 'wp_update_post', [ 'id' => $slug_duplicate['id'], 'status' => 'publish' ] );
+frontman_runtime_assert( 'sample-delivery-guide' === $slug_collision['after']['slug'], 'Publication changed the now-available draft slug.' );
+$slug_collision = $slug_call( 'wp_create_post', array_merge( $slug_fixture, [ 'status' => 'publish' ] ) );
+frontman_runtime_assert( 'sample-delivery-guide-3' === $slug_collision['after']['slug'], 'Published create did not return the unique slug.' );
+$slug_updated = $slug_call( 'wp_update_post', [ 'id' => $slug_id, 'slug' => 'updated-delivery-guide' ] );
+frontman_runtime_assert( 'sample-delivery-guide-2' === $slug_updated['before']['slug'] && 'updated-delivery-guide' === $slug_updated['after']['slug'], 'Slug update snapshots are inaccurate.' );
+$slug_omitted = $slug_call( 'wp_update_post', [ 'id' => $slug_id, 'title' => 'Changed title', 'excerpt' => 'Metadata only' ] );
+frontman_runtime_assert( 'updated-delivery-guide' === $slug_omitted['after']['slug'], 'Metadata-only edit regenerated the slug.' );
+$slug_read = $slug_call( 'wp_read_post', [ 'id' => $slug_id ] );
+frontman_runtime_assert( $slug_read === $slug_omitted['after'], 'Read result differs from the mutation snapshot.' );
+
+foreach ( [ 'draft', 'pending', 'publish' ] as $slug_status ) {
+	$empty_fixture = [ 'title' => 'Runtime Empty ' . $slug_status, 'content' => '', 'status' => $slug_status ];
+	$omitted_create = $slug_call( 'wp_create_post', $empty_fixture );
+	frontman_runtime_assert( ( 'publish' === $slug_status ? sanitize_title( $empty_fixture['title'] ) : '' ) === $omitted_create['after']['slug'], 'Omitted create slug changed core behavior.' );
+	$empty_fixture['title'] .= ' Explicit';
+	$empty_create = $slug_call( 'wp_create_post', array_merge( $empty_fixture, [ 'slug' => '' ] ) );
+	$expected_empty = 'publish' === $slug_status ? sanitize_title( $empty_fixture['title'] ) : '';
+	frontman_runtime_assert( $expected_empty === $empty_create['after']['slug'], 'Empty create slug changed core behavior.' );
+	$slug_call( 'wp_update_post', [ 'id' => $empty_create['id'], 'slug' => 'clear-me-' . $slug_status ] );
+	$empty_update = $slug_call( 'wp_update_post', [ 'id' => $empty_create['id'], 'slug' => '' ] );
+	frontman_runtime_assert( $expected_empty === $empty_update['after']['slug'], 'Empty update slug changed core behavior.' );
+}
+foreach ( [ 'Café — 日本! / Delivery', '%e6%97%a5%e6%9c%ac-guide', 'Quote\'s \\ path & punctuation?!' ] as $raw_slug ) {
+	$normalized = $slug_call( 'wp_create_post', array_merge( $slug_fixture, [ 'slug' => $raw_slug ] ) );
+	frontman_runtime_assert( sanitize_title( $raw_slug ) === $normalized['after']['slug'], 'Create slug normalization differs from core.' );
+	$normalized = $slug_call( 'wp_update_post', [ 'id' => $slug_duplicate['id'], 'status' => 'draft', 'slug' => $raw_slug ] );
+	frontman_runtime_assert( sanitize_title( $raw_slug ) === $normalized['after']['slug'], 'Update slug normalization differs from core.' );
+}
+$posts_before_invalid_slugs = $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A );
+foreach ( [ 'wp_create_post', 'wp_update_post' ] as $slug_tool ) {
+	foreach ( [ null, 123, 1.5, true, false, [], [ 'bad' ], (object) [ 'slug' => 'bad' ] ] as $invalid_slug ) {
+		$invalid = frontman_runtime_tool( $cookie, $slug_nonce, [ 'name' => $slug_tool, 'arguments' => array_merge( $slug_fixture, [ 'id' => $slug_id, 'title' => 'Must not write', 'slug' => $invalid_slug ] ) ] );
+		frontman_runtime_assert( 200 === $invalid['status'] && true === $invalid['body']['isError'], 'Invalid slug type was accepted.' );
+	}
+	$request = [ 'name' => $slug_tool, 'arguments' => array_merge( $slug_fixture, [ 'id' => $slug_id ] ) ];
+	frontman_runtime_assert( 401 === frontman_runtime_tool( '', null, $request )['status'], 'Slug mutation bypassed authentication.' );
+	frontman_runtime_assert( 403 === frontman_runtime_tool( $cookie, null, $request )['status'], 'Slug mutation bypassed nonce validation.' );
+	frontman_runtime_assert( 403 === frontman_runtime_tool( $cookie, 'invalid', $request )['status'], 'Slug mutation accepted an invalid nonce.' );
+}
+frontman_runtime_assert( $posts_before_invalid_slugs === $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A ), 'Rejected slug requests changed posts.' );
+
 $yoast = getenv( 'EXPECTED_YOAST_VERSION' );
 if ( false === $yoast || '' === $yoast ) {
 	frontman_runtime_assert( null === Frontman_Tools::instance()->get( 'wp_read_seo' ), 'SEO tools were registered without Yoast.' );

--- a/libs/frontman-wordpress/tools/class-tool-posts.php
+++ b/libs/frontman-wordpress/tools/class-tool-posts.php
@@ -97,6 +97,10 @@ class Frontman_Tool_Posts {
 						'type'        => 'string',
 						'description' => 'The post title.',
 					],
+					'slug'      => [
+						'type'        => 'string',
+						'description' => 'Optional permalink slug. WordPress sanitizes it and applies status-specific uniqueness. Empty allows an empty draft/pending slug; published posts derive one from the title. The persisted slug is returned in after.slug.',
+					],
 					'content'   => [
 						'type'        => 'string',
 						'description' => 'The post content as HTML or Gutenberg block markup.',
@@ -153,6 +157,10 @@ class Frontman_Tool_Posts {
 					'title'   => [
 						'type'        => 'string',
 						'description' => 'New post title.',
+					],
+					'slug'    => [
+						'type'        => 'string',
+						'description' => 'Optional permalink slug. Omit to retain the current slug, subject to WordPress status transitions. WordPress sanitizes it and applies uniqueness. Empty allows an empty draft/pending slug; published posts derive one from the title. See after.slug for the persisted value.',
 					],
 					'content' => [
 						'type'        => 'string',
@@ -276,6 +284,12 @@ class Frontman_Tool_Posts {
 			'post_type'    => sanitize_key( $input['post_type'] ?? 'post' ),
 			'post_status'  => sanitize_key( $input['status'] ?? 'draft' ),
 		];
+		if ( array_key_exists( 'slug', $input ) ) {
+			if ( ! is_string( $input['slug'] ) ) {
+				throw new Frontman_Tool_Error( 'slug must be a string.' );
+			}
+			$post_data['post_name'] = $input['slug'];
+		}
 
 		$post_id = wp_insert_post( wp_slash( $post_data ), true );
 
@@ -349,6 +363,12 @@ class Frontman_Tool_Posts {
 		$before = $this->read_post( [ 'id' => $id ] );
 
 		$post_data = [ 'ID' => $id ];
+		if ( array_key_exists( 'slug', $input ) ) {
+			if ( ! is_string( $input['slug'] ) ) {
+				throw new Frontman_Tool_Error( 'slug must be a string.' );
+			}
+			$post_data['post_name'] = $input['slug'];
+		}
 		if ( isset( $input['content'] ) && class_exists( 'Frontman_Elementor_Data' ) && Frontman_Elementor_Data::post_uses_elementor( $id ) ) {
 			throw new Frontman_Tool_Error( 'Refusing to update post_content for Elementor-managed page ' . $id . '. Use wp_elementor_update_element, wp_elementor_save_page_data, or wp_elementor_restore_rollback for Elementor content/layout changes. wp_update_post may still update title, status, or excerpt without content.' );
 		}


### PR DESCRIPTION
## Summary
- Add optional string `slug` to post create/update tools and map it to `post_name`.
- Reject non-string slugs before writes; preserve encoded strings for WordPress core sanitization.
- Keep existing authentication, nonce checks, permissions, slashing, and MCP responses unchanged.
- Use core empty-slug and uniqueness behavior; return persisted slugs in existing snapshots.
- Add regression tests and a changeset.

Closes #1649

## Verification
- `make test-wordpress-core-tools`: passed on PHP 7.4 and 8.4.
- `make test-wordpress-runtime`: passed all five compatibility configurations:
  - WordPress 6.0.9 / PHP 7.4
  - WordPress 7.0.2 / PHP 7.4 and 8.4, without Yoast
  - WordPress 7.0.2 / PHP 7.4 and 8.4, with Yoast 28.4
- Covers custom slugs, omission, empty strings, Unicode/encoded strings, published collisions, draft publication, persisted snapshots, invalid types, and authentication/nonce rejection.
- Pre-commit checks passed.