### PR TITLE
feat(astro): include client routing in page context

### DIFF
--- a/.changeset/sour-colts-turn.md
+++ b/.changeset/sour-colts-turn.md
@@ -1,5 +1,6 @@
 ---
 "@frontman-ai/astro-browser": minor
+"@frontman-ai/client": minor
 ---
 
-Add a typed helper that reads the Astro client-routing marker from the preview document. The helper distinguishes enabled, disabled, and unavailable states.
+Include Astro client-routing status in automatic page context. Detect enabled, disabled, and unavailable states from the preview document, and preserve the status in server storage and conversation history. Add conditional lifecycle guidance to agent prompts.

--- a/.changeset/sour-colts-turn.md
+++ b/.changeset/sour-colts-turn.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/astro-browser": minor
+---
+
+Add a typed helper that reads the Astro client-routing marker from the preview document. The helper distinguishes enabled, disabled, and unavailable states.

--- a/apps/frontman_server/lib/frontman_server/current_page_context.ex
+++ b/apps/frontman_server/lib/frontman_server/current_page_context.ex
@@ -46,7 +46,8 @@ defmodule FrontmanServer.CurrentPageContext do
           device_pixel_ratio: device_pixel_ratio(meta["device_pixel_ratio"]),
           title: meta["title"],
           color_scheme: meta["color_scheme"],
-          scroll_y: meta["scroll_y"]
+          scroll_y: meta["scroll_y"],
+          astro_client_routing: astro_client_routing(meta["astro_client_routing"])
         }
 
       _ ->
@@ -55,6 +56,11 @@ defmodule FrontmanServer.CurrentPageContext do
   end
 
   def fields_from_meta(_), do: nil
+
+  defp astro_client_routing(nil), do: nil
+
+  defp astro_client_routing(status) when status in ["enabled", "disabled", "unavailable"],
+    do: status
 
   defp device_pixel_ratio(nil), do: nil
   defp device_pixel_ratio(value) when is_number(value), do: value / 1
@@ -148,7 +154,8 @@ defmodule FrontmanServer.CurrentPageContext do
       device_pixel_ratio_line(page),
       title_line(page),
       color_scheme_line(page),
-      scroll_line(page)
+      scroll_line(page),
+      astro_client_routing_line(page)
     ]
     |> Enum.reject(&is_nil/1)
   end
@@ -194,6 +201,27 @@ defmodule FrontmanServer.CurrentPageContext do
     end
   end
 
+  defp astro_client_routing_line(page) do
+    case page_value(page, :astro_client_routing) do
+      nil ->
+        nil
+
+      "enabled" ->
+        "Astro Client Routing: enabled (current-page opt-in, not proof of completed navigation). " <>
+          "For page scripts, use astro:page-load for initialization after client navigation and " <>
+          "astro:before-swap for cleanup. Avoid duplicate listeners and account for persisted elements. " <>
+          "Exercise the interaction after navigation to verify behavior."
+
+      "disabled" ->
+        "Astro Client Routing: disabled on the current page. " <>
+          "Use normal document-load initialization. Do not assume Astro navigation lifecycle events."
+
+      "unavailable" ->
+        "Astro Client Routing: unavailable because the preview document is unavailable. " <>
+          "Do not infer that client routing is disabled."
+    end
+  end
+
   defp to_meta(page) do
     %{
       @marker_key => true,
@@ -203,7 +231,8 @@ defmodule FrontmanServer.CurrentPageContext do
       "device_pixel_ratio" => page_value(page, :device_pixel_ratio),
       "title" => page_value(page, :title),
       "color_scheme" => page_value(page, :color_scheme),
-      "scroll_y" => page_value(page, :scroll_y)
+      "scroll_y" => page_value(page, :scroll_y),
+      "astro_client_routing" => page_value(page, :astro_client_routing)
     }
     |> reject_nils()
   end

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -210,26 +210,9 @@ defmodule FrontmanServer.Tasks.Interaction do
       |> validate_inclusion(:astro_client_routing, ["enabled", "disabled", "unavailable"])
     end
 
-    def attrs_from_acp_meta(meta) when is_map(meta) do
-      case CurrentPageContext.fields_from_current_page_meta(meta) do
-        %{url: url} = fields ->
-          %{
-            url: url,
-            viewport_width: fields.viewport_width,
-            viewport_height: fields.viewport_height,
-            device_pixel_ratio: fields.device_pixel_ratio,
-            title: fields.title,
-            color_scheme: fields.color_scheme,
-            scroll_y: fields.scroll_y,
-            astro_client_routing: fields.astro_client_routing
-          }
-
-        nil ->
-          nil
-      end
-    end
-
-    def attrs_from_acp_meta(_), do: nil
+    defdelegate attrs_from_acp_meta(meta),
+      to: CurrentPageContext,
+      as: :fields_from_current_page_meta
   end
 
   defmodule Annotation do

--- a/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/interaction.ex
@@ -193,6 +193,7 @@ defmodule FrontmanServer.Tasks.Interaction do
       field :title, :string
       field :color_scheme, :string
       field :scroll_y, :integer
+      field :astro_client_routing, :string
     end
 
     def changeset(%__MODULE__{} = current_page, attrs) do
@@ -203,8 +204,10 @@ defmodule FrontmanServer.Tasks.Interaction do
         :device_pixel_ratio,
         :title,
         :color_scheme,
-        :scroll_y
+        :scroll_y,
+        :astro_client_routing
       ])
+      |> validate_inclusion(:astro_client_routing, ["enabled", "disabled", "unavailable"])
     end
 
     def attrs_from_acp_meta(meta) when is_map(meta) do
@@ -217,7 +220,8 @@ defmodule FrontmanServer.Tasks.Interaction do
             device_pixel_ratio: fields.device_pixel_ratio,
             title: fields.title,
             color_scheme: fields.color_scheme,
-            scroll_y: fields.scroll_y
+            scroll_y: fields.scroll_y,
+            astro_client_routing: fields.astro_client_routing
           }
 
         nil ->

--- a/apps/frontman_server/test/frontman_server/current_page_context_test.exs
+++ b/apps/frontman_server/test/frontman_server/current_page_context_test.exs
@@ -1,0 +1,69 @@
+defmodule FrontmanServer.CurrentPageContextTest do
+  use ExUnit.Case, async: true
+
+  alias FrontmanServer.CurrentPageContext
+  alias FrontmanServer.Tasks.Interaction.CurrentPage
+
+  test "routing status survives ACP parsing, embedded storage, history, and prompt formatting" do
+    for status <- ["enabled", "disabled", "unavailable"] do
+      meta = %{
+        "current_page" => true,
+        "url" => "http://localhost:4321/",
+        "astro_client_routing" => status
+      }
+
+      assert {:ok, page} =
+               %CurrentPage{}
+               |> CurrentPage.changeset(CurrentPage.attrs_from_acp_meta(meta))
+               |> Ecto.Changeset.apply_action(:insert)
+
+      stored = page |> Ecto.embedded_dump(:json) |> Jason.encode!() |> Jason.decode!()
+      restored = Ecto.embedded_load(CurrentPage, stored, :json)
+      assert restored.astro_client_routing == status
+      assert [%{"_meta" => history_meta}] = CurrentPageContext.to_content_blocks(restored)
+      assert history_meta == meta
+      assert CurrentPage.attrs_from_acp_meta(history_meta).astro_client_routing == status
+
+      prompt = CurrentPageContext.to_prompt_section(restored)
+      assert prompt =~ "Astro Client Routing: #{status}"
+
+      case status do
+        "enabled" ->
+          assert prompt =~ "astro:page-load"
+          assert prompt =~ "astro:before-swap"
+          assert prompt =~ "not proof of completed navigation"
+          assert prompt =~ "persisted elements"
+
+        "disabled" ->
+          assert prompt =~ "normal document-load initialization"
+          refute prompt =~ "astro:page-load"
+
+        "unavailable" ->
+          assert prompt =~ "Do not infer that client routing is disabled"
+          refute prompt =~ "astro:page-load"
+      end
+    end
+  end
+
+  test "legacy and non-Astro metadata omit routing status and guidance" do
+    meta = %{"current_page" => true, "url" => "http://localhost:3000/"}
+    fields = CurrentPage.attrs_from_acp_meta(meta)
+    assert fields.astro_client_routing == nil
+    assert [%{"_meta" => ^meta}] = CurrentPageContext.to_content_blocks(fields)
+    refute CurrentPageContext.to_prompt_section(fields) =~ "Astro Client Routing"
+  end
+
+  test "rejects invalid routing metadata at parsing and storage boundaries" do
+    for invalid <- [true, false, "unknown", %{}, 1] do
+      assert_raise FunctionClauseError, fn ->
+        CurrentPageContext.fields_from_meta(%{
+          "url" => "http://localhost:4321/",
+          "astro_client_routing" => invalid
+        })
+      end
+
+      changeset = CurrentPage.changeset(%CurrentPage{}, %{astro_client_routing: invalid})
+      refute changeset.valid?
+    end
+  end
+end

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -645,7 +645,8 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           "device_pixel_ratio" => 2,
           "title" => "Frontman: Visual AI Frontend Editing",
           "color_scheme" => "dark",
-          "scroll_y" => 0
+          "scroll_y" => 0,
+          "astro_client_routing" => "enabled"
         }),
         annotation_block("ann-hero", "H1", "apps/marketing/src/components/Hero.astro", 65, 36,
           comment: "change this text to Danni",
@@ -683,8 +684,10 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       {:ok, task} = Tasks.get_task_with_history(scope, task_id)
       assert [%Interaction.UserMessage{} = persisted_message | _] = Tasks.interactions(task)
 
-      assert %Interaction.CurrentPage{title: "Frontman: Visual AI Frontend Editing"} =
-               persisted_message.current_page
+      assert %Interaction.CurrentPage{
+               title: "Frontman: Visual AI Frontend Editing",
+               astro_client_routing: "enabled"
+             } = persisted_message.current_page
 
       assert [%Interaction.Annotation{bounding_box: %Interaction.BoundingBox{}}] =
                persisted_message.annotations
@@ -695,6 +698,8 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
       assert text =~ "[Current Page Context]"
       assert text =~ "[Annotated Elements]"
       assert text =~ "apps/marketing/src/components/Hero.astro"
+      assert text =~ "Astro Client Routing: enabled"
+      assert text =~ "astro:page-load"
       assert Enum.any?(swarm_message.content, &match?(%{type: :image}, &1))
     end
 

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -710,7 +710,8 @@ defmodule FrontmanServer.Tasks.InteractionTest do
                "device_pixel_ratio" => 2.0,
                "title" => "Settings",
                "color_scheme" => "dark",
-               "scroll_y" => 320
+               "scroll_y" => 320,
+               "astro_client_routing" => nil
              }
 
       assert [ann] = decoded["annotations"]

--- a/libs/client/src/state/Client__State__StateReducer.res
+++ b/libs/client/src/state/Client__State__StateReducer.res
@@ -608,10 +608,16 @@ let sendMessageToAPIImpl = (
 ) => {
   switch state.acpSession {
   | AcpSessionActive({sendPrompt}) =>
+    let runtimeConfig = Client__RuntimeConfig.read()
     let pageContextBlocks =
       state.tasks
       ->Dict.get(taskId)
-      ->Option.mapOr([], Client__State__Types.taskToPageContextBlocks)
+      ->Option.mapOr([], task =>
+        Client__State__Types.taskToPageContextBlocks(
+          task,
+          ~isAstro=runtimeConfig.framework == Astro,
+        )
+      )
 
     let annotationBlocks = Client__State__Types.messageAnnotationsToContentBlocks(annotations)
 
@@ -619,7 +625,6 @@ let sendMessageToAPIImpl = (
     let additionalBlocks =
       Array.concat(pageContextBlocks, annotationBlocks)->Array.concat(attachmentBlocks)
 
-    let runtimeConfig = Client__RuntimeConfig.read()
     let baseMeta = Client__RuntimeConfig.toMeta(runtimeConfig)
     let metadata = baseMeta->JSON.Decode.object->Option.getOrThrow->Dict.copy
     state.selectedModelValue->Option.forEach(modelValue =>

--- a/libs/client/src/state/Client__Task__Types.res
+++ b/libs/client/src/state/Client__Task__Types.res
@@ -778,7 +778,10 @@ let getColorScheme: WebAPI.DomTypes.window => string = %raw(`
   }
 `)
 
-let currentPageToContentBlock = (previewFrame: Task.previewFrame): ContentBlock.t => {
+let currentPageToContentBlock = (
+  previewFrame: Task.previewFrame,
+  ~isAstro: bool,
+): ContentBlock.t => {
   let url = previewFrame.url
 
   let (viewportWidth, viewportHeight, dpr, scrollY) = switch previewFrame.contentWindow {
@@ -833,6 +836,19 @@ let currentPageToContentBlock = (previewFrame: Task.previewFrame): ContentBlock.
   let obj = Dict.make()
   obj->Dict.set("current_page", JSON.Encode.bool(true))
   obj->Dict.set("url", JSON.Encode.string(url))
+
+  switch isAstro {
+  | true =>
+    module ClientRouting = FrontmanAiAstroBrowser.FrontmanAstroBrowser__ClientRouting
+    obj->Dict.set(
+      "astro_client_routing",
+      ClientRouting.read(previewFrame.contentDocument)->S.decodeOrThrow(
+        ~from=ClientRouting.schema,
+        ~to=S.json,
+      ),
+    )
+  | false => ()
+  }
 
   switch viewportWidth {
   | Some(w) => obj->Dict.set("viewport_width", JSON.Encode.int(w))
@@ -924,12 +940,12 @@ let currentPageToContentBlock = (previewFrame: Task.previewFrame): ContentBlock.
   })
 }
 
-let taskToPageContextBlocks = (task: Task.t): array<ContentBlock.t> => {
+let taskToPageContextBlocks = (task: Task.t, ~isAstro: bool): array<ContentBlock.t> => {
   switch task {
   | Task.Unloaded(_) => []
   | Task.New({previewFrame})
   | Task.Loading({previewFrame})
-  | Task.Loaded({previewFrame}) => [currentPageToContentBlock(previewFrame)]
+  | Task.Loaded({previewFrame}) => [currentPageToContentBlock(previewFrame, ~isAstro)]
   }
 }
 

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -12,6 +12,15 @@ module UserMessageId = Client__Message.UserMessageId
 let testUserMessageId = UserMessageId.make()
 let secondTestUserMessageId = UserMessageId.make()
 
+type domParser
+@new external makeDomParser: unit => domParser = "DOMParser"
+@send
+external parseHtml: (domParser, string, @as("text/html") _) => WebAPI.DomTypes.document =
+  "parseFromString"
+
+@schema
+type pageRoutingMeta = {astro_client_routing: option<string>}
+
 let setRuntime: JSON.t => unit = %raw(`function(value) { window.__frontmanRuntime = value }`)
 let clearRuntime: unit => unit = %raw(`function() { delete window.__frontmanRuntime }`)
 
@@ -1805,6 +1814,65 @@ describe("Client State Reducer - Annotations on Messages", () => {
     t
     ->expect(metadata->Dict.get("model")->Option.flatMap(JSON.Decode.string))
     ->Expect.toEqual(Some("anthropic:claude-opus-4-6"))
+  })
+
+  test("SendMessage includes fresh routing metadata only for Astro previews", t => {
+    let enabledDocument =
+      makeDomParser()->parseHtml("<meta name=\"astro-view-transitions-enabled\" content=\"true\">")
+    let disabledDocument = makeDomParser()->parseHtml("<title>No client router</title>")
+    [
+      ("astro", Some(enabledDocument), Some("enabled")),
+      ("astro", Some(disabledDocument), Some("disabled")),
+      ("astro", None, Some("unavailable")),
+      ("nextjs", Some(enabledDocument), None),
+      ("vite", Some(enabledDocument), None),
+      ("wordpress", Some(enabledDocument), None),
+    ]->Array.forEach(
+      ((framework, contentDocument, expected)) => {
+        setRuntime(
+          {"framework": framework}->S.decodeOrThrow(
+            ~from=S.object(s => {"framework": s.field("framework", S.string)}),
+            ~to=S.json,
+          ),
+        )
+        let sentBlocks = ref([])
+        let state = TestHelpers.makeStateWithTask()
+        let task = state.tasks->Dict.get("test-task-1")->Option.getOrThrow
+        state.tasks->Dict.set(
+          "test-task-1",
+          TaskReducer.Lens.setPreviewFrame(task, ~contentDocument, ~contentWindow=None),
+        )
+        let state = {
+          ...state,
+          acpSession: AcpSessionActive({
+            sendPrompt: (_, ~additionalBlocks, ~onComplete as _, ~_meta as _) =>
+              sentBlocks := additionalBlocks,
+            sendSessionCommand: _ => (),
+            loadTask: (_, ~needsHistory as _, ~onComplete as _) => (),
+            deleteSession: (_, ~onComplete as _) => (),
+            requireAuthentication: () => (),
+            apiBaseUrl: "http://localhost:4000",
+          }),
+        }
+        let (state, effects) = Reducer.next(
+          state,
+          Reducer.AddUserMessage({
+            id: UserMessageId.make(),
+            sessionId: "session-1",
+            content: [UserContentPart.text("Fix this")],
+            annotations: [],
+            agentId: "planner-id",
+          }),
+        )
+        effects->Array.forEach(effect => Reducer.handleEffect(effect, state, _ => ()))
+        switch sentBlocks.contents->Array.get(0) {
+        | Some(ContentBlock.EmbeddedResource({_meta: Some(meta)})) =>
+          let metadata = S.parseOrThrow(meta, ~to=pageRoutingMetaSchema)
+          t->expect(metadata.astro_client_routing)->Expect.toEqual(expected)
+        | _ => JsExn.throw("Expected current-page metadata in the submitted prompt")
+        }
+      },
+    )
   })
 
   test("SendMessage dispatches task cleanup when sendPrompt fails", t => {

--- a/libs/client/test/Client__State__StateReducer.test.res
+++ b/libs/client/test/Client__State__StateReducer.test.res
@@ -12,12 +12,6 @@ module UserMessageId = Client__Message.UserMessageId
 let testUserMessageId = UserMessageId.make()
 let secondTestUserMessageId = UserMessageId.make()
 
-type domParser
-@new external makeDomParser: unit => domParser = "DOMParser"
-@send
-external parseHtml: (domParser, string, @as("text/html") _) => WebAPI.DomTypes.document =
-  "parseFromString"
-
 @schema
 type pageRoutingMeta = {astro_client_routing: option<string>}
 
@@ -30,8 +24,9 @@ module TestHelpers = {
   let activeAcpSession = (
     ~deleteSession=(_, ~onComplete as _) => (),
     ~requireAuthentication=() => (),
+    ~sendPrompt=(_, ~additionalBlocks as _, ~onComplete as _, ~_meta as _) => (),
   ): Client__State__Types.acpSession => AcpSessionActive({
-    sendPrompt: (_, ~additionalBlocks as _, ~onComplete as _, ~_meta as _) => (),
+    sendPrompt,
     sendSessionCommand: _ => (),
     loadTask: (_, ~needsHistory as _, ~onComplete as _) => (),
     deleteSession,
@@ -1818,8 +1813,14 @@ describe("Client State Reducer - Annotations on Messages", () => {
 
   test("SendMessage includes fresh routing metadata only for Astro previews", t => {
     let enabledDocument =
-      makeDomParser()->parseHtml("<meta name=\"astro-view-transitions-enabled\" content=\"true\">")
-    let disabledDocument = makeDomParser()->parseHtml("<title>No client router</title>")
+      WebAPI.DomGlobal.document.implementation->WebAPI.DOMImplementation.createHTMLDocument(
+        ~title="",
+      )
+    enabledDocument.head.innerHTML = "<meta name=\"astro-view-transitions-enabled\" content=\"true\">"
+    let disabledDocument =
+      WebAPI.DomGlobal.document.implementation->WebAPI.DOMImplementation.createHTMLDocument(
+        ~title="",
+      )
     [
       ("astro", Some(enabledDocument), Some("enabled")),
       ("astro", Some(disabledDocument), Some("disabled")),
@@ -1844,15 +1845,10 @@ describe("Client State Reducer - Annotations on Messages", () => {
         )
         let state = {
           ...state,
-          acpSession: AcpSessionActive({
-            sendPrompt: (_, ~additionalBlocks, ~onComplete as _, ~_meta as _) =>
+          acpSession: TestHelpers.activeAcpSession(
+            ~sendPrompt=(_, ~additionalBlocks, ~onComplete as _, ~_meta as _) =>
               sentBlocks := additionalBlocks,
-            sendSessionCommand: _ => (),
-            loadTask: (_, ~needsHistory as _, ~onComplete as _) => (),
-            deleteSession: (_, ~onComplete as _) => (),
-            requireAuthentication: () => (),
-            apiBaseUrl: "http://localhost:4000",
-          }),
+          ),
         }
         let (state, effects) = Reducer.next(
           state,

--- a/libs/frontman-astro-browser/package.json
+++ b/libs/frontman-astro-browser/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@frontman-ai/frontman-protocol": "workspace:*",
     "@rescript/webapi": "workspace:*",
+    "jsdom": "^30.0.1",
     "rescript": "catalog:",
     "rescript-vitest": "catalog:",
     "sury": "catalog:",

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__ClientRouting.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__ClientRouting.res
@@ -1,4 +1,8 @@
-type t = Enabled | Disabled | Unavailable
+@schema
+type t =
+  | @as("enabled") Enabled
+  | @as("disabled") Disabled
+  | @as("unavailable") Unavailable
 
 /// Matches Astro 5–7's transitionEnabledOnThisPage: marker presence means
 /// routing opt-in, not browser animation support or completed navigation.

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__ClientRouting.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__ClientRouting.res
@@ -1,0 +1,16 @@
+type t = Enabled | Disabled | Unavailable
+
+/// Matches Astro 5–7's transitionEnabledOnThisPage: marker presence means
+/// routing opt-in, not browser animation support or completed navigation.
+let read = (document: option<WebAPI.DomTypes.document>): t => {
+  switch document {
+  | None => Unavailable
+  | Some(document) =>
+    switch document
+    ->WebAPI.Document.querySelector("[name=\"astro-view-transitions-enabled\"]")
+    ->Null.toOption {
+    | Some(_) => Enabled
+    | None => Disabled
+    }
+  }
+}

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__ClientRouting.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__ClientRouting.test.res
@@ -2,10 +2,12 @@ open Vitest
 
 module ClientRouting = FrontmanAstroBrowser__ClientRouting
 
-@module("jsdom") @new
-external makeDom: string => {"window": {"document": WebAPI.DomTypes.document}} = "JSDOM"
-
-let documentFromHtml = html => makeDom(html)["window"]["document"]
+let documentFromHtml = html => {
+  let document =
+    WebAPI.DomGlobal.document.implementation->WebAPI.DOMImplementation.createHTMLDocument(~title="")
+  document.documentElement.innerHTML = html
+  document
+}
 
 describe("FrontmanAstroBrowser__ClientRouting", _t => {
   test("detects the ClientRouter marker", t => {

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__ClientRouting.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__ClientRouting.test.res
@@ -1,0 +1,49 @@
+open Vitest
+
+module ClientRouting = FrontmanAstroBrowser__ClientRouting
+
+@module("jsdom") @new
+external makeDom: string => {"window": {"document": WebAPI.DomTypes.document}} = "JSDOM"
+
+let documentFromHtml = html => makeDom(html)["window"]["document"]
+
+describe("FrontmanAstroBrowser__ClientRouting", _t => {
+  test("detects the ClientRouter marker", t => {
+    let document = documentFromHtml(
+      "<meta name=\"astro-view-transitions-enabled\" content=\"true\">",
+    )
+    t->expect(ClientRouting.read(Some(document)))->Expect.toBe(ClientRouting.Enabled)
+  })
+
+  test("matches Astro's presence check regardless of marker content", t => {
+    let document = documentFromHtml(
+      "<meta name=\"astro-view-transitions-enabled\" content=\"false\">",
+    )
+    t->expect(ClientRouting.read(Some(document)))->Expect.toBe(ClientRouting.Enabled)
+  })
+
+  test("reports disabled without the routing marker", t => {
+    let document = documentFromHtml(
+      "<meta name=\"astro-view-transitions-fallback\" content=\"animate\"><div transition:persist></div>",
+    )
+    t->expect(ClientRouting.read(Some(document)))->Expect.toBe(ClientRouting.Disabled)
+  })
+
+  test("distinguishes an unavailable document from disabled routing", t => {
+    t->expect(ClientRouting.read(None))->Expect.toBe(ClientRouting.Unavailable)
+  })
+
+  test("reads the current document without caching routing status", t => {
+    let document = documentFromHtml(
+      "<meta name=\"astro-view-transitions-enabled\" content=\"true\">",
+    )
+    t->expect(ClientRouting.read(Some(document)))->Expect.toBe(ClientRouting.Enabled)
+    let marker =
+      document
+      ->WebAPI.Document.querySelector("[name=\"astro-view-transitions-enabled\"]")
+      ->Null.toOption
+      ->Option.getOrThrow
+    marker->WebAPI.Element.remove
+    t->expect(ClientRouting.read(Some(document)))->Expect.toBe(ClientRouting.Disabled)
+  })
+})

--- a/libs/frontman-astro-browser/vitest.config.ts
+++ b/libs/frontman-astro-browser/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
     include: ['test/**/*.test.res.mjs'],
     globals: true,
     passWithNoTests: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,7 @@ __metadata:
     "@frontman-ai/frontman-protocol": "workspace:*"
     "@rescript/runtime": "catalog:"
     "@rescript/webapi": "workspace:*"
+    jsdom: "npm:^30.0.1"
     rescript: "catalog:"
     rescript-vitest: "catalog:"
     sury: "catalog:"


### PR DESCRIPTION
## Summary
- Combine #1669 and #1670 so the routing detector ships with a production caller.
- Read the current preview routing marker when submitting Astro prompts; omit Astro metadata for other frameworks.
- Preserve enabled, disabled, and unavailable states through server parsing, embedded storage, and ACP history replay.
- Add conditional lifecycle guidance to agent prompts without claiming that routing opt-in proves completed navigation.
- Include DOM, submission-path, round-trip, validation, and persistence tests plus a changeset.

## Validation
- Client suite: 430 passed.
- Astro browser suite: 9 passed.
- Server precommit: compile, formatting, strict Credo, and 904 tests passed.
- Commit and push hooks passed.

Closes #1669
Closes #1670