### PR TITLE
feat(wordpress): add scoped Redirection tools and archive metadata

### DIFF
--- a/.changeset/perky-cows-unite.md
+++ b/.changeset/perky-cows-unite.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-wordpress": minor
+---
+
+Expose custom post type archive URLs and registration metadata in site information. Add permission-checked Redirection tools to list rules, create literal-path 301/302 redirects or 404/410 responses, and delete individual rules with confirmation. Keep CPT registration and PHP files unchanged.

--- a/libs/frontman-wordpress/frontman.php
+++ b/libs/frontman-wordpress/frontman.php
@@ -65,6 +65,7 @@ require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-templates.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-widgets.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-cache.php';
 require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-seo.php';
+require_once FRONTMAN_PLUGIN_DIR . 'tools/class-tool-redirection.php';
 
 /**
  * Main plugin bootstrap.
@@ -80,6 +81,10 @@ function frontman_init(): void {
 	( new Frontman_Tool_Templates() )->register( $tools );
 	( new Frontman_Tool_Widgets() )->register( $tools );
 	( new Frontman_Tool_Cache() )->register( $tools );
+
+	if ( Frontman_Tool_Redirection::is_available() ) {
+		( new Frontman_Tool_Redirection() )->register( $tools );
+	}
 
 	if ( Frontman_Tool_Seo::is_available() ) {
 		( new Frontman_Tool_Seo() )->register( $tools );

--- a/libs/frontman-wordpress/tests/integration/RedirectionRuntimeTest.php
+++ b/libs/frontman-wordpress/tests/integration/RedirectionRuntimeTest.php
@@ -1,0 +1,149 @@
+<?php
+/** Integration contract against the official Redirection 5.10.0 package. */
+require '/var/www/html/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+function redirection_check( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$admin = get_user_by( 'login', 'admin' );
+wp_set_current_user( $admin->ID );
+$tools = Frontman_Tools::instance();
+
+if ( in_array( '--setup', $argv, true ) ) {
+	redirection_check( ! Frontman_Tool_Redirection::is_available(), 'Inactive Redirection must be unavailable.' );
+	redirection_check( null === $tools->get( 'wp_create_redirect' ), 'Inactive plugin tools must not be registered.' );
+	$result = activate_plugin( 'redirection/redirection.php' );
+	redirection_check( ! is_wp_error( $result ), 'Redirection activation failed.' );
+	redirection_check( REDIRECTION_VERSION === '5.10.0', 'Unexpected Redirection version.' );
+	$result = ( new \Redirection\Database\Schema\Latest() )->install();
+	redirection_check( true === $result, 'Redirection database installation failed.' );
+	( new \Redirection\Database\Status() )->finish();
+	file_put_contents( WPMU_PLUGIN_DIR . '/frontman-redirection-runtime.php', <<<'PHP'
+<?php
+add_action( 'init', static function () {
+	register_post_type( 'neuros_team_member', [ 'public' => true, 'has_archive' => 'team', 'rewrite' => [ 'slug' => 'team' ] ] );
+} );
+PHP
+	);
+	update_option( 'permalink_structure', '/%postname%/' );
+	file_put_contents( ABSPATH . '.htaccess', "RewriteEngine On\nRewriteBase /\nRewriteRule ^index\\.php$ - [L]\nRewriteCond %{REQUEST_FILENAME} !-f\nRewriteCond %{REQUEST_FILENAME} !-d\nRewriteRule . /index.php [L]\n" );
+	exit( 0 );
+}
+
+set_error_handler( static function ( int $severity, string $message, string $file, int $line ): bool {
+	if ( error_reporting() & $severity ) {
+		throw new ErrorException( $message, 0, $severity, $file, $line );
+	}
+	return false;
+} );
+
+function redirection_call( string $name, array $input, bool $expect_error = false ): array {
+	global $tools;
+	$result = $tools->call( $name, $tools->sanitize_input( $name, $input ) );
+	redirection_check( $result['isError'] === $expect_error, $name . ': ' . $result['content'][0]['text'] );
+	return $expect_error ? $result : json_decode( $result['content'][0]['text'], true, 512, JSON_THROW_ON_ERROR );
+}
+
+function redirection_http( string $path, int $status, ?string $location = null ): void {
+	$response = wp_remote_get( 'http://localhost' . $path, [ 'redirection' => 0, 'headers' => [ 'Host' => 'frontman-runtime.example.test' ] ] );
+	redirection_check( ! is_wp_error( $response ), 'HTTP request failed: ' . $path );
+	redirection_check( $status === wp_remote_retrieve_response_code( $response ), $path . ': expected HTTP ' . $status . ', got ' . wp_remote_retrieve_response_code( $response ) );
+	if ( null !== $location ) {
+		redirection_check( $location === wp_remote_retrieve_header( $response, 'location' ), 'Unexpected redirect target.' );
+	}
+}
+
+redirection_check( null !== $tools->get( 'wp_create_redirect' ), 'Active Redirection tools must register on a fresh request.' );
+redirection_check( $tools->get( 'wp_list_redirects' )->access === 'read', 'List access classification.' );
+redirection_check( $tools->get( 'wp_create_redirect' )->access === 'read-write', 'Create access classification.' );
+redirection_check( $tools->get( 'wp_delete_redirect' )->access === 'read-write', 'Delete access classification.' );
+$info = redirection_call( 'wp_get_site_info', [] );
+$types = array_column( $info['post_types'], null, 'name' );
+redirection_check( $types['neuros_team_member']['has_archive'] === 'team', 'Preserve the archive slug, not just a boolean.' );
+redirection_check( $types['neuros_team_member']['archive_url'] === home_url( '/team/' ), 'Resolved archive URL.' );
+redirection_check( $types['neuros_team_member']['rewrite']['slug'] === 'team', 'Rewrite metadata.' );
+redirection_check( true === $types['neuros_team_member']['publicly_queryable'], 'Queryable metadata.' );
+redirection_check( false === $types['page']['has_archive'] && null === $types['page']['archive_url'], 'No archive uses null URL.' );
+
+$member = wp_insert_post( [ 'post_type' => 'neuros_team_member', 'post_title' => 'Alice', 'post_name' => 'alice', 'post_status' => 'publish' ], true );
+redirection_check( ! is_wp_error( $member ), 'Team member fixture.' );
+flush_rewrite_rules( false );
+redirection_http( '/team/', 200 );
+redirection_http( '/team/alice/', 200 );
+$listing = redirection_call( 'wp_list_redirects', [] );
+$group = $listing['groups']['items'][0]['id'];
+$input = [ 'source' => '/team/', 'code' => 410, 'group_id' => $group, 'confirm' => true ];
+foreach ( [
+	[ 'confirm' => false ], [ 'confirm' => 'true' ], [ 'source' => '/' ], [ 'source' => '//evil.example' ],
+	[ 'source' => '/team/?x=1' ], [ 'source' => '/team/#hash' ], [ 'source' => '/te%61m/' ],
+	[ 'source' => '/team/../' ], [ 'source' => '/team/*' ], [ 'source' => "/team/\r\n" ],
+	[ 'code' => 500 ], [ 'code' => '410' ], [ 'group_id' => 999999 ], [ 'group_id' => '1' ],
+	[ 'target' => '/replacement/' ], [ 'code' => 301 ],
+	[ 'code' => 301, 'target' => '/team' ], [ 'code' => 302, 'target' => '/TEAM/' ],
+	[ 'code' => 301, 'target' => 'https://evil.example/' ], [ 'code' => 301, 'target' => '//evil.example/' ],
+	[ 'code' => 301, 'target' => '/replacement/../team/' ],
+] as $invalid ) {
+	redirection_call( 'wp_create_redirect', array_replace( $input, $invalid ), true );
+}
+redirection_call( 'wp_list_redirects', [ 'page' => -1 ], true );
+redirection_check( redirection_call( 'wp_list_redirects', [] )['redirects']['total'] === $listing['redirects']['total'], 'Invalid input must not write rules.' );
+
+wp_set_current_user( 0 );
+redirection_call( 'wp_list_redirects', [], true );
+redirection_call( 'wp_create_redirect', $input, true );
+wp_set_current_user( $admin->ID );
+$deny = static function ( $capability, $permission ) {
+	return in_array( $permission, [ 'redirection_cap_redirect_add', 'redirection_cap_redirect_delete' ], true ) ? 'do_not_allow' : $capability;
+};
+add_filter( 'redirection_capability_check', $deny, 10, 2 );
+redirection_call( 'wp_create_redirect', $input, true );
+remove_filter( 'redirection_capability_check', $deny );
+
+$created = redirection_call( 'wp_create_redirect', $input );
+$id = $created['after']['id'];
+redirection_check( null === $created['before'], 'Create snapshot.' );
+add_filter( 'redirection_capability_check', $deny, 10, 2 );
+redirection_call( 'wp_delete_redirect', [ 'id' => $id, 'expected_source' => '/team/', 'confirm' => true ], true );
+remove_filter( 'redirection_capability_check', $deny );
+redirection_call( 'wp_create_redirect', $input, true );
+redirection_call( 'wp_create_redirect', array_replace( $input, [ 'source' => '/team' ] ), true );
+redirection_http( '/team/', 410 );
+redirection_http( '/team', 410 );
+redirection_http( '/team/?utm_source=test', 410 );
+redirection_http( '/team/alice/', 200 );
+redirection_http( '/team/feed/', 200 );
+redirection_http( '/team/page/2/', 404 );
+redirection_check( get_post_type_object( 'neuros_team_member' )->has_archive === 'team', 'Registration must not be mutated.' );
+redirection_call( 'wp_delete_redirect', [ 'id' => $id, 'expected_source' => '/wrong/', 'confirm' => true ], true );
+redirection_call( 'wp_delete_redirect', [ 'id' => $id, 'expected_source' => '/team/', 'confirm' => false ], true );
+$deleted = redirection_call( 'wp_delete_redirect', [ 'id' => $id, 'expected_source' => '/team/', 'confirm' => true ] );
+redirection_check( $deleted['before']['id'] === $id && null === $deleted['after'], 'Delete snapshot.' );
+redirection_http( '/team/', 200 );
+redirection_call( 'wp_delete_redirect', [ 'id' => $id, 'expected_source' => '/team/', 'confirm' => true ], true );
+
+foreach ( [ 301, 302, 404 ] as $code ) {
+	$args = array_replace( $input, [ 'code' => $code ] );
+	if ( $code < 400 ) {
+		$args['target'] = '/replacement/';
+	}
+	$rule = redirection_call( 'wp_create_redirect', $args )['after'];
+	redirection_http( '/team/?tracking=1', $code, $code < 400 ? '/replacement/' : null );
+	redirection_call( 'wp_delete_redirect', [ 'id' => $rule['id'], 'expected_source' => '/team/', 'confirm' => true ] );
+}
+
+$seed = [ 'group_id' => $group, 'match_type' => 'url', 'action_type' => 'error', 'action_code' => 410 ];
+$existing = Red_Item::create( $seed + [ 'url' => '/team', 'enabled' => false ] );
+redirection_check( ! is_wp_error( $existing ), 'Disabled duplicate fixture.' );
+for ( $i = 0; $i < 101; $i++ ) {
+	redirection_check( ! is_wp_error( Red_Item::create( $seed + [ 'url' => '/team-child-' . $i ] ) ), 'Pagination fixture.' );
+}
+redirection_call( 'wp_create_redirect', $input, true );
+$page = redirection_call( 'wp_list_redirects', [ 'source' => '/team/', 'page' => 1 ] );
+redirection_check( count( $page['redirects']['items'] ) === 2, 'Second rule page.' );
+
+restore_error_handler();
+fwrite( STDOUT, 'OK (Redirection ' . REDIRECTION_VERSION . ', WordPress ' . get_bloginfo( 'version' ) . ', PHP ' . PHP_VERSION . ")\n" );

--- a/libs/frontman-wordpress/tools/class-tool-redirection.php
+++ b/libs/frontman-wordpress/tools/class-tool-redirection.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Narrow URL retirement tools backed by the Redirection plugin's REST API.
+ *
+ * @package Frontman
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Frontman_Tool_Redirection {
+	public static function is_available(): bool {
+		return Frontman_Plugin_Dependencies::is_available( 'redirection/redirection.php' );
+	}
+
+	public function register( Frontman_Tools $tools ): void {
+		$path = [ 'type' => 'string', 'description' => 'Literal site-root path, e.g. /team/. ASCII letters, digits, slash, dot, underscore, hyphen and tilde only. No query, fragment, encoding, wildcard or dot segments.' ];
+		$confirm = [ 'type' => 'boolean', 'description' => 'Must be true after user approval.' ];
+		$definitions = [
+			'wp_list_redirects' => [
+				'Lists Redirection rules and enabled WordPress groups. Page is zero-based; each page contains up to 100 rules and 100 groups. Optional source filters source URLs by substring. Inspect existing rules before creating one, including regex rules that may overlap.',
+				[ 'page' => [ 'type' => 'integer', 'minimum' => 0 ], 'source' => $path ], [], 'list_redirects', 'read',
+			],
+			'wp_create_redirect' => [
+				'Creates one literal-path Redirection rule: 301/302 to a same-site target path, or 404/410 without a target. Requires an enabled WordPress group ID from wp_list_redirects and confirm=true. Matches both trailing-slash variants, case-sensitively; ignores and drops query strings. Does not cover child paths (pagination, feeds, individual CPT entries), disable CPT archives, or edit PHP. Rejects duplicate literal sources and direct self-redirects, but does not detect redirect chains or regex overlap. Verify the public HTTP result and clear relevant caches afterward. Never retry a failed write blindly; list rules first.',
+				[ 'source' => $path, 'target' => $path, 'code' => [ 'type' => 'integer', 'enum' => [ 301, 302, 404, 410 ] ], 'group_id' => [ 'type' => 'integer', 'minimum' => 1 ], 'confirm' => $confirm ],
+				[ 'source', 'code', 'group_id', 'confirm' ], 'create_redirect', 'read-write',
+			],
+			'wp_delete_redirect' => [
+				'Deletes one Redirection rule by ID after user approval (confirm=true). Supply its exact source URL from wp_list_redirects as expected_source to guard against deleting the wrong rule. Returns the deleted rule for reference.',
+				[ 'id' => [ 'type' => 'integer', 'minimum' => 1 ], 'expected_source' => [ 'type' => 'string' ], 'confirm' => $confirm ],
+				[ 'id', 'expected_source', 'confirm' ], 'delete_redirect', 'read-write',
+			],
+		];
+		foreach ( $definitions as $name => [ $description, $properties, $required, $handler, $access ] ) {
+			$tools->add( new Frontman_Tool_Definition(
+				$name, $description,
+				[ 'type' => 'object', 'additionalProperties' => false, 'properties' => $properties, 'required' => $required ],
+				[ $this, $handler ], $access, true, true
+			) );
+		}
+	}
+
+	private function request( string $method, string $route, array $params = [] ): array {
+		if ( ! self::is_available() || ! current_user_can( 'manage_options' ) ) {
+			throw new Frontman_Tool_Error( 'Redirection must be active and the user must have manage_options permission.' );
+		}
+		$request = new WP_REST_Request( $method, '/redirection/v1/' . $route );
+		if ( 'GET' === $method ) {
+			$request->set_query_params( $params );
+		} else {
+			$request->set_body_params( $params );
+		}
+		$response = rest_do_request( $request );
+		$data = $response->get_data();
+		if ( $response->is_error() ) {
+			throw new Frontman_Tool_Error( 'Redirection: ' . ( $data['message'] ?? 'API request failed.' ) );
+		}
+		if ( ! is_array( $data ) ) {
+			throw new Frontman_Tool_Error( 'Unexpected Redirection API response. Inspect rules before retrying.' );
+		}
+		return $data;
+	}
+
+	private function path( $value ): string {
+		if ( ! is_string( $value ) || strlen( $value ) > 2000 || ! preg_match( '~^/[a-zA-Z0-9/._\x7e-]*$~D', $value )
+			|| strpos( $value, '//' ) !== false || preg_match( '~(?:^|/)\.{1,2}(?:/|$)~', $value ) ) {
+			throw new Frontman_Tool_Error( 'Use a literal site-root ASCII path without query, fragment, encoding, wildcard or dot segments.' );
+		}
+		return $value;
+	}
+
+	private function positive_id( $value ): int {
+		if ( ! is_int( $value ) || $value < 1 ) {
+			throw new Frontman_Tool_Error( 'ID must be a positive integer.' );
+		}
+		return $value;
+	}
+
+	private function confirm( array $input ): void {
+		if ( true !== ( $input['confirm'] ?? null ) ) {
+			throw new Frontman_Tool_Error( 'User approval and confirm=true are required.' );
+		}
+	}
+
+	private function groups( int $page ): array {
+		return $this->request( 'GET', 'group', [ 'page' => $page, 'per_page' => 100, 'filterBy' => [ 'module' => '1', 'status' => 'enabled' ] ] );
+	}
+
+	public function list_redirects( array $input ): array {
+		$page = $input['page'] ?? 0;
+		if ( ! is_int( $page ) || $page < 0 ) {
+			throw new Frontman_Tool_Error( 'page must be a non-negative integer.' );
+		}
+		$params = [ 'page' => $page, 'per_page' => 100 ];
+		if ( array_key_exists( 'source', $input ) ) {
+			$params['filterBy'] = [ 'url' => rtrim( $this->path( $input['source'] ), '/' ) ];
+		}
+		return [ 'page' => $page, 'redirects' => $this->request( 'GET', 'redirect', $params ), 'groups' => $this->groups( $page ) ];
+	}
+
+	/** Read candidate literal sources across all pages, including disabled rules. */
+	private function source_rules( string $source ): array {
+		$items = [];
+		$page = 0;
+		do {
+			$data = $this->request( 'GET', 'redirect', [ 'page' => $page++, 'per_page' => 100, 'filterBy' => [ 'url' => rtrim( $source, '/' ) ] ] );
+			foreach ( $data['items'] as $item ) {
+				if ( ! $item['regex'] && strtolower( rtrim( $item['url'], '/' ) ) === strtolower( rtrim( $source, '/' ) ) ) {
+					$items[] = $item;
+				}
+			}
+		} while ( $page * 100 < $data['total'] );
+		return $items;
+	}
+
+	public function create_redirect( array $input ): array {
+		$this->confirm( $input );
+		$source = $this->path( $input['source'] ?? null );
+		$group_id = $this->positive_id( $input['group_id'] ?? null );
+		$code = $input['code'] ?? null;
+		if ( '/' === $source || ! in_array( $code, [ 301, 302, 404, 410 ], true ) ) {
+			throw new Frontman_Tool_Error( 'Source cannot be the site root; code must be 301, 302, 404 or 410.' );
+		}
+		$target = '';
+		if ( in_array( $code, [ 301, 302 ], true ) ) {
+			$target = $this->path( $input['target'] ?? null );
+			if ( strtolower( rtrim( $source, '/' ) ) === strtolower( rtrim( $target, '/' ) ) ) {
+				throw new Frontman_Tool_Error( 'Source and target must differ, including trailing-slash variants.' );
+			}
+		} elseif ( array_key_exists( 'target', $input ) ) {
+			throw new Frontman_Tool_Error( '404/410 rules must not include a target.' );
+		}
+		$found = false;
+		$page = 0;
+		do {
+			$groups = $this->groups( $page++ );
+			foreach ( $groups['items'] as $group ) {
+				$found = $found || $group['id'] === $group_id;
+			}
+		} while ( ! $found && $page * 100 < $groups['total'] );
+		if ( ! $found ) {
+			throw new Frontman_Tool_Error( 'Choose an enabled WordPress group from wp_list_redirects.' );
+		}
+		if ( $this->source_rules( $source ) ) {
+			throw new Frontman_Tool_Error( 'A rule already exists for this source. Inspect it instead of creating a duplicate.' );
+		}
+		/** ponytail: best-effort duplicate check, not atomic; add locking if concurrent rule creation becomes common. */
+		$this->request( 'POST', 'redirect', [
+			'url' => $source, 'group_id' => $group_id, 'match_type' => 'url',
+			'action_type' => $target === '' ? 'error' : 'url', 'action_code' => $code,
+			'action_data' => [ 'url' => $target ],
+			'match_data' => [ 'source' => [ 'flag_regex' => false, 'flag_trailing' => true, 'flag_case' => false, 'flag_query' => 'ignore' ] ],
+		] );
+		$after = $this->source_rules( $source );
+		if ( count( $after ) !== 1 || $after[0]['action_code'] !== $code || $after[0]['group_id'] !== $group_id
+			|| ! $after[0]['enabled'] || $after[0]['action_type'] !== ( $target === '' ? 'error' : 'url' )
+			|| ( $target !== '' && $after[0]['action_data']['url'] !== $target ) ) {
+			throw new Frontman_Tool_Error( 'Could not verify the saved rule. Inspect wp_list_redirects before retrying.' );
+		}
+		return [ 'before' => null, 'after' => $after[0] ];
+	}
+
+	public function delete_redirect( array $input ): array {
+		$this->confirm( $input );
+		$id = $this->positive_id( $input['id'] ?? null );
+		$params = [ 'filterBy' => [ 'id' => (string) $id ] ];
+		$before = $this->request( 'GET', 'redirect', $params );
+		if ( count( $before['items'] ) !== 1 || ( $input['expected_source'] ?? null ) !== $before['items'][0]['url'] ) {
+			throw new Frontman_Tool_Error( 'Rule not found or source changed. Read wp_list_redirects before deleting.' );
+		}
+		$this->request( 'POST', 'bulk/redirect/delete', [ 'items' => [ $id ], 'global' => false ] );
+		$after = $this->request( 'GET', 'redirect', $params );
+		if ( $after['total'] !== 0 ) {
+			throw new Frontman_Tool_Error( 'Rule deletion did not persist. Inspect wp_list_redirects before retrying.' );
+		}
+		return [ 'before' => $before['items'][0], 'after' => null ];
+	}
+}

--- a/libs/frontman-wordpress/tools/class-tool-templates.php
+++ b/libs/frontman-wordpress/tools/class-tool-templates.php
@@ -21,7 +21,7 @@ class Frontman_Tool_Templates {
 	public function register( Frontman_Tools $tools ): void {
 		$tools->add( new Frontman_Tool_Definition(
 			'wp_get_site_info',
-			'Returns comprehensive site information including WordPress version, active theme, active plugins, registered post types, and taxonomies.',
+			'Returns comprehensive site information including WordPress version, active theme, active plugins, registered public post types with archive URLs and rewrite settings, and taxonomies. CPT archives are generated routes, not backing pages/posts.',
 			[
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -165,9 +165,13 @@ class Frontman_Tool_Templates {
 		$pt_list    = [];
 		foreach ( $post_types as $pt ) {
 			$pt_list[] = [
-				'name'  => $pt->name,
-				'label' => $pt->label,
-				'count' => (int) wp_count_posts( $pt->name )->publish,
+				'name'               => $pt->name,
+				'label'              => $pt->label,
+				'count'              => (int) wp_count_posts( $pt->name )->publish,
+				'has_archive'        => $pt->has_archive,
+				'archive_url'        => get_post_type_archive_link( $pt->name ) ?: null,
+				'rewrite'            => $pt->rewrite,
+				'publicly_queryable' => $pt->publicly_queryable,
 			];
 		}
 

--- a/scripts/test-wordpress-plugin-runtime.sh
+++ b/scripts/test-wordpress-plugin-runtime.sh
@@ -128,3 +128,22 @@ if [[ "$MULTISITE_STATUS" -ne 0 || "$MULTISITE_OUTPUT" != *"OK (Multisite author
   printf 'Multisite author tests did not report successful completion.\n' >&2
   exit 1
 fi
+
+case "$WORDPRESS_VERSION" in
+  6.[0-6].*) printf 'Skipping Redirection 5.10.0: requires WordPress 6.7+.\n'; exit 0 ;;
+esac
+curl -fsSL 'https://downloads.wordpress.org/plugin/redirection.5.10.0.zip' -o "$BUILD_DIR/redirection.zip"
+printf '%s  %s\n' '966ac6267cd6a99f2d79ec05db1dee2e0aa0cddb6060b1c32cde2ffde739e333' "$BUILD_DIR/redirection.zip" | sha256sum --check --status
+unzip -q "$BUILD_DIR/redirection.zip" -d "$BUILD_DIR/redirection"
+"$RUNTIME" cp "$BUILD_DIR/redirection/redirection" "$WORDPRESS:/var/www/html/wp-content/plugins/redirection"
+"$RUNTIME" cp "$ROOT_DIR/libs/frontman-wordpress/tests/integration/RedirectionRuntimeTest.php" "$WORDPRESS:/tmp/RedirectionRuntimeTest.php"
+"$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/RedirectionRuntimeTest.php --setup
+if REDIRECTION_OUTPUT="$("$RUNTIME" exec "$WORDPRESS" php -d display_errors=1 -d error_reporting=E_ALL /tmp/RedirectionRuntimeTest.php)"; then
+  REDIRECTION_STATUS=0
+else REDIRECTION_STATUS=$?
+fi
+printf '%s\n' "$REDIRECTION_OUTPUT"
+if [[ "$REDIRECTION_STATUS" -ne 0 || "$REDIRECTION_OUTPUT" != *"OK (Redirection 5.10.0, WordPress ${WORDPRESS_VERSION}, PHP "* ]]; then
+  printf 'Redirection runtime tests did not report successful completion.\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Closes the CPT archive cleanup gap reported for task `5687f876-4430-4416-8ef3-dc58f6fdf974` without adding PHP-file access or changing CPT registration.

- Extend `wp_get_site_info` with `has_archive`, resolved archive URL, rewrite settings, and public queryability.
- Add `wp_list_redirects`, `wp_create_redirect`, and `wp_delete_redirect` when Redirection is active. Use its existing REST API and permission checks; mutations require confirmation and return observed snapshots.
- Support literal-path 301/302 same-site redirects and 404/410 responses. Reject invalid paths, duplicate literal sources, and direct self-redirects; guard deletion with ID plus expected source.

## Scope limits
No regex creation, external destinations, bulk mutation, CPT toggles, or theme/plugin editing. Matching ignores trailing slashes and query strings but does not cover child paths. Duplicate detection is best-effort, not atomic; redirect chains and overlapping regex rules need inspection. Other caches may need clearing.

## Verification
- `make test-wordpress-core-tools` (PHP 8.4 via Podman): passed.
- `CONTAINER_RUNTIME=podman make test-wordpress-runtime`: passed on WordPress 7.0.2 / PHP 8.4.
- Same runtime target with `PHP_VERSION=7.4`: passed.
- Same runtime target with `YOAST_VERSION=28.4`: passed on PHP 8.4.
- Same runtime target with `WORDPRESS_VERSION=6.0.9 PHP_VERSION=7.4`: core/multisite passed; Redirection 5.10.0 correctly skipped because it requires WordPress 6.7+.
- New tests use the SHA-256-verified official Redirection 5.10.0 package and real HTTP requests: 301/302/404/410, trailing slashes, query handling, individual CPT URLs, feed/pagination boundaries, rollback, provider permissions, and paginated duplicate checks.
- Pre-commit checks passed; changeset included.
