### PR TITLE
fix(wordpress): clean vendor exports and preserve SVN release tags

### DIFF
--- a/.changeset/fix-wordpress-vendor-export.md
+++ b/.changeset/fix-wordpress-vendor-export.md
@@ -1,0 +1,5 @@
+---
+"frontman": patch
+---
+
+Fix WordPress.org publishing by excluding bundled dependency documentation and development tools. Preserve PHP runtime files, licenses, and author attribution, and validate the export before publishing. Keep older SVN release tags when publishing a new version.

--- a/.github/workflows/publish-wordpress-plugin.yml
+++ b/.github/workflows/publish-wordpress-plugin.yml
@@ -83,9 +83,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y rsync subversion zip
 
-      - name: Package WordPress plugin
+      - name: Package and validate WordPress plugin
         if: steps.verify.outputs.publish == 'true'
-        run: make package-wordpress-plugin VERSION="${{ steps.version.outputs.version }}"
+        run: make test-wordpress-plugin-export VERSION="${{ steps.version.outputs.version }}"
 
       - name: Publish to WordPress.org SVN
         if: steps.verify.outputs.publish == 'true'

--- a/Makefile
+++ b/Makefile
@@ -566,6 +566,10 @@ test-wordpress-sentry: build-wordpress-dependencies
 package-wordpress-plugin:
 	@VERSION=$(VERSION) bash ./scripts/package-wordpress-plugin.sh
 
+.PHONY: test-wordpress-plugin-export
+test-wordpress-plugin-export: package-wordpress-plugin
+	@bash ./scripts/test-wordpress-plugin-export.sh
+
 publish-wordpress-plugin-svn: package-wordpress-plugin
 	@VERSION=$(VERSION) bash ./scripts/publish-wordpress-plugin-svn.sh
 

--- a/scripts/build-wordpress-dependencies.sh
+++ b/scripts/build-wordpress-dependencies.sh
@@ -44,4 +44,9 @@ rm -rf "$SCOPED"
     rm vendor/scoper-autoload.php
   '
 mkdir -p "$PLUGIN/vendor"
-rsync -a --delete "$SCOPED/vendor/" "$PLUGIN/vendor/"
+rsync -a --delete --delete-excluded \
+  --exclude 'docs/' --exclude 'scripts/' \
+  --exclude 'README.md' --exclude 'CONTRIBUTING.md' \
+  --exclude 'UPGRADE*.md' --exclude 'UPGRADING.md' \
+  --exclude 'AGENTS.md' --exclude 'CLAUDE.md' --exclude '*.toml' \
+  "$SCOPED/vendor/" "$PLUGIN/vendor/"

--- a/scripts/publish-wordpress-plugin-svn.sh
+++ b/scripts/publish-wordpress-plugin-svn.sh
@@ -79,7 +79,7 @@ scan_export_paths() {
     fi
 
     case "$name" in
-      LICENSE|*.php|*.js|*.css|*.svg|*.txt|*.png|*.jpg|*.jpeg|*.gif|*.webp|*.ico|*.json|*.pot|*.po|*.mo|*.woff|*.woff2|*.ttf|*.eot) ;;
+      LICENSE|AUTHORS|*.php|*.js|*.css|*.svg|*.txt|*.png|*.jpg|*.jpeg|*.gif|*.webp|*.ico|*.json|*.pot|*.po|*.mo|*.woff|*.woff2|*.ttf|*.eot) ;;
       *)
         printf 'Unexpected file type in WordPress.org export: %s\n' "$rel" >&2
         found=1
@@ -175,7 +175,10 @@ trap 'unset svn_password; rm -rf "$SVN_WC"' EXIT
 
 "$svn_bin" checkout --depth infinity "$svn_url" "$SVN_WC"
 
-rsync -a --delete --exclude '.svn/' "$EXPORT_DIR/" "$SVN_WC/"
+for directory in trunk assets "tags/$VERSION"; do
+  mkdir -p "$SVN_WC/$directory"
+  rsync -a --delete --exclude '.svn/' "$EXPORT_DIR/$directory/" "$SVN_WC/$directory/"
+done
 
 while IFS= read -r deleted_path; do
   [ -n "$deleted_path" ] || continue

--- a/scripts/test-wordpress-plugin-export.sh
+++ b/scripts/test-wordpress-plugin-export.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+VERSION="$(bash "$ROOT_DIR/scripts/validate-wordpress-plugin-release.sh")"
+EXPORT_DIR="$ROOT_DIR/dist/frontman-wordpress-org-v${VERSION}"
+TEMP_DIR="$(mktemp -d)"
+PROBE_DIR="$(mktemp -d "$EXPORT_DIR/trunk/export-test.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR" "$PROBE_DIR"' EXIT
+
+cat > "$TEMP_DIR/svn" <<'SVN'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  checkout)
+    mkdir -p "${@: -1}/tags/previous-release"
+    printf 'keep this release\n' > "${@: -1}/tags/previous-release/readme.txt"
+    ;;
+  status)
+    grep -qx 'keep this release' "$2/tags/previous-release/readme.txt"
+    printf 'M       %s/trunk/readme.txt\n' "$2"
+    ;;
+  add|propset) ;;
+  *) printf 'Unexpected SVN operation: %s\n' "$1" >&2; exit 99 ;;
+esac
+SVN
+chmod +x "$TEMP_DIR/svn"
+check_publish_status() {
+  local expected="$1" status=0
+  PATH="$TEMP_DIR:$PATH" DRY_RUN=1 WORDPRESS_ORG_USERNAME=test WORDPRESS_ORG_PASSWORD=test \
+    bash "$ROOT_DIR/scripts/publish-wordpress-plugin-svn.sh" "$VERSION" > "$TEMP_DIR/output" 2>&1 || status=$?
+  if [[ "$status" != "$expected" ]]; then
+    cat "$TEMP_DIR/output" >&2
+    printf 'Expected publisher exit %s, got %s\n' "$expected" "$status" >&2
+    exit 1
+  fi
+}
+
+while IFS= read -r -d '' source; do
+  relative="${source#"$ROOT_DIR/dist/wordpress-dependencies-scoped/vendor/"}"
+  for vendor in "$EXPORT_DIR/trunk/vendor" "$EXPORT_DIR/tags/$VERSION/vendor" \
+    "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/vendor"; do
+    cmp "$source" "$vendor/$relative"
+  done
+done < <(find "$ROOT_DIR/dist/wordpress-dependencies-scoped/vendor" -type f \
+  \( -name '*.php' -o -iname 'LICENSE*' -o -iname 'COPYING*' -o -iname 'NOTICE*' -o -iname 'AUTHORS*' \) -print0)
+
+check_publish_status 0
+grep -q 'DRY_RUN=1; skipping WordPress.org SVN commit' "$TEMP_DIR/output"
+for forbidden in unexpected.sh .env; do
+  printf 'not for publication\n' > "$PROBE_DIR/$forbidden"
+  check_publish_status 1
+  grep -q 'Refusing to publish WordPress.org export' "$TEMP_DIR/output"
+  rm "$PROBE_DIR/$forbidden"
+done
+printf 'OK: export scans pass, runtime and attribution files preserved, old tags retained, forbidden files rejected\n'


### PR DESCRIPTION
## Summary
- Remove upstream dependency docs and development tooling; retain runtime PHP, licenses, and AUTHORS.
- Preserve older WordPress.org SVN tags when publishing a new release.
- Validate the actual export with an offline SVN dry run before publishing.

## Verification
- `make test-wordpress-plugin-export CONTAINER_RUNTIME=podman` passes: byte-identical runtime/license/attribution files in both package layouts, previous tags retained, forbidden files rejected.
- `make test-wordpress-sentry CONTAINER_RUNTIME=podman` passes both SDK load orders and missing-SDK handling.
- Shell syntax and `git diff --check` pass.

Based on v5.1.0 so the failed WordPress release can be republished without unrelated changes. Fixes https://github.com/frontman-ai/frontman/actions/runs/34234397767.