### PR TITLE
fix(wordpress): support existing Custom HTML widget updates

### DIFF
--- a/.changeset/update-custom-html-widgets.md
+++ b/.changeset/update-custom-html-widgets.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Support editing existing Custom HTML widgets while preserving omitted content, plugin metadata, and sidebar placement. Apply WordPress HTML permissions to submitted content and reject invalid settings.

--- a/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
+++ b/libs/frontman-wordpress/tests/MutationSnapshotsTest.php
@@ -572,12 +572,6 @@ if ( ! function_exists( 'wp_setup_nav_menu_item' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wp_get_sidebars_widgets' ) ) {
-	function wp_get_sidebars_widgets(): array {
-		return $GLOBALS['frontman_test_options']['sidebars_widgets'] ?? [];
-	}
-}
-
 if ( ! function_exists( 'wp_get_theme' ) ) {
 	function wp_get_theme() {
 		return new class() {
@@ -640,7 +634,6 @@ require_once __DIR__ . '/../tools/class-tool-blocks.php';
 require_once __DIR__ . '/../tools/class-tool-menus.php';
 require_once __DIR__ . '/../tools/class-tool-options.php';
 require_once __DIR__ . '/../tools/class-tool-templates.php';
-require_once __DIR__ . '/../tools/class-tool-widgets.php';
 require_once __DIR__ . '/../tools/class-tool-cache.php';
 
 class Frontman_Mutation_Snapshots_Test_Runner {
@@ -656,10 +649,9 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->test_menu_management_snapshots();
 		$this->test_block_navigation_management();
 		$this->test_menu_item_creation_includes_before_snapshot();
-		$this->test_menu_option_and_widget_updates_include_before_snapshots();
+		$this->test_menu_and_option_updates_include_before_snapshots();
 		$this->test_theme_source_tools();
 		$this->test_post_backed_menu_items_preserve_metadata();
-		$this->test_widget_management_snapshots();
 		$this->test_template_update_snapshot();
 		$this->test_cache_tools();
 		fwrite( STDOUT, "OK ({$this->assertions} assertions)\n" );
@@ -770,20 +762,6 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 			'page_title_enabled' => true,
 		];
 		$GLOBALS['frontman_test_options']['active_plugins'] = [ 'wp-rocket/wp-rocket.php' ];
-		$GLOBALS['frontman_test_options']['widget_text'] = [
-			2 => [ 'title' => 'Old Widget', 'text' => 'Old text' ],
-		];
-		$GLOBALS['frontman_test_options']['widget_categories'] = [
-			3 => [ 'title' => 'Categories Widget' ],
-		];
-		$GLOBALS['frontman_test_options']['sidebars_widgets'] = [
-			'sidebar-1' => [ 'text-2', 'categories-3' ],
-			'sidebar-2' => [],
-		];
-		$GLOBALS['wp_registered_sidebars'] = [
-			'sidebar-1' => [ 'name' => 'Primary Sidebar', 'description' => '' ],
-			'sidebar-2' => [ 'name' => 'Footer Sidebar', 'description' => '' ],
-		];
 		$GLOBALS['frontman_test_block_templates'][] = (object) [
 			'id' => 'frontman-theme//home',
 			'slug' => 'home',
@@ -1060,7 +1038,7 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 		$this->assert_same( 'Footer Navigation', $deleted['before']['title'], 'wp_delete_navigation_menu returns deleted navigation snapshot' );
 	}
 
-	private function test_menu_option_and_widget_updates_include_before_snapshots(): void {
+	private function test_menu_and_option_updates_include_before_snapshots(): void {
 		$menu_tool = new Frontman_Tool_Menus();
 		$menu = $menu_tool->update_menu_item( [ 'menu_item_id' => 25, 'title' => 'New Label' ] );
 		$this->assert_same( 'Old Label', $menu['before']['title'], 'wp_update_menu_item returns previous menu item snapshot' );
@@ -1086,15 +1064,6 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 			'Option not allowed',
 			'wp_update_option rejects complex widget/sidebar state writes'
 		);
-
-		$widget_tool = new Frontman_Tool_Widgets();
-		$widget = $widget_tool->update_widget( [
-			'sidebar_id' => 'sidebar-1',
-			'widget_id' => 'text-2',
-			'settings' => [ 'title' => 'New Widget' ],
-		] );
-		$this->assert_same( 'Old Widget', $widget['before']['title'], 'wp_update_widget returns previous widget settings' );
-		$this->assert_same( 'New Widget', $widget['settings']['title'], 'wp_update_widget returns updated widget settings' );
 
 		$this->assert_error_contains(
 			static function() use ( $menu_tool ) {
@@ -1453,82 +1422,6 @@ class Frontman_Mutation_Snapshots_Test_Runner {
 			'post-backed menu item',
 			'wp_update_menu_item rejects URL-only updates on post-backed menu items'
 		);
-	}
-
-	private function test_widget_management_snapshots(): void {
-		$tool = new Frontman_Tool_Widgets();
-
-		$this->assert_error_contains(
-			static function() use ( $tool ) {
-				$tool->create_widget( [
-					'sidebar_id' => 'sidebar-2',
-					'widget_base' => 'categories',
-					'settings' => [ 'title' => 'Categories' ],
-				] );
-			},
-			'text',
-			'wp_create_widget rejects unsupported widget bases'
-		);
-
-		$this->assert_error_contains(
-			static function() use ( $tool ) {
-				$tool->update_widget( [
-					'sidebar_id' => 'sidebar-1',
-					'widget_id' => 'categories-3',
-					'settings' => [ 'title' => 'Nope' ],
-				] );
-			},
-			'text',
-			'wp_update_widget rejects unsupported widget bases'
-		);
-
-		$this->assert_error_contains(
-			static function() use ( $tool ) {
-				$tool->delete_widget( [
-					'widget_id' => 'categories-3',
-					'confirm' => true,
-				] );
-			},
-			'text',
-			'wp_delete_widget rejects unsupported widget bases'
-		);
-
-		$created = $tool->create_widget( [
-			'sidebar_id' => 'sidebar-2',
-			'widget_base' => 'text',
-			'settings' => [ 'title' => 'Footer Widget', 'text' => 'Hello' ],
-		] );
-		$this->assert_same( 0, $created['before']['widget_count'], 'wp_create_widget captures sidebar state before creation' );
-		$this->assert_same( 1, $created['after']['widget_count'], 'wp_create_widget captures sidebar state after creation' );
-		$this->assert_same( 'Footer Widget', $tool->read_widget( [ 'widget_id' => $created['widget_id'] ] )['settings']['title'], 'wp_read_widget reads created widget settings' );
-
-		$moved = $tool->move_widget( [
-			'widget_id' => $created['widget_id'],
-			'to_sidebar_id' => 'sidebar-1',
-			'to_position' => 1,
-		] );
-		$this->assert_same( 'sidebar-2', $moved['before']['widget']['sidebar_id'], 'wp_move_widget captures original sidebar' );
-		$this->assert_same( 'sidebar-1', $moved['after']['widget']['sidebar_id'], 'wp_move_widget captures destination sidebar' );
-
-		$reordered = $tool->move_widget( [
-			'widget_id' => $created['widget_id'],
-			'to_sidebar_id' => 'sidebar-1',
-			'to_position' => 2,
-		] );
-		$this->assert_same( 2, $reordered['after']['widget']['position'], 'wp_move_widget can reorder within the same sidebar without duplicating the widget' );
-		$this->assert_same( $reordered['before']['from_sidebar']['widget_count'], $reordered['after']['from_sidebar']['widget_count'], 'same-sidebar widget move keeps the sidebar widget count stable' );
-
-		$this->assert_error_contains(
-			static function() use ( $tool, $created ) {
-				$tool->delete_widget( [ 'widget_id' => $created['widget_id'], 'confirm' => false ] );
-			},
-			'explicit confirmation',
-			'wp_delete_widget requires confirm=true'
-		);
-
-		$deleted = $tool->delete_widget( [ 'widget_id' => $created['widget_id'], 'confirm' => true ] );
-		$this->assert_same( $created['widget_id'], $deleted['widget_id'], 'wp_delete_widget reports deleted widget id' );
-		$this->assert_same( 'Footer Widget', $deleted['before']['widget']['settings']['title'], 'wp_delete_widget returns previous widget snapshot' );
 	}
 
 	private function test_template_update_snapshot(): void {

--- a/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
+++ b/libs/frontman-wordpress/tests/integration/ActivateWordPressPlugin.php
@@ -22,9 +22,11 @@ if ( false !== $yoast && '' !== $yoast ) {
 		throw new RuntimeException( $result->get_error_message() );
 	}
 }
-$result = activate_plugin( 'frontman-agentic-ai-editor/frontman.php' );
-if ( is_wp_error( $result ) ) {
-	throw new RuntimeException( $result->get_error_message() );
+foreach ( [ 'megamenu/megamenu.php', 'frontman-agentic-ai-editor/frontman.php' ] as $plugin ) {
+	$result = activate_plugin( $plugin );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( $result->get_error_message() );
+	}
 }
 
 restore_error_handler();

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -333,6 +333,54 @@ foreach ( [ 1, 2 ] as $position ) {
 $widget_call( 'wp_delete_widget', [ 'widget_id' => $text_input['widget_id'], 'confirm' => false ], true );
 $deleted_widget = $widget_call( 'wp_delete_widget', [ 'widget_id' => $text_input['widget_id'], 'confirm' => true ] );
 frontman_runtime_assert( $text_input['widget_id'] === $deleted_widget['widget_id'] && 'New Footer' === $deleted_widget['before']['widget']['settings']['title'] && 2 === $deleted_widget['after']['widget_count'], 'Widget deletion snapshot or placement changed.' );
+frontman_runtime_assert( is_plugin_active( 'megamenu/megamenu.php' ), 'Max Mega Menu must be active for widget integration coverage.' );
+register_nav_menu( 'frontman-mega', 'Runtime mega menu' );
+$mega_menu = wp_create_nav_menu( 'Runtime mega menu' );
+frontman_runtime_assert( ! is_wp_error( $mega_menu ), 'Could not create mega menu fixture.' );
+$mega_locations = get_theme_mod( 'nav_menu_locations', [] );
+$mega_settings = get_option( 'megamenu_settings', [] );
+set_theme_mod( 'nav_menu_locations', array_merge( $mega_locations, [ 'frontman-mega' => $mega_menu ] ) );
+update_option( 'megamenu_settings', array_merge( $mega_settings, [ 'frontman-mega' => [ 'enabled' => '1' ] ] ) );
+$mega_manager = new Mega_Menu_Widget_Manager();
+foreach ( [ 'megamenu', 'grid' ] as $layout ) {
+	$mega_parent = wp_update_nav_menu_item( $mega_menu, 0, [ 'menu-item-title' => $layout, 'menu-item-url' => home_url( '/' ), 'menu-item-status' => 'publish' ] );
+	frontman_runtime_assert( ! is_wp_error( $mega_parent ), 'Could not create mega menu parent.' );
+	$mega_widgets = (array) $mega_manager->get_mega_menu_sidebar_widgets();
+	$mega_manager->add_widget( 'custom_html', $mega_parent, 'Custom HTML', 'grid' === $layout );
+	$mega_added = array_values( array_diff( $mega_manager->get_mega_menu_sidebar_widgets(), $mega_widgets ) );
+	frontman_runtime_assert( 1 === count( $mega_added ), 'Max Mega Menu did not create exactly one widget.' );
+	$mega_widget_id = $mega_added[0];
+	$mega_meta = [ 'type' => $layout ];
+	if ( 'grid' === $layout ) {
+		$mega_meta['grid'] = [ [ 'columns' => [ [ 'meta' => [ 'span' => 12 ], 'items' => [ [ 'id' => $mega_widget_id, 'type' => 'widget' ] ] ] ] ] ];
+	}
+	update_post_meta( $mega_parent, '_megamenu', $mega_meta );
+	$GLOBALS['wp_widget_factory']->widgets['WP_Widget_Custom_HTML']->_register();
+	$mega_before = $widget_call( 'wp_read_widget', [ 'widget_id' => $mega_widget_id ] );
+	$mega_input = [ 'sidebar_id' => $mega_before['sidebar_id'], 'widget_id' => $mega_widget_id ];
+	$mega_placement = get_option( 'sidebars_widgets' );
+	$mega_expected = $mega_before['settings'];
+	foreach ( [ [ 'title' => 'Original ' . $layout, 'content' => '<a href="/old-' . $layout . '">Old link</a>' ], [ 'title' => 'Resources ' . $layout ], [ 'content' => '<a class="blog" href="/category/blog-' . $layout . '/">Reader\'s 日本 Blog</a>' ] ] as $patch ) {
+		$mega_siblings = get_option( 'widget_custom_html' );
+		$mega_updated = $widget_call( 'wp_update_widget', $mega_input + [ 'settings' => wp_json_encode( $patch ) ] );
+		frontman_runtime_assert( $mega_expected === $mega_updated['before'], 'Mega menu update lost its before snapshot.' );
+		$mega_expected = array_merge( $mega_expected, $patch );
+		$mega_read = $widget_call( 'wp_read_widget', [ 'widget_id' => $mega_widget_id ] );
+		frontman_runtime_assert( $mega_expected === $mega_updated['settings'] && $mega_expected === $mega_read['settings'], 'Mega menu update changed omitted content or plugin metadata.' );
+		$mega_siblings[ $mega_manager->get_widget_number_for_widget_id( $mega_widget_id ) ] = $mega_expected;
+		frontman_runtime_assert( $mega_siblings === get_option( 'widget_custom_html' ) && $mega_placement === get_option( 'sidebars_widgets' ) && $mega_meta === get_post_meta( $mega_parent, '_megamenu', true ), 'Mega menu update changed sibling widgets or placement.' );
+		$mega_rendered = wp_nav_menu( [ 'theme_location' => 'frontman-mega', 'echo' => false ] );
+		frontman_runtime_assert( false !== strpos( $mega_rendered, 'max-mega-menu' ) && 1 === substr_count( $mega_rendered, $mega_expected['content'] ) && false !== strpos( $mega_rendered, $mega_expected['title'] ), 'Max Mega Menu did not render the saved widget exactly once.' );
+		if ( isset( $patch['content'] ) && false !== strpos( $patch['content'], '/category/' ) ) {
+			frontman_runtime_assert( false === strpos( $mega_rendered, '/old-' . $layout ), 'Max Mega Menu still rendered stale widget content.' );
+		}
+	}
+}
+fwrite( STDOUT, 'Max Mega Menu ' . get_plugin_data( WP_PLUGIN_DIR . '/megamenu/megamenu.php', false, false )['Version'] . " standard/grid widget updates and rendering passed.\n" );
+wp_delete_nav_menu( $mega_menu );
+set_theme_mod( 'nav_menu_locations', $mega_locations );
+update_option( 'megamenu_settings', $mega_settings );
+unregister_nav_menu( 'frontman-mega' );
 update_option( 'sidebars_widgets', $widget_sidebars );
 wp_set_current_user( 0 );
 

--- a/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/WordPressRuntimeTest.php
@@ -255,6 +255,87 @@ foreach ( [ 'any', 'draft', 'pending', 'publish' ] as $status ) {
 }
 frontman_runtime_assert( $posts_before_listing === $wpdb->get_results( "SELECT * FROM {$wpdb->posts} ORDER BY ID", ARRAY_A ), 'Listing or reading slugs mutated posts.' );
 
+wp_set_current_user( $admin->ID );
+register_sidebar( [ 'id' => 'frontman-widgets', 'name' => 'Widget runtime fixture' ] );
+register_sidebar( [ 'id' => 'frontman-footer', 'name' => 'Empty runtime footer' ] );
+$widget_sidebars = get_option( 'sidebars_widgets' );
+update_option( 'sidebars_widgets', [ 'frontman-widgets' => [ 'custom_html-4', 'categories-3' ], 'frontman-footer' => [] ] );
+update_option( 'widget_categories', [ 3 => [ 'title' => 'Categories' ] ] );
+$widget_call = static function ( string $name, array $input, bool $error = false ): array {
+	$tools = Frontman_Tools::instance();
+	$result = $tools->call( $name, $tools->sanitize_input( $name, $input ) );
+	frontman_runtime_assert( $error === $result['isError'], $name . ': ' . wp_json_encode( $result ) );
+	return $error ? [] : json_decode( $result['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+};
+$widget_input = [ 'sidebar_id' => 'frontman-widgets', 'widget_id' => 'custom_html-4' ];
+$widget_original = [ 'title' => 'Resources', 'content' => '<script>window.existing = true;</script>', 'mega_menu_is_grid_widget' => 'true', 'plugin_meta' => [ 'keep' => 'untouched' ] ];
+$widget_html = '<a class="blog" href="/category/blog/?a=1&amp;b=2" onclick="alert(1)">Reader\'s 日本 Blog \\ guide</a>' . "\n" . '<script>window.added = true;</script>';
+foreach ( [ true, false ] as $unfiltered ) {
+	$widget_caps = static fn( $caps ) => array_merge( $caps, [ 'unfiltered_html' => $unfiltered ] );
+	add_filter( 'user_has_cap', $widget_caps );
+	update_option( 'widget_custom_html', [ 4 => $widget_original, 6 => $widget_original, '_multiwidget' => 1 ] );
+	$title_update = $widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"title":"<b>Links</b>"}' ] );
+	frontman_runtime_assert( $widget_original === $title_update['before'] && array_merge( $widget_original, [ 'title' => 'Links' ] ) === $title_update['settings'], 'Title-only update changed omitted HTML or metadata.' );
+	$updated_widget = $widget_call( 'wp_update_widget', $widget_input + [ 'settings' => wp_json_encode( [ 'content' => $widget_html ] ) ] );
+	$expected_widget = array_merge( $title_update['settings'], [ 'content' => $unfiltered ? $widget_html : wp_kses_post( $widget_html ) ] );
+	frontman_runtime_assert( $title_update['settings'] === $updated_widget['before'] && $expected_widget === $updated_widget['settings'], 'HTML permissions or update snapshots differ from WordPress.' );
+	frontman_runtime_assert( [ 4 => $expected_widget, 6 => $widget_original, '_multiwidget' => 1 ] === get_option( 'widget_custom_html' ), 'Update changed sibling widgets or metadata.' );
+	$read_widget = $widget_call( 'wp_read_widget', [ 'widget_id' => 'custom_html-4' ] );
+	frontman_runtime_assert( $expected_widget === $read_widget['settings'] && 1 === $read_widget['position'], 'Readback differs from persisted settings or placement.' );
+	ob_start();
+	the_widget( 'WP_Widget_Custom_HTML', $read_widget['settings'] );
+	frontman_runtime_assert( false !== strpos( ob_get_clean(), $expected_widget['content'] ), 'Custom HTML widget did not render the saved link.' );
+	$widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"content":""}' ] );
+	$empty_widget = $widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"content":""}' ] );
+	frontman_runtime_assert( '' === $empty_widget['settings']['content'], 'Clearing content or saving an unchanged value failed.' );
+	remove_filter( 'user_has_cap', $widget_caps );
+}
+$widget_filter = static function ( $value ) {
+	$value[4]['title'] = 'Filtered by WordPress';
+	return $value;
+};
+add_filter( 'pre_update_option_widget_custom_html', $widget_filter );
+$filtered_widget = $widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"title":"Requested title"}' ] );
+frontman_runtime_assert( get_option( 'widget_custom_html' )[4] === $filtered_widget['settings'] && 'Filtered by WordPress' === $filtered_widget['settings']['title'], 'Update returned proposed rather than persisted settings.' );
+remove_filter( 'pre_update_option_widget_custom_html', $widget_filter );
+$widget_filter = static fn( $value, $old ) => $old;
+add_filter( 'pre_update_option_widget_custom_html', $widget_filter, 10, 2 );
+$widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"title":"Rejected save"}' ], true );
+remove_filter( 'pre_update_option_widget_custom_html', $widget_filter );
+$widget_saved = get_option( 'widget_custom_html' );
+$widget_placement = get_option( 'sidebars_widgets' );
+foreach ( [ '', '{broken', '[]', 'null', '42', '{"title":null}', '{"content":[]}', '{"content":false}', '{"title":"Must not save","mega_menu_is_grid_widget":"false"}' ] as $invalid_settings ) {
+	$widget_call( 'wp_update_widget', $widget_input + [ 'settings' => $invalid_settings ], true );
+}
+foreach ( [ [ 'sidebar_id' => 'frontman-footer' ], [ 'widget_id' => 'custom_html-999' ], [ 'widget_id' => 'preview' ] ] as $invalid_widget ) {
+	$widget_call( 'wp_update_widget', $invalid_widget + $widget_input + [ 'settings' => '{"content":"Must not save"}' ], true );
+}
+$widget_caps = static fn( $caps ) => array_merge( $caps, [ 'edit_theme_options' => false ] );
+add_filter( 'user_has_cap', $widget_caps );
+$widget_call( 'wp_update_widget', $widget_input + [ 'settings' => '{"content":"Denied"}' ], true );
+remove_filter( 'user_has_cap', $widget_caps );
+foreach ( [ 'categories', 'custom_html' ] as $base ) {
+	$widget_call( 'wp_create_widget', [ 'sidebar_id' => 'frontman-footer', 'widget_base' => $base, 'settings' => '{}' ], true );
+	$widget_call( 'wp_delete_widget', [ 'widget_id' => 'custom_html' === $base ? 'custom_html-4' : 'categories-3', 'confirm' => true ], true );
+}
+$widget_call( 'wp_update_widget', [ 'sidebar_id' => 'frontman-widgets', 'widget_id' => 'categories-3', 'settings' => '{}' ], true );
+frontman_runtime_assert( $widget_saved === get_option( 'widget_custom_html' ) && $widget_placement === get_option( 'sidebars_widgets' ), 'Rejected updates or content edits mutated widgets/sidebar placement.' );
+$created_widget = $widget_call( 'wp_create_widget', [ 'sidebar_id' => 'frontman-footer', 'widget_base' => 'text', 'settings' => '{"title":"Footer","text":"Hello"}' ] );
+$text_input = [ 'sidebar_id' => 'frontman-footer', 'widget_id' => $created_widget['widget_id'] ];
+frontman_runtime_assert( 0 === $created_widget['before']['widget_count'] && 1 === $created_widget['after']['widget_count'] && 'Footer' === $created_widget['widget']['settings']['title'], 'Text widget creation snapshots changed.' );
+$text_updated = $widget_call( 'wp_update_widget', $text_input + [ 'settings' => '{"title":"New Footer"}' ] );
+frontman_runtime_assert( 'Footer' === $text_updated['before']['title'] && [ 'title' => 'New Footer', 'text' => 'Hello' ] === $text_updated['settings'], 'Text widget update behavior changed.' );
+foreach ( [ 1, 2 ] as $position ) {
+	$moved_widget = $widget_call( 'wp_move_widget', [ 'widget_id' => $text_input['widget_id'], 'to_sidebar_id' => 'frontman-widgets', 'to_position' => $position ] );
+	frontman_runtime_assert( ( 1 === $position ? 'frontman-footer' : 'frontman-widgets' ) === $moved_widget['before']['widget']['sidebar_id'] && 'frontman-widgets' === $moved_widget['after']['widget']['sidebar_id'] && $position === $moved_widget['after']['widget']['position'], 'Move/reorder snapshots changed.' );
+	frontman_runtime_assert( 3 === $moved_widget['after']['to_sidebar']['widget_count'], 'Move/reorder duplicated or lost a widget.' );
+}
+$widget_call( 'wp_delete_widget', [ 'widget_id' => $text_input['widget_id'], 'confirm' => false ], true );
+$deleted_widget = $widget_call( 'wp_delete_widget', [ 'widget_id' => $text_input['widget_id'], 'confirm' => true ] );
+frontman_runtime_assert( $text_input['widget_id'] === $deleted_widget['widget_id'] && 'New Footer' === $deleted_widget['before']['widget']['settings']['title'] && 2 === $deleted_widget['after']['widget_count'], 'Widget deletion snapshot or placement changed.' );
+update_option( 'sidebars_widgets', $widget_sidebars );
+wp_set_current_user( 0 );
+
 $yoast = getenv( 'EXPECTED_YOAST_VERSION' );
 if ( false === $yoast || '' === $yoast ) {
 	frontman_runtime_assert( null === Frontman_Tools::instance()->get( 'wp_read_seo' ), 'SEO tools were registered without Yoast.' );

--- a/libs/frontman-wordpress/tools/class-tool-widgets.php
+++ b/libs/frontman-wordpress/tools/class-tool-widgets.php
@@ -69,7 +69,7 @@ class Frontman_Tool_Widgets {
 
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_update_widget',
-			'Updates a widget\'s settings in a sidebar. Currently supports text widgets only.',
+			'Updates an existing text or Custom HTML widget without moving it. For custom_html, send only title and/or content; omitted settings and plugin metadata are preserved. Read back and verify the rendered page after editing.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -80,7 +80,7 @@ class Frontman_Tool_Widgets {
 					],
 					'widget_id'  => [
 						'type'        => 'string',
-						'description' => 'The widget instance ID (e.g. "text-2", "categories-3").',
+						'description' => 'The persisted widget instance ID (e.g. "text-2", "custom_html-4"), not an editor preview ID.',
 					],
 					'settings'   => [
 						'type'        => 'string',
@@ -142,7 +142,7 @@ class Frontman_Tool_Widgets {
 	}
 
 	private function widget_sidebar_map(): array {
-		$sidebars_widgets = get_option( $this->core_sidebars_widgets_option_name(), [] );
+		$sidebars_widgets = get_option( 'sidebars_widgets', [] );
 		$map = [];
 		foreach ( $sidebars_widgets as $sidebar_id => $widgets ) {
 			if ( ! is_array( $widgets ) ) {
@@ -173,20 +173,6 @@ class Frontman_Tool_Widgets {
 		return $this->sanitize_value_recursive( $settings );
 	}
 
-	/**
-	 * WordPress core stores widget instances in widget_{base} options.
-	 */
-	private function core_widget_option_name( string $widget_base ): string {
-		return 'widget_' . sanitize_key( $widget_base );
-	}
-
-	/**
-	 * WordPress core stores sidebar assignments in this built-in option.
-	 */
-	private function core_sidebars_widgets_option_name(): string {
-		return 'sidebars_widgets';
-	}
-
 	private function sanitize_value_recursive( $value ) {
 		if ( is_array( $value ) ) {
 			$result = [];
@@ -209,7 +195,7 @@ class Frontman_Tool_Widgets {
 	public function list_widget_areas( array $input ): array {
 		global $wp_registered_sidebars;
 
-		$sidebars_widgets = get_option( $this->core_sidebars_widgets_option_name(), [] );
+		$sidebars_widgets = get_option( 'sidebars_widgets', [] );
 		$result           = [];
 
 		foreach ( $wp_registered_sidebars as $id => $sidebar ) {
@@ -233,7 +219,7 @@ class Frontman_Tool_Widgets {
 	public function read_widget( array $input ): array {
 		$widget_id = sanitize_text_field( $input['widget_id'] ?? '' );
 		$parts = $this->parse_widget_id( $widget_id );
-		$settings = get_option( $this->core_widget_option_name( $parts['base'] ), [] );
+		$settings = get_option( 'widget_' . sanitize_key( $parts['base'] ), [] );
 		if ( ! isset( $settings[ $parts['number'] ] ) ) {
 			throw new Frontman_Tool_Error( "Widget instance not found: {$widget_id}" );
 		}
@@ -258,7 +244,7 @@ class Frontman_Tool_Widgets {
 		$before      = $this->sidebar_snapshot( $sidebar_id );
 		$this->assert_mutation_supported( $widget_base );
 
-		$all_settings = get_option( $this->core_widget_option_name( $widget_base ), [] );
+		$all_settings = get_option( 'widget_' . $widget_base, [] );
 		$max_number   = 0;
 		foreach ( array_keys( $all_settings ) as $key ) {
 			if ( is_numeric( $key ) ) {
@@ -269,15 +255,15 @@ class Frontman_Tool_Widgets {
 		$widget_number = $max_number + 1;
 		$widget_id     = $widget_base . '-' . $widget_number;
 		$all_settings[ $widget_number ] = $settings;
-		update_option( $this->core_widget_option_name( $widget_base ), $all_settings );
+		update_option( 'widget_' . $widget_base, $all_settings );
 
-		$sidebars_widgets = get_option( $this->core_sidebars_widgets_option_name(), [] );
+		$sidebars_widgets = get_option( 'sidebars_widgets', [] );
 		$widgets = $sidebars_widgets[ $sidebar_id ] ?? [];
 		$position = isset( $input['position'] ) ? max( 0, absint( $input['position'] ) - 1 ) : count( $widgets );
 		$position = min( $position, count( $widgets ) );
 		array_splice( $widgets, $position, 0, [ $widget_id ] );
 		$sidebars_widgets[ $sidebar_id ] = $widgets;
-		update_option( $this->core_sidebars_widgets_option_name(), $sidebars_widgets );
+		update_option( 'sidebars_widgets', $sidebars_widgets );
 
 		return [
 			'created'   => true,
@@ -294,34 +280,45 @@ class Frontman_Tool_Widgets {
 	public function update_widget( array $input ): array {
 		$sidebar_id = sanitize_key( $input['sidebar_id'] ?? '' );
 		$widget_id  = sanitize_text_field( $input['widget_id'] ?? '' );
-		$settings   = $this->sanitized_settings( $input['settings'] ?? '{}' );
-
-		if ( empty( $sidebar_id ) || empty( $widget_id ) ) {
-			throw new Frontman_Tool_Error( 'Missing sidebar_id or widget_id' );
+		$widget = $this->read_widget( [ 'widget_id' => $widget_id ] );
+		if ( '' === $sidebar_id || $sidebar_id !== $widget['sidebar_id'] ) {
+			throw new Frontman_Tool_Error( 'sidebar_id must match the widget\'s current placement. Read the widget before updating it.' );
 		}
 
 		$parts = $this->parse_widget_id( $widget_id );
-		$widget_base   = $parts['base'];
-		$widget_number = $parts['number'];
-		$this->assert_mutation_supported( $widget_base );
-
-		$all_settings = get_option( $this->core_widget_option_name( $widget_base ), [] );
-
-		if ( ! isset( $all_settings[ $widget_number ] ) ) {
-			throw new Frontman_Tool_Error( "Widget instance not found: {$widget_id}" );
+		if ( 'custom_html' === $parts['base'] ) {
+			if ( ! current_user_can( 'edit_theme_options' ) ) {
+				throw new Frontman_Tool_Error( 'Editing Custom HTML widgets requires edit_theme_options.' );
+			}
+			$raw = $input['settings'] ?? null;
+			$settings = is_string( $raw ) ? json_decode( $raw ) : null;
+			if ( ! $settings instanceof \stdClass ) {
+				throw new Frontman_Tool_Error( 'settings must be a JSON object containing title and/or content strings.' );
+			}
+			$settings = get_object_vars( $settings );
+			foreach ( $settings as $key => $value ) {
+				if ( ! in_array( $key, [ 'title', 'content' ], true ) || ! is_string( $value ) ) {
+					throw new Frontman_Tool_Error( 'Only title and content strings can be updated on Custom HTML widgets.' );
+				}
+				$settings[ $key ] = 'title' === $key ? sanitize_text_field( $value ) : ( current_user_can( 'unfiltered_html' ) ? $value : wp_kses_post( $value ) );
+			}
+		} else {
+			$this->assert_mutation_supported( $parts['base'] );
+			$settings = $this->sanitized_settings( $input['settings'] ?? '{}' );
 		}
 
-		$before = $all_settings[ $widget_number ];
-
-		$all_settings[ $widget_number ] = array_merge( $all_settings[ $widget_number ], $settings );
-
-		update_option( $this->core_widget_option_name( $widget_base ), $all_settings );
+		$option = 'widget_' . sanitize_key( $parts['base'] );
+		$all_settings = get_option( $option, [] );
+		$all_settings[ $parts['number'] ] = array_merge( $widget['settings'], $settings );
+		if ( ! update_option( $option, $all_settings ) && get_option( $option ) !== $all_settings ) {
+			throw new Frontman_Tool_Error( 'Widget settings could not be saved.' );
+		}
 
 		return [
-			'before'    => $before,
+			'before'    => $widget['settings'],
 			'updated'   => true,
 			'widget_id' => $widget_id,
-			'settings'  => $all_settings[ $widget_number ],
+			'settings'  => $this->read_widget( [ 'widget_id' => $widget_id ] )['settings'],
 		];
 	}
 
@@ -344,7 +341,7 @@ class Frontman_Tool_Widgets {
 			'to_sidebar'   => $this->sidebar_snapshot( $to_sidebar_id ),
 		];
 
-		$sidebars_widgets = get_option( $this->core_sidebars_widgets_option_name(), [] );
+		$sidebars_widgets = get_option( 'sidebars_widgets', [] );
 		$from_widgets = array_values( array_filter( $sidebars_widgets[ $from_sidebar_id ] ?? [], static function( $id ) use ( $widget_id ) {
 			return $id !== $widget_id;
 		} ) );
@@ -356,7 +353,7 @@ class Frontman_Tool_Widgets {
 
 		$sidebars_widgets[ $from_sidebar_id ] = $from_widgets;
 		$sidebars_widgets[ $to_sidebar_id ]   = $to_widgets;
-		update_option( $this->core_sidebars_widgets_option_name(), $sidebars_widgets );
+		update_option( 'sidebars_widgets', $sidebars_widgets );
 
 		return [
 			'moved'  => true,
@@ -391,11 +388,11 @@ class Frontman_Tool_Widgets {
 			'sidebar' => $this->sidebar_snapshot( $sidebar_id ),
 		];
 
-		$sidebars_widgets = get_option( $this->core_sidebars_widgets_option_name(), [] );
+		$sidebars_widgets = get_option( 'sidebars_widgets', [] );
 		$sidebars_widgets[ $sidebar_id ] = array_values( array_filter( $sidebars_widgets[ $sidebar_id ] ?? [], static function( $id ) use ( $widget_id ) {
 			return $id !== $widget_id;
 		} ) );
-		update_option( $this->core_sidebars_widgets_option_name(), $sidebars_widgets );
+		update_option( 'sidebars_widgets', $sidebars_widgets );
 
 		return [
 			'deleted'   => true,

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -7,6 +7,14 @@ RUNTIME="${CONTAINER_RUNTIME:-docker}"
 WORDPRESS_VERSION="${WORDPRESS_VERSION:-7.0.2}"
 PHP_VERSION="${PHP_VERSION:-8.4}"
 YOAST_VERSION="${YOAST_VERSION:-}"
+MEGAMENU_VERSION="3.10.7"
+MEGAMENU_SHA256="6cfe5fc2484bccbcc6782364b38e16fde55a496bfaf86d123d1d46b0684c5e7e"
+case "$WORDPRESS_VERSION" in
+  6.0.*|6.1.*)
+    MEGAMENU_VERSION="3.6.2"
+    MEGAMENU_SHA256="df0a37af42b6937fc716bbd302d983a9e78abc9a63caf1e731ac09597856ea55"
+    ;;
+esac
 YOAST_SHA256="93eba5afc65149967a4bb4906bc8fdebf92f4a65ee02bec97f5c01a7e14e7028"
 PLUGIN_VERSION="$(bash "$ROOT_DIR/scripts/validate-wordpress-plugin-release.sh")"
 RUN_ID="frontman-wp-runtime-$$"
@@ -26,6 +34,9 @@ trap cleanup EXIT
 
 make -C "$ROOT_DIR" package-wordpress-plugin VERSION="$PLUGIN_VERSION" >/dev/null
 curl -fsSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz" -o "$BUILD_DIR/wordpress.tar.gz"
+curl -fsSL "https://downloads.wordpress.org/plugin/megamenu.${MEGAMENU_VERSION}.zip" -o "$BUILD_DIR/megamenu.zip"
+printf '%s  %s\n' "$MEGAMENU_SHA256" "$BUILD_DIR/megamenu.zip" | sha256sum --check --status
+unzip -q "$BUILD_DIR/megamenu.zip" -d "$BUILD_DIR/megamenu"
 if [[ -n "$YOAST_VERSION" ]]; then
   if [[ "$YOAST_VERSION" != "28.4" ]]; then
     printf 'Unsupported Yoast runtime test version: %s\n' "$YOAST_VERSION" >&2
@@ -66,6 +77,7 @@ done
 
 "$RUNTIME" exec "$WORDPRESS" php -r '$db = @new mysqli(getenv("WORDPRESS_DB_HOST"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_NAME")); if ($db->connect_errno) { throw new RuntimeException("Database did not become ready."); }'
 "$RUNTIME" exec "$WORDPRESS" php -r '$config = file_get_contents("/var/www/html/wp-config-sample.php"); $config = str_replace(["database_name_here", "username_here", "password_here", "localhost"], [getenv("WORDPRESS_DB_NAME"), getenv("WORDPRESS_DB_USER"), getenv("WORDPRESS_DB_PASSWORD"), getenv("WORDPRESS_DB_HOST")], $config); file_put_contents("/var/www/html/wp-config.php", $config);'
+"$RUNTIME" cp "$BUILD_DIR/megamenu/megamenu" "$WORDPRESS:/var/www/html/wp-content/plugins/megamenu"
 "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/plugins/frontman-agentic-ai-editor
 "$RUNTIME" cp "$ROOT_DIR/dist/frontman-wordpress-package/github/frontman-agentic-ai-editor/." "$WORDPRESS:/var/www/html/wp-content/plugins/frontman-agentic-ai-editor/"
 "$RUNTIME" exec "$WORDPRESS" mkdir -p /var/www/html/wp-content/mu-plugins


### PR DESCRIPTION
## Summary
- Allow wp_update_widget to edit title/content on existing custom_html instances, including widgets used by Max Mega Menu.
- Preserve omitted content, plugin metadata, sibling instances, and placement. Reject sidebar mismatches, invalid settings, and missing edit_theme_options; apply WordPress HTML permissions only to submitted content.
- Return persisted settings and detect rejected saves. Keep create/delete restrictions and text sanitization unchanged.
- Replace stubbed widget tests with real WordPress runtime coverage and remove redundant option-name helpers.
- Install checksum-pinned Max Mega Menu and test actual standard/grid menu rendering. Reuse the widget-call helper and shared assertions for title/content edits, omitted fields, metadata, siblings, placement, and stale-content removal.
- Use Max Mega Menu 3.10.7 on current WordPress and 3.6.2 on WordPress 6.0/6.1, since 3.10.7 requires WordPress 6.2+.

## Validation
- Core tool suite passed on PHP 8.4 (container-backed php; existing dependency build reused).
- make test-wordpress-runtime CONTAINER_RUNTIME=podman — WordPress 7.0.2 / PHP 8.4 passed.
- make test-wordpress-runtime CONTAINER_RUNTIME=podman PHP_VERSION=7.4 — WordPress 7.0.2 / PHP 7.4 passed, including the additional persisted-readback and rejected-save checks.
- Max Mega Menu integration suite passed locally on WordPress 7.0.2 / PHP 8.4 and PHP 7.4, and WordPress 6.0.9 / PHP 7.4.
- WordPress 7.0.2 / PHP 8.4 with Yoast 28.4 also passed.
- Commit hooks passed.

## Scope / limitations
No new tool, arbitrary-widget writes, browser-editor changes, or widget lifecycle/REST migration. Runtime tests render both the core Custom HTML widget and actual Max Mega Menu standard/grid menus. The affected live site, browser layout/interactions, and site-specific caching were not exercised.