### PR TITLE
fix(wordpress): include persisted slugs in post list results

### DIFF
--- a/.changeset/wordpress-list-post-slugs.md
+++ b/.changeset/wordpress-list-post-slugs.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Include the stored slug in WordPress post list results, consistent with single-post reads. Draft and pending slugs can be empty; publication applies WordPress core slug rules.

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -224,6 +224,37 @@ foreach ( [ 'wp_create_post', 'wp_update_post' ] as $slug_tool ) {
 }
 frontman_runtime_assert( $posts_before_invalid_slugs === $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A ), 'Rejected slug requests changed posts.' );
 
+$listed_slug_ids = [];
+foreach ( [ [ 'draft', '' ], [ 'pending', '' ], [ 'draft', 'stored-list-slug' ], [ 'publish', 'unique-list-slug' ], [ 'publish', 'unique-list-slug' ] ] as $index => $fixture ) {
+	$created = $slug_call( 'wp_create_post', [
+		'title' => 'Runtime Listed Slug Fixture ' . $index,
+		'content' => '',
+		'status' => $fixture[0],
+	] + ( '' === $fixture[1] ? [] : [ 'slug' => $fixture[1] ] ) );
+	$listed_slug_ids[] = $created['id'];
+}
+$slug_call( 'wp_update_post', [ 'id' => $listed_slug_ids[2], 'excerpt' => 'Metadata-only list fixture update' ] );
+$expected_slugs = [ '', '', 'stored-list-slug', 'unique-list-slug', 'unique-list-slug-2' ];
+$posts_before_listing = $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A );
+foreach ( [ 'any', 'draft', 'pending', 'publish' ] as $status ) {
+	$expected_ids = array_values( array_filter( $listed_slug_ids, static function ( int $id ) use ( $status ): bool {
+		return 'any' === $status || get_post_status( $id ) === $status;
+	} ) );
+	$total_pages = (int) ceil( count( $expected_ids ) / 2 );
+	for ( $page = 1; $page <= $total_pages; $page++ ) {
+		$listed = $slug_call( 'wp_list_posts', [ 'post_type' => 'post', 'status' => $status, 'search' => 'Runtime Listed Slug Fixture', 'per_page' => 2, 'page' => $page, 'orderby' => 'title', 'order' => 'ASC' ] );
+		frontman_runtime_assert( count( $expected_ids ) === $listed['total'] && $total_pages === $listed['total_pages'] && $page === $listed['page'], 'Slug listing changed pagination metadata.' );
+		frontman_runtime_assert( array_slice( $expected_ids, ( $page - 1 ) * 2, 2 ) === array_column( $listed['posts'], 'id' ), 'Slug listing changed filtering or pagination.' );
+		foreach ( $listed['posts'] as $listed_post ) {
+			$read = $slug_call( 'wp_read_post', [ 'id' => $listed_post['id'] ] );
+			$expected_slug = $expected_slugs[ array_search( $listed_post['id'], $listed_slug_ids, true ) ];
+			frontman_runtime_assert( array_key_exists( 'slug', $listed_post ), 'Post list omitted the persisted slug.' );
+			frontman_runtime_assert( $expected_slug === $listed_post['slug'] && $read['slug'] === $listed_post['slug'] && get_post( $listed_post['id'] )->post_name === $listed_post['slug'], 'List/read slugs differ from the stored slug.' );
+		}
+	}
+}
+frontman_runtime_assert( $posts_before_listing === $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A ), 'Listing or reading slugs mutated posts.' );
+
 $yoast = getenv( 'EXPECTED_YOAST_VERSION' );
 if ( false === $yoast || '' === $yoast ) {
 	frontman_runtime_assert( null === Frontman_Tools::instance()->get( 'wp_read_seo' ), 'SEO tools were registered without Yoast.' );

--- a/libs/frontman-wordpress/tools/class-tool-posts.php
+++ b/libs/frontman-wordpress/tools/class-tool-posts.php
@@ -22,7 +22,7 @@ class Frontman_Tool_Posts {
 	public function register( Frontman_Tools $tools ): void {
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_list_posts',
-			'Lists posts, pages, or custom post types with pagination and filtering.',
+			'Lists posts, pages, or custom post types with pagination and filtering. Returns stored slugs, which can be empty for drafts or pending posts. Publication applies WordPress core slug rules.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -232,6 +232,7 @@ class Frontman_Tool_Posts {
 			$posts[] = [
 				'id'       => $post->ID,
 				'title'    => $post->post_title,
+				'slug'     => $post->post_name,
 				'status'   => $post->post_status,
 				'type'     => $post->post_type,
 				'date'     => $post->post_date,


### PR DESCRIPTION
## Summary
- Return persisted `post_name` as `slug` in `wp_list_posts`, consistent with `wp_read_post`.
- Document empty draft/pending slugs and WordPress publication rules.
- Add runtime coverage for empty and explicit slugs, uniqueness suffixes, metadata-only edits, list/read consistency, filtering, pagination, and read-only behavior.
- Include a patch changeset.

Closes #1648.

## Verification
- New runtime test failed before the fix with `Post list omitted the persisted slug`.
- `make test-wordpress-core-tools` passed on PHP 7.4 and 8.4 (PHP CLI containers through a temporary PATH wrapper; `CONTAINER_RUNTIME=podman`).
- `CONTAINER_RUNTIME=podman WORDPRESS_VERSION=6.0 PHP_VERSION=7.4 make test-wordpress-runtime` passed.
- `CONTAINER_RUNTIME=podman make test-wordpress-runtime` passed on WordPress 7.0.2 / PHP 8.4.
- `git diff --check` passed.