### PR TITLE
feat(wordpress): add permission-checked post authors and account lookup

### DIFF
--- a/.changeset/wordpress-native-post-authors.md
+++ b/.changeset/wordpress-native-post-authors.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Add permission-checked native WordPress author assignment and bounded current-site account lookup for user-requested author tasks. Validate raw IDs and lookup inputs before coercion. Reject boundary-asterisk searches while preserving literal interior asterisks, percent signs, underscores, and quotes. Document account-identifier disclosure to the selected AI provider and task history.

--- a/Makefile
+++ b/Makefile
@@ -570,6 +570,7 @@ publish-wordpress-plugin-svn: package-wordpress-plugin
 	@VERSION=$(VERSION) bash ./scripts/publish-wordpress-plugin-svn.sh
 
 test-wordpress-core-tools: build-wordpress-dependencies
+	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/PostAuthorsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/NoFilesystemToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/ElementorToolsTest.php
 	@php -d auto_prepend_file=libs/frontman-wordpress/tests/ErrorHandler.php libs/frontman-wordpress/tests/MediaToolsTest.php

--- a/libs/frontman-wordpress/frontman.php
+++ b/libs/frontman-wordpress/frontman.php
@@ -56,6 +56,7 @@ require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-router.php';
 require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-ui.php';
 
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-posts.php';
+require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-users.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-blocks.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-media.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-menus.php';
@@ -71,6 +72,7 @@ require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-seo.php';
 function frontman_init(): void {
 	$tools = Frontman_Tools::instance();
 	( new Frontman_Tool_Posts() )->register( $tools );
+	( new Frontman_Tool_Users() )->register( $tools );
 	( new Frontman_Tool_Blocks() )->register( $tools );
 	( new Frontman_Tool_Media() )->register( $tools );
 	( new Frontman_Tool_Menus() )->register( $tools );

--- a/libs/frontman-wordpress/includes/class-frontman-tools.php
+++ b/libs/frontman-wordpress/includes/class-frontman-tools.php
@@ -160,6 +160,13 @@ class Frontman_Tools {
 			return Frontman_Tool_Seo::validate_input( $name, $input );
 		}
 
+		if ( class_exists( 'Frontman_Tool_Posts' ) && in_array( $name, [ 'wp_create_post', 'wp_update_post' ], true ) ) {
+			Frontman_Tool_Posts::validate_author_input( $input );
+		}
+		if ( 'wp_find_users' === $name && class_exists( 'Frontman_Tool_Users' ) ) {
+			return Frontman_Tool_Users::validate_input( $input );
+		}
+
 		$preserve_strings = $tool->preserve_input_strings || ( 'wp_update_custom_css' === $name && 'edit' === ( $input['mode'] ?? null ) );
 		$sanitized = $this->sanitize_value_for_schema( $input, $tool->input_schema, $name, '', $preserve_strings );
 		return is_array( $sanitized ) ? $sanitized : [];

--- a/libs/frontman-wordpress/readme.txt
+++ b/libs/frontman-wordpress/readme.txt
@@ -62,6 +62,18 @@ Frontman then uses WordPress, Elementor, or WooCommerce tools that match the req
 
 Frontman works with WordPress content and structures that its current tools support. Custom themes, custom plugins, hosting controls, and unsupported page builders can require a different workflow.
 
+== Native Post Authors ==
+
+`wp_create_post` and `wp_update_post` accept an optional positive integer `author` account ID. Omission uses the current user on creation and preserves the existing author on update. These tools assign one native WordPress author, not guest authors or coauthors. They do not create accounts or change roles.
+
+The acting user needs the post type's create capability or permission to edit the existing post. A new published or private status requires the mapped publish capability. An explicit other account requires the mapped `edit_others_posts` capability, even when that author stays unchanged. Target accounts do not need a particular role. Frontman also requires author support and, on multisite, current-site membership. These are Frontman safeguards, not additional WordPress directory policy requirements.
+
+For a user-requested author task, `wp_find_users` searches either login or display name on the current site. It requires both `manage_options` and `list_users`. Each page contains at most 20 candidates in account-ID order, with total and pagination metadata. Results contain only account ID, login, and display name. They do not prove assignment eligibility.
+
+Search uses a literal substring of at most 100 Unicode characters after whitespace trimming. Empty input and input that starts or ends with `*` are rejected before any lookup. This restriction includes whitespace-wrapped boundary asterisks and asterisk-only input. Interior `*`, `%`, `_`, and quotes are literal. Case sensitivity depends on the database collation.
+
+Consider the remaining pages before selecting an account. If multiple accounts can match the requested identity, ask which account the user means. Never guess an ID or select the first ambiguous result. Read back successful assignment with `wp_read_post`.
+
 == Optional SEO Tools ==
 
 `wp_read_seo` reads stored SEO title and description overrides. `wp_update_seo` updates one or both overrides. Yoast SEO Free 28.4 is an optional dependency that Frontman does not install.
@@ -83,6 +95,8 @@ Start on a staging site. Keep a current backup. Review each change before you us
 When you submit a request, relevant site content can pass through Frontman AI to your configured model provider. The Third-Party Services section summarizes this data flow.
 
 During an active, user-requested chat task, SEO tool results can include overrides from authorized drafts and private content. Frontman sends these results to the selected AI provider as request context. Frontman also stores the results in task history. This process uses the existing chat request and consent flow.
+
+During a user-requested author task, lookup account IDs, logins, and display names can enter the selected AI provider's request context and stored task history. Names and logins can be personal data even though lookup excludes emails and private metadata. This feature uses the existing chat request and consent flow, not a new service.
 
 == Open Source and Support ==
 
@@ -127,7 +141,7 @@ The hosted service processes your prompts, relevant site or store content, tool 
 This plugin and the hosted Frontman service connect to these external services:
 
 **Frontman Client and API**
-The plugin loads its interface from `app.frontman.sh` and connects to `api.frontman.sh`. Frontman processes prompts, relevant site or store content, tool results, and stored task history to run the agent. SEO tool results can include stored title and description overrides from authorized drafts and private content. Stored provider credentials use server-side encryption.
+The plugin loads its interface from `app.frontman.sh` and connects to `api.frontman.sh`. Frontman processes prompts, relevant site or store content, tool results, and stored task history to run the agent. SEO tool results can include stored title and description overrides from authorized drafts and private content. Author lookup results can include account IDs, logins, and display names in request context and task history. Stored provider credentials use server-side encryption.
 
 * Services: [Client](https://app.frontman.sh), [API](https://api.frontman.sh)
 * Provider: Frontman AI

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -21,6 +21,14 @@ $GLOBALS['frontman_test_cache_cleared'] = [];
 
 class WP_Post extends stdClass {}
 
+function current_user_can( string $capability, ...$args ): bool {
+	return true;
+}
+
+function get_post_type_object( string $type ) {
+	return (object) [ 'cap' => (object) [ 'create_posts' => 'edit_posts', 'publish_posts' => 'publish_posts', 'edit_others_posts' => 'edit_others_posts' ] ];
+}
+
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $value ): string {
 		return trim( (string) $value );

--- a/libs/frontman-wordpress/tests/PostAuthorsTest.php
+++ b/libs/frontman-wordpress/tests/PostAuthorsTest.php
@@ -21,28 +21,10 @@ function wp_check_invalid_utf8( $v ) { return $v; }
 function wp_kses_post( $v ) { return $v; }
 function absint( $v ) { return abs( (int) $v ); }
 function wp_json_encode( $v ) { return json_encode( $v ); }
-function get_current_user_id() { return 1; }
-function get_current_blog_id() { return 7; }
-function current_user_can( $cap, ...$args ) { return ! in_array( $cap, $GLOBALS['denied'], true ); }
-function get_post_type_object( $type ) { return (object) [ 'cap' => (object) [ 'create_posts' => 'create_items', 'publish_posts' => 'publish_items', 'edit_others_posts' => 'edit_others_items' ] ]; }
-function post_type_supports( $type, $feature ) { return 'no_author' !== $type; }
-function get_userdata( $id ) { return in_array( $id, [ 1, 2, 3 ], true ) ? (object) [ 'ID' => $id ] : false; }
-function is_multisite() { return true; }
-function is_user_member_of_blog( $id, $blog ) { author_assert( 7 === $blog, 'Wrong blog' ); return 3 !== $id; }
+function current_user_can( $cap, ...$args ) { throw new RuntimeException( 'Invalid input reached permission checks' ); }
+function get_post_type_object( $type ) { throw new RuntimeException( 'Invalid author reached post-type lookup' ); }
 class WP_Post extends stdClass {}
-function get_post( $id ) { return $GLOBALS['post']; }
-function wp_insert_post( ...$args ) { throw new RuntimeException( 'Unexpected write' ); }
-function wp_update_post( ...$args ) { throw new RuntimeException( 'Unexpected write' ); }
-class WP_User_Query {
-	public function __construct( $args ) { $GLOBALS['queries'][] = $args; }
-	public function get_results() { return [ (object) [ 'ID' => '2', 'user_login' => 'second', 'display_name' => 'Same', 'user_email' => 'must-not-return' ], (object) [ 'ID' => '3', 'user_login' => 'third', 'display_name' => 'Same' ] ]; }
-	public function get_total() { return 3; }
-}
-$GLOBALS['denied'] = [];
-$GLOBALS['queries'] = [];
-$post = new WP_Post();
-$post->ID = 9; $post->post_type = 'item'; $post->post_status = 'draft'; $post->post_author = 2;
-$GLOBALS['post'] = $post;
+function get_post( $id ) { $post = new WP_Post(); $post->post_type = 'post'; return $post; }
 $tools = new Frontman_Tools();
 $posts = new Frontman_Tool_Posts(); $posts->register( $tools );
 $users = new Frontman_Tool_Users(); $users->register( $tools );
@@ -55,16 +37,6 @@ foreach ( [ '1', 1.0, true, false, null, 0, -1, [], (object) [] ] as $bad ) {
 	}
 }
 author_assert( ! array_key_exists( 'author', $tools->sanitize_input( 'wp_create_post', [ 'title' => 'T', 'content' => 'C' ] ) ), 'Omitted author injected' );
-foreach ( [ [ 99, 'not found' ], [ 3, 'current site' ] ] as [ $id, $error ] ) {
-	author_error( static fn() => $posts->create_post( [ 'author' => $id ] ), $error );
-	author_error( static fn() => $posts->update_post( [ 'id' => 9, 'author' => $id ] ), $error );
-}
-author_error( static fn() => $posts->create_post( [ 'post_type' => 'no_author', 'author' => 1 ] ), 'does not support' );
-foreach ( [ [ 'create_items', 'create_post', [] ], [ 'edit_post', 'update_post', [ 'id' => 9 ] ], [ 'publish_items', 'create_post', [ 'status' => 'private' ] ], [ 'publish_items', 'update_post', [ 'id' => 9, 'status' => 'publish' ] ], [ 'edit_others_items', 'update_post', [ 'id' => 9, 'author' => 2 ] ], [ 'edit_others_items', 'create_post', [ 'author' => 2 ] ] ] as [ $cap, $method, $input ] ) {
-	$GLOBALS['denied'] = [ $cap ];
-	author_error( static fn() => $posts->$method( $input ), 'permission' );
-}
-$GLOBALS['denied'] = [];
 $base = [ 'search' => 'Same', 'match_by' => 'display_name' ];
 $invalid = [ [], [ 'search' => '' ], [ 'search' => '  ' ], [ 'search' => str_repeat( 'é', 101 ) ], [ 'search' => "\xC3\x28" ], [ 'match_by' => 'email' ], [ 'unexpected' => 1 ], [ 'page' => PHP_INT_MAX ] ];
 foreach ( [ '*Same', 'Same*', '*', '**', ' *Same ', " Same*\t", "\u{2003}*\u{2003}" ] as $search ) { $invalid[] = [ 'search' => $search ]; }
@@ -77,24 +49,9 @@ foreach ( $invalid as $i => $override ) {
 	$input = 0 === $i ? [] : array_merge( $base, $override );
 	foreach ( [ static fn() => $tools->sanitize_input( 'wp_find_users', $input ), static fn() => $users->find_users( $input ) ] as $call ) { author_error( $call, '' ); }
 }
-author_assert( [] === $GLOBALS['queries'], 'Invalid input queried users' );
-foreach ( [ 'manage_options', 'list_users' ] as $cap ) {
-	$GLOBALS['denied'] = [ $cap ]; author_error( static fn() => $users->find_users( $base ), 'requires' );
-}
-author_assert( [] === $GLOBALS['queries'], 'Denied lookup queried users' );
-$GLOBALS['denied'] = [];
 foreach ( [ '%', '_', 'in*terior', "O'Neil", '"quoted"', str_repeat( 'é', 100 ), '0' ] as $search ) {
-	$input = $tools->sanitize_input( 'wp_find_users', [ 'search' => ' ' . $search . ' ', 'match_by' => 'login', 'page' => 2, 'per_page' => 2 ] );
-	$result = $users->find_users( $input );
-	$args = end( $GLOBALS['queries'] );
-	author_assert( '*' . $search . '*' === $args['search'], 'Literal search altered' );
-	author_assert( [ 'user_login' ] === $args['search_columns'] && 7 === $args['blog_id'] && 2 === $args['number'] && 2 === $args['paged'] && 'ID' === $args['orderby'] && 'ASC' === $args['order'] && true === $args['count_total'], 'Unbounded or incorrect query' );
-	author_assert( [ 'ID', 'user_login', 'display_name' ] === $args['fields'], 'Private fields requested' );
-	author_assert( [ 'users', 'page', 'per_page', 'total', 'total_pages' ] === array_keys( $result ) && 2 === $result['total_pages'], 'Pagination contract' );
-	foreach ( $result['users'] as $user ) { author_assert( [ 'id', 'login', 'display_name' ] === array_keys( $user ) && is_int( $user['id'] ), 'Output allowlist' ); }
-	author_assert( [ 2, 3 ] === array_column( $result['users'], 'id' ), 'Ambiguous candidates lost' );
+	$input = $tools->sanitize_input( 'wp_find_users', [ 'search' => ' ' . $search . ' ', 'match_by' => 'login' ] );
+	author_assert( $search === $input['search'], 'Literal search altered' );
 }
-$users->find_users( $base );
-author_assert( [ 'display_name' ] === end( $GLOBALS['queries'] )['search_columns'], 'Display-name search column' );
 author_assert( 'read' === $tools->get( 'wp_find_users' )->access, 'Lookup is not read-only' );
-echo "OK (author raw validation, permission preflight, lookup bounds and allowlist)\n";
+echo "OK (author and lookup raw validation)\n";

--- a/libs/frontman-wordpress/tests/PostAuthorsTest.php
+++ b/libs/frontman-wordpress/tests/PostAuthorsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+require_once __DIR__ . '/../includes/class-frontman-tools.php';
+require_once __DIR__ . '/../tools/class-tool-posts.php';
+require_once __DIR__ . '/../tools/class-tool-users.php';
+
+function author_assert( bool $ok, string $message ): void {
+	if ( ! $ok ) { throw new RuntimeException( $message ); }
+}
+function author_error( callable $call, string $message ): void {
+	try { $call(); } catch ( Frontman_Tool_Error $e ) {
+		author_assert( '' === $message || false !== strpos( $e->getMessage(), $message ), 'Unexpected error: ' . $e->getMessage() );
+		return;
+	}
+	throw new RuntimeException( 'Expected error: ' . $message );
+}
+function sanitize_key( $v ) { return $v; }
+function sanitize_text_field( $v ) { return $v; }
+function wp_check_invalid_utf8( $v ) { return $v; }
+function wp_kses_post( $v ) { return $v; }
+function absint( $v ) { return abs( (int) $v ); }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function get_current_user_id() { return 1; }
+function get_current_blog_id() { return 7; }
+function current_user_can( $cap, ...$args ) { return ! in_array( $cap, $GLOBALS['denied'], true ); }
+function get_post_type_object( $type ) { return (object) [ 'cap' => (object) [ 'create_posts' => 'create_items', 'publish_posts' => 'publish_items', 'edit_others_posts' => 'edit_others_items' ] ]; }
+function post_type_supports( $type, $feature ) { return 'no_author' !== $type; }
+function get_userdata( $id ) { return in_array( $id, [ 1, 2, 3 ], true ) ? (object) [ 'ID' => $id ] : false; }
+function is_multisite() { return true; }
+function is_user_member_of_blog( $id, $blog ) { author_assert( 7 === $blog, 'Wrong blog' ); return 3 !== $id; }
+class WP_Post extends stdClass {}
+function get_post( $id ) { return $GLOBALS['post']; }
+function wp_insert_post( ...$args ) { throw new RuntimeException( 'Unexpected write' ); }
+function wp_update_post( ...$args ) { throw new RuntimeException( 'Unexpected write' ); }
+class WP_User_Query {
+	public function __construct( $args ) { $GLOBALS['queries'][] = $args; }
+	public function get_results() { return [ (object) [ 'ID' => '2', 'user_login' => 'second', 'display_name' => 'Same', 'user_email' => 'must-not-return' ], (object) [ 'ID' => '3', 'user_login' => 'third', 'display_name' => 'Same' ] ]; }
+	public function get_total() { return 3; }
+}
+$GLOBALS['denied'] = [];
+$GLOBALS['queries'] = [];
+$post = new WP_Post();
+$post->ID = 9; $post->post_type = 'item'; $post->post_status = 'draft'; $post->post_author = 2;
+$GLOBALS['post'] = $post;
+$tools = new Frontman_Tools();
+$posts = new Frontman_Tool_Posts(); $posts->register( $tools );
+$users = new Frontman_Tool_Users(); $users->register( $tools );
+foreach ( [ '1', 1.0, true, false, null, 0, -1, [], (object) [] ] as $bad ) {
+	foreach ( [ 'wp_create_post' => 'create_post', 'wp_update_post' => 'update_post' ] as $name => $method ) {
+		$input = [ 'id' => 9, 'title' => 'Changed', 'content' => 'Changed', 'status' => 'publish', 'author' => $bad ];
+		author_error( static fn() => $tools->sanitize_input( $name, $input ), 'positive integer' );
+		author_error( static fn() => $posts->$method( $input ), 'positive integer' );
+		author_assert( $tools->call( $name, $input )['isError'], 'Direct dispatch accepted invalid author' );
+	}
+}
+author_assert( ! array_key_exists( 'author', $tools->sanitize_input( 'wp_create_post', [ 'title' => 'T', 'content' => 'C' ] ) ), 'Omitted author injected' );
+foreach ( [ [ 99, 'not found' ], [ 3, 'current site' ] ] as [ $id, $error ] ) {
+	author_error( static fn() => $posts->create_post( [ 'author' => $id ] ), $error );
+	author_error( static fn() => $posts->update_post( [ 'id' => 9, 'author' => $id ] ), $error );
+}
+author_error( static fn() => $posts->create_post( [ 'post_type' => 'no_author', 'author' => 1 ] ), 'does not support' );
+foreach ( [ [ 'create_items', 'create_post', [] ], [ 'edit_post', 'update_post', [ 'id' => 9 ] ], [ 'publish_items', 'create_post', [ 'status' => 'private' ] ], [ 'publish_items', 'update_post', [ 'id' => 9, 'status' => 'publish' ] ], [ 'edit_others_items', 'update_post', [ 'id' => 9, 'author' => 2 ] ], [ 'edit_others_items', 'create_post', [ 'author' => 2 ] ] ] as [ $cap, $method, $input ] ) {
+	$GLOBALS['denied'] = [ $cap ];
+	author_error( static fn() => $posts->$method( $input ), 'permission' );
+}
+$GLOBALS['denied'] = [];
+$base = [ 'search' => 'Same', 'match_by' => 'display_name' ];
+$invalid = [ [], [ 'search' => '' ], [ 'search' => '  ' ], [ 'search' => str_repeat( 'é', 101 ) ], [ 'search' => "\xC3\x28" ], [ 'match_by' => 'email' ], [ 'unexpected' => 1 ], [ 'page' => PHP_INT_MAX ] ];
+foreach ( [ '*Same', 'Same*', '*', '**', ' *Same ', " Same*\t", "\u{2003}*\u{2003}" ] as $search ) { $invalid[] = [ 'search' => $search ]; }
+foreach ( [ null, true, [], 1, 1.0 ] as $bad ) { $invalid[] = [ 'search' => $bad ]; $invalid[] = [ 'match_by' => $bad ]; }
+foreach ( [ 'page', 'per_page' ] as $field ) {
+	foreach ( [ null, '1', 1.0, true, [], 0, -1 ] as $bad ) { $invalid[] = [ $field => $bad ]; }
+}
+$invalid[] = [ 'per_page' => 21 ];
+foreach ( $invalid as $i => $override ) {
+	$input = 0 === $i ? [] : array_merge( $base, $override );
+	foreach ( [ static fn() => $tools->sanitize_input( 'wp_find_users', $input ), static fn() => $users->find_users( $input ) ] as $call ) { author_error( $call, '' ); }
+}
+author_assert( [] === $GLOBALS['queries'], 'Invalid input queried users' );
+foreach ( [ 'manage_options', 'list_users' ] as $cap ) {
+	$GLOBALS['denied'] = [ $cap ]; author_error( static fn() => $users->find_users( $base ), 'requires' );
+}
+author_assert( [] === $GLOBALS['queries'], 'Denied lookup queried users' );
+$GLOBALS['denied'] = [];
+foreach ( [ '%', '_', 'in*terior', "O'Neil", '"quoted"', str_repeat( 'é', 100 ), '0' ] as $search ) {
+	$input = $tools->sanitize_input( 'wp_find_users', [ 'search' => ' ' . $search . ' ', 'match_by' => 'login', 'page' => 2, 'per_page' => 2 ] );
+	$result = $users->find_users( $input );
+	$args = end( $GLOBALS['queries'] );
+	author_assert( '*' . $search . '*' === $args['search'], 'Literal search altered' );
+	author_assert( [ 'user_login' ] === $args['search_columns'] && 7 === $args['blog_id'] && 2 === $args['number'] && 2 === $args['paged'] && 'ID' === $args['orderby'] && 'ASC' === $args['order'] && true === $args['count_total'], 'Unbounded or incorrect query' );
+	author_assert( [ 'ID', 'user_login', 'display_name' ] === $args['fields'], 'Private fields requested' );
+	author_assert( [ 'users', 'page', 'per_page', 'total', 'total_pages' ] === array_keys( $result ) && 2 === $result['total_pages'], 'Pagination contract' );
+	foreach ( $result['users'] as $user ) { author_assert( [ 'id', 'login', 'display_name' ] === array_keys( $user ) && is_int( $user['id'] ), 'Output allowlist' ); }
+	author_assert( [ 2, 3 ] === array_column( $result['users'], 'id' ), 'Ambiguous candidates lost' );
+}
+$users->find_users( $base );
+author_assert( [ 'display_name' ] === end( $GLOBALS['queries'] )['search_columns'], 'Display-name search column' );
+author_assert( 'read' === $tools->get( 'wp_find_users' )->access, 'Lookup is not read-only' );
+echo "OK (author raw validation, permission preflight, lookup bounds and allowlist)\n";

--- a/libs/frontman-wordpress/tests/integration/MultisiteAuthorsRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/MultisiteAuthorsRuntimeTest.php
@@ -1,0 +1,49 @@
+<?php
+set_error_handler( static function( int $severity, string $message, string $file, int $line ): bool {
+	if ( error_reporting() & $severity ) { throw new ErrorException( $message, 0, $severity, $file, $line ); }
+	return false;
+} );
+$_SERVER['HTTP_HOST'] = 'frontman-multisite.example.test';
+$_SERVER['REQUEST_URI'] = '/';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+require '/tmp/frontman-multisite/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+$result = activate_plugin( 'frontman-agentic-ai-editor/frontman.php', '', true );
+if ( is_wp_error( $result ) ) { throw new RuntimeException( $result->get_error_message() ); }
+frontman_init();
+function multi_assert( bool $ok, string $message ): void { if ( ! $ok ) { throw new RuntimeException( $message ); } }
+multi_assert( is_multisite() && 1 === get_current_blog_id(), 'Multisite fixture not active' );
+$actor = wp_insert_user( [ 'user_login' => 'multi-actor', 'user_pass' => wp_generate_password(), 'role' => 'administrator' ] );
+$member = wp_insert_user( [ 'user_login' => 'multi-member', 'user_pass' => wp_generate_password(), 'display_name' => 'Multisite Candidate', 'role' => 'subscriber' ] );
+$other = wp_insert_user( [ 'user_login' => 'multi-other', 'user_pass' => wp_generate_password(), 'display_name' => 'Multisite Candidate', 'role' => 'subscriber' ] );
+$site = wpmu_create_blog( 'frontman-multisite.example.test', '/other/', 'Other', $actor );
+multi_assert( is_int( $site ), 'Other-site fixture failed' );
+add_user_to_blog( $site, $other, 'subscriber' );
+remove_user_from_blog( $other, 1 );
+wp_set_current_user( $actor );
+multi_assert( ! is_super_admin( $actor ) && is_user_member_of_blog( $member, 1 ) && ! is_user_member_of_blog( $other, 1 ) && is_user_member_of_blog( $other, $site ), 'Membership fixture ineffective' );
+$registry = Frontman_Tools::instance();
+$call = static function( string $name, array $input, bool $error = false ) use ( $registry ): array {
+	try { $result = $registry->call( $name, $registry->sanitize_input( $name, $input ) ); }
+	catch ( Frontman_Tool_Error $e ) { $result = Frontman_Tools::error_result( $e->getMessage() ); }
+	multi_assert( $error === $result['isError'], 'Multisite tool outcome mismatch: ' . $name );
+	return $error ? $result : json_decode( $result['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+};
+$base = [ 'title' => 'Multisite post', 'content' => 'Original', 'author' => $member ];
+$post = $call( 'wp_create_post', $base );
+$id = $post['id'];
+multi_assert( $member === $post['after']['author'], 'Member assignment failed' );
+$receipt = $call( 'wp_update_post', [ 'id' => $id, 'author' => $actor ] );
+multi_assert( $member === $receipt['before']['author'] && $actor === $receipt['after']['author'], 'Multisite update snapshots failed' );
+$call( 'wp_update_post', [ 'id' => $id, 'author' => $member ] );
+$before = get_post( $id, ARRAY_A );
+$count = array_sum( (array) wp_count_posts() );
+$call( 'wp_create_post', array_merge( $base, [ 'author' => $other, 'status' => 'publish' ] ), true );
+$call( 'wp_update_post', [ 'id' => $id, 'author' => $other, 'title' => 'Rejected', 'content' => 'Rejected', 'status' => 'publish' ], true );
+clean_post_cache( $id );
+multi_assert( $before === get_post( $id, ARRAY_A ) && $count === array_sum( (array) wp_count_posts() ), 'Nonmember rejection partially wrote state' );
+$lookup = $call( 'wp_find_users', [ 'search' => 'Multisite Candidate', 'match_by' => 'display_name' ] );
+multi_assert( [ $member ] === array_column( $lookup['users'], 'id' ) && 1 === $lookup['total'], 'Current-site lookup disclosed another-site account' );
+multi_assert( [ 'id', 'login', 'display_name' ] === array_keys( $lookup['users'][0] ), 'Multisite privacy allowlist failed' );
+multi_assert( $member === $call( 'wp_read_post', [ 'id' => $id ] )['author'] && 1 === get_current_blog_id(), 'Readback or blog scope changed' );
+echo 'OK (Multisite authors, WordPress ' . get_bloginfo( 'version' ) . ', PHP ' . PHP_VERSION . ")\n";

--- a/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeFixture.php
+++ b/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeFixture.php
@@ -1,0 +1,14 @@
+<?php
+/** Test-only post types with real custom capabilities, loaded in CLI and HTTP requests. */
+add_action( 'init', static function(): void {
+	register_post_type( 'fm_author_item', [
+		'public' => true, 'supports' => [ 'title', 'editor', 'author' ],
+		'capability_type' => [ 'fm_item', 'fm_items' ], 'map_meta_cap' => true,
+		'capabilities' => [ 'create_posts' => 'create_fm_items' ],
+	] );
+	register_post_type( 'fm_no_author', [ 'public' => true, 'supports' => [ 'title', 'editor' ] ] );
+	register_post_type( 'fm_primitive', [
+		'public' => true, 'supports' => [ 'title', 'editor', 'author' ],
+		'capability_type' => [ 'fm_primitive', 'fm_primitives' ], 'map_meta_cap' => false,
+	] );
+} );

--- a/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeTest.php
@@ -25,13 +25,13 @@ foreach ( [ [], [ 'author' => $actor_id ], [ 'author' => $target_id ] ] as $assi
 	$created = $call( 'wp_create_post', array_merge( $base, $assignment ) );
 	$id = $created['id']; $expected = $assignment['author'] ?? $actor_id;
 	frontman_runtime_assert( $expected === $created['after']['author'] && $expected === $call( 'wp_read_post', [ 'id' => $id ] )['author'], 'Create author/default/read-back failed' );
-	$omitted = $call( 'wp_update_post', [ 'id' => $id, 'title' => 'Omitted author' ] );
-	frontman_runtime_assert( $expected === $omitted['before']['author'] && $expected === $omitted['after']['author'], 'Omitted update overwrote author' );
-	foreach ( [ $target_id, $actor_id ] as $author ) {
-		$updated = $call( 'wp_update_post', [ 'id' => $id, 'author' => $author ] );
-		frontman_runtime_assert( $expected === $updated['before']['author'] && $author === $updated['after']['author'] && $author === $call( 'wp_read_post', [ 'id' => $id ] )['author'], 'Update snapshots/read-back author failed' );
-		$expected = $author;
-	}
+}
+$omitted = $call( 'wp_update_post', [ 'id' => $id, 'title' => 'Omitted author' ] );
+frontman_runtime_assert( $target_id === $omitted['before']['author'] && $target_id === $omitted['after']['author'], 'Omitted update overwrote author' );
+foreach ( [ $actor_id, $target_id ] as $author ) {
+	$updated = $call( 'wp_update_post', [ 'id' => $id, 'author' => $author ] );
+	frontman_runtime_assert( $expected === $updated['before']['author'] && $author === $updated['after']['author'] && $author === $call( 'wp_read_post', [ 'id' => $id ] )['author'], 'Update snapshots/read-back author failed' );
+	$expected = $author;
 }
 $fixture = $call( 'wp_create_post', $base )['id'];
 $snapshot = static function( int $id ): array { clean_post_cache( $id ); return get_post( $id, ARRAY_A ); };
@@ -47,7 +47,7 @@ $reject_both = static function( array $override ) use ( $call, $base, $combined,
 	$call( 'wp_update_post', array_merge( $combined, $override ), true );
 	frontman_runtime_assert( $before_count === $count() && $unchanged === $snapshot( $fixture ), 'Rejected combined request partially wrote a post' );
 };
-foreach ( [ '2', 2.5, true, false, null, 0, -1, [], 99999999 ] as $bad ) { $reject_both( [ 'author' => $bad ] ); }
+foreach ( [ (string) $target_id, 99999999 ] as $bad ) { $reject_both( [ 'author' => $bad ] ); }
 foreach ( [ 'wp_create_post' => array_merge( $base, [ 'status' => 'publish' ] ), 'wp_update_post' => $combined ] as $name => $input ) {
 	$input['author'] = 2.0;
 	$before_count = $count();
@@ -117,8 +117,7 @@ foreach ( [ '%', '_', 'in*terior', "O'Neil", '"quoted"', '0' ] as $index => $lit
 for ( $i = 0; $i < 21; $i++ ) { wp_insert_user( [ 'user_login' => 'bounded-author-' . $i, 'user_pass' => wp_generate_password(), 'display_name' => 'Bounded Author' ] ); }
 $bounded = $call( 'wp_find_users', [ 'search' => 'Bounded Author', 'match_by' => 'display_name' ] );
 frontman_runtime_assert( 20 === count( $bounded['users'] ) && 21 === $bounded['total'] && 2 === $bounded['total_pages'], 'Lookup exceeded bound or lost count' );
-foreach ( [ '*', '**', '*name', 'name*', ' *name ', " name*\t", "\u{2003}*\u{2003}", '', '   ', str_repeat( 'é', 101 ), null, true, [], 1 ] as $bad ) { $call( 'wp_find_users', [ 'search' => $bad, 'match_by' => 'login' ], true ); }
-foreach ( [ [ 'page' => '1' ], [ 'page' => 0 ], [ 'page' => PHP_INT_MAX, 'per_page' => 20 ], [ 'per_page' => 21 ], [ 'per_page' => null ], [ 'match_by' => 'email' ] ] as $bad ) { $call( 'wp_find_users', array_merge( $lookup, $bad ), true ); }
+foreach ( [ [ 'search' => "\u{2003}*\u{2003}" ], [ 'page' => '1' ] ] as $bad ) { $call( 'wp_find_users', array_merge( $lookup, $bad ), true ); }
 $actor->add_cap( 'list_users', false );
 $call( 'wp_find_users', $lookup, true );
 foreach ( [ $actor_id, $target_id ] as $denied_id ) {
@@ -130,17 +129,6 @@ foreach ( [ $actor_id, $target_id ] as $denied_id ) {
 	frontman_runtime_assert( $queries_before === $wpdb->num_queries, 'Denied lookup queried database' );
 }
 $actor->add_cap( 'list_users' );
-wp_set_current_user( 0 );
-wp_set_current_user( $actor_id );
-foreach ( [ '*', '**', '*name', 'name*', ' *name ', " name*\t", "\u{2003}*\u{2003}" ] as $search ) {
-	$queries_before = $wpdb->num_queries;
-	try {
-		$input = Frontman_Tools::instance()->sanitize_input( 'wp_find_users', [ 'search' => $search, 'match_by' => 'display_name' ] );
-		Frontman_Tools::instance()->call( 'wp_find_users', $input );
-		throw new RuntimeException( 'Boundary asterisk validation missing' );
-	} catch ( Frontman_Tool_Error $e ) { frontman_runtime_assert( false !== strpos( $e->getMessage(), 'must not start or end' ), 'Boundary asterisk error unclear' ); }
-	frontman_runtime_assert( $queries_before === $wpdb->num_queries, 'Invalid lookup queried database' );
-}
 $subscriber_cookie = wp_generate_auth_cookie( $target_id, time() + HOUR_IN_SECONDS, 'logged_in' );
 $request = [ 'name' => 'wp_find_users', 'arguments' => $lookup ];
 frontman_runtime_assert( 403 === frontman_runtime_tool( $subscriber_cookie, null, $request )['status'], 'Subscriber discovered accounts' );

--- a/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeTest.php
@@ -1,0 +1,150 @@
+<?php
+/** Real packaged plugin HTTP author permissions and lookup privacy. */
+
+$wp_rewrite->set_permalink_structure( '' );
+$actor_id = wp_insert_user( [ 'user_login' => 'author-actor', 'user_pass' => wp_generate_password(), 'role' => 'administrator' ] );
+$target_id = wp_insert_user( [ 'user_login' => 'author-target', 'user_pass' => wp_generate_password(), 'role' => 'subscriber', 'display_name' => 'Author Duplicate' ] );
+$twin_id = wp_insert_user( [ 'user_login' => 'author-twin', 'user_pass' => wp_generate_password(), 'role' => 'subscriber', 'display_name' => 'Author Duplicate' ] );
+foreach ( [ $actor_id, $target_id, $twin_id ] as $id ) { frontman_runtime_assert( is_int( $id ), 'Author fixture creation failed' ); }
+update_user_meta( $target_id, 'frontman_private_fixture', 'Must stay private' );
+wp_update_user( [ 'ID' => $target_id, 'user_email' => 'email-only-author-token@example.test' ] );
+$actor = new WP_User( $actor_id );
+foreach ( [ 'create_fm_items', 'edit_fm_items', 'edit_others_fm_items', 'publish_fm_items', 'edit_published_fm_items', 'edit_private_fm_items', 'edit_fm_primitive' ] as $cap ) { $actor->add_cap( $cap ); }
+$actor_cookie = wp_generate_auth_cookie( $actor_id, time() + HOUR_IN_SECONDS, 'logged_in' );
+wp_set_current_user( $actor_id );
+$_COOKIE[ LOGGED_IN_COOKIE ] = $actor_cookie;
+$actor_nonce = Frontman_Auth::create_nonce();
+unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+$call = static function( string $name, array $input, bool $error = false ) use ( $actor_cookie, $actor_nonce ): array {
+	$response = frontman_runtime_tool( $actor_cookie, $actor_nonce, [ 'name' => $name, 'arguments' => $input ] );
+	frontman_runtime_assert( 200 === $response['status'] && $error === $response['body']['isError'], 'Unexpected author tool outcome: ' . $name );
+	return $error ? $response['body'] : json_decode( $response['body']['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+};
+$base = [ 'title' => 'Author original', 'content' => '<p>Original body</p>', 'post_type' => 'fm_author_item' ];
+foreach ( [ [], [ 'author' => $actor_id ], [ 'author' => $target_id ] ] as $assignment ) {
+	$created = $call( 'wp_create_post', array_merge( $base, $assignment ) );
+	$id = $created['id']; $expected = $assignment['author'] ?? $actor_id;
+	frontman_runtime_assert( $expected === $created['after']['author'] && $expected === $call( 'wp_read_post', [ 'id' => $id ] )['author'], 'Create author/default/read-back failed' );
+	$omitted = $call( 'wp_update_post', [ 'id' => $id, 'title' => 'Omitted author' ] );
+	frontman_runtime_assert( $expected === $omitted['before']['author'] && $expected === $omitted['after']['author'], 'Omitted update overwrote author' );
+	foreach ( [ $target_id, $actor_id ] as $author ) {
+		$updated = $call( 'wp_update_post', [ 'id' => $id, 'author' => $author ] );
+		frontman_runtime_assert( $expected === $updated['before']['author'] && $author === $updated['after']['author'] && $author === $call( 'wp_read_post', [ 'id' => $id ] )['author'], 'Update snapshots/read-back author failed' );
+		$expected = $author;
+	}
+}
+$fixture = $call( 'wp_create_post', $base )['id'];
+$snapshot = static function( int $id ): array { clean_post_cache( $id ); return get_post( $id, ARRAY_A ); };
+$count = static function( string $type = 'fm_author_item' ): int {
+	wp_cache_flush();
+	return (int) array_sum( (array) wp_count_posts( $type ) );
+};
+$unchanged = $snapshot( $fixture );
+$combined = [ 'id' => $fixture, 'title' => 'Must not persist', 'content' => '<p>Must not persist</p>', 'status' => 'publish' ];
+$reject_both = static function( array $override ) use ( $call, $base, $combined, $fixture, $snapshot, $count, $unchanged ): void {
+	$before_count = $count();
+	$call( 'wp_create_post', array_merge( $base, [ 'status' => 'publish' ], $override ), true );
+	$call( 'wp_update_post', array_merge( $combined, $override ), true );
+	frontman_runtime_assert( $before_count === $count() && $unchanged === $snapshot( $fixture ), 'Rejected combined request partially wrote a post' );
+};
+foreach ( [ '2', 2.5, true, false, null, 0, -1, [], 99999999 ] as $bad ) { $reject_both( [ 'author' => $bad ] ); }
+foreach ( [ 'wp_create_post' => array_merge( $base, [ 'status' => 'publish' ] ), 'wp_update_post' => $combined ] as $name => $input ) {
+	$input['author'] = 2.0;
+	$before_count = $count();
+	$response = frontman_runtime_tool( $actor_cookie, $actor_nonce, [], json_encode( [ 'name' => $name, 'arguments' => $input ], JSON_PRESERVE_ZERO_FRACTION ) );
+	frontman_runtime_assert( true === $response['body']['isError'] && $before_count === $count() && $unchanged === $snapshot( $fixture ), 'Float author was coerced or wrote state' );
+}
+foreach ( [ 'create_fm_items', 'edit_fm_items', 'publish_fm_items', 'edit_others_fm_items' ] as $cap ) {
+	$actor->add_cap( $cap, false );
+	frontman_runtime_assert( user_can( $actor, 'manage_options' ) && ! user_can( $actor, $cap ), 'Custom denial fixture ineffective' );
+	$before_count = $count();
+	switch ( $cap ) {
+		case 'create_fm_items': $call( 'wp_create_post', $base, true ); break;
+		case 'edit_fm_items': $call( 'wp_update_post', $combined, true ); break;
+		case 'publish_fm_items':
+			$reject_both( [ 'author' => $actor_id ] );
+			$reject_both( [ 'author' => $actor_id, 'status' => 'private' ] );
+			break;
+		case 'edit_others_fm_items': $reject_both( [ 'author' => $target_id ] ); break;
+	}
+	frontman_runtime_assert( $before_count === $count() && $unchanged === $snapshot( $fixture ), 'Permission check ran after write' );
+	$actor->add_cap( $cap );
+}
+foreach ( [ 'publish', 'private' ] as $status ) {
+	$id = $call( 'wp_create_post', array_merge( $base, [ 'status' => $status ] ) )['id'];
+	$actor->add_cap( 'publish_fm_items', false );
+	$receipt = $call( 'wp_update_post', [ 'id' => $id, 'status' => $status, 'author' => $target_id ] );
+	frontman_runtime_assert( $status === $receipt['after']['status'] && $target_id === $receipt['after']['author'], 'Unchanged status incorrectly required publish permission' );
+	$actor->add_cap( 'publish_fm_items' );
+}
+$primitive = wp_insert_post( [ 'post_title' => 'Primitive', 'post_status' => 'draft', 'post_type' => 'fm_primitive', 'post_author' => $target_id ], true );
+frontman_runtime_assert( current_user_can( 'edit_post', $primitive ) && ! current_user_can( 'edit_others_fm_primitives' ), 'Primitive capability fixture ineffective' );
+$call( 'wp_update_post', [ 'id' => $primitive, 'title' => 'Omission allowed' ] );
+$primitive_before = $snapshot( $primitive );
+$call( 'wp_update_post', [ 'id' => $primitive, 'title' => 'Rejected', 'author' => $target_id ], true );
+frontman_runtime_assert( $primitive_before === $snapshot( $primitive ), 'Explicit unchanged other author bypassed permission' );
+$unsupported = $call( 'wp_create_post', array_merge( $base, [ 'post_type' => 'fm_no_author' ] ) )['id'];
+$unsupported_before = $snapshot( $unsupported );
+$unsupported_count = $count( 'fm_no_author' );
+$call( 'wp_create_post', array_merge( $base, [ 'post_type' => 'fm_no_author', 'author' => $actor_id ] ), true );
+$call( 'wp_update_post', [ 'id' => $unsupported, 'author' => $actor_id, 'title' => 'Rejected', 'content' => 'Rejected', 'status' => 'publish' ], true );
+frontman_runtime_assert( $unsupported_before === $snapshot( $unsupported ) && $unsupported_count === $count( 'fm_no_author' ), 'Unsupported authorship wrote state' );
+update_post_meta( $fixture, '_elementor_edit_mode', 'builder' );
+require_once FRONTMAN_PLUGIN_DIR . 'includes/class-frontman-elementor-data.php';
+try { ( new Frontman_Tool_Posts() )->update_post( array_merge( $combined, [ 'author' => $target_id ] ) ); throw new RuntimeException( 'Elementor overwrite accepted' ); }
+catch ( Frontman_Tool_Error $e ) { frontman_runtime_assert( false !== strpos( $e->getMessage(), 'Elementor' ), 'Wrong Elementor error' ); }
+frontman_runtime_assert( $unchanged === $snapshot( $fixture ), 'Elementor rejection wrote state' );
+
+$lookup = [ 'search' => 'Author Duplicate', 'match_by' => 'display_name', 'per_page' => 1 ];
+$first = $call( 'wp_find_users', $lookup );
+$second = $call( 'wp_find_users', array_merge( $lookup, [ 'page' => 2 ] ) );
+frontman_runtime_assert( [ 'users', 'page', 'per_page', 'total', 'total_pages' ] === array_keys( $first ) && 2 === $first['total'] && 2 === $first['total_pages'] && 1 === $first['page'] && 1 === $first['per_page'], 'Lookup pagination metadata' );
+frontman_runtime_assert( [ $target_id, $twin_id ] === [ $first['users'][0]['id'], $second['users'][0]['id'] ], 'Duplicate names merged, guessed or unordered' );
+frontman_runtime_assert( [] === $call( 'wp_find_users', array_merge( $lookup, [ 'page' => 3 ] ) )['users'], 'Out-of-range page not empty' );
+foreach ( [ $first, $second ] as $result ) { foreach ( $result['users'] as $user ) { frontman_runtime_assert( [ 'id', 'login', 'display_name' ] === array_keys( $user ), 'Lookup leaked private fields' ); } }
+frontman_runtime_assert( [] === $call( 'wp_find_users', [ 'search' => 'Author Duplicate', 'match_by' => 'login' ] )['users'], 'Display name leaked into login search' );
+frontman_runtime_assert( [ $target_id ] === array_column( $call( 'wp_find_users', [ 'search' => 'author-target', 'match_by' => 'login' ] )['users'], 'id' ), 'Login match failed' );
+foreach ( [ 'login', 'display_name' ] as $column ) {
+	frontman_runtime_assert( [] === $call( 'wp_find_users', [ 'search' => 'email-only-author-token', 'match_by' => $column ] )['users'], 'Lookup implicitly searched email' );
+}
+$none = $call( 'wp_find_users', [ 'search' => 'nonexistent-author-token', 'match_by' => 'display_name' ] );
+frontman_runtime_assert( [] === $none['users'] && 0 === $none['total'] && 0 === $none['total_pages'] && 20 === $none['per_page'], 'Empty/default lookup contract' );
+foreach ( [ '%', '_', 'in*terior', "O'Neil", '"quoted"', '0' ] as $index => $literal ) {
+	$id = wp_insert_user( [ 'user_login' => 'literal-author-' . $index, 'user_pass' => wp_generate_password(), 'display_name' => 'Needle ' . $literal . ' end' ] );
+	$result = $call( 'wp_find_users', [ 'search' => ' ' . $literal . ' ', 'match_by' => 'display_name' ] );
+	frontman_runtime_assert( [ $id ] === array_column( $result['users'], 'id' ), 'Literal wildcard/quote search broadened or changed' );
+}
+for ( $i = 0; $i < 21; $i++ ) { wp_insert_user( [ 'user_login' => 'bounded-author-' . $i, 'user_pass' => wp_generate_password(), 'display_name' => 'Bounded Author' ] ); }
+$bounded = $call( 'wp_find_users', [ 'search' => 'Bounded Author', 'match_by' => 'display_name' ] );
+frontman_runtime_assert( 20 === count( $bounded['users'] ) && 21 === $bounded['total'] && 2 === $bounded['total_pages'], 'Lookup exceeded bound or lost count' );
+foreach ( [ '*', '**', '*name', 'name*', ' *name ', " name*\t", "\u{2003}*\u{2003}", '', '   ', str_repeat( 'é', 101 ), null, true, [], 1 ] as $bad ) { $call( 'wp_find_users', [ 'search' => $bad, 'match_by' => 'login' ], true ); }
+foreach ( [ [ 'page' => '1' ], [ 'page' => 0 ], [ 'page' => PHP_INT_MAX, 'per_page' => 20 ], [ 'per_page' => 21 ], [ 'per_page' => null ], [ 'match_by' => 'email' ] ] as $bad ) { $call( 'wp_find_users', array_merge( $lookup, $bad ), true ); }
+$actor->add_cap( 'list_users', false );
+$call( 'wp_find_users', $lookup, true );
+foreach ( [ $actor_id, $target_id ] as $denied_id ) {
+	wp_set_current_user( 0 );
+	wp_set_current_user( $denied_id );
+	$queries_before = $wpdb->num_queries;
+	try { ( new Frontman_Tool_Users() )->find_users( $lookup ); throw new RuntimeException( 'Direct lookup bypassed permissions' ); }
+	catch ( Frontman_Tool_Error $e ) { frontman_runtime_assert( false !== strpos( $e->getMessage(), 'requires' ), 'Wrong denied lookup error' ); }
+	frontman_runtime_assert( $queries_before === $wpdb->num_queries, 'Denied lookup queried database' );
+}
+$actor->add_cap( 'list_users' );
+wp_set_current_user( 0 );
+wp_set_current_user( $actor_id );
+foreach ( [ '*', '**', '*name', 'name*', ' *name ', " name*\t", "\u{2003}*\u{2003}" ] as $search ) {
+	$queries_before = $wpdb->num_queries;
+	try {
+		$input = Frontman_Tools::instance()->sanitize_input( 'wp_find_users', [ 'search' => $search, 'match_by' => 'display_name' ] );
+		Frontman_Tools::instance()->call( 'wp_find_users', $input );
+		throw new RuntimeException( 'Boundary asterisk validation missing' );
+	} catch ( Frontman_Tool_Error $e ) { frontman_runtime_assert( false !== strpos( $e->getMessage(), 'must not start or end' ), 'Boundary asterisk error unclear' ); }
+	frontman_runtime_assert( $queries_before === $wpdb->num_queries, 'Invalid lookup queried database' );
+}
+$subscriber_cookie = wp_generate_auth_cookie( $target_id, time() + HOUR_IN_SECONDS, 'logged_in' );
+$request = [ 'name' => 'wp_find_users', 'arguments' => $lookup ];
+frontman_runtime_assert( 403 === frontman_runtime_tool( $subscriber_cookie, null, $request )['status'], 'Subscriber discovered accounts' );
+$mutation = [ 'name' => 'wp_update_post', 'arguments' => $combined ];
+frontman_runtime_assert( [ 401, 403, 403, 403 ] === array_column( [ frontman_runtime_tool( '', null, $mutation ), frontman_runtime_tool( $subscriber_cookie, null, $mutation ), frontman_runtime_tool( $actor_cookie, null, $mutation ), frontman_runtime_tool( $actor_cookie, 'invalid', $mutation ) ], 'status' ), 'Auth/nonce bypass' );
+frontman_runtime_assert( $unchanged === $snapshot( $fixture ), 'Auth/nonce rejection wrote state' );
+echo "Author permissions, HTTP raw validation, literal lookup and privacy checks passed.\n";

--- a/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php
@@ -13,6 +13,7 @@ require '/var/www/html/wp-load.php';
 require '/tmp/WordPressRuntimeTest.php';
 require '/tmp/CustomCssRuntimeTest.php';
 require '/tmp/ElementorSnapshotRuntimeTest.php';
+require '/tmp/PostAuthorsRuntimeTest.php';
 restore_error_handler();
 
 fwrite( STDOUT, 'OK (WordPress ' . get_bloginfo( 'version' ) . ', PHP ' . PHP_VERSION . ")\n" );

--- a/libs/frontman-wordpress/tests/integration/SetupAuthorsMultisite.php
+++ b/libs/frontman-wordpress/tests/integration/SetupAuthorsMultisite.php
@@ -1,0 +1,22 @@
+<?php
+/** Fresh table prefix and separate document root: never convert the single-site fixture. */
+define( 'WP_INSTALLING', true );
+define( 'WP_ALLOW_MULTISITE', true );
+define( 'WP_SITEURL', 'http://frontman-multisite.example.test' );
+define( 'WP_HOME', 'http://frontman-multisite.example.test' );
+$_SERVER['HTTP_HOST'] = 'frontman-multisite.example.test';
+$_SERVER['REQUEST_URI'] = '/';
+require '/tmp/frontman-multisite/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+require_once ABSPATH . 'wp-admin/includes/network.php';
+wp_install( 'Authors Multisite', 'multi-admin', 'multi-admin@example.test', true, '', wp_generate_password() );
+foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table ) {
+	$wpdb->$table = $prefixed_table;
+}
+install_network();
+$result = populate_network( 1, 'frontman-multisite.example.test', 'multi-admin@example.test', 'Authors Network', '/', false );
+if ( is_wp_error( $result ) ) { throw new RuntimeException( $result->get_error_message() ); }
+$config = file_get_contents( ABSPATH . 'wp-config.php' );
+$config = str_replace( '<?php', "<?php\ndefine('MULTISITE', true);\ndefine('SUBDOMAIN_INSTALL', false);\ndefine('DOMAIN_CURRENT_SITE', 'frontman-multisite.example.test');\ndefine('PATH_CURRENT_SITE', '/');\ndefine('SITE_ID_CURRENT_SITE', 1);\ndefine('BLOG_ID_CURRENT_SITE', 1);", $config );
+file_put_contents( ABSPATH . 'wp-config.php', $config );
+echo "Isolated authors multisite installed.\n";

--- a/libs/frontman-wordpress/tools/class-tool-posts.php
+++ b/libs/frontman-wordpress/tools/class-tool-posts.php
@@ -88,7 +88,7 @@ class Frontman_Tool_Posts {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_create_post',
-			'Creates a new post or page. Returns the new post ID and permalink. Use wp_duplicate_post when the user asks to duplicate or clone an existing page so Elementor/post metadata is copied.',
+			'Creates a new post or page. For a user-requested author task, resolve the account with wp_find_users; never guess IDs or choose an ambiguous match. Read back successful author assignment with wp_read_post. Returns the new post ID and permalink. Use wp_duplicate_post when the user asks to duplicate or clone an existing page so Elementor/post metadata is copied.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -104,6 +104,11 @@ class Frontman_Tool_Posts {
 					'content'   => [
 						'type'        => 'string',
 						'description' => 'The post content as HTML or Gutenberg block markup.',
+					],
+					'author' => [
+						'type' => 'integer',
+						'minimum' => 1,
+						'description' => 'Native WordPress account ID. Omit to use the current user. Requires author support; assigning another account requires edit_others_posts for this post type.',
 					],
 					'post_type' => [
 						'type'        => 'string',
@@ -145,7 +150,7 @@ class Frontman_Tool_Posts {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_update_post',
-			'Updates an existing post or page. Only the fields you provide will be changed. Do not use content on Elementor-managed pages; use wp_elementor_* tools for Elementor content/layout changes.',
+			'Updates an existing post or page. For a user-requested author task, resolve the account with wp_find_users; never guess IDs or choose an ambiguous match. Read back successful author assignment with wp_read_post. Only the fields you provide will be changed. Do not use content on Elementor-managed pages; use wp_elementor_* tools for Elementor content/layout changes.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -170,6 +175,11 @@ class Frontman_Tool_Posts {
 						'type'        => 'string',
 						'description' => 'New post status.',
 						'enum'        => [ 'draft', 'publish', 'pending', 'private', 'trash' ],
+					],
+					'author' => [
+						'type' => 'integer',
+						'minimum' => 1,
+						'description' => 'Native WordPress account ID. Omit to preserve the current author. Requires author support; an explicit other account requires edit_others_posts even when unchanged.',
 					],
 					'excerpt' => [
 						'type'        => 'string',
@@ -275,10 +285,49 @@ class Frontman_Tool_Posts {
 		];
 	}
 
+	/** Validate before registry coercion and for direct handler calls. */
+	public static function validate_author_input( array $input ): void {
+		if ( array_key_exists( 'author', $input ) && ( ! is_int( $input['author'] ) || $input['author'] <= 0 ) ) {
+			throw new Frontman_Tool_Error( 'author must be a positive integer account ID.' );
+		}
+	}
+
+	/** Native writes do not enforce the REST permission layer. Check permissions before writing. */
+	private function check_write_permissions( array $input, string $type, ?\WP_Post $post = null ): void {
+		self::validate_author_input( $input );
+		$post_type = get_post_type_object( $type );
+		if ( ! $post_type ) {
+			throw new Frontman_Tool_Error( 'Post type not found.' );
+		}
+		if ( null === $post ? ! current_user_can( $post_type->cap->create_posts ) : ! current_user_can( 'edit_post', $post->ID ) ) {
+			throw new Frontman_Tool_Error( 'Insufficient permission to create or edit this post.' );
+		}
+		$status = sanitize_key( $input['status'] ?? ( null === $post ? 'draft' : $post->post_status ) );
+		if ( ( null === $post || $status !== $post->post_status ) && in_array( $status, [ 'publish', 'future', 'private' ], true ) && ! current_user_can( $post_type->cap->publish_posts ) ) {
+			throw new Frontman_Tool_Error( 'Insufficient permission to publish or create private posts of this type.' );
+		}
+		if ( ! array_key_exists( 'author', $input ) ) {
+			return;
+		}
+		if ( get_current_user_id() !== $input['author'] && ! current_user_can( $post_type->cap->edit_others_posts ) ) {
+			throw new Frontman_Tool_Error( 'Insufficient permission to assign another author for this post type.' );
+		}
+		if ( ! post_type_supports( $type, 'author' ) ) {
+			throw new Frontman_Tool_Error( 'This post type does not support author assignment.' );
+		}
+		if ( ! get_userdata( $input['author'] ) ) {
+			throw new Frontman_Tool_Error( 'Author account not found.' );
+		}
+		if ( is_multisite() && ! is_user_member_of_blog( $input['author'], get_current_blog_id() ) ) {
+			throw new Frontman_Tool_Error( 'Author must be a member of the current site.' );
+		}
+	}
+
 	/**
 	 * wp_create_post handler.
 	 */
 	public function create_post( array $input ): array {
+		$this->check_write_permissions( $input, sanitize_key( $input['post_type'] ?? 'post' ) );
 		$post_data = [
 			'post_title'   => sanitize_text_field( $input['title'] ),
 			'post_content' => wp_kses_post( $input['content'] ),
@@ -292,6 +341,9 @@ class Frontman_Tool_Posts {
 			$post_data['post_name'] = $input['slug'];
 		}
 
+		if ( array_key_exists( 'author', $input ) ) {
+			$post_data['post_author'] = $input['author'];
+		}
 		$post_id = wp_insert_post( wp_slash( $post_data ), true );
 
 		if ( is_wp_error( $post_id ) ) {
@@ -361,6 +413,7 @@ class Frontman_Tool_Posts {
 			throw new Frontman_Tool_Error( "Post not found: {$id}" );
 		}
 
+		$this->check_write_permissions( $input, $post->post_type, $post );
 		$before = $this->read_post( [ 'id' => $id ] );
 
 		$post_data = [ 'ID' => $id ];
@@ -369,6 +422,9 @@ class Frontman_Tool_Posts {
 				throw new Frontman_Tool_Error( 'slug must be a string.' );
 			}
 			$post_data['post_name'] = $input['slug'];
+		}
+		if ( array_key_exists( 'author', $input ) ) {
+			$post_data['post_author'] = $input['author'];
 		}
 		if ( isset( $input['content'] ) && class_exists( 'Frontman_Elementor_Data' ) && Frontman_Elementor_Data::post_uses_elementor( $id ) ) {
 			throw new Frontman_Tool_Error( 'Refusing to update post_content for Elementor-managed page ' . $id . '. Use wp_elementor_update_element, wp_elementor_save_page_data, or wp_elementor_restore_rollback for Elementor content/layout changes. wp_update_post may still update title, status, or excerpt without content.' );

--- a/libs/frontman-wordpress/tools/class-tool-users.php
+++ b/libs/frontman-wordpress/tools/class-tool-users.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Bounded, read-only current-site author account lookup.
+ *
+ * @package Frontman
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Frontman_Tool_Users {
+	public function register( Frontman_Tools $tools ): void {
+		$tools->add( new Frontman_Tool_Definition(
+			'wp_find_users',
+			'Find candidate accounts only for a user-requested author task, not bulk background discovery. Distinguish login from display name and consider remaining pages. If identity is ambiguous, ask which account; never choose the first result or guess IDs. Candidates are not proof of assignment eligibility. After assigning an author with wp_create_post or wp_update_post, read back with wp_read_post.',
+			[
+				'type' => 'object',
+				'additionalProperties' => false,
+				'properties' => [
+					'search' => [
+						'type' => 'string', 'minLength' => 1, 'maxLength' => 100,
+						'description' => 'Trimmed nonempty literal substring, at most 100 Unicode characters. Must not start or end with * after whitespace trimming (including asterisk-only input). Interior *, %, _, and quotes are literal. Case sensitivity depends on database collation.',
+					],
+					'match_by' => [ 'type' => 'string', 'enum' => [ 'login', 'display_name' ], 'description' => 'Search only this column; never implicitly search email.' ],
+					'page' => [ 'type' => 'integer', 'minimum' => 1, 'default' => 1 ],
+					'per_page' => [ 'type' => 'integer', 'minimum' => 1, 'maximum' => 20, 'default' => 20 ],
+				],
+				'required' => [ 'search', 'match_by' ],
+			],
+			[ $this, 'find_users' ],
+			'read'
+		) );
+	}
+
+	/** Shared by the raw registry boundary and direct calls; no schema coercion. */
+	public static function validate_input( array $input ): array {
+		if ( array_diff( array_keys( $input ), [ 'search', 'match_by', 'page', 'per_page' ] ) ) {
+			throw new Frontman_Tool_Error( 'Unexpected account lookup field.' );
+		}
+		if ( ! isset( $input['search'] ) || ! is_string( $input['search'] ) ) {
+			throw new Frontman_Tool_Error( 'search must be a nonempty string of at most 100 Unicode characters.' );
+		}
+		$search = preg_replace( '/\A\s+|\s+\z/u', '', $input['search'] );
+		if ( null === $search || 1 !== preg_match( '/\A.{1,100}\z/us', $search ) ) {
+			throw new Frontman_Tool_Error( 'search must be a nonempty string of at most 100 Unicode characters.' );
+		}
+		if ( '*' === $search[0] || '*' === substr( $search, -1 ) ) {
+			throw new Frontman_Tool_Error( 'search must not start or end with * after trimming whitespace; use a more specific name or login.' );
+		}
+		if ( ! isset( $input['match_by'] ) || ! in_array( $input['match_by'], [ 'login', 'display_name' ], true ) ) {
+			throw new Frontman_Tool_Error( 'match_by must be login or display_name.' );
+		}
+		foreach ( [ 'page' => 1, 'per_page' => 20 ] as $field => $default ) {
+			if ( ! array_key_exists( $field, $input ) ) {
+				$input[ $field ] = $default;
+			}
+			if ( ! is_int( $input[ $field ] ) || $input[ $field ] < 1 || ( 'per_page' === $field && $input[ $field ] > 20 ) ) {
+				throw new Frontman_Tool_Error( 'page must be a positive integer and per_page an integer from 1 to 20.' );
+			}
+		}
+		if ( $input['page'] - 1 > intdiv( PHP_INT_MAX, $input['per_page'] ) ) {
+			throw new Frontman_Tool_Error( 'page is too large for the requested per_page.' );
+		}
+		$input['search'] = $search;
+		return $input;
+	}
+
+	public function find_users( array $input ): array {
+		$input = self::validate_input( $input );
+		if ( ! current_user_can( 'manage_options' ) || ! current_user_can( 'list_users' ) ) {
+			throw new Frontman_Tool_Error( 'Account lookup requires manage_options and list_users.' );
+		}
+		$query = new \WP_User_Query( [
+			'blog_id' => get_current_blog_id(),
+			'search' => '*' . $input['search'] . '*',
+			'search_columns' => [ 'login' === $input['match_by'] ? 'user_login' : 'display_name' ],
+			'number' => $input['per_page'],
+			'paged' => $input['page'],
+			'orderby' => 'ID', 'order' => 'ASC', 'count_total' => true,
+			'fields' => [ 'ID', 'user_login', 'display_name' ],
+		] );
+		$users = [];
+		foreach ( $query->get_results() as $user ) {
+			$users[] = [ 'id' => (int) $user->ID, 'login' => $user->user_login, 'display_name' => $user->display_name ];
+		}
+		$total = (int) $query->get_total();
+		return [
+			'users' => $users, 'page' => $input['page'], 'per_page' => $input['per_page'],
+			'total' => $total, 'total_pages' => (int) ceil( $total / $input['per_page'] ),
+		];
+	}
+}

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -76,6 +76,9 @@ done
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ElementorSnapshotRuntimeTest.php" "$WORDPRESS:/tmp/ElementorSnapshotRuntimeTest.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php" "$WORDPRESS:/tmp/ActivateWordPressPlugin.php"
 "$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RunWordPressRuntimeTest.php" "$WORDPRESS:/tmp/RunWordPressRuntimeTest.php"
+"$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/mu-plugins
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeFixture.php" "$WORDPRESS:/var/www/html/wp-content/mu-plugins/frontman-authors-runtime.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/PostAuthorsRuntimeTest.php" "$WORDPRESS:/tmp/PostAuthorsRuntimeTest.php"
 if [[ -n "$YOAST_VERSION" ]]; then
   "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/mu-plugins /var/www/html/wp-content/plugins/wordpress-seo
   "$RUNTIME" cp "$BUILD_DIR/yoast/wordpress-seo/." "$WORDPRESS:/var/www/html/wp-content/plugins/wordpress-seo/"
@@ -96,5 +99,20 @@ fi
 printf '%s\n' "$TEST_OUTPUT"
 if [[ "$TEST_STATUS" -ne 0 || "$TEST_OUTPUT" != *"OK (WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
   printf 'WordPress runtime tests did not report successful completion.\n' >&2
+  exit 1
+fi
+
+"$RUNTIME" exec "$WORDPRESS" cp -a /var/www/html /tmp/frontman-multisite
+"$RUNTIME" exec "$WORDPRESS" php -r '$path = "/tmp/frontman-multisite/wp-config.php"; $config = file_get_contents($path); $config = str_replace("\x27wp_\x27", "\x27fm_multi_\x27", $config); file_put_contents($path, $config);'
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/SetupAuthorsMultisite.php" "$WORDPRESS:/tmp/SetupAuthorsMultisite.php"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/MultisiteAuthorsRuntimeTest.php" "$WORDPRESS:/tmp/MultisiteAuthorsRuntimeTest.php"
+"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/SetupAuthorsMultisite.php
+if MULTISITE_OUTPUT="$("$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/MultisiteAuthorsRuntimeTest.php)"; then
+  MULTISITE_STATUS=0
+else MULTISITE_STATUS=$?
+fi
+printf '%s\n' "$MULTISITE_OUTPUT"
+if [[ "$MULTISITE_STATUS" -ne 0 || "$MULTISITE_OUTPUT" != *"OK (Multisite authors, WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
+  printf 'Multisite author tests did not report successful completion.\n' >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Add native WordPress author assignment on create/update, preserving omitted authors and before/after snapshots.
- Add current-site account lookup with deterministic pagination, at most 20 candidates per page, and only ID, login, and display name in results. Ambiguous identities require clarification.
- Validate raw inputs before coercion and direct dispatch. Enforce mapped create/edit/publish/edit-others capabilities, author support, account existence, and multisite membership before writes.
- Apply the approved restriction: reject leading/trailing asterisks after whitespace trimming, including asterisk-only input. Native substring lookup preserves interior asterisks, percent signs, underscores, and quotes literally; no custom SQL or query filters.
- Document native-author scope, search restrictions, and account identifiers entering selected AI-provider request context and task history through existing user-requested chat.

Closes #1650

## Completed verification
All entries below passed after implementation using Podman. Host PHP was unavailable.

### Isolated PHP suite
| PHP | Result |
|---|---|
| 7.4 | Exit 0 |
| 8.4 | Exit 0 |

Executed every libs/frontman-wordpress/tests/*Test.php with ErrorHandler.php auto-prepended, using the compatibility-workflow PHP CLI container pattern and a read-only worktree mount.

### Packaged WordPress runtime suite
| WordPress | PHP | Yoast | Result |
|---|---|---|---|
| 6.0.9 | 7.4 | none | Exit 0 |
| 7.0.2 | 7.4 | none | Exit 0 |
| 7.0.2 | 8.4 | none | Exit 0 |
| 7.0.2 | 7.4 | 28.4 | Exit 0 |
| 7.0.2 | 8.4 | 28.4 | Exit 0 |

Runtime command: CONTAINER_RUNTIME=podman WORDPRESS_VERSION="$wp" PHP_VERSION="$php" YOAST_VERSION="$yoast" make test-wordpress-runtime.

Includes new HTTP author/permission/privacy checks, separate real multisite fixtures through registry dispatch, raw validation, absence of partial writes, literal search cases, and existing regression suites. Runtime PHP versions were 7.4.33 and 8.4.23. Package builds are covered by runtime runs.

Also passed: git diff --check, git diff --cached --check, bash -n scripts/test-wordpress-plugin-runtime.sh, and make check-source-comments.

## Review status and limits
- Independent advisor review is pending.
- Author support and current-site membership are Frontman safeguards, not additional WordPress directory-policy mandates.
- This is not a whole-plugin compliance certification or a guarantee of rollback for arbitrary third-party hook effects.
- Commit: c69cc5bbc467c34377bafa91f4ea7d497e0a9486.

## Test cleanup — 0070fd57
- Remove 55 net lines across two test files. Production code is unchanged.
- Remove mocked permission and query checks already covered by real WordPress tests.
- Keep exhaustive raw-input validation, representative HTTP coercion checks, and real permission, privacy, and multisite coverage.
- Run update scenarios once instead of repeating them for every creation variant.

Verification after cleanup passed:
- `make test-wordpress-core-tools` on PHP 7.4 and 8.4 through Podman.
- Packaged runtime and multisite suites on WordPress 6.0.9 / PHP 7.4 without Yoast.
- Packaged runtime and multisite suites on WordPress 7.0.2 / PHP 8.4 with Yoast 28.4.
- `make check-source-comments` and `git diff --check`.

The other three runtime combinations in the original verification table were not rerun after this test-only cleanup.
