### PR TITLE
fix(wordpress): persist Elementor snapshots as Unicode-safe JSON

### DIFF
--- a/.changeset/fix-elementor-snapshot-unicode.md
+++ b/.changeset/fix-elementor-snapshot-unicode.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Store Elementor undo snapshots as Unicode-escaped JSON so emoji can be saved on legacy WordPress metadata charsets. Verify snapshot contents before saving edits, preserve existing rollback history, and report rejected writes separately from readback mismatches.

--- a/libs/frontman-wordpress/includes/class-frontman-elementor-data.php
+++ b/libs/frontman-wordpress/includes/class-frontman-elementor-data.php
@@ -239,14 +239,26 @@ class Frontman_Elementor_Data {
     }
 
     public static function save_rollback( int $post_id, array $rollback ): array {
+        $rollback_id = (string) ( $rollback['rollback_id'] ?? '' );
+        if ( '' === $rollback_id ) {
+            throw new Frontman_Tool_Error( 'Elementor rollback snapshot requires a nonempty rollback ID. Elementor content was not saved.' );
+        }
+
         $rollbacks = self::get_rollbacks( $post_id );
         array_unshift( $rollbacks, $rollback );
         $rollbacks = array_slice( $rollbacks, 0, self::MAX_ROLLBACKS );
-        update_post_meta( $post_id, self::ROLLBACK_META_KEY, function_exists( 'wp_slash' ) ? wp_slash( $rollbacks ) : $rollbacks );
+        $json = wp_json_encode( $rollbacks, JSON_PRESERVE_ZERO_FRACTION );
+        if ( false === $json || json_decode( $json, true ) !== $rollbacks ) {
+            throw new Frontman_Tool_Error( 'Could not encode Elementor rollback snapshot without changing its contents. Elementor content was not saved.' );
+        }
 
-        $rollback_id = (string) ( $rollback['rollback_id'] ?? '' );
-        if ( '' === $rollback_id || ! self::rollback_exists( self::get_rollbacks( $post_id ), $rollback_id ) ) {
-            throw new Frontman_Tool_Error( 'Failed to persist Elementor rollback snapshot.' );
+        $written = update_post_meta( $post_id, self::ROLLBACK_META_KEY, wp_slash( $json ) );
+        if ( self::get_rollbacks( $post_id ) !== $rollbacks ) {
+            throw new Frontman_Tool_Error(
+                false === $written
+                    ? 'WordPress did not persist the Elementor rollback snapshot. Elementor content was not saved.'
+                    : 'Elementor rollback snapshot readback did not match. Elementor content was not saved.'
+            );
         }
 
         return $rollback;
@@ -587,16 +599,6 @@ class Frontman_Elementor_Data {
         }
 
         return $response;
-    }
-
-    private static function rollback_exists( array $rollbacks, string $rollback_id ): bool {
-        foreach ( $rollbacks as $rollback ) {
-            if ( $rollback_id === (string) ( $rollback['rollback_id'] ?? '' ) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static function is_element_list( array $elements ): bool {

--- a/libs/frontman-wordpress/tests/ElementorToolsTest.php
+++ b/libs/frontman-wordpress/tests/ElementorToolsTest.php
@@ -5,6 +5,7 @@ define( 'ABSPATH', sys_get_temp_dir() . '/frontman-wordpress-elementor-tools/' )
 $GLOBALS['frontman_test_posts'] = [];
 $GLOBALS['frontman_test_meta']  = [];
 $GLOBALS['frontman_test_update_meta_callbacks'] = [];
+$GLOBALS['frontman_test_reject_rollback_write'] = false;
 
 if ( ! class_exists( 'WP_Post' ) ) {
 	class WP_Post {
@@ -157,7 +158,14 @@ if ( ! function_exists( 'get_post_meta' ) ) {
 
 if ( ! function_exists( 'update_post_meta' ) ) {
 	function update_post_meta( int $post_id, string $key, $value ): bool {
-		$GLOBALS['frontman_test_meta'][ $post_id ][ $key ] = wp_unslash( $value );
+		if ( '_frontman_elementor_rollbacks' === $key && $GLOBALS['frontman_test_reject_rollback_write'] ) {
+			return false;
+		}
+		$value = wp_unslash( $value );
+		if ( ( $GLOBALS['frontman_test_meta'][ $post_id ][ $key ] ?? null ) === $value ) {
+			return false;
+		}
+		$GLOBALS['frontman_test_meta'][ $post_id ][ $key ] = $value;
 		foreach ( $GLOBALS['frontman_test_update_meta_callbacks'] as $callback ) {
 			$callback( $post_id, $key, $value );
 		}
@@ -232,6 +240,9 @@ class Frontman_Elementor_Tools_Test_Runner {
 		$this->test_add_element_rejects_empty_element();
 		$this->test_add_duplicate_and_move_restore_rollbacks();
 		$this->test_rollback_preserves_backslash_newline_styles();
+		$this->test_rollback_json_and_legacy_storage();
+		$this->test_rollback_write_failures_abort_elementor_save();
+		$this->test_rollback_invalid_encoding_and_id();
 		$this->test_generate_element();
 
 		fwrite( STDOUT, "OK ({$this->assertions} assertions)\n" );
@@ -961,6 +972,74 @@ class Frontman_Elementor_Tools_Test_Runner {
 
 		$element = Frontman_Elementor_Data::get_element( Frontman_Elementor_Data::get_page_data( 45 ), 'html4501' );
 		$this->assert_same( $original, $element['settings']['html'], 'Rollback preserves backslash-newline CSS data URI content' );
+	}
+
+	private function test_rollback_json_and_legacy_storage(): void {
+		$key = '_frontman_elementor_rollbacks';
+		$data = Frontman_Elementor_Data::get_page_data( 42 );
+		$data[0]['settings']['snapshot_test'] = [ 'text' => "🎃🎄💜 \"quoted\" \\path\nnext", 'size' => 1.0 ];
+		$legacy = Frontman_Elementor_Data::make_page_rollback( 'saved_page_data', $data );
+		$GLOBALS['frontman_test_meta'][42][$key] = [ $legacy ];
+		$rollback = Frontman_Elementor_Data::make_page_rollback( 'saved_page_data', $data );
+		Frontman_Elementor_Data::save_rollback( 42, $rollback );
+		$stored = get_post_meta( 42, $key, true );
+		$this->assert_true( is_string( $stored ), 'New snapshots use JSON storage' );
+		$this->assert_same( 0, preg_match( '/[^\x00-\x7f]/', $stored ), 'JSON snapshots escape Unicode' );
+		$this->assert_same( [ $rollback, $legacy ], json_decode( $stored, true ), 'JSON preserves new and legacy snapshots exactly, including floats' );
+		$restored = $this->call_success( 'wp_elementor_restore_rollback', [ 'post_id' => 42, 'rollback_id' => $legacy['rollback_id'], 'confirm' => true ] );
+		$this->assert_same( true, $restored['success'], 'Legacy snapshot remains restorable after JSON conversion' );
+		$this->assert_same( $data[0]['settings']['snapshot_test']['text'], Frontman_Elementor_Data::get_page_data( 42 )[0]['settings']['snapshot_test']['text'], 'Restore preserves emoji, quotes, backslashes and newlines' );
+
+		$GLOBALS['frontman_test_meta'][42][$key] = array_fill( 0, 20, $rollback );
+		Frontman_Elementor_Data::save_rollback( 42, $rollback );
+		Frontman_Elementor_Data::save_rollback( 42, $rollback );
+		$this->assert_same( array_fill( 0, 20, $rollback ), json_decode( get_post_meta( 42, $key, true ), true ), 'Retention stays at 20 and unchanged writes succeed after exact readback' );
+	}
+
+	private function test_rollback_write_failures_abort_elementor_save(): void {
+		$before = get_post_meta( 42, '_elementor_data', true );
+		$input = [ 'post_id' => 42, 'element_id' => 'head2222', 'settings' => [ 'title' => 'Must not save' ] ];
+		$GLOBALS['frontman_test_reject_rollback_write'] = true;
+		try {
+			$error = $this->call_error( 'wp_elementor_update_element', $input );
+			$this->assert_true( false !== strpos( $error, 'WordPress did not persist' ), 'Rejected metadata writes have a specific error' );
+			$this->assert_same( $before, get_post_meta( 42, '_elementor_data', true ), 'Rejected snapshot writes leave Elementor data unchanged' );
+		} finally {
+			$GLOBALS['frontman_test_reject_rollback_write'] = false;
+		}
+
+		$GLOBALS['frontman_test_update_meta_callbacks'][] = static function ( int $post_id, string $key, $value ): void {
+			if ( '_frontman_elementor_rollbacks' === $key ) {
+				$rollbacks = json_decode( $value, true );
+				$rollbacks[0]['element']['settings']['title'] = 'Corrupted snapshot with original ID';
+				$GLOBALS['frontman_test_meta'][$post_id][$key] = wp_json_encode( $rollbacks, JSON_PRESERVE_ZERO_FRACTION );
+			}
+		};
+		try {
+			$error = $this->call_error( 'wp_elementor_update_element', $input );
+			$this->assert_true( false !== strpos( $error, 'readback did not match' ), 'Content corruption is detected even when the ID survives' );
+			$this->assert_same( $before, get_post_meta( 42, '_elementor_data', true ), 'Corrupted snapshot writes leave Elementor data unchanged' );
+		} finally {
+			$GLOBALS['frontman_test_update_meta_callbacks'] = [];
+		}
+	}
+
+	private function test_rollback_invalid_encoding_and_id(): void {
+		$before = $GLOBALS['frontman_test_meta'][42];
+		foreach ( [
+			[ 'rollback_id' => '', 'data' => [] ],
+			[ 'rollback_id' => 'invalid', 'data' => [ 'number' => INF ] ],
+			[ 'rollback_id' => 'lossy', 'data' => [ 'object' => (object) [] ] ],
+		] as $rollback ) {
+			$error = null;
+			try {
+				Frontman_Elementor_Data::save_rollback( 42, $rollback );
+			} catch ( Frontman_Tool_Error $exception ) {
+				$error = $exception->getMessage();
+			}
+			$this->assert_true( null !== $error && false !== strpos( $error, 'Elementor content was not saved' ), 'Invalid or lossy snapshots fail before writing' );
+			$this->assert_same( $before, $GLOBALS['frontman_test_meta'][42], 'Invalid snapshots leave all metadata unchanged' );
+		}
 	}
 
 	private function test_generate_element(): void {

--- a/libs/frontman-wordpress/tests/integration/ElementorSnapshotRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/ElementorSnapshotRuntimeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once WP_PLUGIN_DIR . '/frontman-agentic-ai-editor/includes/class-frontman-elementor-data.php';
+require_once WP_PLUGIN_DIR . '/frontman-agentic-ai-editor/tools/class-tool-elementor.php';
+
+foreach ( [ 'utf8mb3', 'utf8mb4' ] as $charset ) {
+	$post_id = wp_insert_post( [ 'post_type' => 'page', 'post_title' => 'Snapshot charset test', 'post_status' => 'draft' ], true );
+	frontman_runtime_assert( ! is_wp_error( $post_id ), 'Could not create snapshot fixture.' );
+	$original_table = $wpdb->postmeta;
+	$table = $wpdb->prefix . 'frontman_snapshot_' . $charset;
+	frontman_runtime_assert( false !== $wpdb->query( "CREATE TEMPORARY TABLE $table LIKE $original_table" ), 'Could not create isolated metadata table.' );
+	try {
+		frontman_runtime_assert( false !== $wpdb->query( "ALTER TABLE $table MODIFY meta_value LONGTEXT CHARACTER SET $charset COLLATE {$charset}_general_ci" ), 'Could not configure test metadata charset.' );
+		$wpdb->postmeta = $table;
+		wp_cache_delete( $post_id, 'post_meta' );
+		$key = '_frontman_elementor_rollbacks';
+		$text = "🎃🎄💜 \"quoted\" \\path\nnext";
+		$data = [ [ 'id' => 'heading1', 'elType' => 'widget', 'widgetType' => 'heading', 'settings' => [ 'title' => $text ], 'elements' => [] ] ];
+		update_post_meta( $post_id, '_elementor_data', wp_slash( wp_json_encode( $data ) ) );
+		$rollback = Frontman_Elementor_Data::make_page_rollback( 'saved_page_data', $data );
+		$old_result = update_post_meta( $post_id, $key, wp_slash( [ $rollback ] ) );
+		frontman_runtime_assert( 'utf8mb3' === $charset ? false === $old_result : false !== $old_result, 'Legacy array writer did not exhibit expected charset behavior.' );
+		delete_post_meta( $post_id, $key );
+
+		$legacy = Frontman_Elementor_Data::make_page_rollback( 'saved_page_data', [] );
+		frontman_runtime_assert( false !== update_post_meta( $post_id, $key, wp_slash( [ $legacy ] ) ), 'Could not seed legacy array snapshot.' );
+		Frontman_Elementor_Data::save_rollback( $post_id, $rollback );
+		wp_cache_delete( $post_id, 'post_meta' );
+		$stored = get_post_meta( $post_id, $key, true );
+		frontman_runtime_assert( is_string( $stored ) && [ $rollback, $legacy ] === json_decode( $stored, true ), 'Snapshot JSON did not survive real database readback.' );
+		frontman_runtime_assert( 0 === preg_match( '/[^\x00-\x7f]/', $stored ), 'Snapshot storage contains unescaped Unicode.' );
+
+		$tool = new Frontman_Tool_Elementor();
+		$updated = $tool->update_element( [ 'post_id' => $post_id, 'element_id' => 'heading1', 'settings' => [ 'title' => 'Changed' ] ] );
+		frontman_runtime_assert( true === $updated['success'], 'Granular edit failed with emoji in its snapshot.' );
+		$restored = $tool->restore_rollback( [ 'post_id' => $post_id, 'rollback_id' => $updated['rollback_id'], 'confirm' => true ] );
+		wp_cache_delete( $post_id, 'post_meta' );
+		frontman_runtime_assert( true === $restored['success'] && $data === Frontman_Elementor_Data::get_page_data( $post_id ), 'Granular rollback did not restore exact original content.' );
+		$restored = $tool->restore_rollback( [ 'post_id' => $post_id, 'rollback_id' => $legacy['rollback_id'], 'confirm' => true ] );
+		frontman_runtime_assert( true === $restored['success'] && [] === Frontman_Elementor_Data::get_page_data( $post_id ), 'Legacy snapshot was not restorable after JSON conversion.' );
+		fwrite( STDOUT, "OK (Elementor snapshots, $charset)\n" );
+	} finally {
+		$wpdb->postmeta = $original_table;
+		wp_cache_delete( $post_id, 'post_meta' );
+		$wpdb->query( "DROP TEMPORARY TABLE $table" );
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
@@ -12,6 +12,7 @@ set_error_handler(
 require '/var/www/html/wp-load.php';
 require '/tmp/WordPressRuntimeTest.php';
 require '/tmp/CustomCssRuntimeTest.php';
+require '/tmp/ElementorSnapshotRuntimeTest.php';
 restore_error_handler();
 
 fwrite( STDOUT, 'OK (WordPress ' . get_bloginfo( 'version' ) . ', PHP ' . PHP_VERSION . ")\n" );

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -70,6 +70,7 @@ done
 "$RUNTIME" cp "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/." "$WORDPRESS:/var/www/html/wp-content/plugins/frontman-agentic-ai-editor/"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php" "$WORDPRESS:/tmp/WordPressRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/CustomCssRuntimeTest.php" "$WORDPRESS:/tmp/CustomCssRuntimeTest.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ElementorSnapshotRuntimeTest.php" "$WORDPRESS:/tmp/ElementorSnapshotRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php" "$WORDPRESS:/tmp/RunWordPressRuntimeTest.php"
 if [[ -n "$YOAST_VERSION" ]]; then


### PR DESCRIPTION
## Summary
- Store private Elementor rollback snapshots as Unicode-escaped JSON using WordPress metadata APIs.
- Verify encoding and full snapshot readback before saving Elementor edits; distinguish rejected writes from readback mismatches.
- Preserve legacy array snapshots and the existing 20-snapshot retention limit.
- Add a patch changeset and regression coverage for Unicode, escaping, floats, legacy restore, invalid snapshots, rejected writes, and corrupted readback.

## Verification
- `make test-wordpress-core-tools` — passed (1,183 assertions).
- `CONTAINER_RUNTIME=podman make test-wordpress-runtime` — passed on WordPress 7.0.2 / PHP 8.4.23.
- Real MariaDB tests reproduce the old emoji-write failure on utf8mb3 and verify save/restore on both utf8mb3 and utf8mb4 using isolated temporary metadata tables.
- `git diff --check` and commit hooks passed.

## Scope
No new agent permissions, production schema changes, or bypass of snapshot-before-edit protection. The charset compatibility bug is reproduced in tests; this does not establish the cause of any particular customer incident.