### PR TITLE
fix(wordpress): recover tool nonces and consolidate auth checks

### DIFF
--- a/.changeset/cyan-swans-yell.md
+++ b/.changeset/cyan-swans-yell.md
@@ -1,0 +1,6 @@
+---
+"@frontman-ai/frontman-client": patch
+"@frontman-ai/frontman-wordpress": patch
+---
+
+Recover authenticated WordPress nonce rejections once, preserve access errors, and consolidate request authorization without weakening permission checks.

--- a/.changeset/cyan-swans-yell.md
+++ b/.changeset/cyan-swans-yell.md
@@ -1,6 +1,7 @@
 ---
+"@frontman-ai/client": patch
 "@frontman-ai/frontman-client": patch
 "@frontman-ai/frontman-wordpress": patch
 ---
 
-Recover authenticated WordPress nonce rejections once, preserve access errors, and consolidate request authorization without weakening permission checks.
+Recover authenticated nonce rejections in the WordPress integration, preserve access errors, and consolidate request authorization without weakening permission checks.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ permissions:
 
 concurrency:
   group: e2e
-  cancel-in-progress: true
+  queue: max
 
 jobs:
   nextjs-compat:

--- a/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
+++ b/apps/frontman_server/lib/frontman_server/agents/system_prompt.ex
@@ -79,6 +79,10 @@ defmodule FrontmanServer.Agents.SystemPrompt do
     You are working with a WordPress site. Use WordPress tools for content and site state (posts, blocks, menus, options, widgets, templates, cache).
     Inspect relevant WordPress data before state-dependent recommendations or changes.
     Do not make state-dependent claims unsupported by inspected WordPress data.
+    If tool authentication still fails, stop and report the error code. A question answer does not restore access.
+    For session errors, ask the user to log in to WordPress and reload the full Frontman page. Permission errors require administrator access; do not suggest disabling security.
+    Only claim recovery after a WordPress tool succeeds, then read the target again before editing.
+    An unexplained 403 does not prove nonce expiry. Native REST uses a different nonce from Frontman; never extract credentials into tool results for diagnosis.
 
     **Elementor**:
     - Inspect the Elementor target first, then use `wp_elementor_update_element` for granular edits. It inspects the actual Elementor element and handles normal settings updates vs HTML-widget fragment updates from `old_html`/`new_html`.

--- a/apps/swarm_ai/test/swarm_ai/parallel_tool_execution_test.exs
+++ b/apps/swarm_ai/test/swarm_ai/parallel_tool_execution_test.exs
@@ -18,8 +18,9 @@ defmodule SwarmAi.ParallelToolExecutionTest do
   def run_instant(tool_call), do: ToolResult.make(tool_call.id, "OK", false)
   def run_crash(_tool_call), do: raise("boom")
 
-  def start_await(test_pid, tool_call) do
-    send(test_pid, {:await_started, tool_call.id, self()})
+  def start_await(runtime, tool_call) do
+    assert SwarmAi.running?(runtime, "task-human")
+    Process.send_after(self(), {:tool_result, tool_call.id, "approved", false}, 50)
     :ok
   end
 
@@ -170,28 +171,30 @@ defmodule SwarmAi.ParallelToolExecutionTest do
   test "a delayed interactive answer continues the same loop to completion" do
     runtime = start_runtime!()
     test_pid = self()
+
     llm = tool_then_complete_llm([tool_call("approval", %{}, id: "human")], "done")
 
-    execute_tools = fn tool_calls, task_supervisor ->
-      Enum.map(tool_calls, fn tool_call ->
-        %ToolExecution.Await{
-          tool_call: tool_call,
-          timeout_ms: :infinity,
-          start: {__MODULE__, :start_await, [test_pid]},
-          on_error: {SwarmAi.Testing, :default_tool_error, []}
-        }
-      end)
-      |> SwarmAi.ParallelExecutor.run(task_supervisor)
+    execute_tools = fn [tool_call], task_supervisor ->
+      execution = %ToolExecution.Await{
+        tool_call: tool_call,
+        timeout_ms: :infinity,
+        start: {__MODULE__, :start_await, [runtime]},
+        on_error: {SwarmAi.Testing, :default_tool_error, []}
+      }
+
+      SwarmAi.ParallelExecutor.run([execution], task_supervisor)
+      |> tap(fn results -> send(test_pid, {:tool_results, self(), results}) end)
     end
 
-    {:ok, pid} = run_execution(runtime, "task-human", llm, execute_tools: execute_tools)
-    assert_receive {:await_started, "human", ^pid}
-    refute_receive {:test_event, "task-human", :completed}, 50
-    assert SwarmAi.running?(runtime, "task-human")
-    send(pid, {:tool_result, "human", "approved", false})
+    {:ok, pid} =
+      run_execution(runtime, "task-human", %{llm | delay_ms: 150}, execute_tools: execute_tools)
+
     await_exit(pid)
-    assert_receive {:test_event, "task-human", :completed}
-    refute_receive {:test_event, "task-human", {:failed, _}}, 0
+
+    expected = ToolResult.make("human", "approved", false)
+    assert_received {:tool_results, ^pid, {:ok, [^expected]}}
+    assert_received {:test_event, "task-human", :completed}
+    refute_received {:test_event, "task-human", {:failed, _}}
   end
 
   defp start_runtime! do

--- a/libs/client/src/Client__FrontmanProvider.res
+++ b/libs/client/src/Client__FrontmanProvider.res
@@ -160,10 +160,10 @@ module Provider = {
 
       let runtimeConfig = RuntimeConfig.read()
       let _meta = RuntimeConfig.toMeta(runtimeConfig)
-      let relayHeaders = Dict.make()
-      runtimeConfig.wpNonce->Option.forEach(nonce => relayHeaders->Dict.set("X-WP-Nonce", nonce))
-
-      let relay = Relay.make(~baseUrl, ~requestHeaders=relayHeaders)
+      let relay = switch runtimeConfig.framework {
+      | Wordpress => Client__WordPressRelay.make(~baseUrl, ~nonce=runtimeConfig.wpNonce)
+      | Nextjs | Vite | Astro => Relay.make(~baseUrl)
+      }
       let toolRegistry = Client__ToolRegistry.forFramework(runtimeConfig.framework)
       let mcpServer = MCPServer.make(~relay, ~serverName=clientName, ~serverVersion=clientVersion)
       let mcpServer = Client__ToolRegistry.registerAll(toolRegistry, mcpServer)

--- a/libs/client/src/Client__WordPressRelay.res
+++ b/libs/client/src/Client__WordPressRelay.res
@@ -1,0 +1,32 @@
+module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
+
+@new external makeHeaders: option<WebAPI.HeadersInit.t> => WebAPI.FetchTypes.headers = "Headers"
+
+let make = (~baseUrl, ~nonce: option<string>) => {
+  let nonce = ref(nonce)
+  let fetch = async (url, init: WebAPI.FetchTypes.requestInit) => {
+    let headers = makeHeaders(init.headers)
+    nonce.contents->Option.forEach(value => headers->WebAPI.Headers.set(~name="X-WP-Nonce", ~value))
+    let init = {
+      ...init,
+      headers: WebAPI.HeadersInit.fromHeaders(headers),
+      mode: WebAPI.FetchTypes.SameOrigin,
+      redirect: WebAPI.FetchTypes.Error,
+      cache: WebAPI.FetchTypes.NoStore,
+    }
+    let response = await WebAPI.Fetch.fetch(url, ~init)
+    switch (response.status, response.headers->WebAPI.Headers.get("X-WP-Nonce")->Null.toOption) {
+    | (403, Some(replacement)) if replacement->String.trim != "" =>
+      let failure = await Relay.readHttpError(response->WebAPI.Response.clone)
+      switch failure.code {
+      | Some("frontman_missing_nonce" | "frontman_invalid_nonce") =>
+        nonce := Some(replacement)
+        headers->WebAPI.Headers.set(~name="X-WP-Nonce", ~value=replacement)
+        await WebAPI.Fetch.fetch(url, ~init)
+      | _ => response
+      }
+    | _ => response
+    }
+  }
+  Relay.make(~baseUrl, ~fetch)
+}

--- a/libs/client/test/Client__WordPressRelay.test.res
+++ b/libs/client/test/Client__WordPressRelay.test.res
@@ -1,0 +1,36 @@
+open Vitest
+
+module Relay = FrontmanAiFrontmanClient.FrontmanClient__Relay
+
+@module("vitest") @scope("vi") external stubGlobal: (string, 'a) => unit = "stubGlobal"
+@module("vitest") @scope("vi") external unstubAllGlobals: unit => unit = "unstubAllGlobals"
+afterEach(unstubAllGlobals)
+
+testAsync("nonce recovery is bounded and only enabled by the WordPress integration", async t => {
+  for i in 0 to 2 {
+    let code =
+      ["frontman_invalid_nonce", "frontman_forbidden", "frontman_invalid_nonce"]
+      ->Array.get(i)
+      ->Option.getOrThrow
+    let calls = ref(0)
+    let baseUrl = "https://example.test"
+    let relay = switch i {
+    | 2 => Relay.make(~baseUrl, ~requestHeaders=dict{"X-WP-Nonce": "old"})
+    | _ => Client__WordPressRelay.make(~baseUrl, ~nonce=Some("old"))
+    }
+    relay.state := Relay.Connected({tools: [], serverInfo: {name: "test", version: "5"}})
+    stubGlobal("fetch", async (_, _: WebAPI.FetchTypes.requestInit) => {
+      calls := calls.contents + 1
+      WebAPI.Response.fromString(
+        `{"code":"${code}","error":"Rejected"}`,
+        ~init={
+          status: 403,
+          headers: WebAPI.HeadersInit.fromDict(dict{"X-WP-Nonce": "fresh"}),
+        },
+      )
+    })
+    let result = await relay->Relay.executeTool(~name="wp_update_block")
+    t->expect(result)->Expect.toEqual(Error(`HTTP 403 [${code}]: Rejected`))
+    t->expect(calls.contents)->Expect.toBe([2, 1, 1]->Array.get(i)->Option.getOrThrow)
+  }
+})

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -14,13 +14,19 @@ type relayState =
 type t = {
   baseUrl: string,
   requestHeaders: Dict.t<string>,
+  fetch: (string, WebAPI.FetchTypes.requestInit) => promise<WebAPI.Response.t>,
   state: ref<relayState>,
 }
 
 @@live
-let make = (~baseUrl: string, ~requestHeaders: Dict.t<string>=Dict.make()): t => {
+let make = (
+  ~baseUrl: string,
+  ~requestHeaders: Dict.t<string>=Dict.make(),
+  ~fetch=(url, init) => WebAPI.Fetch.fetch(url, ~init),
+): t => {
   baseUrl,
   requestHeaders,
+  fetch,
   state: ref(Disconnected),
 }
 
@@ -86,62 +92,42 @@ let parseToolsResponse = (json: JSON.t): result<Types.toolsResponse, string> => 
 @schema
 type httpError = {code: option<string>, error: string}
 
-let request = async (relay: t, ~path, ~body=?, ~signal=?, ~decode): result<'a, string> => {
-  let wordpress = relay.requestHeaders->Dict.get("X-WP-Nonce")->Option.isSome
-  let (mode, redirect): (
-    WebAPI.FetchTypes.requestMode,
-    WebAPI.FetchTypes.requestRedirect,
-  ) = switch wordpress {
-  | true => (SameOrigin, Error)
-  | false => (Cors, Follow)
+let readHttpError = async response => {
+  try {
+    S.parseOrThrow(await response->WebAPI.Response.json, ~to=httpErrorSchema)
+  } catch {
+  | _ => {code: None, error: "Request rejected without JSON error details."}
   }
-  let rec send = async (retry): result<'a, string> => {
+}
+
+let request = async (relay: t, ~path, ~body=?, ~signal=?, ~decode): result<'a, string> => {
+  let result: result<'a, string> = try {
     let (method, headers) = switch body {
     | Some(_) => ("POST", dict{"Content-Type": "application/json", "Accept": "text/event-stream"})
     | None => ("GET", Dict.make())
     }
     relay.requestHeaders->Dict.forEachWithKey((value, key) => headers->Dict.set(key, value))
-    let response = await WebAPI.Fetch.fetch(
+    let response = await relay.fetch(
       `${relay.baseUrl}/frontman/${path}`,
-      ~init={
+      {
         method,
         headers: WebAPI.HeadersInit.fromDict(headers),
         body: ?(body->Option.map(WebAPI.BodyInit.fromString)),
         signal: ?(signal->Option.map(Null.make)),
-        mode,
-        redirect,
-        cache: NoStore,
       },
     )
     switch response.ok {
     | true => await decode(response)
     | false =>
-      let failure = try {
-        S.parseOrThrow(await response->WebAPI.Response.json, ~to=httpErrorSchema)
-      } catch {
-      | _ => {code: None, error: "Request rejected without JSON error details."}
-      }
-      switch (
-        retry,
-        response.status,
-        failure.code,
-        response.headers->WebAPI.Headers.get("X-WP-Nonce")->Null.toOption,
-      ) {
-      | (true, 403, Some("frontman_missing_nonce" | "frontman_invalid_nonce"), Some(nonce))
-        if nonce->String.trim != "" =>
-        relay.requestHeaders->Dict.set("X-WP-Nonce", nonce)
-        await send(false)
-      | _ =>
-        let code =
-          failure.code
-          ->Option.map(code => ` [${code->String.slice(~start=0, ~end=80)}]`)
-          ->Option.getOr("")
-        let message = failure.error->String.slice(~start=0, ~end=500)
-        Error(`HTTP ${response.status->Int.toString}${code}: ${message}`)
-      }
+      let failure = await readHttpError(response)
+      let code =
+        failure.code
+        ->Option.map(code => ` [${code->String.slice(~start=0, ~end=80)}]`)
+        ->Option.getOr("")
+      let message = failure.error->String.slice(~start=0, ~end=500)
+      Error(`HTTP ${response.status->Int.toString}${code}: ${message}`)
     }
-  }
-  let result = try {await send(wordpress)} catch {
+  } catch {
   | exn =>
     Error(
       exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Relay request failed"),

--- a/libs/frontman-client/src/FrontmanClient__Relay.res
+++ b/libs/frontman-client/src/FrontmanClient__Relay.res
@@ -83,48 +83,91 @@ let parseToolsResponse = (json: JSON.t): result<Types.toolsResponse, string> => 
   )
 }
 
-let connect = async (relay: t, ~signal: option<WebAPI.EventTypes.abortSignal>=?): result<
-  unit,
-  string,
-> => {
-  let url = `${relay.baseUrl}/frontman/tools`
-  try {
+@schema
+type httpError = {code: option<string>, error: string}
+
+let request = async (relay: t, ~path, ~body=?, ~signal=?, ~decode): result<'a, string> => {
+  let wordpress = relay.requestHeaders->Dict.get("X-WP-Nonce")->Option.isSome
+  let (mode, redirect): (
+    WebAPI.FetchTypes.requestMode,
+    WebAPI.FetchTypes.requestRedirect,
+  ) = switch wordpress {
+  | true => (SameOrigin, Error)
+  | false => (Cors, Follow)
+  }
+  let rec send = async (retry): result<'a, string> => {
+    let (method, headers) = switch body {
+    | Some(_) => ("POST", dict{"Content-Type": "application/json", "Accept": "text/event-stream"})
+    | None => ("GET", Dict.make())
+    }
+    relay.requestHeaders->Dict.forEachWithKey((value, key) => headers->Dict.set(key, value))
     let response = await WebAPI.Fetch.fetch(
-      url,
+      `${relay.baseUrl}/frontman/${path}`,
       ~init={
-        headers: WebAPI.HeadersInit.fromDict(relay.requestHeaders),
+        method,
+        headers: WebAPI.HeadersInit.fromDict(headers),
+        body: ?(body->Option.map(WebAPI.BodyInit.fromString)),
         signal: ?(signal->Option.map(Null.make)),
+        mode,
+        redirect,
+        cache: NoStore,
       },
     )
-
     switch response.ok {
+    | true => await decode(response)
     | false =>
-      let msg = `HTTP ${response.status->Int.toString}: ${response.statusText}`
-      relay.state := Error(msg)
-      Error(msg)
-    | true =>
-      let json = await response->WebAPI.Response.json
-      switch json->parseToolsResponse {
-      | Ok(data) =>
-        relay.state := Connected({tools: data.tools, serverInfo: data.serverInfo})
-        Ok()
-      | Error(parseError) =>
-        let msg = `Invalid tools response: ${parseError}`
-        relay.state := Error(msg)
-        Error(msg)
+      let failure = try {
+        S.parseOrThrow(await response->WebAPI.Response.json, ~to=httpErrorSchema)
+      } catch {
+      | _ => {code: None, error: "Request rejected without JSON error details."}
+      }
+      switch (
+        retry,
+        response.status,
+        failure.code,
+        response.headers->WebAPI.Headers.get("X-WP-Nonce")->Null.toOption,
+      ) {
+      | (true, 403, Some("frontman_missing_nonce" | "frontman_invalid_nonce"), Some(nonce))
+        if nonce->String.trim != "" =>
+        relay.requestHeaders->Dict.set("X-WP-Nonce", nonce)
+        await send(false)
+      | _ =>
+        let code =
+          failure.code
+          ->Option.map(code => ` [${code->String.slice(~start=0, ~end=80)}]`)
+          ->Option.getOr("")
+        let message = failure.error->String.slice(~start=0, ~end=500)
+        Error(`HTTP ${response.status->Int.toString}${code}: ${message}`)
       }
     }
-  } catch {
+  }
+  let result = try {await send(wordpress)} catch {
   | exn =>
+    Error(
+      exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Relay request failed"),
+    )
+  }
+  result->Result.mapError(message => {
+    Log.error(~ctx={"path": path}, message)
+    message
+  })
+}
+
+let connect = async (relay: t, ~signal: option<WebAPI.EventTypes.abortSignal>=?) => {
+  let result = await request(relay, ~path="tools", ~signal?, ~decode=async response => {
+    (await response->WebAPI.Response.json)
+    ->parseToolsResponse
+    ->Result.mapError(message => `Invalid tools response: ${message}`)
+  })
+  switch result {
+  | Ok(data) => relay.state := Connected({tools: data.tools, serverInfo: data.serverInfo})
+  | Error(message) =>
     switch signal {
-    | Some(s) if s.aborted => Error("Connection aborted")
-    | _ =>
-      let msg =
-        exn->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr("Relay fetch failed")
-      relay.state := Error(msg)
-      Error(msg)
+    | Some(s) if s.aborted => ()
+    | _ => relay.state := Error(message)
     }
   }
+  result->Result.map(_ => ())
 }
 
 @@live
@@ -145,12 +188,8 @@ let toolName = tool =>
   ->Option.flatMap(tool => tool->Dict.get("name"))
   ->Option.flatMap(JSON.Decode.string)
 
-let hasTool = (relay: t, name: string): bool => {
-  switch relay.state.contents {
-  | Connected({tools}) => tools->Array.some(tool => tool->toolName == Some(name))
-  | Disconnected | Error(_) => false
-  }
-}
+let hasTool = (relay: t, name: string): bool =>
+  relay->getToolsJson->Array.some(tool => tool->toolName == Some(name))
 
 let executeTool = async (relay: t, ~name: string, ~arguments: option<Dict.t<JSON.t>>=?): result<
   MCPTypes.CallToolResult.t,
@@ -160,49 +199,14 @@ let executeTool = async (relay: t, ~name: string, ~arguments: option<Dict.t<JSON
   | false => Error("Relay not connected")
   | true =>
     Log.debug(~ctx={"tool": name}, "Executing relay tool")
-    let url = `${relay.baseUrl}/frontman/tools/call`
-    let request: Types.toolCallRequest = {name, arguments}
-    let body =
-      request->S.decodeOrThrow(~from=Types.toolCallRequestSchema, ~to=S.json->S.noValidation(true))
-    let headers = Dict.fromArray([
-      ("Content-Type", "application/json"),
-      ("Accept", "text/event-stream"),
-    ])
-    relay.requestHeaders->Dict.forEachWithKey((value, key) => headers->Dict.set(key, value))
-
-    try {
-      let response = await WebAPI.Fetch.fetch(
-        url,
-        ~init={
-          method: "POST",
-          headers: WebAPI.HeadersInit.fromDict(headers),
-          body: WebAPI.BodyInit.fromString(JSON.stringify(body)),
-        },
+    let input: Types.toolCallRequest = {name, arguments}
+    let body = input->S.decodeOrThrow(~from=Types.toolCallRequestSchema, ~to=S.jsonString)
+    await request(relay, ~path="tools/call", ~body, ~decode=async response => {
+      (await SSE.readStream(response))->Result.flatMap(json =>
+        json
+        ->Decoders.parseSchema(MCPTypes.callToolResultSchema)
+        ->Result.mapError(message => `Invalid result: ${message}`)
       )
-
-      switch response.ok {
-      | false =>
-        let msg = `HTTP ${response.status->Int.toString}: ${response.statusText}`
-        Log.error(~ctx={"tool": name}, msg)
-        Error(msg)
-      | true =>
-        switch await SSE.readStream(response) {
-        | Ok(json) =>
-          json
-          ->Decoders.parseSchema(MCPTypes.callToolResultSchema)
-          ->Result.mapError(msg => `Invalid result: ${msg}`)
-        | Error(msg) => Error(msg)
-        }
-      }
-    } catch {
-    | exn =>
-      let msg =
-        exn
-        ->JsExn.fromException
-        ->Option.flatMap(JsExn.message)
-        ->Option.getOr("Relay tool execution failed")
-      Log.error(~ctx={"tool": name, "url": url}, msg)
-      Error(msg)
-    }
+    })
   }
 }

--- a/libs/frontman-client/test/FrontmanClient__Relay.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Relay.test.res
@@ -2,35 +2,6 @@ open Vitest
 
 module Relay = FrontmanClient__Relay
 
-@module("vitest") @scope("vi") external stubGlobal: (string, 'a) => unit = "stubGlobal"
-@module("vitest") @scope("vi") external unstubAllGlobals: unit => unit = "unstubAllGlobals"
-afterEach(unstubAllGlobals)
-
-testAsync("only replays an authenticated nonce rejection once", async t => {
-  for i in 0 to 1 {
-    let code = ["frontman_invalid_nonce", "frontman_forbidden"]->Array.get(i)->Option.getOrThrow
-    let calls = ref(0)
-    let relay = Relay.make(
-      ~baseUrl="https://example.test",
-      ~requestHeaders=dict{"X-WP-Nonce": "old"},
-    )
-    relay.state := Relay.Connected({tools: [], serverInfo: {name: "wordpress", version: "5"}})
-    stubGlobal("fetch", async (_, _: WebAPI.FetchTypes.requestInit) => {
-      calls := calls.contents + 1
-      WebAPI.Response.fromString(
-        `{"code":"${code}","error":"Rejected"}`,
-        ~init={
-          status: 403,
-          headers: WebAPI.HeadersInit.fromDict(dict{"X-WP-Nonce": "fresh"}),
-        },
-      )
-    })
-    let result = await relay->Relay.executeTool(~name="wp_update_block")
-    t->expect(result)->Expect.toEqual(Error(`HTTP 403 [${code}]: Rejected`))
-    t->expect(calls.contents)->Expect.toBe([2, 1]->Array.get(i)->Option.getOrThrow)
-  }
-})
-
 describe("Relay.connect", _t => {
   test("accepts only the current relay protocol version", t => {
     let json = JSON.parseOrThrow(`{"tools":[],"serverInfo":{"name":"test","version":"1"},"protocolVersion":"1.0"}`)

--- a/libs/frontman-client/test/FrontmanClient__Relay.test.res
+++ b/libs/frontman-client/test/FrontmanClient__Relay.test.res
@@ -2,7 +2,34 @@ open Vitest
 
 module Relay = FrontmanClient__Relay
 
-let jsonString = json => JSON.stringify(json)
+@module("vitest") @scope("vi") external stubGlobal: (string, 'a) => unit = "stubGlobal"
+@module("vitest") @scope("vi") external unstubAllGlobals: unit => unit = "unstubAllGlobals"
+afterEach(unstubAllGlobals)
+
+testAsync("only replays an authenticated nonce rejection once", async t => {
+  for i in 0 to 1 {
+    let code = ["frontman_invalid_nonce", "frontman_forbidden"]->Array.get(i)->Option.getOrThrow
+    let calls = ref(0)
+    let relay = Relay.make(
+      ~baseUrl="https://example.test",
+      ~requestHeaders=dict{"X-WP-Nonce": "old"},
+    )
+    relay.state := Relay.Connected({tools: [], serverInfo: {name: "wordpress", version: "5"}})
+    stubGlobal("fetch", async (_, _: WebAPI.FetchTypes.requestInit) => {
+      calls := calls.contents + 1
+      WebAPI.Response.fromString(
+        `{"code":"${code}","error":"Rejected"}`,
+        ~init={
+          status: 403,
+          headers: WebAPI.HeadersInit.fromDict(dict{"X-WP-Nonce": "fresh"}),
+        },
+      )
+    })
+    let result = await relay->Relay.executeTool(~name="wp_update_block")
+    t->expect(result)->Expect.toEqual(Error(`HTTP 403 [${code}]: Rejected`))
+    t->expect(calls.contents)->Expect.toBe([2, 1]->Array.get(i)->Option.getOrThrow)
+  }
+})
 
 describe("Relay.connect", _t => {
   test("accepts only the current relay protocol version", t => {
@@ -28,7 +55,7 @@ describe("Relay.connect", _t => {
 
     t->expect(response.protocolVersion)->Expect.toBe("2.0")
     t
-    ->expect(response.tools->Array.get(0)->Option.map(jsonString))
+    ->expect(response.tools->Array.get(0)->Option.map(json => JSON.stringify(json)))
     ->Expect.toEqual(
       Some(
         JSON.stringify(
@@ -81,7 +108,7 @@ test("preserves relayed MCP tool metadata and parses legacy results", t => {
     })
 
   t
-  ->expect(relay->Relay.getToolsJson->Array.get(0)->Option.map(jsonString))
+  ->expect(relay->Relay.getToolsJson->Array.get(0)->Option.map(json => JSON.stringify(json)))
   ->Expect.toEqual(Some(JSON.stringify(tool)))
   t->expect(relay->Relay.hasTool("tool"))->Expect.toBe(true)
   JSON.parseOrThrow(`{"content":[]}`)

--- a/libs/frontman-wordpress/includes/class-frontman-auth.php
+++ b/libs/frontman-wordpress/includes/class-frontman-auth.php
@@ -78,33 +78,6 @@ class Frontman_Auth {
 	}
 
 	/**
-	 * Verify the request nonce sent by the browser client.
-	 *
-	 * @return true|\WP_Error
-	 */
-	public static function verify_nonce() {
-		$nonce = self::request_nonce();
-
-		if ( empty( $nonce ) ) {
-			return new \WP_Error(
-				'frontman_missing_nonce',
-				__( 'Missing request nonce.', 'frontman-agentic-ai-editor' ),
-				[ 'status' => 403 ],
-			);
-		}
-
-		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
-			return new \WP_Error(
-				'frontman_invalid_nonce',
-				__( 'Invalid request nonce.', 'frontman-agentic-ai-editor' ),
-				[ 'status' => 403 ],
-			);
-		}
-
-		return true;
-	}
-
-	/**
 	 * Send an error response and exit.
 	 *
 	 * Handles both JSON API errors and HTML redirects depending on context.
@@ -117,7 +90,12 @@ class Frontman_Auth {
 		$status     = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 403;
 
 		if ( $is_api ) {
-			wp_send_json( [ 'error' => $error->get_error_message() ], $status );
+			nocache_headers();
+			$code = $error->get_error_code();
+			if ( in_array( $code, [ 'frontman_missing_nonce', 'frontman_invalid_nonce' ], true ) && true === self::check() ) {
+				header( 'X-WP-Nonce: ' . self::create_nonce() );
+			}
+			wp_send_json( [ 'code' => $code, 'error' => $error->get_error_message() ], $status );
 			return;
 		}
 

--- a/libs/frontman-wordpress/includes/class-frontman-router.php
+++ b/libs/frontman-wordpress/includes/class-frontman-router.php
@@ -57,14 +57,18 @@ class Frontman_Router {
 		$request_uri = $this->get_request_path();
 		$method      = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_key( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : 'GET';
 		$route       = $this->classify_route( $request_uri, $method );
+		if ( 'none' === $route['type'] ) {
+			return;
+		}
+
+		$auth = Frontman_Auth::check();
+		if ( is_wp_error( $auth ) ) {
+			Frontman_Auth::send_error( $auth, 'prefix' === $route['type'] );
+		}
 
 		if ( 'prefix' === $route['type'] ) {
 			$sub_path = $route['subPath'];
-
-			$this->require_auth( true );
-			if ( $method === 'POST' ) {
-				$this->require_nonce();
-			}
+			$body = $method === 'POST' ? $this->read_json_body() : [];
 
 			switch ( true ) {
 				case $method === 'GET' && $sub_path === 'tools':
@@ -76,7 +80,7 @@ class Frontman_Router {
 					exit;
 
 				case $method === 'POST' && $sub_path === 'tools/call':
-					$this->handle_tool_call();
+					$this->handle_tool_call( $body );
 					exit;
 
 				case $method === 'POST' && $sub_path === 'resolve-source-location':
@@ -92,13 +96,7 @@ class Frontman_Router {
 			}
 		}
 
-		if ( 'suffix' !== $route['type'] ) {
-			return;
-		}
-
 		$suffix_prefix = $route['prefix'];
-
-		$this->require_auth( false );
 
 		$canonical = $this->get_canonical_redirect( $suffix_prefix );
 		if ( $canonical !== null ) {
@@ -135,26 +133,6 @@ class Frontman_Router {
 		}
 
 		return [ 'type' => 'none' ];
-	}
-
-	/**
-	 * Check auth and send error response if unauthorized.
-	 */
-	private function require_auth( bool $is_api ): void {
-		$auth = Frontman_Auth::check();
-		if ( is_wp_error( $auth ) ) {
-			Frontman_Auth::send_error( $auth, $is_api );
-		}
-	}
-
-	/**
-	 * Check nonce and send API error response if invalid.
-	 */
-	private function require_nonce(): void {
-		$nonce = Frontman_Auth::verify_nonce();
-		if ( is_wp_error( $nonce ) ) {
-			Frontman_Auth::send_error( $nonce, true );
-		}
 	}
 
 	/**
@@ -272,8 +250,8 @@ class Frontman_Router {
 		if ( '' === $nonce || ! wp_verify_nonce( $nonce, Frontman_Auth::nonce_action() ) ) {
 			Frontman_Auth::send_error(
 				new \WP_Error(
-					'frontman_invalid_nonce',
-					__( 'Invalid request nonce.', 'frontman-agentic-ai-editor' ),
+					'' === $nonce ? 'frontman_missing_nonce' : 'frontman_invalid_nonce',
+					'' === $nonce ? __( 'Missing request nonce.', 'frontman-agentic-ai-editor' ) : __( 'Invalid request nonce.', 'frontman-agentic-ai-editor' ),
 					[ 'status' => 403 ]
 				),
 				true
@@ -361,8 +339,7 @@ class Frontman_Router {
 	 *
 	 * Tools are handled locally in the WordPress plugin.
 	 */
-	private function handle_tool_call(): void {
-		$body      = $this->read_json_body();
+	private function handle_tool_call( array $body ): void {
 		$name      = sanitize_key( $body['name'] ?? '' );
 		$raw_input = $body['arguments'] ?? $body['input'] ?? [];
 

--- a/libs/frontman-wordpress/includes/class-frontman-ui.php
+++ b/libs/frontman-wordpress/includes/class-frontman-ui.php
@@ -118,6 +118,7 @@ class Frontman_UI {
 		$this->enqueue_frontman_page_assets( $client_url, $client_css );
 
 		status_header( 200 );
+		nocache_headers();
 		header( 'Content-Type: text/html; charset=utf-8' );
 		?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Return a replacement nonce only for authenticated, pre-dispatch nonce rejections; replay the original tool request at most once.
- Preserve structured access errors, reject WordPress cross-origin requests and redirects, and prevent caching of nonce-bearing responses.
- Consolidate duplicate PHP authorization and relay transport code; clarify that an agent question cannot restore access.
- Select `Client__WordPressRelay` explicitly from the framework setting. The shared relay accepts a fetch function and contains no WordPress detection or retry policy.
- Net **+26 lines**, including tests and changeset. No new endpoint, dependency, or auth subsystem.

## Safety
- Every replay still passes WordPress cookie, administrator, and nonce checks.
- No replay for generic 403s, permission failures, network exceptions, or tool errors.
- Nonces stay in browser headers, outside tool results and agent context.

## Verification
- 88 relay tests and 430 client tests passed. The nonce regression moved to the WordPress integration and now also checks that a generic relay does not retry WordPress-shaped errors, even with an `X-WP-Nonce` request header.
- PHP core suite and WordPress 7.0.2 / PHP 8.4.23 runtime and multisite suites passed.
- Manual real-WordPress checks: rejected writes leave content unchanged, recovery updates only the draft, unauthorized requests receive no nonce, native REST nonces are rejected, all POST routes remain protected, and nonce-bearing HTML is not cacheable.
- 20 Chromium checks passed, including concurrent recovery, retry bounds, unchanged replay bodies, cross-origin denial, missing bootstrap nonce recovery, and connection cancellation. Manual verification scripts remain outside the repository.
- Commit hooks passed: ReScript formatting, source-comment policy, Elixir formatting, and scoped Credo. The full Elixir server test suite subsequently passed in CI.

## CI root-cause fixes
- Reproduced the Swarm failure deterministically with a valid 150 ms mock LLM delay: the old test demanded tool readiness within ExUnit's default 100 ms, including all LLM startup. Approval now starts from tool readiness, and the test verifies the exact successful result from the same worker after its bounded exit. The slow mock remains as regression coverage. No production timeout or assertion timeout was increased; 20 seeded runs and all 125 Swarm tests passed locally.
- The E2E workflow's repository-wide concurrency group cancelled unrelated PRs. Keep the original shared-API-quota serialization but use GitHub's native `queue: max` instead of cancelling active or replacing pending runs (up to 100 waiting runs). [GitHub documentation announcement](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/).
- All CI checks passed on `f6333ded`, including E2E, on the first attempt. An earlier E2E job on `3643abdc` was requeued after an older branch using the former cancellation policy interrupted it before tests began; its completed run executed the full suite. Older branches must adopt the queue policy to stop cancelling other runs. No failing tests were skipped and no checks were bypassed.


