### PR TITLE
fix: replace Git dependency with published component-source package

### DIFF
--- a/.changeset/good-pigs-prove.md
+++ b/.changeset/good-pigs-prove.md
@@ -1,0 +1,7 @@
+---
+"@frontman-ai/astro": patch
+"@frontman-ai/nextjs": patch
+"@frontman-ai/vite": patch
+---
+
+Install the prebuilt component-source package from npm instead of building it from Git. This removes the nested Yarn install that blocked Dependabot updates.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,4 @@
 approvedGitRepositories:
-  - "https://github.com/frontman-ai/dom-element-to-component-source.git"
   - "https://github.com/frontman-ai/reworker.git"
 
 catalog:

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -56,7 +56,7 @@
 		"@zumer/snapdom": "^2.24.7",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"dom-accessibility-api": "^0.7.1",
-		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",
+		"dom-element-to-component-source": "npm:@frontman-ai/dom-element-to-component-source@0.5.0",
 		"lucide-react": "^1.28.0",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",

--- a/libs/frontman-astro/package.json
+++ b/libs/frontman-astro/package.json
@@ -73,7 +73,7 @@
 		"@frontman/bindings": "*",
 		"@rescript/runtime": "catalog:",
 		"@rescript/webapi": "workspace:*",
-		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",
+		"dom-element-to-component-source": "npm:@frontman-ai/dom-element-to-component-source@0.5.0",
 		"rescript": "catalog:",
 		"rescript-vitest": "catalog:",
 		"sury": "catalog:",

--- a/libs/frontman-core/package.json
+++ b/libs/frontman-core/package.json
@@ -37,7 +37,7 @@
 		"@frontman/bindings": "0.3.2",
 		"@rescript/runtime": "catalog:",
 		"chrome-launcher": "^1.1.2",
-		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",
+		"dom-element-to-component-source": "npm:@frontman-ai/dom-element-to-component-source@0.5.0",
 		"lighthouse": "^13.4.0",
 		"sury": "catalog:"
 	},

--- a/libs/frontman-nextjs/package.json
+++ b/libs/frontman-nextjs/package.json
@@ -65,7 +65,7 @@
 	"dependencies": {
 		"@sentry/nextjs": "^10.69.0",
 		"chrome-launcher": "^1.1.2",
-		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",
+		"dom-element-to-component-source": "npm:@frontman-ai/dom-element-to-component-source@0.5.0",
 		"lighthouse": "^13.4.0",
 		"source-map": "^0.7.6"
 	},

--- a/libs/frontman-vite/package.json
+++ b/libs/frontman-vite/package.json
@@ -69,7 +69,7 @@
 		"@frontman-ai/frontman-protocol": "*",
 		"@rescript/runtime": "catalog:",
 		"@rescript/webapi": "workspace:*",
-		"dom-element-to-component-source": "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb",
+		"dom-element-to-component-source": "npm:@frontman-ai/dom-element-to-component-source@0.5.0",
 		"rescript": "catalog:",
 		"rescript-vitest": "catalog:",
 		"sury": "catalog:",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,7 +2362,7 @@ __metadata:
     "@rescript/webapi": "workspace:*"
     "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+    dom-element-to-component-source: "npm:@frontman-ai/dom-element-to-component-source@0.5.0"
     lighthouse: "npm:^13.4.0"
     magic-string: "npm:^0.30.21"
     rescript: "catalog:"
@@ -2417,7 +2417,7 @@ __metadata:
     border-beam: "npm:^1.3.0"
     diff: "npm:^9.0.0"
     dom-accessibility-api: "npm:^0.7.1"
-    dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+    dom-element-to-component-source: "npm:@frontman-ai/dom-element-to-component-source@0.5.0"
     lucide-react: "npm:^1.28.0"
     react: "npm:^19.2.8"
     react-dom: "npm:^19.2.8"
@@ -2466,7 +2466,7 @@ __metadata:
     "@rescript/webapi": "workspace:*"
     "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+    dom-element-to-component-source: "npm:@frontman-ai/dom-element-to-component-source@0.5.0"
     lighthouse: "npm:^13.4.0"
     rescript: "catalog:"
     rescript-vitest: "catalog:"
@@ -2526,7 +2526,7 @@ __metadata:
     "@sentry/nextjs": "npm:^10.69.0"
     "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+    dom-element-to-component-source: "npm:@frontman-ai/dom-element-to-component-source@0.5.0"
     lighthouse: "npm:^13.4.0"
     next: "npm:^16.2.10"
     react: "npm:^19.2.8"
@@ -2593,7 +2593,7 @@ __metadata:
     "@rescript/webapi": "workspace:*"
     "@vscode/ripgrep": "npm:^1.18.0"
     chrome-launcher: "npm:^1.1.2"
-    dom-element-to-component-source: "https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+    dom-element-to-component-source: "npm:@frontman-ai/dom-element-to-component-source@0.5.0"
     lighthouse: "npm:^13.4.0"
     rescript: "catalog:"
     rescript-vitest: "catalog:"
@@ -10039,14 +10039,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-element-to-component-source@https://github.com/frontman-ai/dom-element-to-component-source.git#7f5fa7f3fecc65a23cc05a92345f1c556fb252bb":
+"dom-element-to-component-source@npm:@frontman-ai/dom-element-to-component-source@0.5.0":
   version: 0.5.0
-  resolution: "dom-element-to-component-source@https://github.com/frontman-ai/dom-element-to-component-source.git#commit=7f5fa7f3fecc65a23cc05a92345f1c556fb252bb"
+  resolution: "@frontman-ai/dom-element-to-component-source@npm:0.5.0"
   dependencies:
     error-stack-parser: "npm:^2.1.4"
     source-map: "npm:^0.7.6"
     stacktrace-gps: "npm:^3.1.2"
-  checksum: 10c0/49f21fe8798944d261a707e1d7e677b4d5d0c829d417e1530a43c3c052cf989d2306c7780ada3daa9d5fec8521eba3ebf4df4c0ceb36d6ccdb8849fda0c526a0
+  checksum: 10c0/47a598974093c0e96f4beb34e38eb8c9f4080b18a992bfbf7c0750df3c52ccc1fc9a408d6cccffb6a67506204c75dc49f368638c31217d2b27c5951345b9f018
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Replace all five component-source Git dependencies with npm aliases for `@frontman-ai/dom-element-to-component-source@0.5.0`.
- Keep existing imports and the fork’s source-resolution fixes.
- Remove the unused Git approval, regenerate the lockfile, and add a changeset.

## Why
The sharp Dependabot job exposed a network failure during the nested Yarn install used to pack this Git dependency. Installing the prebuilt npm package removes that step for all dependency updates.

## Validation
- Published package build and 79 targeted tests passed before publication.
- Immutable Yarn install passed.
- Published browser and server exports loaded successfully.
- Pre-commit checks passed.
- Dependabot verification remains pending after merge.

Related failure: https://github.com/frontman-ai/frontman/actions/runs/34332471202