### PR TITLE
fix(client): handle connection loss without rewriting agent state

### DIFF
--- a/.changeset/silent-cougars-lick.md
+++ b/.changeset/silent-cougars-lick.md
@@ -3,4 +3,4 @@
 "@frontman-ai/frontman-client": patch
 ---
 
-Fix connection loss that left the agent UI stuck. Failed channels now settle pending ACP requests, clear local activity, and show a reload option.
+Fix connection loss that left the agent UI stuck. Preserve the last server-reported execution state, settle pending ACP requests, and disable disconnected controls with a reload option.

--- a/.changeset/silent-cougars-lick.md
+++ b/.changeset/silent-cougars-lick.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/client": patch
+"@frontman-ai/frontman-client": patch
+---
+
+Fix connection loss that left the agent UI stuck. Failed channels now settle pending ACP requests, clear local activity, and show a reload option.

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -443,11 +443,13 @@ let make = (~onConfigureProvider: unit => unit) => {
         />
 
         {switch (retryStatus, turnError, currentTaskId) {
-        | (Some(rs), _, _) => <Client__RetryBanner retryStatus=rs />
+        | (Some(rs), _, _) if hasActiveACPSession => <Client__RetryBanner retryStatus=rs />
         | (None, Some({id, message, category, retryErrorId}), Some(taskId))
           if shouldRenderTurnError(messages, id) =>
           let onRetry =
-            retryErrorId->Option.map(retriedErrorId =>
+            retryErrorId
+            ->Option.filter(_ => hasActiveACPSession)
+            ->Option.map(retriedErrorId =>
               () => Client__State.Actions.retryTurn(~taskId, ~retriedErrorId)
             )
           <ErrorBanner error=message category onConfigureProvider onRetry=?onRetry />
@@ -462,14 +464,16 @@ let make = (~onConfigureProvider: unit => unit) => {
       </ScrollContainer.ContentWrapper>
     </ScrollContainer>
     <Client__PlanList entries=planEntries />
-    <Client__QueuedMessagesDrawer
-      messages=queuedUserMessages
-      onUnqueue={messageId =>
-        switch currentTaskId {
-        | Some(taskId) => Client__State.Actions.unqueueMessage(~taskId, ~messageId)
-        | None => ()
-        }}
-    />
+    <fieldset disabled={!hasActiveACPSession} className="contents">
+      <Client__QueuedMessagesDrawer
+        messages=queuedUserMessages
+        onUnqueue={messageId =>
+          switch currentTaskId {
+          | Some(taskId) => Client__State.Actions.unqueueMessage(~taskId, ~messageId)
+          | None => ()
+          }}
+      />
+    </fieldset>
     <div className="border-t border-white/8 shrink-0">
       <Client__SelectedElementDisplay />
       {switch hasPendingQuestion {

--- a/libs/client/src/Client__Chatbox.res
+++ b/libs/client/src/Client__Chatbox.res
@@ -408,7 +408,9 @@ let make = (~onConfigureProvider: unit => unit) => {
         | (true, _) => React.null
         | (false, Error(message)) =>
           <div role="alert" className="py-3 px-4 text-[13px] text-red-400">
-            {React.string(`Could not load project context: ${message}`)}
+            {React.string(message)}
+            {React.string(" ")}
+            <a href="" className="underline"> {React.string("Reload")} </a>
           </div>
         | (false, Connecting | LoggingOut | Connected | SessionActive(_) | Disconnected) =>
           <div className="flex items-center gap-2 py-3 px-4 text-[13px] text-zinc-400">

--- a/libs/client/src/Client__ConnectionReducer.res
+++ b/libs/client/src/Client__ConnectionReducer.res
@@ -129,7 +129,6 @@ type effect =
   | ScheduleAuthRetry({signal: WebAPI.EventTypes.abortSignal})
   | LogoutEffect({
       connection: ACP.connection,
-      session: option<ACP.session>,
       apiBaseUrl: string,
       signal: WebAPI.EventTypes.abortSignal,
     })
@@ -255,20 +254,11 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
       ],
     )
 
-  | ({acp: ACPConnecting}, ACPConnectSuccess(conn)) => (
-      {
-        ...state,
-        acp: ACPConnected(conn),
-        authRetryActive: false,
-        authRetryInFlight: false,
-      },
-      [FetchSessionsEffect(conn)],
-    )
-
+  | ({acp: ACPConnecting}, ACPConnectSuccess(conn))
   | (
-      {acp: ACPAuthRequired(_), authRetryActive: true, authRetryInFlight: true},
-      ACPConnectSuccess(conn),
-    ) => (
+    {acp: ACPAuthRequired(_), authRetryActive: true, authRetryInFlight: true},
+    ACPConnectSuccess(conn),
+  ) => (
       {
         ...state,
         acp: ACPConnected(conn),
@@ -324,31 +314,31 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
         abortController: Some(signalController),
       },
       BeginLogout,
-    ) => {
-      let session = switch state.session {
-      | SessionActive(session) => Some(session)
-      | NoSession | SessionCreating(_) | SessionError(_) => None
-      }
-      {
-        ...state,
-        acp: ACPLoggingOut,
-        authRetryActive: false,
-        authRetryInFlight: false,
-        session: NoSession,
-      }->StateReducer.update(
-        ~sideEffect=LogoutEffect({
-          connection,
-          session,
-          apiBaseUrl: apiBaseUrlFromLoginUrl(config.loginUrl),
-          signal: signalController.signal,
-        }),
-      )
-    }
+    ) =>
+    {
+      ...state,
+      acp: ACPLoggingOut,
+      authRetryActive: false,
+      authRetryInFlight: false,
+      session: NoSession,
+    }->StateReducer.update(
+      ~sideEffect=LogoutEffect({
+        connection,
+        apiBaseUrl: apiBaseUrlFromLoginUrl(config.loginUrl),
+        signal: signalController.signal,
+      }),
+    )
 
   | (_, BeginLogout) => (state, [])
 
-  | ({acp: ACPConnecting}, ACPConnectError(msg)) => (
-      {...state, acp: ACPError(msg), authRetryActive: false, authRetryInFlight: false},
+  | ({acp: ACPConnecting | ACPConnected(_)}, ACPConnectError(msg)) => (
+      {
+        ...state,
+        acp: ACPError(msg),
+        session: NoSession,
+        authRetryActive: false,
+        authRetryInFlight: false,
+      },
       [LogError(`ACP connect failed: ${msg}`)],
     )
 
@@ -393,15 +383,10 @@ let reduce = (state: state, action: action): (state, array<effect>) => {
     )
 
   | ({session: SessionCreating(expectedSessionId)}, SessionCreateError({sessionId, error}))
-    if expectedSessionId == sessionId => (
-      {...state, session: SessionError(error)},
-      [LogError(`Session failed: ${error}`)],
-    )
-
   | (
-      {session: SessionActive({sessionId: expectedSessionId}) | SessionCreating(expectedSessionId)},
-      SessionFailed({sessionId, error}),
-    ) if expectedSessionId == sessionId => (
+    {session: SessionActive({sessionId: expectedSessionId}) | SessionCreating(expectedSessionId)},
+    SessionFailed({sessionId, error}),
+  ) if expectedSessionId == sessionId => (
       {...state, session: SessionError(error)},
       [LogError(`Session failed: ${error}`)],
     )
@@ -553,7 +538,10 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
   | NotifyDeleteSessionRejected({onComplete, reason}) => onComplete(Error(reason))
   | ConnectACP({config, signal}) =>
     let connect = async () => {
-      let result = await ACP.connect(config, ~signal)
+      let result = await ACP.connect(config, ~signal, ~onError=error => {
+        Client__TextDeltaBuffer.flush()
+        dispatch(ACPConnectError(error))
+      })
       switch (signal.aborted, result) {
       | (true, Ok(conn)) =>
         ACP.disconnect(conn)
@@ -589,8 +577,8 @@ let handleEffect = (effect: effect, state: state, dispatch: action => unit) => {
       | false => dispatch(RetryAuthentication)
       }
     })
-  | LogoutEffect({connection, session, apiBaseUrl, signal}) =>
-    ACP.disconnect(connection, ~session?)
+  | LogoutEffect({connection, apiBaseUrl, signal}) =>
+    ACP.disconnect(connection)
     revokeEmbeddedClientToken(~apiBaseUrl, ~signal)->ignore
   | ConnectRelay(relay, signal) =>
     let connect = async () => {

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -198,12 +198,8 @@ module Provider = {
             WebAPI.AbortController.abort(controller)
           )
           state.relayInstance->Option.forEach(relay => Relay.disconnect(relay))
-          let activeSession = switch state.session {
-          | SessionActive(session) => Some(session)
-          | NoSession | SessionCreating(_) | SessionError(_) => None
-          }
           switch state.acp {
-          | ACPConnected(conn) => ACP.disconnect(conn, ~session=?activeSession)
+          | ACPConnected(conn) => ACP.disconnect(conn)
           | ACPDisconnected | ACPConnecting | ACPLoggingOut | ACPAuthRequired(_) | ACPError(_) => ()
           }
           dispatch(Dispose)

--- a/libs/client/src/components/frontman/Client__PromptInput.res
+++ b/libs/client/src/components/frontman/Client__PromptInput.res
@@ -256,38 +256,31 @@ module SubmitButton = {
     ~onClick: unit => unit,
     ~onCancel: unit => unit,
   ) => {
-    if showStop {
-      <button
-        type_="button"
-        onClick={e => {
-          ReactEvent.Mouse.preventDefault(e)
-          onCancel()
-        }}
-        className="inline-flex items-center gap-2 h-8 px-4 rounded-full
-                   bg-[#985DF7] hover:bg-[#8247E5] text-white text-xs font-medium
-                   transition-all hover:scale-105 cursor-pointer"
-        title="Stop generation"
-      >
-        <StopIcon size=12 />
-        <span> {React.string("Stop")} </span>
-      </button>
-    } else {
-      <button
-        type_="submit"
-        disabled
-        onClick={e => {
-          ReactEvent.Mouse.preventDefault(e)
-          onClick()
-        }}
-        className="flex items-center justify-center w-8 h-8 rounded-full
-                   transition-all text-white cursor-pointer
-                   bg-[#985DF7] hover:bg-[#8247E5] hover:scale-105
-                   disabled:bg-zinc-700/50 disabled:text-zinc-500 disabled:cursor-not-allowed disabled:scale-100"
-        title="Send (Enter)"
-      >
-        <Icons.SendArrowIcon size=14 />
-      </button>
-    }
+    <button
+      type_={showStop ? "button" : "submit"}
+      disabled
+      onClick={e => {
+        ReactEvent.Mouse.preventDefault(e)
+        switch showStop {
+        | true => onCancel()
+        | false => onClick()
+        }
+      }}
+      className={`inline-flex items-center justify-center gap-2 h-8 rounded-full
+        transition-all text-white cursor-pointer bg-[#985DF7] hover:bg-[#8247E5] hover:scale-105
+        disabled:bg-zinc-700/50 disabled:text-zinc-500 disabled:cursor-not-allowed disabled:scale-100
+        ${showStop ? "px-4 text-xs font-medium" : "w-8"}`}
+      title={showStop ? "Stop generation" : "Send (Enter)"}
+    >
+      {switch showStop {
+      | true =>
+        <>
+          <StopIcon size=12 />
+          <span> {React.string("Stop")} </span>
+        </>
+      | false => <Icons.SendArrowIcon size=14 />
+      }}
+    </button>
   }
 }
 
@@ -411,8 +404,11 @@ let make = (
   let hasSubmittableContent = hasContent || hasAnnotations
   let noModelSelected = selectedModelValue->Option.isNone
   let isInputDisabled = !hasActiveACPSession || disabled || noModelsConfigured || noModelSelected
-  let isSubmitDisabled = isInputDisabled || !hasSubmittableContent || isEnrichingAnnotations
   let showStopButton = isAgentRunning && !hasSubmittableContent
+  let isSubmitDisabled = switch showStopButton {
+  | true => !hasActiveACPSession || disabled
+  | false => isInputDisabled || !hasSubmittableContent || isEnrichingAnnotations
+  }
 
   let currentPlaceholder = switch (
     noModelsConfigured,

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1787,15 +1787,13 @@ let next = (state: state, action) => {
   | ClearAcpSession =>
     let updatedTasks = state.tasks->Dict.copy
     updatedTasks->Dict.forEachWithKey((task, taskId) => {
-      switch TaskReducer.Selectors.pendingQuestion(task) {
-      | Some(_) =>
-        switch task {
-        | Task.Loaded(data) =>
-          updatedTasks->Dict.set(taskId, Task.Loaded({...data, pendingQuestion: None}))
-        | _ => ()
-        }
-      | None => ()
+      let task = switch task->TaskReducer.Lens.completeStreamingMessage {
+      | Task.Loaded(data) =>
+        Task.Loaded({...data, isAgentRunning: false, pendingQuestion: None, retryStatus: None})
+      | Task.Loading(data) => Task.Loading({...data, isAgentRunning: false})
+      | Task.New(_) | Task.Unloaded(_) => task
       }
+      updatedTasks->Dict.set(taskId, task)
     })
     {
       ...state,

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -1787,13 +1787,11 @@ let next = (state: state, action) => {
   | ClearAcpSession =>
     let updatedTasks = state.tasks->Dict.copy
     updatedTasks->Dict.forEachWithKey((task, taskId) => {
-      let task = switch task->TaskReducer.Lens.completeStreamingMessage {
+      switch task {
       | Task.Loaded(data) =>
-        Task.Loaded({...data, isAgentRunning: false, pendingQuestion: None, retryStatus: None})
-      | Task.Loading(data) => Task.Loading({...data, isAgentRunning: false})
-      | Task.New(_) | Task.Unloaded(_) => task
+        updatedTasks->Dict.set(taskId, Task.Loaded({...data, pendingQuestion: None}))
+      | Task.New(_) | Task.Unloaded(_) | Task.Loading(_) => ()
       }
-      updatedTasks->Dict.set(taskId, task)
     })
     {
       ...state,

--- a/libs/client/test/Client__Chatbox.test.res
+++ b/libs/client/test/Client__Chatbox.test.res
@@ -65,6 +65,18 @@ describe("selectGetStartedTask", () => {
   })
 })
 
+test("both stop and send respect the disconnected control's disabled state", t => {
+  [true, false]->Array.forEach(showStop => {
+    let html = renderToStaticMarkup(
+      <Client__PromptInput.SubmitButton
+        disabled=true showStop onClick={() => ()} onCancel={() => ()}
+      />,
+    )
+    t->expect(html->String.includes("disabled=\"\""))->Expect.toBe(true)
+    t->expect(html->String.includes("Stop generation"))->Expect.toBe(showStop)
+  })
+})
+
 describe("ExecutePlanAction", () => {
   test("hides execute action without a selected model", t => {
     let html = renderToStaticMarkup(

--- a/libs/client/test/Client__ConnectionReducer.test.res
+++ b/libs/client/test/Client__ConnectionReducer.test.res
@@ -259,6 +259,28 @@ describe("Connection Reducer", () => {
     )
   })
 
+  test("connection loss cannot leave an active session masking the error", t => {
+    let connection = mock({"id": "connection"})
+    [
+      (Reducer.ACPConnecting, Reducer.NoSession),
+      (Reducer.ACPConnected(connection), Reducer.SessionCreating("sess-1")),
+      (Reducer.ACPConnected(connection), Reducer.SessionActive(mock({"sessionId": "sess-1"}))),
+    ]->Array.forEach(
+      ((acp, session)) => {
+        let (failed, _) = Reducer.reduce(
+          {...Reducer.initialState, acp, session},
+          ACPConnectError("Connection lost"),
+        )
+        t->expect(failed.session)->Expect.toEqual(NoSession)
+        t
+        ->expect(Reducer.Selectors.getConnectionStatus(failed))
+        ->Expect.toEqual(Error("Connection lost"))
+        let (late, _) = Reducer.reduce(failed, SessionCreateSuccess(mock({"sessionId": "sess-1"})))
+        t->expect(late)->Expect.toBe(failed)
+      },
+    )
+  })
+
   test("logout disconnects ACP and starts confirmation", t => {
     let (initialized, _) = initialize(Reducer.initialState)
     let state = {...initialized, acp: ACPConnected(mock({"id": "connection"}))}

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -2073,12 +2073,38 @@ describe("Client State Reducer - Annotations on Messages", () => {
     )
 
     test(
-      "clearing the ACP session invalidates loaded provider settings",
+      "clearing the ACP session ends local running and streaming state without losing text",
       t => {
-        let state = _makeStateWithSession()
+        let taskState = TestHelpers.makeStateWithTask(
+          ~isAgentRunning=true,
+          ~messages=[
+            Reducer.Message.Assistant(
+              Streaming({id: "partial", textBuffer: "Saved text", agentId: "agent-1"}),
+            ),
+          ],
+        )
+        let state = {
+          ..._makeStateWithSession(),
+          tasks: taskState.tasks,
+          currentTask: taskState.currentTask,
+        }
+        t->expect(Reducer.Selectors.isStreaming(state))->Expect.toBe(true)
         let (nextState, _effects) = Reducer.next(state, ClearAcpSession)
 
         t->expect(Reducer.Selectors.hasActiveACPSession(nextState))->Expect.toBe(false)
+        t->expect(Reducer.Selectors.isAgentRunning(nextState))->Expect.toBe(false)
+        t->expect(Reducer.Selectors.isStreaming(nextState))->Expect.toBe(false)
+        t
+        ->expect(TestHelpers.getMessages(nextState))
+        ->Expect.toEqual([
+          Reducer.Message.Assistant(
+            Completed({
+              id: "partial",
+              content: [AssistantContentPart.Text({text: "Saved text"})],
+              agentId: "agent-1",
+            }),
+          ),
+        ])
       },
     )
   })

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -2073,7 +2073,7 @@ describe("Client State Reducer - Annotations on Messages", () => {
     )
 
     test(
-      "clearing the ACP session ends local running and streaming state without losing text",
+      "connection loss preserves the last reported execution and streaming state",
       t => {
         let taskState = TestHelpers.makeStateWithTask(
           ~isAgentRunning=true,
@@ -2083,28 +2083,32 @@ describe("Client State Reducer - Annotations on Messages", () => {
             ),
           ],
         )
-        let state = {
-          ..._makeStateWithSession(),
-          tasks: taskState.tasks,
-          currentTask: taskState.currentTask,
-        }
-        t->expect(Reducer.Selectors.isStreaming(state))->Expect.toBe(true)
+        let (state, _) = Reducer.next(
+          {..._makeStateWithSession(), tasks: taskState.tasks, currentTask: taskState.currentTask},
+          TaskAction({
+            target: CurrentTask,
+            action: RetryingUpdate({
+              retryStatus: {
+                attempt: 1,
+                maxAttempts: 5,
+                retryAt: 1000.0,
+                error: "Retry pending",
+              },
+            }),
+          }),
+        )
         let (nextState, _effects) = Reducer.next(state, ClearAcpSession)
 
         t->expect(Reducer.Selectors.hasActiveACPSession(nextState))->Expect.toBe(false)
-        t->expect(Reducer.Selectors.isAgentRunning(nextState))->Expect.toBe(false)
-        t->expect(Reducer.Selectors.isStreaming(nextState))->Expect.toBe(false)
-        t
-        ->expect(TestHelpers.getMessages(nextState))
-        ->Expect.toEqual([
-          Reducer.Message.Assistant(
-            Completed({
-              id: "partial",
-              content: [AssistantContentPart.Text({text: "Saved text"})],
-              agentId: "agent-1",
-            }),
-          ),
-        ])
+        t->expect(nextState.tasks)->Expect.toEqual(state.tasks)
+        t->expect(Reducer.Selectors.isAgentRunning(nextState))->Expect.toBe(true)
+        t->expect(Reducer.Selectors.isStreaming(nextState))->Expect.toBe(true)
+        let thinking = Client__UseThinkingState.use(
+          ~messages=TestHelpers.getMessages(nextState),
+          ~isAgentRunning=Reducer.Selectors.isAgentRunning(nextState),
+          ~hasActiveACPSession=Reducer.Selectors.hasActiveACPSession(nextState),
+        )
+        t->expect(thinking.showThinking)->Expect.toBe(false)
       },
     )
   })

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -76,33 +76,35 @@ let cleanupChannel = channel => {
   channel->Channel.off(~event=#"acp:message")
   channel->Channel.off(~event=#"mcp:message")
   channel->Channel.off(~event=#title_updated)
+  channel->Channel.off(~event=#config_options_updated)
   Channel.leave(channel)->ignore
 }
 
 let cleanupSessionChannel = (session: session): unit => cleanupChannel(session.channel)
 
-let disconnect = (conn: connection, ~session: option<session>=?): unit => {
-  session->Option.forEach(cleanupSessionChannel)
-  conn.channel->Channel.off(~event=#"acp:message")
-  conn.channel->Channel.off(~event=#config_options_updated)
-  Channel.leave(conn.channel)->ignore
-  Socket.disconnect(conn.socket)
+let cleanupConnection = (socket, state: ref<Client.state>): unit => {
+  state := state.contents->Client.reduce(Client.ACPStateChanged(Disconnected))
+  state.contents.pendingRequests
+  ->Dict.valuesToArray
+  ->Array.forEach(pending => pending.reject(Protocol.connectionLost))
+  socket->Socket.channels->Array.forEach(cleanupChannel)
+  Socket.disconnect(socket)
 }
 
-let waitForSocket = (socket: Socket.t): promise<result<unit, string>> => {
-  Promise.make((resolve, _) => {
-    socket->Socket.onError(~callback=_ => resolve(Error("Socket connection failed")))
-    socket->Socket.onOpen(~callback=() => resolve(Ok()))
-    socket->Socket.connect
-  })
-}
+let disconnect = (conn: connection): unit => cleanupConnection(conn.socket, conn.state)
 
 type joinError =
   | AuthRequired({loginUrl: string})
   | JoinFailed(string)
 
-let joinChannel = (channel: Channel.t): promise<result<unit, joinError>> => {
+let joinChannel = (channel: Channel.t, ~onError: string => unit): promise<
+  result<unit, joinError>,
+> => {
   Promise.make((resolve, _) => {
+    channel->Channel.on(~event=#phx_error, ~callback=_ => {
+      resolve(Error(JoinFailed(Protocol.connectionLost)))
+      onError(Protocol.connectionLost)
+    })
     Channel.join(channel).receive(~status="ok", ~callback=_ =>
       resolve(Ok())
     ).receive(~status="error", ~callback=err => {
@@ -116,7 +118,9 @@ let joinChannel = (channel: Channel.t): promise<result<unit, joinError>> => {
       | (Some("unauthorized"), Some(url)) => resolve(Error(AuthRequired({loginUrl: url})))
       | _ => resolve(Error(JoinFailed(JSON.stringify(err))))
       }
-    })->ignore
+    }).receive(~status="timeout", ~callback=_ =>
+      resolve(Error(JoinFailed("Channel join timed out")))
+    )->ignore
   })
 }
 
@@ -132,10 +136,11 @@ type connectError =
   | ConnectionFailed(string)
 
 @@live
-let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSignal>=?): result<
-  connection,
-  connectError,
-> => {
+let connect = async (
+  config: config,
+  ~signal: option<WebAPI.EventTypes.abortSignal>=?,
+  ~onError: string => unit,
+): result<connection, connectError> => {
   Sentry.initialize()
   Sentry.addBreadcrumb(~category=#acp, ~message="Starting ACP connection")
 
@@ -170,33 +175,24 @@ let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSign
 
     Protocol.attachMessageHandler(~channel, ~state, ~onUpdate=None, ~onParseError=None)
 
-    let socketResult = await waitForSocket(socket)
-
-    let joinResult = switch (socketResult, checkAborted(signal)) {
-    | (_, Error(_)) => Error(ConnectionFailed("Connection aborted"))
-    | (Error(e), _) =>
-      Log.error(`Socket connection failed: ${e}`)
-      Error(ConnectionFailed(e))
-    | (Ok(), Ok()) =>
-      Sentry.addBreadcrumb(~category=#acp, ~message="Socket connected, joining channel")
-      switch await joinChannel(channel) {
-      | Error(AuthRequired({loginUrl})) => Error(AuthRequired({loginUrl: loginUrl}))
-      | Error(JoinFailed(e)) =>
-        Log.error(`Channel join failed: ${e}`)
-        Error(ConnectionFailed(e))
-      | Ok() => Ok()
-      }
-    }
+    Socket.connect(socket)
+    let joinResult = await joinChannel(channel, ~onError=error => {
+      cleanupConnection(socket, state)
+      onError(error)
+    })
 
     switch (joinResult, checkAborted(signal)) {
     | (_, Error(_)) =>
-      cleanupChannel(channel)
-      Socket.disconnect(socket)
+      cleanupConnection(socket, state)
       Error(ConnectionFailed("Connection aborted"))
     | (Error(e), _) =>
-      cleanupChannel(channel)
-      Socket.disconnect(socket)
-      Error(e)
+      cleanupConnection(socket, state)
+      Error(
+        switch e {
+        | AuthRequired({loginUrl}) => AuthRequired({loginUrl: loginUrl})
+        | JoinFailed(error) => ConnectionFailed(error)
+        },
+      )
     | (Ok(), Ok()) =>
       switch config.onConfigOptionsUpdated {
       | Some(callback) =>
@@ -213,9 +209,7 @@ let connect = async (config: config, ~signal: option<WebAPI.EventTypes.abortSign
       switch await Protocol.sendInitialize(~channel, ~state, ~clientConfig) {
       | Error(e) =>
         Log.error(`ACP initialize failed: ${e}`)
-        channel->Channel.off(~event=#config_options_updated)
-        cleanupChannel(channel)
-        Socket.disconnect(socket)
+        cleanupConnection(socket, state)
         Error(ConnectionFailed(e))
       | Ok(result) =>
         Sentry.addBreadcrumb(~category=#acp, ~message="ACP initialized successfully")
@@ -265,7 +259,7 @@ let joinSession = async (
   ~mcpServerInterface: option<MCPTypes.serverInterface<'server>>=?,
 ): result<session, string> => {
   let sessionChannel = conn.socket->Socket.channel(~topic=Constants.makeTaskTopic(sessionId))
-  let handleParseError = err => {
+  let handleSessionError = err => {
     switch cleanupOnParseError->Option.mapOr(true, enabled => enabled.contents) {
     | true => cleanupChannel(sessionChannel)
     | false => ()
@@ -280,7 +274,7 @@ let joinSession = async (
     ~channel=sessionChannel,
     ~state=conn.state,
     ~onUpdate=Some(onUpdate),
-    ~onParseError=Some(handleParseError),
+    ~onParseError=Some(handleSessionError),
   )
 
   mcpServerInterface->Option.forEach(serverInterface => {
@@ -301,7 +295,7 @@ let joinSession = async (
     }
   })
 
-  let joinResult = await joinChannel(sessionChannel)
+  let joinResult = await joinChannel(sessionChannel, ~onError=handleSessionError)
 
   joinResult
   ->Result.mapError(err => {

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -9,7 +9,7 @@ module Log = FrontmanLogs.Logs.Make({
 })
 
 let requestTimeoutMs = 120000
-let connectionLost = "Connection lost. Reload to reconnect."
+let connectionLost = "Connection lost. The agent may still be running. Reload to reconnect."
 
 let pushReplyMessageSchema: S.t<JSON.t> = S.object(s => s.field("acp:message", S.json))
 

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -9,6 +9,7 @@ module Log = FrontmanLogs.Logs.Make({
 })
 
 let requestTimeoutMs = 120000
+let connectionLost = "Connection lost. Reload to reconnect."
 
 let pushReplyMessageSchema: S.t<JSON.t> = S.object(s => s.field("acp:message", S.json))
 
@@ -26,47 +27,48 @@ let sendRequest = (
   ~timeoutMs: int=requestTimeoutMs,
   ~parseResult: JSON.t => result<'a, string>,
 ): promise<result<'a, string>> => {
-  Promise.make((resolve, _) => {
-    let id = state.contents.currentId + 1
-    let idStr = Int.toString(id)
-    let request = JsonRpc.Request.make(~id=JsonRpc.Id.fromInt(id), ~method, ~params)
-    let timer = ref(None)
-    let finish = result => {
-      timer.contents->Option.forEach(WebAPI.DomGlobal.clearTimeout)
-      resolve(result)
-    }
-
-    let pending: Client.pendingRequest = {
-      resolve: json => {
-        switch parseResult(json) {
-        | Ok(result) => finish(Ok(result))
-        | Error(e) => finish(Error(e))
-        }
-      },
-      reject: e => finish(Error(e)),
-    }
-
-    state := state.contents->Client.reduce(Client.RequestSent(id, pending))
-    timer :=
-      Some(
-        WebAPI.DomGlobal.setTimeout(~timeout=timeoutMs, ~handler=() => {
-          state.contents.pendingRequests->Dict.get(idStr)->Option.getOrThrow->ignore
-          state := state.contents->Client.reduce(Client.ResponseReceived(id))
-          pending.reject(`Request ${method} timed out after ${Int.toString(timeoutMs)}ms`)
-        }),
-      )
-
-    let payload = request->JsonRpc.Request.toJson
-    let push = channel->Channel.push(~event=Constants.acpMessageEvent, ~payload, ~timeout=timeoutMs)
-    push.receive(~status="ok", ~callback=reply => {
-      switch parsePushReply(reply) {
-      | Ok(message) => state := Client.handleResponse(state.contents, message)
-      | Error(error) =>
+  switch Channel.state(channel) {
+  | "joined" =>
+    Promise.make((resolve, _) => {
+      let id = state.contents.currentId + 1
+      let request = JsonRpc.Request.make(~id=JsonRpc.Id.fromInt(id), ~method, ~params)
+      let timer = ref(None)
+      let listeners = ref([])
+      let finish = result => {
+        timer.contents->Option.forEach(WebAPI.DomGlobal.clearTimeout)
+        listeners.contents->Array.forEach(((event, ref)) => channel->Channel.off(~event, ~ref))
         state := state.contents->Client.reduce(Client.ResponseReceived(id))
-        pending.reject(error)
+        resolve(result)
       }
-    })->ignore
-  })
+      let pending: Client.pendingRequest = {
+        resolve: json => finish(parseResult(json)),
+        reject: e => finish(Error(e)),
+      }
+      listeners :=
+        [#phx_error, #phx_close]->Array.map(event => (
+          event,
+          channel->Channel.onWithRef(~event, ~callback=_ => pending.reject(connectionLost)),
+        ))
+
+      state := state.contents->Client.reduce(Client.RequestSent(id, pending))
+      timer :=
+        Some(
+          WebAPI.DomGlobal.setTimeout(~timeout=timeoutMs, ~handler=() =>
+            pending.reject(`Request ${method} timed out after ${Int.toString(timeoutMs)}ms`)
+          ),
+        )
+      let payload = request->JsonRpc.Request.toJson
+      let push =
+        channel->Channel.push(~event=Constants.acpMessageEvent, ~payload, ~timeout=timeoutMs)
+      push.receive(~status="ok", ~callback=reply => {
+        switch parsePushReply(reply) {
+        | Ok(message) => state := Client.handleResponse(state.contents, message)
+        | Error(error) => pending.reject(error)
+        }
+      }).receive(~status="error", ~callback=_ => pending.reject("ACP request failed"))->ignore
+    })
+  | _ => Promise.resolve(Error(connectionLost))
+  }
 }
 
 let sendInitialize = (

--- a/libs/frontman-client/src/FrontmanClient__Phoenix__Channel.res
+++ b/libs/frontman-client/src/FrontmanClient__Phoenix__Channel.res
@@ -12,6 +12,8 @@ type channelEvent = [
   | #delete_session
   | #title_updated
   | #config_options_updated
+  | #phx_error
+  | #phx_close
 ]
 
 type rec pushResponse = {receive: (~status: string, ~callback: JSON.t => unit) => pushResponse}
@@ -24,7 +26,8 @@ type rec pushResponse = {receive: (~status: string, ~callback: JSON.t => unit) =
 external push: (t, ~event: channelEvent, ~payload: JSON.t, ~timeout: int=?) => pushResponse = "push"
 
 @send external on: (t, ~event: channelEvent, ~callback: JSON.t => unit) => unit = "on"
+@send external onWithRef: (t, ~event: channelEvent, ~callback: JSON.t => unit) => int = "on"
 
-@send external off: (t, ~event: channelEvent) => unit = "off"
+@send external off: (t, ~event: channelEvent, ~ref: int=?) => unit = "off"
 
 @get external state: t => string = "state"

--- a/libs/frontman-client/src/FrontmanClient__Phoenix__Socket.res
+++ b/libs/frontman-client/src/FrontmanClient__Phoenix__Socket.res
@@ -18,11 +18,7 @@ external make: (~endpoint: string, ~opts: socketOptions=?) => t = "Socket"
 
 @send external disconnect: (t, ~callback: unit => unit=?) => unit = "disconnect"
 
+@get external channels: t => array<channel> = "channels"
+
 @send
 external channel: (t, ~topic: string, ~params: dict<JSON.t>=?) => channel = "channel"
-
-@send external onOpen: (t, ~callback: unit => unit) => unit = "onOpen"
-
-@send external onError: (t, ~callback: 'error => unit) => unit = "onError"
-
-@send external onClose: (t, ~callback: 'event => unit) => unit = "onClose"

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -22,11 +22,14 @@ type mockTransport = {
 let makeLoadTransport: (array<JSON.t>, JSON.t) => mockTransport = %raw(`
   function(history, loadResult) {
     const handlers = {};
+    let ref = 0;
     const events = [];
     const inertPush = { receive() { return this; } };
     const channel = {
-      on(event, callback) { handlers[event] = callback; },
-      off(event) {
+      state: "joined",
+      on(event, callback) { (handlers[event] ||= new Map()).set(++ref, callback); return ref; },
+      off(event, ref) {
+        if (ref !== undefined) { handlers[event]?.delete(ref); return; }
         events.push("off:" + event);
         delete handlers[event];
       },
@@ -44,7 +47,7 @@ let makeLoadTransport: (array<JSON.t>, JSON.t) => mockTransport = %raw(`
       },
       push(event, payload) {
         if (event === "acp:message" && payload.method === "session/load") {
-          const handler = handlers["acp:message"];
+          const handler = payload => handlers["acp:message"].forEach(callback => callback(payload));
           for (const notification of history) handler(notification);
           events.push("load-response");
           handler({
@@ -60,7 +63,7 @@ let makeLoadTransport: (array<JSON.t>, JSON.t) => mockTransport = %raw(`
       socket: {channel() { return channel; }},
       channel,
       events,
-      emit(payload) { handlers["acp:message"](payload); }
+      emit(payload) { handlers["acp:message"].forEach(callback => callback(payload)); }
     };
   }
 `)
@@ -143,6 +146,7 @@ let loadCleanupEvents = [
   "off:acp:message",
   "off:mcp:message",
   "off:title_updated",
+  "off:config_options_updated",
   "leave",
 ]
 
@@ -372,90 +376,131 @@ describe("ACP Client parseInitializeResult", _t => {
   })
 })
 
-describe("ACP Protocol sendRequest", _t => {
-  testAsync("resolves Phoenix push reply envelopes", async t => {
+@send external trigger: (Channel.t, string, JSON.t, ~ref: string=?) => unit = "trigger"
+type pushRef = {ref: string}
+@get external joinPush: Channel.t => pushRef = "joinPush"
+@get external pushBuffer: Channel.t => array<pushRef> = "pushBuffer"
+@send external socketClosed: (Socket.t, JSON.t) => unit = "onConnClose"
+
+let joinedChannel = (socket, ~onError, ~topic="task:test") => {
+  let channel = socket->Socket.channel(~topic)
+  let joined = ACP.joinChannel(channel, ~onError)
+  trigger(
+    channel,
+    "phx_reply",
+    JSON.parseOrThrow(`{"status":"ok","response":{}}`),
+    ~ref=joinPush(channel).ref,
+  )
+  (channel, joined)
+}
+
+let request = (channel, state) =>
+  Protocol.sendRequest(
+    ~channel,
+    ~state,
+    ~method="test/method",
+    ~params=None,
+    ~timeoutMs=10,
+    ~parseResult=json => Ok(S.parseOrThrow(json, ~to=S.string)),
+  )
+
+let reply = (channel, response) =>
+  trigger(
+    channel,
+    "phx_reply",
+    response,
+    ~ref=(pushBuffer(channel)->Array.get(0)->Option.getOrThrow).ref,
+  )
+
+describe("ACP request and channel lifetime", _t => {
+  testAsync("joining without an open socket is bounded by channel failure or timeout", async t => {
     Vi.useFakeTimers()->ignore
-    let channel = %raw(`{
-      push(_event, payload) {
-        return {
-          receive(status, callback) {
-            if (status === "ok") {
-              callback({"acp:message": {jsonrpc: "2.0", id: payload.id, result: "accepted"}});
-            }
-            return this;
-          }
-        };
+    for timeout in 0 to 1 {
+      let socket = Socket.make(~endpoint="ws://localhost/socket", ~opts={timeout: 10})
+      let channel = socket->Socket.channel(~topic="tasks")
+      let joined = ACP.joinChannel(channel, ~onError=_ => ACP.cleanupChannel(channel))
+      switch timeout {
+      | 0 => socketClosed(socket, JSON.parseOrThrow(`{"code":1000}`))
+      | _ => (await Vi.advanceTimersByTimeAsync(10))->ignore
       }
-    }`)
-    let state = ref(Client.initialState)
-    let result = await Protocol.sendRequest(
-      ~channel,
-      ~state,
-      ~method="session/prompt",
-      ~params=None,
-      ~timeoutMs=10,
-      ~parseResult=json =>
-        json->JSON.Decode.string->Option.mapOr(Error("Expected string"), value => Ok(value)),
-    )
-
-    t->expect(result)->Expect.toEqual(Ok("accepted"))
-    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+      t->expect((await joined)->Result.isError)->Expect.toBe(true)
+      ACP.cleanupChannel(channel)
+    }
   })
 
-  testAsync("rejects malformed Phoenix push reply envelopes immediately", async t => {
+  testAsync("handles native push replies, malformed replies, errors and timeouts", async t => {
     Vi.useFakeTimers()->ignore
-    let channel = %raw(`{
-      push(_event, _payload) {
-        return {
-          receive(status, callback) {
-            if (status === "ok") {
-              callback({});
-            }
-            return this;
-          }
-        };
+    let socket = Socket.make(~endpoint="ws://localhost/socket")
+    for index in 0 to 3 {
+      let (channel, joined) = joinedChannel(socket, ~onError=_ => ())
+      t->expect(await joined)->Expect.toEqual(Ok())
+      let state = ref(Client.initialState)
+      let pending = request(channel, state)
+      switch index {
+      | 0 =>
+        reply(
+          channel,
+          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":"accepted"}}}`),
+        )
+      | 1 => reply(channel, JSON.parseOrThrow(`{"status":"ok","response":{}}`))
+      | 2 => reply(channel, JSON.parseOrThrow(`{"status":"error","response":{}}`))
+      | _ => (await Vi.advanceTimersByTimeAsync(10))->ignore
       }
-    }`)
-    let state = ref(Client.initialState)
-    let result = await Protocol.sendRequest(
-      ~channel,
-      ~state,
-      ~method="session/prompt",
-      ~params=None,
-      ~timeoutMs=10,
-      ~parseResult=_ => Ok("unused"),
-    )
-
-    t->expect(result->Result.isError)->Expect.toEqual(true)
-    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+      let result = await pending
+      switch index {
+      | 0 => t->expect(result)->Expect.toEqual(Ok("accepted"))
+      | 3 => t->expect(result)->Expect.toEqual(Error("Request test/method timed out after 10ms"))
+      | _ => t->expect(result->Result.isError)->Expect.toBe(true)
+      }
+      t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual([])
+      ACP.cleanupChannel(channel)
+    }
   })
 
-  testAsync("times out and removes pending request when no response arrives", async t => {
-    Vi.useFakeTimers()->ignore
-    let transport = makeLoadTransport([], loadResult)
-    let state = ref(Client.initialState)
-    let promise = Protocol.sendRequest(
-      ~channel=transport.channel,
-      ~state,
-      ~method="test/method",
-      ~params=None,
-      ~timeoutMs=10,
-      ~parseResult=json =>
-        switch json->JSON.Decode.string {
-        | Some(value) => Ok(value)
-        | None => Error("Expected string")
-        },
-    )
-
-    t->expect(state.contents.pendingRequests->Dict.get("1")->Option.isSome)->Expect.toBe(true)
-    let _ = await Vi.advanceTimersByTimeAsync(10)
-    let result = await promise
-
-    t
-    ->expect(result)
-    ->Expect.toEqual(Error("Request test/method timed out after 10ms"))
-    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
-  })
+  testAsync(
+    "socket loss and channel errors invalidate even a session with no pending prompt",
+    async t => {
+      Vi.useFakeTimers()->ignore
+      for socketLoss in 0 to 1 {
+        let socket = Socket.make(~endpoint="ws://localhost/socket")
+        let errors = ref([])
+        let (channel, joined) = joinedChannel(
+          socket,
+          ~onError=error => errors := errors.contents->Array.concat([error]),
+        )
+        (await joined)->ignore
+        let state = ref(Client.initialState)
+        let accepted = request(channel, state)
+        reply(
+          channel,
+          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":"accepted"}}}`),
+        )
+        t->expect(await accepted)->Expect.toEqual(Ok("accepted"))
+        let pending = request(channel, state)
+        let (other, otherJoined) = joinedChannel(socket, ~onError=_ => (), ~topic="task:other")
+        (await otherJoined)->ignore
+        let otherPending = request(other, state)
+        switch socketLoss {
+        | 0 => trigger(channel, "phx_error", JSON.Encode.null)
+        | _ => socketClosed(socket, JSON.parseOrThrow(`{"code":1000}`))
+        }
+        t->expect(await pending)->Expect.toEqual(Error(Protocol.connectionLost))
+        t->expect(await request(channel, state))->Expect.toEqual(Error(Protocol.connectionLost))
+        t->expect(errors.contents)->Expect.toEqual([Protocol.connectionLost])
+        switch socketLoss {
+        | 0 => t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual(["3"])
+        | _ => t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual([])
+        }
+        ACP.cleanupConnection(socket, state)
+        t->expect(await otherPending)->Expect.toEqual(Error(Protocol.connectionLost))
+        t->expect(socket->Socket.channels->Array.length)->Expect.toBe(0)
+        t->expect(errors.contents)->Expect.toEqual([Protocol.connectionLost])
+        (await Vi.advanceTimersByTimeAsync(20))->ignore
+        t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual([])
+        ACP.cleanupChannel(channel)
+      }
+    },
+  )
 })
 
 describe("ACP Client handleResponse", _t => {

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -180,26 +180,6 @@ describe("ACP Client State Reducer", _t => {
     t->expect(state.pendingRequests->Dict.keysToArray->Array.length)->Expect.toEqual(0)
   })
 
-  test("pending request lifecycle accumulates and removes by ID", t => {
-    let pending: Client.pendingRequest = {
-      resolve: _ => (),
-      reject: _ => (),
-    }
-
-    let state =
-      Client.initialState
-      ->Client.reduce(Client.RequestSent(1, pending))
-      ->Client.reduce(Client.RequestSent(2, pending))
-
-    t->expect(state.currentId)->Expect.toEqual(2)
-    t->expect(state.pendingRequests->Dict.keysToArray->Array.length)->Expect.toEqual(2)
-
-    let state = state->Client.reduce(Client.ResponseReceived(1))
-
-    t->expect(state.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
-    t->expect(state.pendingRequests->Dict.get("2")->Option.isSome)->Expect.toEqual(true)
-  })
-
   test("ACPStateChanged action updates acpState", t => {
     let state = Client.initialState
     let initResult: Types.initializeResult = {
@@ -382,7 +362,7 @@ type pushRef = {ref: string}
 @get external pushBuffer: Channel.t => array<pushRef> = "pushBuffer"
 @send external socketClosed: (Socket.t, JSON.t) => unit = "onConnClose"
 
-let joinedChannel = (socket, ~onError, ~topic="task:test") => {
+let joinedChannel = async (socket, ~onError, ~topic="task:test") => {
   let channel = socket->Socket.channel(~topic)
   let joined = ACP.joinChannel(channel, ~onError)
   trigger(
@@ -391,7 +371,8 @@ let joinedChannel = (socket, ~onError, ~topic="task:test") => {
     JSON.parseOrThrow(`{"status":"ok","response":{}}`),
     ~ref=joinPush(channel).ref,
   )
-  (channel, joined)
+  (await joined)->Result.getOrThrow
+  channel
 }
 
 let request = (channel, state) =>
@@ -401,7 +382,7 @@ let request = (channel, state) =>
     ~method="test/method",
     ~params=None,
     ~timeoutMs=10,
-    ~parseResult=json => Ok(S.parseOrThrow(json, ~to=S.string)),
+    ~parseResult=json => Ok(json),
   )
 
 let reply = (channel, response) =>
@@ -411,6 +392,8 @@ let reply = (channel, response) =>
     response,
     ~ref=(pushBuffer(channel)->Array.get(0)->Option.getOrThrow).ref,
   )
+
+let acceptedReply = JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":"accepted"}}}`)
 
 describe("ACP request and channel lifetime", _t => {
   testAsync("joining without an open socket is bounded by channel failure or timeout", async t => {
@@ -431,25 +414,32 @@ describe("ACP request and channel lifetime", _t => {
   testAsync("handles native push replies, malformed replies, errors and timeouts", async t => {
     Vi.useFakeTimers()->ignore
     let socket = Socket.make(~endpoint="ws://localhost/socket")
-    for index in 0 to 3 {
-      let (channel, joined) = joinedChannel(socket, ~onError=_ => ())
-      t->expect(await joined)->Expect.toEqual(Ok())
+    for index in 0 to 5 {
+      let channel = await joinedChannel(socket, ~onError=_ => ())
       let state = ref(Client.initialState)
       let pending = request(channel, state)
       switch index {
-      | 0 =>
-        reply(
-          channel,
-          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":"accepted"}}}`),
-        )
+      | 0 => reply(channel, acceptedReply)
       | 1 => reply(channel, JSON.parseOrThrow(`{"status":"ok","response":{}}`))
       | 2 => reply(channel, JSON.parseOrThrow(`{"status":"error","response":{}}`))
+      | 3 =>
+        reply(
+          channel,
+          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid request"}}}}`),
+        )
+      | 4 =>
+        reply(
+          channel,
+          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":null}}}`),
+        )
       | _ => (await Vi.advanceTimersByTimeAsync(10))->ignore
       }
       let result = await pending
       switch index {
-      | 0 => t->expect(result)->Expect.toEqual(Ok("accepted"))
-      | 3 => t->expect(result)->Expect.toEqual(Error("Request test/method timed out after 10ms"))
+      | 0 => t->expect(result)->Expect.toEqual(Ok(JSON.Encode.string("accepted")))
+      | 3 => t->expect(result)->Expect.toEqual(Error("Invalid request"))
+      | 4 => t->expect(result)->Expect.toEqual(Ok(JSON.Encode.null))
+      | 5 => t->expect(result)->Expect.toEqual(Error("Request test/method timed out after 10ms"))
       | _ => t->expect(result->Result.isError)->Expect.toBe(true)
       }
       t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual([])
@@ -464,22 +454,19 @@ describe("ACP request and channel lifetime", _t => {
       for socketLoss in 0 to 1 {
         let socket = Socket.make(~endpoint="ws://localhost/socket")
         let errors = ref([])
-        let (channel, joined) = joinedChannel(
+        let channel = await joinedChannel(
           socket,
           ~onError=error => errors := errors.contents->Array.concat([error]),
         )
-        (await joined)->ignore
         let state = ref(Client.initialState)
         let accepted = request(channel, state)
-        reply(
-          channel,
-          JSON.parseOrThrow(`{"status":"ok","response":{"acp:message":{"jsonrpc":"2.0","id":1,"result":"accepted"}}}`),
-        )
-        t->expect(await accepted)->Expect.toEqual(Ok("accepted"))
+        reply(channel, acceptedReply)
+        t->expect(await accepted)->Expect.toEqual(Ok(JSON.Encode.string("accepted")))
         let pending = request(channel, state)
-        let (other, otherJoined) = joinedChannel(socket, ~onError=_ => (), ~topic="task:other")
-        (await otherJoined)->ignore
+        let other = await joinedChannel(socket, ~onError=_ => (), ~topic="task:other")
         let otherPending = request(other, state)
+        t->expect(state.contents.currentId)->Expect.toBe(3)
+        t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual(["2", "3"])
         switch socketLoss {
         | 0 => trigger(channel, "phx_error", JSON.Encode.null)
         | _ => socketClosed(socket, JSON.parseOrThrow(`{"code":1000}`))
@@ -497,73 +484,12 @@ describe("ACP request and channel lifetime", _t => {
         t->expect(errors.contents)->Expect.toEqual([Protocol.connectionLost])
         (await Vi.advanceTimersByTimeAsync(20))->ignore
         t->expect(state.contents.pendingRequests->Dict.keysToArray)->Expect.toEqual([])
-        ACP.cleanupChannel(channel)
       }
     },
   )
 })
 
 describe("ACP Client handleResponse", _t => {
-  test("resolves pending request on success", t => {
-    let resolved = ref(false)
-    let pending: Client.pendingRequest = {
-      resolve: _ => resolved := true,
-      reject: _ => (),
-    }
-
-    let state = Client.initialState->Client.reduce(Client.RequestSent(1, pending))
-
-    let responseJson = Dict.make()
-    responseJson->Dict.set("jsonrpc", JSON.Encode.string("2.0"))
-    responseJson->Dict.set("id", JSON.Encode.int(1))
-    responseJson->Dict.set("result", JSON.Encode.string("success"))
-
-    Client.handleResponse(state, JSON.Encode.object(responseJson))->ignore
-
-    t->expect(resolved.contents)->Expect.toEqual(true)
-  })
-
-  test("rejects pending request on error", t => {
-    let rejected = ref(false)
-    let pending: Client.pendingRequest = {
-      resolve: _ => (),
-      reject: _ => rejected := true,
-    }
-
-    let state = Client.initialState->Client.reduce(Client.RequestSent(2, pending))
-
-    let errorObj = Dict.make()
-    errorObj->Dict.set("code", JSON.Encode.int(-32600))
-    errorObj->Dict.set("message", JSON.Encode.string("Invalid request"))
-
-    let responseJson = Dict.make()
-    responseJson->Dict.set("jsonrpc", JSON.Encode.string("2.0"))
-    responseJson->Dict.set("id", JSON.Encode.int(2))
-    responseJson->Dict.set("error", JSON.Encode.object(errorObj))
-
-    Client.handleResponse(state, JSON.Encode.object(responseJson))->ignore
-
-    t->expect(rejected.contents)->Expect.toEqual(true)
-  })
-
-  test("removes request from pending after handling", t => {
-    let pending: Client.pendingRequest = {
-      resolve: _ => (),
-      reject: _ => (),
-    }
-
-    let state = Client.initialState->Client.reduce(Client.RequestSent(3, pending))
-
-    let responseJson = Dict.make()
-    responseJson->Dict.set("jsonrpc", JSON.Encode.string("2.0"))
-    responseJson->Dict.set("id", JSON.Encode.int(3))
-    responseJson->Dict.set("result", JSON.Encode.null)
-
-    let newState = Client.handleResponse(state, JSON.Encode.object(responseJson))
-
-    t->expect(newState.pendingRequests->Dict.get("3"))->Expect.toEqual(None)
-  })
-
   test("unknown agent_turn_complete notification is ignored without resolving prompt", t => {
     let resolved = ref(None)
     let parseError = ref(None)
@@ -574,29 +500,10 @@ describe("ACP Client handleResponse", _t => {
     }
     let state = ref(Client.initialState->Client.reduce(Client.RequestSent(1, pending)))
 
-    let payload = JSON.Encode.object(
-      Dict.fromArray([
-        ("jsonrpc", JSON.Encode.string("2.0")),
-        ("method", JSON.Encode.string("session/update")),
-        (
-          "params",
-          JSON.Encode.object(
-            Dict.fromArray([
-              ("sessionId", JSON.Encode.string("task-1")),
-              (
-                "update",
-                JSON.Encode.object(
-                  Dict.fromArray([
-                    ("sessionUpdate", JSON.Encode.string("agent_turn_complete")),
-                    ("stopReason", JSON.Encode.string("end_turn")),
-                  ]),
-                ),
-              ),
-            ]),
-          ),
-        ),
-      ]),
-    )
+    let payload = JSON.parseOrThrow(`{
+      "jsonrpc":"2.0", "method":"session/update",
+      "params":{"sessionId":"task-1","update":{"sessionUpdate":"agent_turn_complete","stopReason":"end_turn"}}
+    }`)
 
     Protocol.handleIncomingMessage(
       ~state,


### PR DESCRIPTION
## Summary
Connection loss invalidates the client's connection, not the server's execution state.

- Preserve the last server-reported running, streaming, and retry state.
- Reuse session availability to hide Thinking and disable stop, retry, and queue controls. Warn that the agent may still be running and offer reload recovery.
- Tie pending ACP requests to channel lifetime. Reject failed-channel requests and stale sends, and let the connection clean up all its channels.
- Remove the separate socket-open wait and duplicate state transitions. Share the stop/send button's disabled behavior and consolidate overlapping request tests into real Phoenix channel checks.

Closes #591.

## Scope
- Runtime code: **23 fewer lines**.
- Entire PR, including tests and changeset: **379 additions / 380 deletions (net -1)**.

## Validation
- `make -C libs/frontman-client test`: 84 tests passed.
- `make -C libs/client test`: 431 tests passed.
- Regression coverage checks preserved execution/streaming/retry state, hidden Thinking, disabled stop/send buttons, socket loss, channel failure, stale sends, request cleanup, and join timeouts.
- Consolidated request tests retain successful, null, malformed, and failed response coverage.
- Formatting, source-comment checks, and dead-code analysis passed.
- Browser verification remains pending.