### PR TITLE
Add exact-text editing for WordPress Additional CSS

### DIFF
--- a/.changeset/wordpress-exact-css-edits.md
+++ b/.changeset/wordpress-exact-css-edits.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Add exact-text editing to `wp_update_custom_css` with `oldText`, `newText`, and optional `replaceAll`. Agents can change small sections without sending the complete stylesheet. Existing full-replacement calls remain supported.
+
+Add persisted-source reads, scope checks, best-effort conflict detection, and compact edit receipts. Reject edits to preprocessor-backed CSS.

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -160,7 +160,8 @@ class Frontman_Tools {
 			return Frontman_Tool_Seo::validate_input( $name, $input );
 		}
 
-		$sanitized = $this->sanitize_value_for_schema( $input, $tool->input_schema, $name, '', $tool->preserve_input_strings );
+		$preserve_strings = $tool->preserve_input_strings || ( 'wp_update_custom_css' === $name && 'edit' === ( $input['mode'] ?? null ) );
+		$sanitized = $this->sanitize_value_for_schema( $input, $tool->input_schema, $name, '', $preserve_strings );
 		return is_array( $sanitized ) ? $sanitized : [];
 	}
 
@@ -265,14 +266,14 @@ class Frontman_Tools {
 				return (float) $value;
 
 			case 'boolean':
-				if ( $preserve_input_strings && 'confirm' === $field_name && ! is_bool( $value ) ) {
+				if ( $preserve_input_strings && in_array( $field_name, [ 'confirm', 'replaceAll' ], true ) && ! is_bool( $value ) ) {
 					return $value;
 				}
 
 				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 
 			case 'string':
-				if ( 'css' === $field_name && 'wp_update_custom_css' === $tool_name && ! is_string( $value ) ) {
+				if ( in_array( $tool_name, [ 'wp_update_custom_css', 'wp_get_custom_css' ], true ) && ! is_string( $value ) ) {
 					return $value;
 				}
 
@@ -362,7 +363,7 @@ class Frontman_Tools {
 			return in_array( $tool_name, [ 'wp_update_template', 'wp_upload_media' ], true ) ? $value : wp_kses_post( $value );
 		}
 
-		if ( 'css' === $field_name && 'wp_update_custom_css' === $tool_name ) {
+		if ( in_array( $tool_name, [ 'wp_update_custom_css', 'wp_get_custom_css' ], true ) ) {
 			return $value;
 		}
 

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -1289,6 +1289,79 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$registry_payload = json_decode( $registry_result['content'][0]['text'], true );
 		$this->assert_same( $registry_css, $registry_payload['after'], 'wp_update_custom_css preserves CSS through registry sanitization' );
 
+		$original = str_repeat( "/* unchanged padding */\r\n", 900 ) . '.target { color: red; }' . "\n" . $registry_css;
+		wp_update_custom_css_post( $original );
+		$GLOBALS['frontman_test_custom_css']['frontman-theme'] = '/* rendered filter output */';
+		$this->assert_same( '/* rendered filter output */', $tool->get_custom_css( [] )['css'], 'Default CSS reads preserve rendered output' );
+		$read = $tool->get_custom_css( [ 'source' => 'persisted' ] );
+		$this->assert_same( $original, $read['css'], 'Persisted CSS reads match fingerprint source' );
+		$edit = [
+			'mode' => 'edit', 'stylesheet' => $read['stylesheet'], 'parent_post_id' => $read['parent_post_id'],
+			'expected_current_sha256' => $read['persisted_css_sha256'], 'confirm' => true,
+			'oldText' => '.target { color: red; }', 'newText' => ".target {\n  color: blue;\n}",
+		];
+		$call_edit = static function( array $input ) use ( $registry ): array {
+			return $registry->call( 'wp_update_custom_css', $registry->sanitize_input( 'wp_update_custom_css', $input ) );
+		};
+		foreach ( [
+			[ [ 'mode' => 'append' ], 'mode must' ],
+			[ [ 'mode' => null ], 'mode must' ],
+			[ [ 'mode' => 'replace' ], 'only allowed' ],
+			[ [ 'css' => '' ], 'not allowed' ],
+			[ [ 'oldText' => '' ], 'nonempty' ],
+			[ [ 'newText' => $edit['oldText'] ], 'different' ],
+			[ [ 'oldText' => 'not present' ], 'not found' ],
+			[ [ 'oldText' => '/* unchanged padding */' ], 'Multiple matches' ],
+			[ [ 'oldText' => [] ], 'must be a string' ],
+			[ [ 'newText' => 42 ], 'must be a string' ],
+			[ [ 'replaceAll' => 'true' ], 'must be a boolean' ],
+			[ [ 'replaceAll' => null ], 'must be a boolean' ],
+			[ [ 'confirm' => 'true' ], 'confirm=true' ],
+			[ [ 'confirm' => false ], 'confirm=true' ],
+			[ [ 'parent_post_id' => '9001junk' ], 'positive integer' ],
+			[ [ 'parent_post_id' => 9999 ], 'does not match' ],
+			[ [ 'stylesheet' => 'inactive-theme' ], 'active stylesheet' ],
+			[ [ 'expected_current_sha256' => 'bad' ], 'SHA-256' ],
+			[ [ 'expected_current_sha256' => hash( 'sha256', 'stale' ) ], 'changed' ],
+		] as [ $overrides, $error ] ) {
+			$this->assert_tool_error_result_contains( $call_edit( array_merge( $edit, $overrides ) ), $error, 'CSS edit rejects ' . json_encode( $overrides ) );
+			$this->assert_same( $original, $tool->get_custom_css( [ 'source' => 'persisted' ] )['css'], 'Rejected edit leaves persisted CSS unchanged' );
+		}
+		foreach ( [ 'oldText', 'newText', 'stylesheet', 'parent_post_id', 'expected_current_sha256', 'confirm' ] as $field ) {
+			$missing = $edit;
+			unset( $missing[$field] );
+			$this->assert_same( true, $call_edit( $missing )['isError'], 'CSS edit requires ' . $field );
+		}
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme']->post_content_filtered = 'source';
+		$this->assert_tool_error_result_contains( $call_edit( $edit ), 'preprocessor', 'CSS edit rejects preprocessor state' );
+		$GLOBALS['frontman_test_custom_css_posts']['frontman-theme']->post_content_filtered = '';
+		$result = $call_edit( $edit );
+		$this->assert_same( false, $result['isError'], 'Exact CSS edit succeeds through registry' );
+		$receipt = json_decode( $result['content'][0]['text'], true );
+		$expected = str_replace( $edit['oldText'], $edit['newText'], $original );
+		$this->assert_same( $expected, $tool->get_custom_css( [ 'source' => 'persisted' ] )['css'], 'Small edit preserves all other bytes in a 20KB stylesheet' );
+		$this->assert_same( 1, $receipt['replacements'], 'Edit receipt reports replacement count' );
+		$this->assert_same( hash( 'sha256', $expected ), $receipt['after']['persisted_css_sha256'], 'Edit receipt fingerprints persisted output' );
+		$this->assert_same( strlen( $expected ), $receipt['after']['persisted_css_bytes'], 'Edit receipt counts persisted bytes' );
+		$this->assert_true( strlen( $result['content'][0]['text'] ) < 1000, 'Edit receipt does not echo stylesheet' );
+		$this->assert_tool_error_result_contains( $call_edit( $edit ), 'changed', 'Replaying successful edit with old fingerprint fails' );
+		foreach ( [
+			[ 'oldText' => $registry_css, 'newText' => $registry_css . "\n" . '.inserted::after { content: "\\31 $1 $$ \\path"; }' ],
+			[ 'oldText' => '.inserted::after { content: "\\31 $1 $$ \\path"; }', 'newText' => '' ],
+			[ 'oldText' => 'unchanged padding', 'newText' => 'literal $1 \\replacement', 'replaceAll' => true ],
+		] as $change ) {
+			$input = array_merge( $edit, $change, [ 'expected_current_sha256' => hash( 'sha256', $expected ) ] );
+			$result = $call_edit( $input );
+			$this->assert_same( false, $result['isError'], 'Insertion, deletion and replaceAll succeed' );
+			$expected = str_replace( $input['oldText'], $input['newText'], $expected, $count );
+			$receipt = json_decode( $result['content'][0]['text'], true );
+			$this->assert_same( $count, $receipt['replacements'], 'Exact occurrence count is reported' );
+			$this->assert_same( $expected, $tool->get_custom_css( [ 'source' => 'persisted' ] )['css'], 'Replacement strings stay literal through registry' );
+		}
+		foreach ( [ null, [], 'invalid' ] as $source ) {
+			$this->assert_tool_error_result_contains( $registry->call( 'wp_get_custom_css', $registry->sanitize_input( 'wp_get_custom_css', [ 'source' => $source ] ) ), 'source must', 'CSS read rejects invalid source' );
+		}
+
 		$mods = $tool->list_theme_mods( [] );
 		$this->assert_same( 'https://example.com/header.jpg', $mods['mods']['header_image'], 'wp_list_theme_mods exposes theme header source state' );
 

--- a/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php
@@ -427,6 +427,87 @@ function frontman_test_custom_css_restore_tool(): void {
 	remove_filter( 'wp_insert_post_data', $change_scope );
 }
 
+function frontman_test_custom_css_edit_tool(): void {
+	$stylesheet = get_stylesheet();
+	$original = str_repeat( "/* unchanged */\r\n", 1400 ) . '.target::after { content: "\\31 $1 \\path"; }';
+	$post = frontman_custom_css_update( $stylesheet, $original );
+	$tool = new Frontman_Tool_Options();
+	$registry = new Frontman_Tools();
+	$tool->register( $registry );
+	$render = static function( string $css ): string {
+		return $css . ' /* render-only */';
+	};
+	add_filter( 'wp_get_custom_css', $render );
+	frontman_runtime_assert( $original . ' /* render-only */' === $tool->get_custom_css( [] )['css'], 'Default read lost rendered CSS behavior.' );
+	$read = $tool->get_custom_css( [ 'source' => 'persisted' ] );
+	frontman_runtime_assert( $original === $read['css'], 'Persisted read included render filter output.' );
+	frontman_runtime_assert( hash( 'sha256', $read['css'] ) === $read['persisted_css_sha256'], 'Persisted read did not match fingerprint.' );
+	$input = [
+		'mode' => 'edit', 'stylesheet' => $stylesheet, 'parent_post_id' => $post->ID,
+		'expected_current_sha256' => $read['persisted_css_sha256'], 'confirm' => true,
+		'oldText' => '.target::after { content: "\\31 $1 \\path"; }',
+		'newText' => ".target {\n  color: blue;\n}" . '\n.literal::after { content: "\\32 $$ \\new"; }',
+	];
+	foreach ( [
+		[ 'expected_current_sha256' => hash( 'sha256', 'stale' ) ],
+		[ 'parent_post_id' => $post->ID + 1 ],
+		[ 'parent_post_id' => $post->ID . 'junk' ],
+		[ 'stylesheet' => 'inactive-theme' ],
+		[ 'confirm' => 'true' ],
+		[ 'oldText' => '/* unchanged */' ],
+		[ 'oldText' => 'missing' ],
+		[ 'newText' => [] ],
+		[ 'replaceAll' => 'true' ],
+	] as $overrides ) {
+		$result = $registry->call( 'wp_update_custom_css', $registry->sanitize_input( 'wp_update_custom_css', array_merge( $input, $overrides ) ) );
+		frontman_runtime_assert( true === $result['isError'], 'Invalid edit was accepted: ' . json_encode( $overrides ) );
+		frontman_runtime_assert( $original === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Rejected edit changed persisted CSS.' );
+	}
+	frontman_custom_css_update( $stylesheet, $original, 'preprocessor-source' );
+	frontman_custom_css_assert_tool_error( static function() use ( $tool, $input ): void {
+		$tool->update_custom_css( $input );
+	}, 'preprocessor' );
+	frontman_runtime_assert( 'preprocessor-source' === frontman_custom_css_persisted_post( $post->ID )->post_content_filtered, 'Rejected edit changed preprocessor source.' );
+	frontman_custom_css_update( $stylesheet, $original );
+	$result = $registry->call( 'wp_update_custom_css', $registry->sanitize_input( 'wp_update_custom_css', $input ) );
+	frontman_runtime_assert( false === $result['isError'], 'Exact edit failed through registry.' );
+	$receipt = json_decode( $result['content'][0]['text'], true );
+	$expected = str_replace( $input['oldText'], $input['newText'], $original );
+	frontman_runtime_assert( $expected === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Edit changed unrelated bytes or escaped replacement text.' );
+	frontman_runtime_assert( hash( 'sha256', $expected ) === $receipt['after']['persisted_css_sha256'], 'Edit receipt did not fingerprint persisted output.' );
+	frontman_runtime_assert( strlen( $expected ) === $receipt['after']['persisted_css_bytes'], 'Edit receipt byte count is incorrect.' );
+	frontman_runtime_assert( 1 === $receipt['replacements'] && strlen( $result['content'][0]['text'] ) < 1000, 'Edit receipt is not compact.' );
+	remove_filter( 'wp_get_custom_css', $render );
+
+	foreach ( [
+		[ 'oldText' => '/* unchanged */', 'newText' => '/* replaced $1 \\literal */', 'replaceAll' => true ],
+		[ 'oldText' => $input['newText'], 'newText' => $input['newText'] . "\n.inserted { color: red; }" ],
+		[ 'oldText' => "\n.inserted { color: red; }", 'newText' => '' ],
+	] as $change ) {
+		$next = array_merge( $input, $change, [ 'expected_current_sha256' => hash( 'sha256', $expected ) ] );
+		$result = $registry->call( 'wp_update_custom_css', $registry->sanitize_input( 'wp_update_custom_css', $next ) );
+		frontman_runtime_assert( false === $result['isError'], 'Replace-all, insert, or delete failed.' );
+		$expected = str_replace( $next['oldText'], $next['newText'], $expected, $count );
+		$receipt = json_decode( $result['content'][0]['text'], true );
+		frontman_runtime_assert( $count === $receipt['replacements'], 'Wrong replacement count.' );
+		frontman_runtime_assert( $expected === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Literal replacement was not persisted.' );
+	}
+
+	frontman_custom_css_update( $stylesheet, $original );
+	$transform = static function( array $data ): array {
+		if ( 'custom_css' === $data['post_type'] ) {
+			$data['post_content'] .= ' /* save-filter */';
+		}
+		return $data;
+	};
+	add_filter( 'wp_insert_post_data', $transform );
+	$receipt = $tool->update_custom_css( $input );
+	remove_filter( 'wp_insert_post_data', $transform );
+	$expected = str_replace( $input['oldText'], $input['newText'], $original ) . ' /* save-filter */';
+	frontman_runtime_assert( $expected === frontman_custom_css_persisted_post( $post->ID )->post_content, 'Save filter fixture did not transform edit.' );
+	frontman_runtime_assert( hash( 'sha256', $expected ) === $receipt['after']['persisted_css_sha256'], 'Edit receipt reported intended rather than observed output.' );
+}
+
 frontman_characterize_custom_css_revision_history();
 frontman_characterize_custom_css_revision_availability();
 frontman_characterize_custom_css_revision_scope();
@@ -435,4 +516,5 @@ frontman_characterize_preprocessor_custom_css_restore();
 frontman_characterize_custom_css_save_transformation();
 frontman_characterize_custom_css_conflicts();
 frontman_test_custom_css_read_tools();
+frontman_test_custom_css_edit_tool();
 frontman_test_custom_css_restore_tool();

--- a/libs/frontman-wordpress/tools/class-tool-options.php
+++ b/libs/frontman-wordpress/tools/class-tool-options.php
@@ -143,6 +143,7 @@ class Frontman_Tool_Options {
 				'additionalProperties' => false,
 				'properties'           => [
 					'stylesheet' => [ 'type' => 'string', 'description' => 'Optional theme stylesheet slug. Defaults to the active stylesheet.' ],
+					'source'     => [ 'type' => 'string', 'enum' => [ 'rendered', 'persisted' ], 'description' => 'Defaults to rendered. Use persisted before exact-text editing; its css matches persisted_css_sha256.' ],
 				],
 			],
 			[ $this, 'get_custom_css' ]
@@ -208,16 +209,22 @@ class Frontman_Tool_Options {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_update_custom_css',
-			'Updates WordPress Additional CSS for the active theme and returns before/after CSS. Use only after inspecting the current CSS; requires confirm=true because it changes site-wide persistent styling.',
+			'Updates WordPress Additional CSS for the active theme. Default mode=replace accepts complete css and returns before/after CSS. For small changes, read wp_get_custom_css with source=persisted, then use mode=edit with oldText/newText and the returned scope and fingerprint. Matching is exact, not fuzzy. Insert by replacing an anchor with anchor plus new text; delete with empty newText. Edit returns compact observed metadata. Requires confirm=true after user approval. Conflict detection is best-effort, not atomic. Never retry automatically after a lost response.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
 				'properties'           => [
-					'css'        => [ 'type' => 'string', 'description' => 'Complete replacement Additional CSS contents for the active theme.' ],
-					'stylesheet' => [ 'type' => 'string', 'description' => 'Optional theme stylesheet slug. If provided, it must match the active stylesheet.' ],
+					'mode'       => [ 'type' => 'string', 'enum' => [ 'replace', 'edit' ], 'description' => 'Defaults to replace. Edit requires oldText, newText, stylesheet, parent_post_id, and expected_current_sha256; css is not allowed.' ],
+					'css'        => [ 'type' => 'string', 'description' => 'Required in replace mode: complete replacement Additional CSS contents.' ],
+					'oldText'    => [ 'type' => 'string', 'description' => 'Edit only: nonempty exact text to replace. Must match once unless replaceAll=true.' ],
+					'newText'    => [ 'type' => 'string', 'description' => 'Edit only: literal replacement text, different from oldText. Empty string deletes.' ],
+					'replaceAll' => [ 'type' => 'boolean', 'description' => 'Edit only: replace all non-overlapping exact occurrences. Defaults to false.' ],
+					'parent_post_id' => [ 'type' => 'integer', 'description' => 'Edit only: current Custom CSS post ID from wp_get_custom_css.' ],
+					'expected_current_sha256' => [ 'type' => 'string', 'pattern' => '^[a-f0-9]{64}$', 'description' => 'Edit only: persisted_css_sha256 from the prior read. Best-effort conflict detection, not an atomic lock.' ],
+					'stylesheet' => [ 'type' => 'string', 'description' => 'Theme stylesheet slug. Required in edit mode, optional in replace mode. Must match the active stylesheet.' ],
 					'confirm'    => [ 'type' => 'boolean', 'description' => 'Must be true after the user approves changing persistent site CSS.' ],
 				],
-				'required'             => [ 'css', 'confirm' ],
+				'required'             => [ 'confirm' ],
 			],
 			[ $this, 'update_custom_css' ]
 		) );
@@ -335,6 +342,10 @@ class Frontman_Tool_Options {
 			throw new Frontman_Tool_Error( 'WordPress custom CSS API is unavailable.' );
 		}
 
+		$source = array_key_exists( 'source', $input ) ? $input['source'] : 'rendered';
+		if ( ! in_array( $source, [ 'rendered', 'persisted' ], true ) ) {
+			throw new Frontman_Tool_Error( 'source must be rendered or persisted.' );
+		}
 		$stylesheet   = $this->stylesheet_from_input( $input, false );
 		$post         = wp_get_custom_css_post( $stylesheet );
 		if ( null !== $post ) {
@@ -344,7 +355,7 @@ class Frontman_Tool_Options {
 
 		return [
 			'stylesheet'                  => $stylesheet,
-			'css'                         => wp_get_custom_css( $stylesheet ),
+			'css'                         => 'persisted' === $source ? $persisted_css : wp_get_custom_css( $stylesheet ),
 			'parent_post_id'              => null === $post ? null : (int) $post->ID,
 			'persisted_css_bytes'         => strlen( $persisted_css ),
 			'persisted_css_sha256'        => hash( 'sha256', $persisted_css ),
@@ -452,6 +463,18 @@ class Frontman_Tool_Options {
 			throw new Frontman_Tool_Error( 'WordPress custom CSS API is unavailable.' );
 		}
 
+		$mode = array_key_exists( 'mode', $input ) ? $input['mode'] : 'replace';
+		if ( ! in_array( $mode, [ 'replace', 'edit' ], true ) ) {
+			throw new Frontman_Tool_Error( 'mode must be replace or edit.' );
+		}
+		if ( 'edit' === $mode ) {
+			return $this->edit_custom_css( $input );
+		}
+		foreach ( [ 'oldText', 'newText', 'replaceAll', 'parent_post_id', 'expected_current_sha256' ] as $field ) {
+			if ( array_key_exists( $field, $input ) ) {
+				throw new Frontman_Tool_Error( "{$field} is only allowed in edit mode." );
+			}
+		}
 		if ( ! array_key_exists( 'css', $input ) || ! is_string( $input['css'] ) ) {
 			throw new Frontman_Tool_Error( 'css is required and must be a string.' );
 		}
@@ -470,6 +493,69 @@ class Frontman_Tool_Options {
 			'stylesheet' => $stylesheet,
 			'before'     => $before,
 			'after'      => wp_get_custom_css( $stylesheet ),
+		];
+	}
+
+	private function edit_custom_css( array $input ): array {
+		if ( array_key_exists( 'css', $input ) ) {
+			throw new Frontman_Tool_Error( 'css is not allowed in edit mode.' );
+		}
+		foreach ( [ 'oldText', 'newText' ] as $field ) {
+			if ( ! array_key_exists( $field, $input ) || ! is_string( $input[ $field ] ) ) {
+				throw new Frontman_Tool_Error( "{$field} is required and must be a string." );
+			}
+		}
+		if ( '' === $input['oldText'] || $input['oldText'] === $input['newText'] ) {
+			throw new Frontman_Tool_Error( 'oldText must be nonempty and different from newText.' );
+		}
+		$replace_all = array_key_exists( 'replaceAll', $input ) ? $input['replaceAll'] : false;
+		if ( ! is_bool( $replace_all ) ) {
+			throw new Frontman_Tool_Error( 'replaceAll must be a boolean.' );
+		}
+		if ( ! function_exists( 'clean_post_cache' ) || ! function_exists( 'get_post' ) ) {
+			throw new Frontman_Tool_Error( 'WordPress post API is unavailable.' );
+		}
+		[ $stylesheet, $post ] = $this->custom_css_post_from_expected_scope( $input, 'wp_update_custom_css' );
+		$before = $this->custom_css_post_metadata( $post );
+		$expected_hash = $input['expected_current_sha256'] ?? null;
+		if ( ! is_string( $expected_hash ) || 1 !== preg_match( '/\A[a-f0-9]{64}\z/', $expected_hash ) ) {
+			throw new Frontman_Tool_Error( 'expected_current_sha256 must be a lowercase SHA-256 fingerprint.' );
+		}
+		if ( $expected_hash !== $before['persisted_css_sha256'] ) {
+			throw new Frontman_Tool_Error( 'Current Additional CSS changed after inspection. Read current state again before editing.' );
+		}
+		if ( $before['preprocessor_source_present'] ) {
+			throw new Frontman_Tool_Error( 'Custom CSS editing does not support preprocessor-backed CSS.' );
+		}
+		$current = (string) $post->post_content;
+		$first = strpos( $current, $input['oldText'] );
+		if ( false === $first ) {
+			throw new Frontman_Tool_Error( 'oldText not found. Read wp_get_custom_css with source=persisted and copy exact text.' );
+		}
+		if ( ! $replace_all && $first !== strrpos( $current, $input['oldText'] ) ) {
+			throw new Frontman_Tool_Error( 'Multiple matches for oldText. Provide more context or use replaceAll=true.' );
+		}
+		$css = str_replace( $input['oldText'], $input['newText'], $current, $replacements );
+		$saved = wp_update_custom_css_post( $css, [ 'stylesheet' => $stylesheet ] );
+		if ( is_wp_error( $saved ) ) {
+			throw new Frontman_Tool_Error( $saved->get_error_message() );
+		}
+		clean_post_cache( $post->ID );
+		$observed = get_post( $post->ID );
+		if ( ! $saved || (int) $saved->ID !== (int) $post->ID || null === $observed || ! $this->is_custom_css_post_in_scope( $observed, $stylesheet ) ) {
+			throw new Frontman_Tool_Error( 'Custom CSS edit outcome is ambiguous. Read current state and do not retry automatically.' );
+		}
+		$after = $this->custom_css_post_metadata( $observed );
+		if ( $after['preprocessor_source_present'] ) {
+			throw new Frontman_Tool_Error( 'Custom CSS edit produced unsupported preprocessor state. Read current state and do not retry automatically.' );
+		}
+		return [
+			'updated'        => true,
+			'stylesheet'     => $stylesheet,
+			'parent_post_id' => (int) $post->ID,
+			'replacements'   => $replacements,
+			'before'         => $before,
+			'after'          => $after,
 		];
 	}
 


### PR DESCRIPTION
## Summary
- Extend `wp_update_custom_css` with exact-text edit mode (`oldText`, `newText`, optional `replaceAll`) while preserving full-replacement calls.
- Add persisted-source reads, active-theme/post scope checks, best-effort fingerprint conflict detection, and preprocessor rejection.
- Return compact edit receipts instead of full stylesheets. Include a minor changeset.

## Validation
- `make test-wordpress-core-tools` passed in the PHP 8.4 CLI container.
- `CONTAINER_RUNTIME=podman make test-wordpress-runtime` passed on WordPress 7.0.2 / PHP 8.4.23.
- Coverage includes 20KB+ stylesheets, insertion/deletion, replace-all, literal escapes, invalid inputs, stale fingerprints, rendered versus persisted source, and save-filter transformations.
- Pre-commit checks passed.

## Limitations
Matching is exact, not fuzzy. Conflict checks are best-effort, not atomic; ambiguous responses must not trigger automatic retries.