### PR TITLE
Add opt-in Sentry reporting for WordPress PHP exceptions

### DIFF
--- a/.changeset/fix-runtime-shutdown-events.md
+++ b/.changeset/fix-runtime-shutdown-events.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Report pending agent terminations when the runtime shuts down after supervisor restart failures. This prevents the loss of termination events during registry crash recovery.

--- a/.changeset/wordpress-php-sentry.md
+++ b/.changeset/wordpress-php-sentry.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Add opt-in Sentry reports for unexpected WordPress PHP tool exceptions under Settings > Frontman. Bundle an isolated PHP SDK and remove sensitive data from reports. Keep expected tool errors out of Sentry and preserve tool responses if reporting fails.

--- a/.github/workflows/wordpress-compatibility.yml
+++ b/.github/workflows/wordpress-compatibility.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "libs/frontman-wordpress/**"
+      - "scripts/build-wordpress-dependencies.sh"
+      - "scripts/wordpress-*.php"
       - "scripts/test-wordpress-plugin-runtime.sh"
       - "scripts/package-wordpress-plugin.sh"
       - "scripts/validate-wordpress-plugin-release.sh"
@@ -14,6 +16,8 @@ on:
       - main
     paths:
       - "libs/frontman-wordpress/**"
+      - "scripts/build-wordpress-dependencies.sh"
+      - "scripts/wordpress-*.php"
       - "scripts/test-wordpress-plugin-runtime.sh"
       - "scripts/package-wordpress-plugin.sh"
       - "scripts/validate-wordpress-plugin-release.sh"
@@ -47,13 +51,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Build isolated PHP dependencies
+        run: make build-wordpress-dependencies
+
       - name: Run isolated PHP tests
         run: |
           docker run --rm \
             -v "$PWD:/workspace:ro" \
             -w /workspace \
             "php:${{ matrix.php }}-cli" \
-            sh -c 'for test in libs/frontman-wordpress/tests/*Test.php; do php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php "$test" || exit 1; done'
+            sh -ec 'for test in libs/frontman-wordpress/tests/*Test.php; do php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php "$test"; done; php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SentryTest.php --site-first'
 
       - name: Run WordPress runtime tests
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib/
 .compiler.log
 
 node_modules/
+libs/frontman-wordpress/vendor/
 
 .env.local
 test/e2e/.env

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ HELP_infra-down := Tear down all pods, volumes, and Caddy
 HELP_infra-build := Rebuild the frontman-dev container image
 
 HELP_REL_TITLE := Release
-HELP_REL_TARGETS := publish publish-astro publish-vite publish-nextjs publish-react-statestore publish-swarm-ai release package-wordpress-plugin publish-wordpress-plugin-svn test-wordpress-core-tools test-wordpress-runtime
+HELP_REL_TARGETS := publish publish-astro publish-vite publish-nextjs publish-react-statestore publish-swarm-ai release package-wordpress-plugin publish-wordpress-plugin-svn build-wordpress-dependencies wordpress-composer-lock test-wordpress-core-tools test-wordpress-sentry test-wordpress-runtime
 HELP_publish := Publish all npm packages (pass OTP=<code> for 2FA)
 HELP_publish-astro := Publish @frontman-ai/astro to npm (pass OTP=<code> for 2FA)
 HELP_publish-vite := Publish @frontman-ai/vite to npm (pass OTP=<code> for 2FA)
@@ -118,6 +118,9 @@ HELP_package-wordpress-plugin := Build WordPress ZIP and WordPress.org bundle
 HELP_publish-wordpress-plugin-svn := Publish WordPress.org bundle to SVN (requires WORDPRESS_ORG_* env vars)
 HELP_test-wordpress-core-tools := Run PHP tests for WordPress tool implementations
 HELP_test-wordpress-runtime := Run plugin integration tests in WordPress containers
+HELP_build-wordpress-dependencies := Bundle the locked PHP SDK (Docker, or CONTAINER_RUNTIME=podman)
+HELP_wordpress-composer-lock := Update PHP dependencies while preserving PHP 7.4 compatibility
+HELP_test-wordpress-sentry := Test PHP diagnostics and SDK coexistence (PHP_VERSION=7.4 or 8.4)
 
 HELP_E2E_TITLE := E2E Tests
 HELP_E2E_TARGETS := e2e e2e-nextjs e2e-nextjs-compat e2e-astro e2e-vite e2e-vue-vite e2e-oauth-start
@@ -549,13 +552,24 @@ release:
 	@printf "$(GREEN)Release workflow triggered.$(RESET)\n"
 	@echo "Watch for the PR at: https://github.com/frontman-ai/frontman/pulls"
 
+.PHONY: build-wordpress-dependencies wordpress-composer-lock test-wordpress-sentry
+
+build-wordpress-dependencies:
+	@bash ./scripts/build-wordpress-dependencies.sh
+
+wordpress-composer-lock:
+	@bash ./scripts/build-wordpress-dependencies.sh --update-lock
+
+test-wordpress-sentry: build-wordpress-dependencies
+	@$(or $(CONTAINER_RUNTIME),docker) run --rm -v "$(CURDIR):/workspace:ro" -w /workspace docker.io/library/php:$(or $(PHP_VERSION),8.4)-cli sh -ec 'for order in --frontman-first --site-first; do php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SentryTest.php "$$order"; done; php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SentryUnavailableTest.php'
+
 package-wordpress-plugin:
 	@VERSION=$(VERSION) bash ./scripts/package-wordpress-plugin.sh
 
 publish-wordpress-plugin-svn: package-wordpress-plugin
 	@VERSION=$(VERSION) bash ./scripts/publish-wordpress-plugin-svn.sh
 
-test-wordpress-core-tools:
+test-wordpress-core-tools: build-wordpress-dependencies
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/ElementorToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/MediaToolsTest.php
@@ -564,6 +578,8 @@ test-wordpress-core-tools:
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/PluginDependenciesTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SeoToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/RouterTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SentryTest.php
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/SentryUnavailableTest.php
 
 test-wordpress-runtime:
 	@bash scripts/test-wordpress-plugin-runtime.sh

--- a/apps/swarm_ai/lib/swarm_ai/runtime.ex
+++ b/apps/swarm_ai/lib/swarm_ai/runtime.ex
@@ -76,6 +76,7 @@ defmodule SwarmAi.Runtime do
   @impl true
   @spec init(atom()) :: {:ok, state()}
   def init(runtime) when is_atom(runtime) do
+    Process.flag(:trap_exit, true)
     {:ok, %{runtime: runtime, monitors: %{}}}
   end
 
@@ -115,6 +116,13 @@ defmodule SwarmAi.Runtime do
         SwarmAi.TerminalEvent.emit(loop, reason)
         {:noreply, %{state | monitors: monitors}}
     end
+  end
+
+  @impl true
+  def terminate(reason, state) do
+    Enum.each(state.monitors, fn {_ref, loop} ->
+      SwarmAi.TerminalEvent.emit(loop, reason)
+    end)
   end
 
   defp await_finishing_execution(runtime, task_id) do

--- a/apps/swarm_ai/test/swarm_ai/supervisor_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/supervisor_test.exs
@@ -156,6 +156,32 @@ defmodule SwarmAi.SupervisorTest do
       refute_receive {:test_event, "task-reg", {:crashed, _}}, 100
     end
 
+    test "reports pending terminations when registry restart failures stop the runtime" do
+      runtime = :"TestRuntime_#{:erlang.unique_integer([:positive])}"
+      supervisor = start_supervised!({SwarmAi, name: runtime}, restart: :temporary)
+      supervisor_ref = Process.monitor(supervisor)
+
+      {:ok, pid} =
+        run_agent(runtime, "task-reg-restart", %MockLLM{response: "slow", delay_ms: 5000})
+
+      worker_ref = Process.monitor(pid)
+      :ok = :sys.suspend(runtime, 2000)
+
+      registry = Process.whereis(SwarmAi.Runtime.Registry.name(runtime))
+      [{_id, partition, _type, _modules}] = Supervisor.which_children(registry)
+      true = :erlang.suspend_process(partition)
+
+      try do
+        Process.exit(registry, :kill)
+        assert_receive {:DOWN, ^supervisor_ref, :process, ^supervisor, :shutdown}, 2000
+        assert_receive {:DOWN, ^worker_ref, :process, ^pid, _reason}, 2000
+        assert_receive {:test_event, "task-reg-restart", {:terminated, nil}}, 2000
+        refute_receive {:test_event, "task-reg-restart", _event}, 100
+      after
+        true = :erlang.resume_process(partition)
+      end
+    end
+
     test "accepts new work after registry crash" do
       runtime = start_runtime!()
 

--- a/libs/frontman-wordpress/composer.json
+++ b/libs/frontman-wordpress/composer.json
@@ -1,0 +1,14 @@
+{
+  "name": "frontman-ai/wordpress-diagnostics",
+  "description": "Private Sentry runtime bundled with the Frontman WordPress plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "php": ">=7.4",
+    "sentry/sentry": "^4.0"
+  },
+  "config": {
+    "platform": { "php": "7.4.33" },
+    "allow-plugins": false,
+    "sort-packages": true
+  }
+}

--- a/libs/frontman-wordpress/composer.lock
+++ b/libs/frontman-wordpress/composer.lock
@@ -1,0 +1,837 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "990f082dfbbab0ab4d12621bd13ff096",
+    "packages": [
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "a3059ba1a84c9139c4ae03cf0f45bea276c97c74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a3059ba1a84c9139c4ae03cf0f45bea276c97c74",
+                "reference": "a3059ba1a84c9139c4ae03cf0f45bea276c97c74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^2.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.1",
+                "psr/http-message-implementation": "2.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "php-http/psr7-integration-tests": "^1.5.1",
+                "phpunit/phpunit": "^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-24T11:02:13+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "sentry/sentry",
+            "version": "4.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "39d9f86bd56c6cc6ae7b64c2b849f7f046d38394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/39d9f86bd56c6cc6ae7b64c2b849f7f046d38394",
+                "reference": "39d9f86bd56c6cc6ae7b64c2b849f7f046d38394",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/psr7": "^1.8.4|^2.1.1|^3.0.0",
+                "jean85/pretty-package-versions": "^1.5|^2.0.4",
+                "php": "^7.2|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "carthage-software/mago": "1.30.0",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "guzzlehttp/guzzle": "^7.0|^8.0",
+                "guzzlehttp/promises": "^2.0.3|^3.0.0",
+                "monolog/monolog": "^1.6|^2.0|^3.0",
+                "nyholm/psr7": "^1.8",
+                "open-telemetry/api": "^1.1",
+                "open-telemetry/context": "^1.1",
+                "open-telemetry/exporter-otlp": "^1.1",
+                "open-telemetry/sdk": "^1.1",
+                "open-telemetry/sem-conv": "^1.27",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^8.5.52|^9.6.34",
+                "spiral/roadrunner-http": "^3.6",
+                "spiral/roadrunner-worker": "^3.6"
+            },
+            "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+                "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Sentry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sentry",
+                    "email": "accounts@sentry.io"
+                }
+            ],
+            "description": "PHP SDK for Sentry (http://sentry.io)",
+            "homepage": "http://sentry.io",
+            "keywords": [
+                "crash-reporting",
+                "crash-reports",
+                "error-handler",
+                "error-monitoring",
+                "log",
+                "logging",
+                "profiling",
+                "sentry",
+                "tracing"
+            ],
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-php/issues",
+                "source": "https://github.com/getsentry/sentry-php/tree/4.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-08-27T12:59:01+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
+                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php73": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4.33"
+    },
+    "plugin-api-version": "2.6.0"
+}

--- a/libs/frontman-wordpress/frontman.php
+++ b/libs/frontman-wordpress/frontman.php
@@ -51,6 +51,7 @@ define( 'FRONTMAN_PLUGIN_FILE', __FILE__ );
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-auth.php';
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-plugin-dependencies.php';
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-tools.php';
+require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-sentry.php';
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-router.php';
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-ui.php';
 
@@ -98,6 +99,7 @@ function frontman_init(): void {
 
 	$router->register();
 	$ui->register();
+	Frontman_Sentry::register();
 }
 add_action( 'init', 'frontman_init' );
 

--- a/libs/frontman-wordpress/includes/class-frontman-router.php
+++ b/libs/frontman-wordpress/includes/class-frontman-router.php
@@ -377,6 +377,7 @@ class Frontman_Router {
 				$result = $this->tools->call( $name, $input );
 				$this->send_sse_tool_result( $result );
 			} catch ( \Throwable $e ) {
+				Frontman_Sentry::capture( $e, $name );
 				$this->send_sse_tool_result( Frontman_Tools::error_result( $e->getMessage() ) );
 			}
 			return;

--- a/libs/frontman-wordpress/includes/class-frontman-sentry.php
+++ b/libs/frontman-wordpress/includes/class-frontman-sentry.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Opt-in diagnostics for unexpected Frontman PHP tool exceptions only.
+ *
+ * @package Frontman
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Frontman_Sentry {
+	private const OPTION = 'frontman_php_diagnostics';
+	private const DSN = 'https://442ae992e5a5ccfc42e6910220aeb2a9@o4510512511320064.ingest.de.sentry.io/4510512546185296';
+
+	public static function register(): void {
+		add_action( 'admin_init', [ self::class, 'register_setting' ] );
+		add_action( 'admin_menu', static function (): void {
+			add_options_page( 'Frontman', 'Frontman', 'manage_options', 'frontman-diagnostics', [ self::class, 'render_settings' ] );
+		} );
+	}
+
+	public static function sanitize_enabled( $value ): bool {
+		return in_array( $value, [ true, 1, '1' ], true );
+	}
+
+	public static function register_setting(): void {
+		register_setting( 'frontman_diagnostics', self::OPTION, [
+			'type' => 'boolean',
+			'default' => false,
+			'sanitize_callback' => [ self::class, 'sanitize_enabled' ],
+		] );
+	}
+
+	public static function render_settings(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Administrator access required.', 'frontman-agentic-ai-editor' ) );
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Frontman PHP Diagnostics', 'frontman-agentic-ai-editor' ); ?></h1>
+			<form action="options.php" method="post">
+				<?php settings_fields( 'frontman_diagnostics' ); ?>
+				<input type="hidden" name="frontman_php_diagnostics" value="0">
+				<label>
+					<input type="checkbox" name="frontman_php_diagnostics" value="1" <?php checked( self::sanitize_enabled( get_option( self::OPTION, false ) ) ); ?>>
+					<?php esc_html_e( 'Send unexpected Frontman PHP tool errors to Sentry.', 'frontman-agentic-ai-editor' ); ?>
+				</label>
+				<p><?php esc_html_e( 'Reports include exception types, sanitized stack traces, tool names, and software versions. They exclude exception messages, tool arguments, source code, site URLs, and user data. Sentry receives the server IP address when delivering reports. You can disable reporting here at any time.', 'frontman-agentic-ai-editor' ); ?></p>
+				<p><a href="https://frontman.sh/privacy/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Frontman Privacy Policy', 'frontman-agentic-ai-editor' ); ?></a> · <a href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Sentry Privacy Policy', 'frontman-agentic-ai-editor' ); ?></a></p>
+				<?php submit_button(); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	public static function capture( \Throwable $exception, string $tool, ?\FrontmanVendor\Sentry\Transport\TransportInterface $transport = null ): void {
+		if ( $exception instanceof Frontman_Tool_Error || ! self::sanitize_enabled( get_option( self::OPTION, false ) ) ) {
+			return;
+		}
+
+		$autoload = FRONTMAN_PLUGIN_DIR . 'vendor/autoload.php';
+		if ( ! extension_loaded( 'curl' ) || ! extension_loaded( 'mbstring' ) || ! is_readable( $autoload ) ) {
+			error_log( 'Frontman PHP diagnostics unavailable: bundled SDK, cURL, and mbstring are required.' );
+			return;
+		}
+
+		try {
+			require_once $autoload;
+			$builder = \FrontmanVendor\Sentry\ClientBuilder::create( [
+				'dsn' => self::DSN,
+				'release' => 'frontman-wordpress@' . FRONTMAN_VERSION,
+				'environment' => wp_get_environment_type(),
+				'default_integrations' => false,
+				'spotlight' => false,
+				'send_default_pii' => false,
+				'max_request_body_size' => 'never',
+				'context_lines' => 0,
+				'server_name' => '',
+				'http_connect_timeout' => 1,
+				'http_timeout' => 2,
+				'before_send' => [ self::class, 'scrub_event' ],
+			] );
+			if ( null !== $transport ) {
+				$builder->setTransport( $transport );
+			}
+			$scope = new \FrontmanVendor\Sentry\State\Scope();
+			$scope->setTags( [
+				'service' => 'frontman-wordpress',
+				'framework' => 'wordpress',
+				'tool_name' => $tool,
+				'wordpress_version' => get_bloginfo( 'version' ),
+				'php_version' => PHP_VERSION,
+			] );
+			if ( null === $builder->getClient()->captureException( $exception, $scope ) ) {
+				error_log( 'Frontman PHP diagnostics could not deliver an exception report.' );
+			}
+		} catch ( \Throwable $reporting_error ) {
+			error_log( 'Frontman PHP diagnostics failed to report an exception.' );
+		}
+	}
+
+	public static function scrub_event( \FrontmanVendor\Sentry\Event $event ): \FrontmanVendor\Sentry\Event {
+		$event->setRequest( [] );
+		$event->setUser( null );
+		$event->setServerName( null );
+		foreach ( $event->getExceptions() as $exception ) {
+			$exception->setValue( 'Unexpected Frontman tool exception (message omitted for privacy).' );
+			$exception->setType( explode( '@anonymous', $exception->getType() )[0] );
+			$exception->setMechanism( null );
+			$stacktrace = $exception->getStacktrace();
+			if ( null === $stacktrace ) {
+				continue;
+			}
+			$frames = [];
+			foreach ( $stacktrace->getFrames() as $frame ) {
+				$file = $frame->getAbsoluteFilePath() ?? $frame->getFile();
+				$in_plugin = 0 === strpos( $file, FRONTMAN_PLUGIN_DIR );
+				$file = $in_plugin ? 'frontman/' . substr( $file, strlen( FRONTMAN_PLUGIN_DIR ) ) : basename( $file );
+				$function = $frame->getFunctionName();
+				if ( null !== $function && ( false !== strpos( $function, '@anonymous' ) || false !== strpos( $function, '{closure' ) ) ) {
+					$function = '[anonymous]';
+				}
+				$frames[] = new \FrontmanVendor\Sentry\Frame( $function, $file, $frame->getLine(), null, null, [], $in_plugin );
+			}
+			$exception->setStacktrace( new \FrontmanVendor\Sentry\Stacktrace( $frames ) );
+		}
+		return $event;
+	}
+}

--- a/libs/frontman-wordpress/readme.txt
+++ b/libs/frontman-wordpress/readme.txt
@@ -149,6 +149,13 @@ Heap measures product use and onboarding. Sentry records errors and performance 
 * Heap: [Service](https://heap.io), [Privacy](https://www.heap.io/privacy)
 * Sentry: [Service](https://sentry.io), [Privacy](https://sentry.io/privacy/)
 
+**Optional PHP Error Reports**
+PHP error reports are off by default. An administrator can enable or disable them under Settings > Frontman. This setting controls PHP reports only, not diagnostics from the hosted browser client.
+
+When enabled, unexpected Frontman tool exceptions send reports directly to Sentry. Reports include exception types, sanitized stack traces, tool names, and Frontman, WordPress, and PHP versions. Stack traces retain function names, line numbers, and plugin-relative paths or external file names. Reports omit exception messages, source code, arguments, request bodies, cookies, nonces, site URLs, and user context. Sentry receives the server IP address through the network connection.
+
+Expected validation errors and unrelated WordPress errors do not produce PHP reports. Reporting requires the PHP cURL and mbstring extensions. Reporting failures do not replace tool results. Delivery has a two-second HTTP timeout.
+
 Loading the Frontman UI requests hosted client assets. Your site content is not sent to the Frontman API or model providers until you actively use the chat interface and submit a message.
 
 == Screenshots ==

--- a/libs/frontman-wordpress/tests/SentryTest.php
+++ b/libs/frontman-wordpress/tests/SentryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use FrontmanVendor\Sentry\Event;
+use FrontmanVendor\Sentry\Options;
+use FrontmanVendor\Sentry\Serializer\PayloadSerializer;
+use FrontmanVendor\Sentry\Transport\Result;
+use FrontmanVendor\Sentry\Transport\ResultStatus;
+use FrontmanVendor\Sentry\Transport\TransportInterface;
+
+define( 'ABSPATH', '/private/site-owner/wordpress/' );
+define( 'FRONTMAN_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+define( 'FRONTMAN_VERSION', '5.0.0' );
+
+function get_option( string $name, $default = false ) { return $GLOBALS['options'][ $name ] ?? $default; }
+function get_bloginfo( string $name ): string { return '6.0.9'; }
+function wp_get_environment_type(): string { return 'staging'; }
+function register_setting( string $group, string $name, array $args ): void { $GLOBALS['setting'] = [ $group, $name, $args ]; }
+function check( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$site_first = in_array( '--site-first', $argv, true );
+if ( $site_first ) {
+	require_once dirname( __DIR__, 3 ) . '/dist/wordpress-dependencies-source/vendor/autoload.php';
+}
+
+require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-tools.php';
+require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-sentry.php';
+
+Frontman_Sentry::capture( new RuntimeException( 'Not opted in' ), 'wp_test' );
+check( ! class_exists( 'FrontmanVendor\\Sentry\\ClientBuilder', false ), 'Disabled reporting must not load the SDK.' );
+Frontman_Sentry::register_setting();
+check( false === $GLOBALS['setting'][2]['default'], 'Diagnostics must default to off.' );
+check( is_callable( $GLOBALS['setting'][2]['sanitize_callback'] ), 'Consent must have a settings sanitizer.' );
+foreach ( [ null, false, 0, '0', 'false', 'yes', [], [ '1' ] ] as $value ) {
+	check( ! Frontman_Sentry::sanitize_enabled( $value ), 'Only explicit opt-in should enable reporting.' );
+}
+foreach ( [ true, 1, '1' ] as $value ) {
+	check( Frontman_Sentry::sanitize_enabled( $value ), 'Saved opt-in should enable reporting.' );
+}
+
+require_once FRONTMAN_PLUGIN_DIR . 'vendor/autoload.php';
+check( ! class_exists( 'Sentry\\ClientBuilder', false ), 'Bundled SDK must not expose unprefixed Sentry classes.' );
+check( $site_first === function_exists( 'Sentry\\init' ), 'Bundled SDK must not expose global Sentry functions.' );
+
+class MemoryTransport implements TransportInterface {
+	public array $events = [];
+	public bool $fail = false;
+	public function send( Event $event ): Result {
+		$this->events[] = $event;
+		if ( $this->fail ) {
+			throw new RuntimeException( 'Private transport credentials' );
+		}
+		return new Result( ResultStatus::success(), $event );
+	}
+	public function close( ?int $timeout = null ): Result { return new Result( ResultStatus::success() ); }
+}
+
+$GLOBALS['options']['frontman_php_diagnostics'] = '1';
+$standalone_transport = new MemoryTransport();
+Frontman_Sentry::capture( new RuntimeException( 'Standalone SDK' ), 'wp_test', $standalone_transport );
+check( 1 === count( $standalone_transport->events ), 'Scoped SDK must work without another plugin providing polyfills.' );
+
+require_once dirname( __DIR__, 3 ) . '/dist/wordpress-dependencies-source/vendor/autoload.php';
+\Sentry\init( [ 'default_integrations' => false, 'dsn' => null ] );
+$site_hub = \Sentry\SentrySdk::getCurrentHub();
+$site_client = $site_hub->getClient();
+$previous_handler = set_error_handler( static function (): bool { return false; } );
+$our_handler = set_error_handler( static function (): bool { return false; } );
+restore_error_handler();
+
+$GLOBALS['options']['frontman_php_diagnostics'] = '1';
+$transport = new MemoryTransport();
+$_COOKIE['auth'] = 'cookie-secret';
+$_POST['content'] = 'private-page-content';
+$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer authorization-secret';
+$_SERVER['HTTP_X_WP_NONCE'] = 'nonce-secret';
+$_SERVER['REQUEST_URI'] = '/private-page?secret=query-secret';
+
+function throw_private_error( string $argument ): void {
+	throw new RuntimeException( 'customer@example.test ' . $argument, 12345, new LogicException( 'previous-secret' ) );
+}
+try {
+	throw_private_error( 'argument-secret' );
+} catch ( Throwable $exception ) {
+	ob_start();
+	Frontman_Sentry::capture( $exception, 'wp_test', $transport );
+	check( '' === ob_get_clean(), 'Reporting must not write into the SSE response.' );
+}
+check( 1 === count( $transport->events ), 'A thrown exception must produce exactly one event.' );
+$event = $transport->events[0];
+check( 'frontman-wordpress@5.0.0' === $event->getRelease(), 'Release must identify the plugin version.' );
+check( 'staging' === $event->getEnvironment(), 'Environment must come from WordPress.' );
+check( 'wp_test' === $event->getTags()['tool_name'], 'Event must identify the tool.' );
+check( 'frontman-wordpress' === $event->getTags()['service'], 'Event must identify the PHP plugin.' );
+check( '6.0.9' === $event->getTags()['wordpress_version'], 'Event must identify WordPress version.' );
+check( PHP_VERSION === $event->getTags()['php_version'], 'Event must identify PHP version.' );
+check( 2 === count( $event->getExceptions() ), 'Chained exceptions must retain their types and stacks.' );
+$frames = $event->getExceptions()[0]->getStacktrace()->getFrames();
+check( count( $frames ) > 0, 'Exception must retain a PHP stack trace.' );
+foreach ( $frames as $frame ) {
+	check( [] === $frame->getVars(), 'Frame arguments must be removed.' );
+	check( null === $frame->getAbsoluteFilePath(), 'Absolute file paths must be removed.' );
+	check( null === $frame->getContextLine(), 'Source code must be removed.' );
+}
+$payload = str_replace( '\\/', '/', ( new PayloadSerializer( new Options() ) )->serialize( $event ) );
+foreach ( [ 'cookie-secret', 'private-page-content', 'authorization-secret', 'nonce-secret', 'query-secret', 'argument-secret', 'previous-secret', 'customer@example.test', FRONTMAN_PLUGIN_DIR, ABSPATH, '"code":12345' ] as $secret ) {
+	check( false === strpos( $payload, $secret ), 'Event leaked sensitive data: ' . $secret );
+}
+check( false !== strpos( $payload, 'frontman/tests/SentryTest.php' ), 'Plugin-relative stack paths must survive scrubbing.' );
+check( $site_hub === \Sentry\SentrySdk::getCurrentHub() && $site_client === $site_hub->getClient(), 'Reporting must not replace another plugin\'s Sentry hub or client.' );
+$current_handler = set_error_handler( static function (): bool { return false; } );
+restore_error_handler();
+check( $our_handler === $current_handler, 'Reporting must not install a global error handler.' );
+restore_error_handler();
+
+Frontman_Sentry::capture( new Frontman_Tool_Error( 'Expected validation failure' ), 'wp_test', $transport );
+check( 1 === count( $transport->events ), 'Expected tool errors must not be reported.' );
+$GLOBALS['options']['frontman_php_diagnostics'] = '0';
+Frontman_Sentry::capture( new RuntimeException( 'Consent revoked' ), 'wp_test', $transport );
+check( 1 === count( $transport->events ), 'Revoking consent must stop reporting immediately.' );
+$GLOBALS['options']['frontman_php_diagnostics'] = '1';
+$transport->fail = true;
+ob_start();
+Frontman_Sentry::capture( new RuntimeException( 'Tool failure' ), 'wp_test', $transport );
+check( '' === ob_get_clean(), 'Transport failures must not corrupt the SSE response.' );
+check( 2 === count( $transport->events ), 'Failing transport must have been exercised.' );
+
+fwrite( STDOUT, "OK (Sentry consent, privacy, SDK isolation, exception capture, transport failure)\n" );

--- a/libs/frontman-wordpress/tests/SentryUnavailableTest.php
+++ b/libs/frontman-wordpress/tests/SentryUnavailableTest.php
@@ -1,0 +1,15 @@
+<?php
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'FRONTMAN_PLUGIN_DIR', __DIR__ . '/missing-sdk/' );
+function get_option( string $name, $default = false ) { return '1'; }
+require_once __DIR__ . '/../includes/class-frontman-tools.php';
+require_once __DIR__ . '/../includes/class-frontman-sentry.php';
+
+ob_start();
+Frontman_Sentry::capture( new RuntimeException( 'Private tool error' ), 'wp_test' );
+$output = ob_get_clean();
+if ( '' !== $output || class_exists( 'FrontmanVendor\\Sentry\\ClientBuilder', false ) ) {
+	throw new RuntimeException( 'Missing SDK must not load Sentry or corrupt the tool response.' );
+}
+fwrite( STDOUT, "OK (missing SDK does not break tool error handling)\n" );

--- a/libs/frontman-wordpress/tests/integration/SentryRuntimeFixture.php
+++ b/libs/frontman-wordpress/tests/integration/SentryRuntimeFixture.php
@@ -1,0 +1,26 @@
+<?php
+
+add_action( 'init', static function (): void {
+	if ( ! defined( 'FRONTMAN_PLUGIN_DIR' ) ) {
+		return;
+	}
+	require_once FRONTMAN_PLUGIN_DIR . 'vendor/autoload.php';
+	\FrontmanVendor\Sentry\State\Scope::addGlobalEventProcessor( static function ( \FrontmanVendor\Sentry\Event $event ) {
+		update_option( 'frontman_test_sentry_count', (int) get_option( 'frontman_test_sentry_count', 0 ) + 1 );
+		if ( get_option( 'frontman_test_sentry_fail', false ) ) {
+			throw new RuntimeException( 'Injected reporting failure.' );
+		}
+		return null;
+	} );
+	Frontman_Tools::instance()->add( new Frontman_Tool_Definition(
+		'wp_test_diagnostics',
+		'Test exception reporting.',
+		[ 'type' => 'object', 'properties' => [ 'expected' => [ 'type' => 'boolean' ] ] ],
+		static function ( array $input ): array {
+			if ( $input['expected'] ?? false ) {
+				throw new Frontman_Tool_Error( 'Expected tool failure.' );
+			}
+			throw new RuntimeException( 'Unexpected tool failure.' );
+		}
+	) );
+}, 20 );

--- a/libs/frontman-wordpress/tests/integration/SentryRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/SentryRuntimeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+frontman_runtime_assert( is_file( FRONTMAN_PLUGIN_DIR . 'vendor/autoload.php' ), 'Release package must include the scoped SDK.' );
+frontman_runtime_assert( false === get_option( 'frontman_php_diagnostics', false ), 'PHP diagnostics must default to off.' );
+frontman_runtime_assert( extension_loaded( 'curl' ) && extension_loaded( 'mbstring' ), 'Runtime tests require cURL and mbstring.' );
+$original_user_id = get_current_user_id();
+wp_set_current_user( $admin->ID );
+$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
+$nonce = wp_create_nonce( Frontman_Auth::nonce_action() );
+
+try {
+	foreach ( [ [ false, false, false, 0 ], [ true, false, false, 1 ], [ true, true, false, 0 ], [ true, false, true, 1 ], [ false, false, false, 0 ] ] as [ $enabled, $expected, $fail_reporting, $captures ] ) {
+		update_option( 'frontman_php_diagnostics', $enabled );
+		update_option( 'frontman_test_sentry_fail', $fail_reporting );
+		update_option( 'frontman_test_sentry_count', 0 );
+		$response = frontman_runtime_tool( $cookie, $nonce, [ 'name' => 'wp_test_diagnostics', 'arguments' => [ 'expected' => $expected ] ] );
+		frontman_runtime_assert( 200 === $response['status'], 'Tool exception changed HTTP status.' );
+		frontman_runtime_assert( Frontman_Tools::error_result( $expected ? 'Expected tool failure.' : 'Unexpected tool failure.' ) === $response['body'], 'Diagnostics changed the SSE tool error result.' );
+		wp_cache_delete( 'frontman_test_sentry_count', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+		frontman_runtime_assert( $captures === (int) get_option( 'frontman_test_sentry_count' ), 'Router reporting did not respect consent or expected errors: ' . json_encode( [ $enabled, $expected, $fail_reporting, $captures, get_option( 'frontman_test_sentry_count' ) ] ) );
+	}
+} finally {
+	delete_option( 'frontman_php_diagnostics' );
+	delete_option( 'frontman_test_sentry_count' );
+	delete_option( 'frontman_test_sentry_fail' );
+	unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+	wp_set_current_user( $original_user_id );
+}

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -58,6 +58,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 $plugin = plugin_basename( FRONTMAN_PLUGIN_FILE );
 $admin = get_user_by( 'login', 'admin' );
 $cookie = wp_generate_auth_cookie( $admin->ID, time() + HOUR_IN_SECONDS, 'logged_in' );
+require __DIR__ . '/SentryRuntimeTest.php';
 $authenticated_context = stream_context_create( [ 'http' => [
 	'ignore_errors' => true,
 	'header' => 'Cookie: ' . LOGGED_IN_COOKIE . '=' . $cookie,

--- a/libs/frontman-wordpress/uninstall.php
+++ b/libs/frontman-wordpress/uninstall.php
@@ -10,3 +10,4 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 delete_option( 'frontman_settings' );
+delete_option( 'frontman_php_diagnostics' );

--- a/scripts/build-wordpress-dependencies.sh
+++ b/scripts/build-wordpress-dependencies.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+RUNTIME="${CONTAINER_RUNTIME:-docker}"
+TOOLS="$ROOT_DIR/dist/wordpress-build-tools"
+SOURCE="$ROOT_DIR/dist/wordpress-dependencies-source"
+SCOPED="$ROOT_DIR/dist/wordpress-dependencies-scoped"
+PLUGIN="$ROOT_DIR/libs/frontman-wordpress"
+SCOPER_SHA256="4775eb87675b2fb4eb0a31b56fe3d44f276ff3bfaadf69d497fef6d4ea738c48"
+
+USER_ARGS=()
+if [[ "$(basename "$RUNTIME")" != "podman" ]]; then
+  USER_ARGS=(--user "$(id -u):$(id -g)")
+fi
+if [[ "${1:-}" == "--update-lock" ]]; then
+  "$RUNTIME" run --rm "${USER_ARGS[@]}" -e COMPOSER_HOME=/tmp/composer \
+    -v "$ROOT_DIR:/workspace" -w /workspace/libs/frontman-wordpress \
+    docker.io/library/composer:2.8.12 update --no-install --no-interaction --no-scripts --no-plugins
+  exit
+fi
+
+mkdir -p "$TOOLS" "$SOURCE"
+if [[ ! -f "$TOOLS/php-scoper.phar" ]]; then
+  curl -fL --retry 3 https://github.com/humbug/php-scoper/releases/download/0.18.17/php-scoper.phar -o "$TOOLS/php-scoper.phar"
+fi
+printf '%s  %s\n' "$SCOPER_SHA256" "$TOOLS/php-scoper.phar" | sha256sum --check --status
+cp "$PLUGIN/composer.json" "$PLUGIN/composer.lock" "$SOURCE/"
+rm -rf "$SCOPED"
+
+"$RUNTIME" run --rm "${USER_ARGS[@]}" \
+  -e COMPOSER_HOME=/tmp/composer \
+  -v "$ROOT_DIR:/workspace" -w /workspace/dist/wordpress-dependencies-source \
+  docker.io/library/composer:2.8.12 sh -ec '
+    composer install --no-dev --no-interaction --prefer-dist --no-scripts --no-plugins
+    php /workspace/dist/wordpress-build-tools/php-scoper.phar add-prefix \
+      --config=/workspace/scripts/wordpress-scoper.inc.php \
+      --output-dir=/workspace/dist/wordpress-dependencies-scoped --force \
+      composer.json vendor
+    cd /workspace/dist/wordpress-dependencies-scoped
+    composer config autoloader-suffix FrontmanWordPress
+    composer dump-autoload --no-dev --classmap-authoritative --no-scripts --no-plugins
+    php /workspace/scripts/wordpress-scope-autoload.php
+    rm vendor/scoper-autoload.php
+  '
+mkdir -p "$PLUGIN/vendor"
+rsync -a --delete "$SCOPED/vendor/" "$PLUGIN/vendor/"

--- a/scripts/package-wordpress-plugin.sh
+++ b/scripts/package-wordpress-plugin.sh
@@ -19,6 +19,8 @@ if [ "$VERSION" != "$PLUGIN_VERSION" ]; then
   exit 1
 fi
 
+make -C "$ROOT_DIR" build-wordpress-dependencies
+
 ZIP_PATH="$DIST_DIR/frontman-wordpress-v${VERSION}.zip"
 WPORG_TARBALL_PATH="$DIST_DIR/frontman-wordpress-org-v${VERSION}.tar.gz"
 WPORG_EXPORT_PATH="$DIST_DIR/frontman-wordpress-org-v${VERSION}"
@@ -27,8 +29,8 @@ rm -rf "$BUILD_DIR" "$ZIP_PATH" "$WPORG_TARBALL_PATH" "$WPORG_EXPORT_PATH"
 mkdir -p "$DIST_DIR"
 mkdir -p "$PLUGIN_DIR" "$WPORG_DIR/trunk" "$WPORG_DIR/tags/$VERSION"
 
-rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' "$PLUGIN_SRC/" "$PLUGIN_DIR/"
-rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' --exclude 'CHANGELOG.md' "$PLUGIN_SRC/" "$WPORG_DIR/trunk/"
+rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' --exclude '/composer.json' --exclude '/composer.lock' "$PLUGIN_SRC/" "$PLUGIN_DIR/"
+rsync -a --delete --exclude '.DS_Store' --exclude '.wordpress-org/' --exclude 'tests/' --exclude 'package.json' --exclude '/composer.json' --exclude '/composer.lock' --exclude 'CHANGELOG.md' "$PLUGIN_SRC/" "$WPORG_DIR/trunk/"
 rsync -a --delete "$WPORG_DIR/trunk/" "$WPORG_DIR/tags/$VERSION/"
 
 if [ -d "$PLUGIN_SRC/.wordpress-org/assets" ]; then

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -68,6 +68,9 @@ done
 "$RUNTIME" exec "$WORDPRESS" php -r '$config = file_get_contents("/var/www/html/wp-config-sample.php"); $config = str_replace(["database_name_here", "username_here", "password_here", "localhost"], [getenv("WORDPRESS_DB_NAME"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_HOST")], $config); file_put_contents("/var/www/html/wp-config.php", $config);'
 "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/plugins/frontman-agentic-ai-editor
 "$RUNTIME" cp "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/." "$WORDPRESS:/var/www/html/wp-content/plugins/frontman-agentic-ai-editor/"
+"$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/mu-plugins
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/SentryRuntimeFixture.php" "$WORDPRESS:/var/www/html/wp-content/mu-plugins/frontman-sentry-test.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/SentryRuntimeTest.php" "$WORDPRESS:/tmp/SentryRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php" "$WORDPRESS:/tmp/WordPressRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php" "$WORDPRESS:/tmp/CustomCssRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"

--- a/scripts/wordpress-scope-autoload.php
+++ b/scripts/wordpress-scope-autoload.php
@@ -1,0 +1,8 @@
+<?php
+
+$ids = array_keys( require 'vendor/composer/autoload_files.php' );
+$scoped_ids = array_map( static function ( string $id ): string { return 'frontman-' . $id; }, $ids );
+foreach ( [ 'autoload_files.php', 'autoload_static.php' ] as $file ) {
+	$path = 'vendor/composer/' . $file;
+	file_put_contents( $path, str_replace( $ids, $scoped_ids, file_get_contents( $path ) ) );
+}

--- a/scripts/wordpress-scoper.inc.php
+++ b/scripts/wordpress-scoper.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+$polyfills = [];
+foreach ( glob( 'vendor/symfony/polyfill-*' ) as $directory ) {
+	foreach ( new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $directory, FilesystemIterator::SKIP_DOTS ) ) as $file ) {
+		$polyfills[] = $file->getRealPath();
+	}
+}
+
+return [
+	'prefix' => 'FrontmanVendor',
+	'exclude-files' => $polyfills,
+	'exclude-namespaces' => [ 'Symfony\\Polyfill' ],
+	'expose-global-constants' => false,
+	'expose-global-classes' => false,
+	'expose-global-functions' => false,
+];


### PR DESCRIPTION
## Summary
- Add administrator opt-in under Settings → Frontman for unexpected PHP tool exceptions.
- Bundle the official Sentry PHP SDK with isolated namespaces and PHP 7.4-compatible locked dependencies. Keep native PHP polyfills unscoped and separate Composer autoload identifiers to support other Sentry installations.
- Remove exception messages, arguments, source context, absolute paths, and request/user data from reports. Preserve tool responses when reporting fails.
- Add packaging, compatibility CI coverage, privacy disclosures, and a changeset.

## Verification
- WordPress core tool tests passed.
- Sentry tests passed on PHP 7.4 and 8.4, including both SDK load orders, consent, privacy, transport failure, and missing dependencies.
- Runtime tests passed on WordPress 6.0.9 / PHP 7.4 and WordPress 7.0.2 / PHP 7.4 and 8.4.
- Release ZIP contains the SDK and excludes test fixtures.
- Commit hooks passed after removing inline comments; no behavior changed.

## Limits
- Reporting is disabled by default and covers caught unexpected tool exceptions, not site-wide warnings or fatal errors.
- Live Sentry delivery remains unverified. Tests intercept events rather than send production telemetry.

## CI failure fix
- Fix the SwarmAi termination-event loss exposed by the failed registry crash test.
- Registry restart attempts can collide with an old partition and exhaust the supervisor restart limit. The resulting shutdown previously killed Runtime before it reported pending worker terminations.
- Runtime now traps exits and reports remaining tracked executions during shutdown.
- Add a regression that holds the old partition alive and suspends Runtime event processing to force the failure. Check that it reports termination exactly once.

### Additional verification
- `make -C apps/swarm_ai format check` passed: formatting, strict Credo, and 124 tests.
- The new regression failed without the runtime fix and passed with it.
- The original failing test passed 201 consecutive runs with the fix.
- Commit and push hooks passed. GitHub CI must pass on the updated commit before merge.
