### PR TITLE
fix(deploy): print active execution count for slot draining

### DIFF
--- a/.changeset/fix-deploy-drain-rpc-output.md
+++ b/.changeset/fix-deploy-drain-rpc-output.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Print the active execution count during deployment so the old server can stop when its work finishes instead of always waiting five minutes.

--- a/infra/production/deploy.sh
+++ b/infra/production/deploy.sh
@@ -46,7 +46,7 @@ active_execution_count() {
     source "${DEPLOY_ROOT}/${ACTIVE_SLOT}/env"
     set +a
     "${DEPLOY_ROOT}/${ACTIVE_SLOT}/current/bin/${APP_NAME}" rpc \
-      "SwarmAi.active_count(FrontmanServer.AgentRuntime)" 2>&1
+      "IO.puts(SwarmAi.active_count(FrontmanServer.AgentRuntime))" 2>&1
   ); then
     echo "  WARNING: Could not read active execution count from ${ACTIVE_SLOT}: ${output}" >&2
     return 1


### PR DESCRIPTION
## Summary
- Print the RPC result with `IO.puts` so deployment can read the active execution count.
- Preserve count validation and the five-minute fallback for failed or malformed RPC responses.
- Add a patch changeset.

## Evidence
Deployment #34200603334 received an empty count and waited 300 seconds before stopping green. Read-only checks on production reproduced empty stdout for the existing expression and numeric output with `IO.puts`.

## Validation
- `bash -n infra/production/deploy.sh`
- `git diff --check`
- Temporary Bash harness exercised the actual count/drain functions with mocked RPC and sleep: zero drains immediately; positive counts keep polling; empty, invalid, and failed responses retain the 300-second fallback.

No production files or services were changed.