### PR TITLE
feat(astro): expose persistence boundaries in DOM inspection

### DIFF
--- a/.changeset/two-garlics-wink.md
+++ b/.changeset/two-garlics-wink.md
@@ -1,0 +1,8 @@
+---
+"@frontman-ai/client": minor
+"@frontman-ai/astro-browser": minor
+---
+
+Show Astro persistence keys in DOM inspection and element annotations. Astro `get_dom` also describes marked DOM ancestors outside the selected subtree in both output modes.
+
+Ancestor inspection stops at 50 parent steps, 10 marked ancestors, or 4 KB of context, with explicit truncation. It does not cross shadow roots. These markers do not prove that elements or state survived navigation. Inspection for other frameworks remains unchanged.

--- a/libs/client/src/Client__ElementInspector.res
+++ b/libs/client/src/Client__ElementInspector.res
@@ -177,10 +177,11 @@ let describe = (
   ~document: WebAPI.DomTypes.document,
   ~selector: option<string>,
   ~pierceShadowDom: bool,
+  ~additionalAttributes: array<string>,
 ): (string, array<walkChild>) => {
   let fields = [relation]
   pushField(fields, "tag", element.tagName->String.toLowerCase)
-  keyAttributes->Array.forEach(name =>
+  Array.concat(keyAttributes, additionalAttributes)->Array.forEach(name =>
     switch element->WebAPI.Element.getAttribute(name)->Null.toOption {
     | Some(value) =>
       pushField(
@@ -222,6 +223,26 @@ let describe = (
   (fields->Array.join(" "), children)
 }
 
+let describeAncestor = (
+  ~element: WebAPI.DomTypes.element,
+  ~document: WebAPI.DomTypes.document,
+  ~additionalAttributes: array<string>,
+): string => {
+  let selector = switch findSelector(~element, ~document) {
+  | Ok(selector) => Some(selector)
+  | Error(_) => None
+  }
+  let (description, _) = describe(
+    ~relation="ancestor",
+    ~element,
+    ~document,
+    ~selector,
+    ~pierceShadowDom=false,
+    ~additionalAttributes,
+  )
+  description
+}
+
 let rec walk = (
   ~element: WebAPI.DomTypes.element,
   ~document: WebAPI.DomTypes.document,
@@ -230,6 +251,7 @@ let rec walk = (
   ~maxDepth: int,
   ~pierceShadowDom: bool,
   ~insideShadowDom: bool,
+  ~additionalAttributes: array<string>,
   ~state: walkState,
 ): unit =>
   switch state.truncated || state.nodeCount >= state.maxNodes {
@@ -244,6 +266,7 @@ let rec walk = (
       ~document,
       ~selector,
       ~pierceShadowDom,
+      ~additionalAttributes,
     )
     let appended = appendLine(state, "  "->String.repeat(depth) ++ description)
     switch appended {
@@ -271,6 +294,7 @@ let rec walk = (
           | ShadowChild(_) => true
           | LightChild(_) => insideShadowDom
           },
+          ~additionalAttributes,
           ~state,
         )
       })
@@ -291,6 +315,7 @@ let inspect = (
   ~maxNodes: int,
   ~pierceShadowDom=false,
   ~selectedSelector: option<string>=?,
+  ~additionalAttributes=[],
 ): t => {
   let selector = switch selectedSelector {
   | Some(selector) => Ok(selector)
@@ -313,6 +338,7 @@ let inspect = (
       ~document,
       ~selector=parentSelector,
       ~pierceShadowDom=false,
+      ~additionalAttributes,
     )
     description
   | None => "parent none"
@@ -337,6 +363,7 @@ let inspect = (
     ~insideShadowDom=selectedSelector->Option.mapOr(false, selector =>
       selector->String.includes(" >>> ")
     ),
+    ~additionalAttributes,
     ~state,
   )
   switch state.truncated {

--- a/libs/client/src/Client__ToolRegistry.res
+++ b/libs/client/src/Client__ToolRegistry.res
@@ -31,7 +31,18 @@ let forFramework = (framework: Client__RuntimeConfig.frameworkId): t => {
       [
         FrontmanAiAstroBrowser.FrontmanAstroBrowser__Tool__GetDom.make(
           ~getPreviewDoc,
-          ~inspect=Client__Tool__GetDom.inspect,
+          ~inspect=(input, preview) =>
+            Client__Tool__GetDom.inspect(
+              input,
+              preview,
+              ~additionalAttributes=FrontmanAiAstroBrowser.FrontmanAstroBrowser__Persistence.inspectionAttributes,
+            ),
+          ~describeAncestor=(element, preview) =>
+            Client__ElementInspector.describeAncestor(
+              ~element,
+              ~document=preview.doc,
+              ~additionalAttributes=FrontmanAiAstroBrowser.FrontmanAstroBrowser__Persistence.inspectionAttributes,
+            ),
           ~description=Client__Tool__GetDom.description,
         ),
       ],

--- a/libs/client/src/state/Client__Task__Reducer.res
+++ b/libs/client/src/state/Client__Task__Reducer.res
@@ -1381,7 +1381,19 @@ let fetchAnnotationDetails = (
   let inspection = switch document {
   | Some(document) =>
     try {
-      Ok(Client__ElementInspector.inspect(~element, ~document, ~maxDepth=1, ~maxNodes=200))
+      let additionalAttributes = switch Client__RuntimeConfig.read().framework {
+      | Astro => Some(FrontmanAiAstroBrowser.FrontmanAstroBrowser__Persistence.inspectionAttributes)
+      | Nextjs | Vite | Wordpress => None
+      }
+      Ok(
+        Client__ElementInspector.inspect(
+          ~element,
+          ~document,
+          ~maxDepth=1,
+          ~maxNodes=200,
+          ~additionalAttributes?,
+        ),
+      )
     } catch {
     | exn =>
       let message = formatError(exn)

--- a/libs/client/src/tools/Client__Tool__GetDom.res
+++ b/libs/client/src/tools/Client__Tool__GetDom.res
@@ -47,12 +47,22 @@ let countElements = (el: WebAPI.DomTypes.element): int =>
 let buildTooLargeHint = (
   ~el: WebAPI.DomTypes.element,
   ~document: WebAPI.DomTypes.document,
+  ~additionalAttributes: array<string>,
 ): string => {
-  let overview = Client__ElementInspector.inspect(~element=el, ~document, ~maxDepth=1, ~maxNodes=16)
+  let overview = Client__ElementInspector.inspect(
+    ~element=el,
+    ~document,
+    ~maxDepth=1,
+    ~maxNodes=16,
+    ~additionalAttributes,
+  )
   `Target a child selector from this overview instead:\n${overview.html}`
 }
 
-let inspect = (input: input, {doc, win}: Tool.previewContext): result<output, string> => {
+let inspect = (input: input, {doc, win}: Tool.previewContext, ~additionalAttributes=[]): result<
+  (output, WebAPI.DomTypes.element),
+  string,
+> => {
   let (element, _matchCount) = Client__Tool__SelectorResolver.resolveBySelector(
     ~doc,
     ~selector=input.selector,
@@ -74,7 +84,7 @@ let inspect = (input: input, {doc, win}: Tool.previewContext): result<output, st
           `Subtree too large for full mode (${Int.toString(
               elementCount,
             )} elements, limit: ${Int.toString(maxNodes)}).\n` ++
-          buildTooLargeHint(~el, ~document=doc),
+          buildTooLargeHint(~el, ~document=doc, ~additionalAttributes),
         )
       | false =>
         let raw = el.outerHTML
@@ -85,7 +95,7 @@ let inspect = (input: input, {doc, win}: Tool.previewContext): result<output, st
             `HTML too large: ${Int.toString(byteSize)} bytes (limit: ${Int.toString(
                 fullModeMaxBytes,
               )}). Use simplified mode for an overview, or target a smaller component.\n` ++
-            buildTooLargeHint(~el, ~document=doc),
+            buildTooLargeHint(~el, ~document=doc, ~additionalAttributes),
           )
         | false => Ok((raw, elementCount, None))
         }
@@ -106,6 +116,7 @@ let inspect = (input: input, {doc, win}: Tool.previewContext): result<output, st
         ~maxNodes,
         ~pierceShadowDom,
         ~selectedSelector?,
+        ~additionalAttributes,
       )
       let hint = switch inspection.truncated {
       | true =>
@@ -116,13 +127,16 @@ let inspect = (input: input, {doc, win}: Tool.previewContext): result<output, st
       }
       Ok((inspection.html, inspection.nodeCount, hint))
     }
-    content->Result.map(((html, nodeCount, hint)): output => {
-      url: (win->WebAPI.Window.location).href,
-      html,
-      nodeCount,
-      byteSize: Client__ElementInspector.utf8ByteSize(html),
-      hint,
-    })
+    content->Result.map(((html, nodeCount, hint)) => (
+      {
+        GetDom.url: (win->WebAPI.Window.location).href,
+        html,
+        nodeCount,
+        byteSize: Client__ElementInspector.utf8ByteSize(html),
+        hint,
+      },
+      el,
+    ))
   }
 }
 
@@ -135,7 +149,7 @@ let execute = async (
   | None => Tool.MCP.CallToolResult.makeError("Preview frame not available")
   | Some(preview) =>
     switch inspect(input, preview) {
-    | Ok(output) => Tool.structuredResult(output, outputSchema)
+    | Ok((output, _element)) => Tool.structuredResult(output, outputSchema)
     | Error(message) => Tool.MCP.CallToolResult.makeError(message)
     }
   }

--- a/libs/client/test/Client__ElementInspector.test.mjs
+++ b/libs/client/test/Client__ElementInspector.test.mjs
@@ -5,10 +5,7 @@ vi.mock("@medv/finder", () => ({
 }));
 
 import { finder } from "@medv/finder";
-import {
-	describeAncestor,
-	inspect,
-} from "../src/Client__ElementInspector.res.mjs";
+import { inspect } from "../src/Client__ElementInspector.res.mjs";
 
 beforeEach(() => {
 	document.body.innerHTML = "";
@@ -40,35 +37,6 @@ it("describes bounded context with navigable child selectors", () => {
 		nodeCount: 1,
 		truncated: true,
 	});
-});
-
-it("includes caller-supplied attributes only when requested, using shared escaping and limits", () => {
-	document.body.innerHTML = `
-		<main data-boundary="outer"><div id="inspection-root" data-boundary="a&amp;&quot;b">
-			<span data-boundary=""></span>
-		</div></main>
-	`;
-	const root = document.querySelector("#inspection-root");
-	expect(inspect(root, document, 1, 20).html).not.toContain("data-boundary");
-	const result = inspect(root, document, 1, 20, false, undefined, [
-		"data-boundary",
-	]);
-	expect(result.html).toContain('data-boundary="outer"');
-	expect(result.html).toContain(`data-boundary=${JSON.stringify('a&"b')}`);
-	expect(result.html).toContain('data-boundary=""');
-	expect(
-		describeAncestor(root.parentElement, document, ["data-boundary"]),
-	).toContain(
-		'ancestor tag="main" data-boundary="outer" selector="#inspection-root"',
-	);
-	root.setAttribute("data-boundary", "é".repeat(40_000));
-	const bounded = inspect(root, document, 1, 20, false, undefined, [
-		"data-boundary",
-	]);
-	expect(bounded.html).toContain(`data-boundary="${"é".repeat(80)}..."`);
-	expect(new TextEncoder().encode(bounded.html).byteLength).toBeLessThanOrEqual(
-		30_000,
-	);
 });
 
 it("caps simplified context at 30 KB of UTF-8", () => {

--- a/libs/client/test/Client__ElementInspector.test.mjs
+++ b/libs/client/test/Client__ElementInspector.test.mjs
@@ -5,7 +5,10 @@ vi.mock("@medv/finder", () => ({
 }));
 
 import { finder } from "@medv/finder";
-import { inspect } from "../src/Client__ElementInspector.res.mjs";
+import {
+	describeAncestor,
+	inspect,
+} from "../src/Client__ElementInspector.res.mjs";
 
 beforeEach(() => {
 	document.body.innerHTML = "";
@@ -37,6 +40,35 @@ it("describes bounded context with navigable child selectors", () => {
 		nodeCount: 1,
 		truncated: true,
 	});
+});
+
+it("includes caller-supplied attributes only when requested, using shared escaping and limits", () => {
+	document.body.innerHTML = `
+		<main data-boundary="outer"><div id="inspection-root" data-boundary="a&amp;&quot;b">
+			<span data-boundary=""></span>
+		</div></main>
+	`;
+	const root = document.querySelector("#inspection-root");
+	expect(inspect(root, document, 1, 20).html).not.toContain("data-boundary");
+	const result = inspect(root, document, 1, 20, false, undefined, [
+		"data-boundary",
+	]);
+	expect(result.html).toContain('data-boundary="outer"');
+	expect(result.html).toContain(`data-boundary=${JSON.stringify('a&"b')}`);
+	expect(result.html).toContain('data-boundary=""');
+	expect(
+		describeAncestor(root.parentElement, document, ["data-boundary"]),
+	).toContain(
+		'ancestor tag="main" data-boundary="outer" selector="#inspection-root"',
+	);
+	root.setAttribute("data-boundary", "é".repeat(40_000));
+	const bounded = inspect(root, document, 1, 20, false, undefined, [
+		"data-boundary",
+	]);
+	expect(bounded.html).toContain(`data-boundary="${"é".repeat(80)}..."`);
+	expect(new TextEncoder().encode(bounded.html).byteLength).toBeLessThanOrEqual(
+		30_000,
+	);
 });
 
 it("caps simplified context at 30 KB of UTF-8", () => {

--- a/libs/client/test/Client__ElementInspector.test.res
+++ b/libs/client/test/Client__ElementInspector.test.res
@@ -1,0 +1,46 @@
+open Vitest
+
+module Inspector = Client__ElementInspector
+
+let document = WebAPI.DomGlobal.document
+
+afterEach(() => document.body.innerHTML = "")
+
+test(
+  "includes caller-supplied attributes only when requested, using shared escaping and limits",
+  t => {
+    document.body.innerHTML = `<main id="inspection-parent" data-boundary="outer"><div id="inspection-root" data-boundary="a&amp;&quot;b"><span data-boundary=""></span></div></main>`
+    let element =
+      document->WebAPI.Document.querySelector("#inspection-root")->Null.toOption->Option.getOrThrow
+    let inspect = (~additionalAttributes=?) =>
+      Inspector.inspect(~element, ~document, ~maxDepth=1, ~maxNodes=20, ~additionalAttributes?)
+    t->expect(inspect().html->String.includes("data-boundary"))->Expect.toBe(false)
+    let result = inspect(~additionalAttributes=["data-boundary"])
+    [
+      "data-boundary=\"outer\"",
+      "data-boundary=\"a&\\\"b\"",
+      "data-boundary=\"\"",
+    ]->Array.forEach(field => t->expect(result.html->String.includes(field))->Expect.toBe(true))
+    let ancestor = Inspector.describeAncestor(
+      ~element=element.parentElement
+      ->Null.toOption
+      ->Option.getOrThrow
+      ->WebAPI.HTMLElement.asElement,
+      ~document,
+      ~additionalAttributes=["data-boundary"],
+    )
+    t->expect(ancestor->String.includes("ancestor tag=\"main\""))->Expect.toBe(true)
+    t
+    ->expect(ancestor->String.includes("data-boundary=\"outer\" selector=\"#inspection-parent\""))
+    ->Expect.toBe(true)
+    element->WebAPI.Element.setAttribute(
+      ~qualifiedName="data-boundary",
+      ~value="é"->String.repeat(40_000),
+    )
+    let bounded = inspect(~additionalAttributes=["data-boundary"])
+    t
+    ->expect(bounded.html->String.includes(`data-boundary="${"é"->String.repeat(80)}..."`))
+    ->Expect.toBe(true)
+    t->expect(WebAPI.Blob.make(~blobParts=[String(bounded.html)]).size <= 30_000)->Expect.toBe(true)
+  },
+)

--- a/libs/client/test/Client__Task__AnnotationEnrichment.test.mjs
+++ b/libs/client/test/Client__Task__AnnotationEnrichment.test.mjs
@@ -94,6 +94,7 @@ describe("FetchAnnotationDetails effect handler", () => {
 		dispatch = (action) => dispatched.push(action);
 		delegate = () => {};
 		vi.restoreAllMocks();
+		window.__frontmanRuntime = { framework: "nextjs" };
 
 		finder.mockImplementation(() => "button.submit");
 		snapdom.mockImplementation(() =>
@@ -111,6 +112,7 @@ describe("FetchAnnotationDetails effect handler", () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		delete window.__frontmanRuntime;
 	});
 
 	it("dispatches AnnotationDetailsResolved with Enriched when all promises succeed", async () => {
@@ -128,6 +130,25 @@ describe("FetchAnnotationDetails effect handler", () => {
 		expect(action.elementContext.TAG).toBe("Ok");
 		expect(action.elementContext._0).toContain('selected tag="button"');
 	});
+
+	it.each(["astro", "nextjs", "vite", "wordpress"])(
+		"scopes persistence markers by framework when annotating %s",
+		async (framework) => {
+			window.__frontmanRuntime = { framework };
+			const effect = makeEffect();
+			effect.element.setAttribute(
+				"data-astro-transition-persist",
+				"submit-action",
+			);
+			handleEffect(effect, dispatch, delegate);
+			await waitForDispatch(dispatched);
+			const context = dispatched[0].elementContext;
+			expect(context.TAG).toBe("Ok");
+			expect(
+				context._0.includes('data-astro-transition-persist="submit-action"'),
+			).toBe(framework === "astro");
+		},
+	);
 
 	it("dispatches Ok(None) sourceLocation when contentWindow is None", async () => {
 		handleEffect(makeEffect({ contentWindow: undefined }), dispatch, delegate);
@@ -216,27 +237,29 @@ describe("FetchAnnotationDetails effect handler", () => {
 		expect(resolveSourceLocation).not.toHaveBeenCalled();
 	});
 
-	it.each([
-		"detection",
-		"resolution",
-	])("times out source %s after five seconds", async (stage) => {
-		vi.useFakeTimers();
-		if (stage === "detection") {
-			getElementSourceLocation.mockImplementation(() => new Promise(() => {}));
-		} else {
-			getElementSourceLocation.mockResolvedValue(virtualContext);
-			resolveSourceLocation.mockImplementation(() => new Promise(() => {}));
-		}
+	it.each(["detection", "resolution"])(
+		"times out source %s after five seconds",
+		async (stage) => {
+			vi.useFakeTimers();
+			if (stage === "detection") {
+				getElementSourceLocation.mockImplementation(
+					() => new Promise(() => {}),
+				);
+			} else {
+				getElementSourceLocation.mockResolvedValue(virtualContext);
+				resolveSourceLocation.mockImplementation(() => new Promise(() => {}));
+			}
 
-		handleEffect(makeEffect({ contentWindow: {} }), dispatch, delegate);
-		await vi.advanceTimersByTimeAsync(5000);
+			handleEffect(makeEffect({ contentWindow: {} }), dispatch, delegate);
+			await vi.advanceTimersByTimeAsync(5000);
 
-		expect(dispatched).toHaveLength(1);
-		expect(dispatched[0].sourceLocation).toEqual({
-			TAG: "Error",
-			_0: "Source location detection or resolution timed out",
-		});
-	});
+			expect(dispatched).toHaveLength(1);
+			expect(dispatched[0].sourceLocation).toEqual({
+				TAG: "Error",
+				_0: "Source location detection or resolution timed out",
+			});
+		},
+	);
 
 	it.each([
 		{
@@ -273,26 +296,24 @@ describe("FetchAnnotationDetails effect handler", () => {
 			error: "CORS blocked source map",
 			contentWindow: {},
 		},
-	])("preserves enrichment when $name fails", async ({
-		arrange,
-		field,
-		error,
-		contentWindow,
-	}) => {
-		arrange();
-		handleEffect(makeEffect({ contentWindow }), dispatch, delegate);
-		await waitForDispatch(dispatched);
+	])(
+		"preserves enrichment when $name fails",
+		async ({ arrange, field, error, contentWindow }) => {
+			arrange();
+			handleEffect(makeEffect({ contentWindow }), dispatch, delegate);
+			await waitForDispatch(dispatched);
 
-		expect(dispatched[0].enrichmentStatus).toBe("Enriched");
-		expect(dispatched[0][field]).toEqual({ TAG: "Error", _0: error });
-		for (const unaffected of [
-			"selector",
-			"screenshot",
-			"sourceLocation",
-		].filter((candidate) => candidate !== field)) {
-			expect(dispatched[0][unaffected].TAG).toBe("Ok");
-		}
-	});
+			expect(dispatched[0].enrichmentStatus).toBe("Enriched");
+			expect(dispatched[0][field]).toEqual({ TAG: "Error", _0: error });
+			for (const unaffected of [
+				"selector",
+				"screenshot",
+				"sourceLocation",
+			].filter((candidate) => candidate !== field)) {
+				expect(dispatched[0][unaffected].TAG).toBe("Ok");
+			}
+		},
+	);
 
 	it("isolates a synchronous source resolver failure", async () => {
 		const mockLoc = {

--- a/libs/client/test/Client__ToolRegistry.test.res
+++ b/libs/client/test/Client__ToolRegistry.test.res
@@ -69,6 +69,8 @@ describe("ToolRegistry", _t => {
           )
         t->expect(description->String.includes("Astro"))->Expect.toBe(isAstro)
         t->expect(properties->Dict.has("astro_client_routing"))->Expect.toBe(isAstro)
+        t->expect(properties->Dict.has("astro_persistence"))->Expect.toBe(isAstro)
+        t->expect(description->String.includes("not proof"))->Expect.toBe(isAstro)
         t
         ->expect(properties->Dict.has("success") || properties->Dict.has("error"))
         ->Expect.toBe(false)

--- a/libs/client/test/Client__Tool__GetDom.test.res
+++ b/libs/client/test/Client__Tool__GetDom.test.res
@@ -138,13 +138,32 @@ let input: GetDom.input = {
   })
 })
 
-testAsync("distinguishes an empty direct marker and does not invent a selected key", async t => {
-  showPage(false, ~html="<div id=\"page\" data-astro-transition-persist=\"\"></div>")
-  let response = await execute(Astro, input)
-  let page = response.structuredContent->Option.getOrThrow
-  t->expect(page.astro_client_routing)->Expect.toEqual(Some("disabled"))
-  t->expect(page.html->String.includes("data-astro-transition-persist=\"\""))->Expect.toBe(true)
-  t->expect((page.astro_persistence->Option.getOrThrow).ancestors)->Expect.toEqual([])
+testAsync("reads current runtime markers, including empty keys, not source directives", async t => {
+  showPage(
+    false,
+    ~html="<main id=\"boundary\" transition:persist=\"audio\"><div id=\"page\" data-astro-transition-persist=\"\"></div></main>",
+  )
+  let {doc} = Client__Tool__PreviewContext.get()->Option.getOrThrow
+  let boundary = doc->WebAPI.Document.querySelector("#boundary")->Null.toOption->Option.getOrThrow
+  for index in 0 to 2 {
+    switch index {
+    | 1 =>
+      boundary->WebAPI.Element.setAttribute(~qualifiedName=Persistence.markerAttribute, ~value="")
+    | _ => boundary->WebAPI.Element.removeAttribute(Persistence.markerAttribute)
+    }
+    let response = await execute(Astro, input)
+    let page = response.structuredContent->Option.getOrThrow
+    t->expect(page.astro_client_routing)->Expect.toEqual(Some("disabled"))
+    t->expect(page.html->String.includes("data-astro-transition-persist=\"\""))->Expect.toBe(true)
+    let persistence = page.astro_persistence->Option.getOrThrow
+    t->expect(persistence.truncated)->Expect.toBe(false)
+    t->expect(persistence.ancestors->Array.length)->Expect.toBe(index == 1 ? 1 : 0)
+    switch persistence.ancestors->Array.get(0) {
+    | Some(ancestor) =>
+      t->expect(ancestor->String.includes("data-astro-transition-persist=\"\""))->Expect.toBe(true)
+    | None => ()
+    }
+  }
 })
 
 testAsync(

--- a/libs/client/test/Client__Tool__GetDom.test.res
+++ b/libs/client/test/Client__Tool__GetDom.test.res
@@ -2,6 +2,7 @@ open Vitest
 
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module GetDom = Client__Tool__GetDom
+module Persistence = FrontmanAiAstroBrowser.FrontmanAstroBrowser__Persistence
 
 type previewModule
 type spy
@@ -16,7 +17,12 @@ external createIframe: (
 ) => WebAPI.DomTypes.htmliFrameElement = "createElement"
 
 @schema
-type page = {url: string, html: string, astro_client_routing: option<string>}
+type page = {
+  url: string,
+  html: string,
+  astro_client_routing: option<string>,
+  astro_persistence: option<Persistence.t>,
+}
 @schema
 type textContent = {text: string}
 @schema
@@ -32,7 +38,7 @@ afterEach(() => {
   resetAllMocks()
 })
 
-let showPage = (enabled, ~text="Content") => {
+let showPage = (enabled, ~text="Content", ~html=?) => {
   let frame = WebAPI.DomGlobal.document->createIframe
   frame->WebAPI.HTMLIFrameElement.setAttribute(
     ~qualifiedName="src",
@@ -47,9 +53,8 @@ let showPage = (enabled, ~text="Content") => {
   | true => "<meta name=\"astro-view-transitions-enabled\">"
   | false => ""
   }
-  doc->WebAPI.Document.write(
-    `<html><head>${marker}</head><body><main id="page"><span>${text}</span></main></body></html>`,
-  )
+  let content = html->Option.getOr(`<main id="page"><span>${text}</span></main>`)
+  doc->WebAPI.Document.write(`<html><head>${marker}</head><body>${content}</body></html>`)
   doc->WebAPI.Document.close
   get->mockReturnValue(Some({doc, win}))
 }
@@ -94,6 +99,90 @@ let input: GetDom.input = {
       t->expect(page.html->String.includes("Content"))->Expect.toBe(true)
       t->expect(page.astro_client_routing)->Expect.toEqual(Some(routing))
     }
+  })
+})
+
+[#simplified, #full]->Array.forEach(mode => {
+  testAsync("shows direct markers and ancestors outside the inspected subtree", async t => {
+    showPage(
+      true,
+      ~html="<main id=\"layout\" data-astro-transition-persist=\"outer\"><section id=\"player\" data-astro-transition-persist=\"audio\"><div><button id=\"page\" data-astro-transition-persist=\"control\"><span data-astro-transition-persist=\"label\">Play</span></button></div></section></main>",
+    )
+    for index in 0 to 1 {
+      let selector = ["#page", "//button[@id='page']"]->Array.get(index)->Option.getOrThrow
+      let response = await execute(Astro, {...input, selector, mode: Some(mode)})
+      let page = response.structuredContent->Option.getOrThrow
+      t
+      ->expect(page.html->String.includes("data-astro-transition-persist=\"control\""))
+      ->Expect.toBe(true)
+      t
+      ->expect(page.html->String.includes("data-astro-transition-persist=\"label\""))
+      ->Expect.toBe(true)
+      let persistence = page.astro_persistence->Option.getOrThrow
+      t->expect(persistence.truncated)->Expect.toBe(false)
+      t->expect(persistence.ancestors->Array.length)->Expect.toBe(2)
+      let nearest = persistence.ancestors->Array.get(0)->Option.getOrThrow
+      let farthest = persistence.ancestors->Array.get(1)->Option.getOrThrow
+      t
+      ->expect(nearest->String.includes("data-astro-transition-persist=\"audio\""))
+      ->Expect.toBe(true)
+      t->expect(nearest->String.includes("selector=\"#player\""))->Expect.toBe(true)
+      t->expect(farthest->String.includes("selector=\"#layout\""))->Expect.toBe(true)
+    }
+    showPage(false)
+    let response = await execute(Astro, {...input, mode: Some(mode)})
+    let persistence =
+      (response.structuredContent->Option.getOrThrow).astro_persistence->Option.getOrThrow
+    t->expect(persistence.ancestors)->Expect.toEqual([])
+    t->expect(persistence.truncated)->Expect.toBe(false)
+  })
+})
+
+testAsync("distinguishes an empty direct marker and does not invent a selected key", async t => {
+  showPage(false, ~html="<div id=\"page\" data-astro-transition-persist=\"\"></div>")
+  let response = await execute(Astro, input)
+  let page = response.structuredContent->Option.getOrThrow
+  t->expect(page.astro_client_routing)->Expect.toEqual(Some("disabled"))
+  t->expect(page.html->String.includes("data-astro-transition-persist=\"\""))->Expect.toBe(true)
+  t->expect((page.astro_persistence->Option.getOrThrow).ancestors)->Expect.toEqual([])
+})
+
+testAsync(
+  "reuses shadow-path resolution and scopes ancestor evidence to that DOM tree",
+  async t => {
+    showPage(true, ~html="<div id=\"page\" data-astro-transition-persist=\"host\"></div>")
+    let {doc} = Client__Tool__PreviewContext.get()->Option.getOrThrow
+    let host = doc->WebAPI.Document.querySelector("#page")->Null.toOption->Option.getOrThrow
+    let shadow = host->WebAPI.Element.attachShadow({mode: Open})
+    shadow.innerHTML = "<section data-astro-transition-persist=\"inside-shadow\"><button data-astro-transition-persist=\"button\">Play</button></section>"
+    let response = await execute(Astro, {...input, selector: "#page >>> 1/1"})
+    let page = response.structuredContent->Option.getOrThrow
+    t
+    ->expect(page.html->String.includes("data-astro-transition-persist=\"button\""))
+    ->Expect.toBe(true)
+    let ancestors = (page.astro_persistence->Option.getOrThrow).ancestors
+    t->expect(ancestors->Array.length)->Expect.toBe(1)
+    t
+    ->expect(
+      ancestors
+      ->Array.get(0)
+      ->Option.getOrThrow
+      ->String.includes("data-astro-transition-persist=\"inside-shadow\""),
+    )
+    ->Expect.toBe(true)
+  },
+)
+
+[Client__RuntimeConfig.Nextjs, Vite, Wordpress]->Array.forEach(framework => {
+  testAsync("keeps persistence enrichment out of non-Astro inspection", async t => {
+    showPage(
+      true,
+      ~html="<main data-astro-transition-persist=\"outer\"><div id=\"page\" data-astro-transition-persist=\"inner\"></div></main>",
+    )
+    let response = await execute(framework, input)
+    let page = response.structuredContent->Option.getOrThrow
+    t->expect(page.html->String.includes("data-astro-transition-persist"))->Expect.toBe(false)
+    t->expect(page.astro_persistence)->Expect.toEqual(None)
   })
 })
 

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Persistence.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Persistence.res
@@ -1,0 +1,71 @@
+let markerAttribute = "data-astro-transition-persist"
+let inspectionAttributes = [markerAttribute]
+let maxParentSteps = 50
+let maxAncestors = 10
+let maxOutputBytes = 4096
+
+type boundaries = {
+  elements: array<WebAPI.DomTypes.element>,
+  truncated: bool,
+}
+
+@schema
+type t = {
+  @s.describe(
+    "Marked DOM ancestors, nearest first, described with selectors and persistence keys. Descriptors may shorten attribute values with '...'. Follows parentElement only; does not cross shadow roots. Markers do not prove node or state survival across navigation."
+  )
+  @live
+  ancestors: array<string>,
+  @s.describe(
+    "Ancestor inspection stopped at the 50-parent, 10-boundary, or 4 KB context limit. An empty truncated result does not prove there are no marked ancestors."
+  )
+  @live
+  truncated: bool,
+}
+
+let findAncestors = (element: WebAPI.DomTypes.element): boundaries => {
+  let elements = []
+  let current = ref(element.parentElement->Null.toOption)
+  let steps = ref(0)
+  while (
+    current.contents->Option.isSome &&
+    steps.contents < maxParentSteps &&
+    elements->Array.length < maxAncestors
+  ) {
+    let parent = current.contents->Option.getOrThrow->WebAPI.HTMLElement.asElement
+    switch parent->WebAPI.Element.hasAttribute(markerAttribute) {
+    | true => elements->Array.push(parent)->ignore
+    | false => ()
+    }
+    steps := steps.contents + 1
+    current := parent.parentElement->Null.toOption
+  }
+  {elements, truncated: current.contents->Option.isSome}
+}
+
+let read = (
+  element: WebAPI.DomTypes.element,
+  ~describeAncestor: WebAPI.DomTypes.element => string,
+): t => {
+  let found = findAncestors(element)
+  let rec describe = (index, ancestors) => {
+    switch found.elements->Array.get(index) {
+    | None => {ancestors, truncated: found.truncated}
+    | Some(element) =>
+      let candidate = {
+        ancestors: Array.concat(ancestors, [describeAncestor(element)]),
+        truncated: false,
+      }
+      let json =
+        candidate
+        ->S.decodeOrThrow(~from=schema, ~to=S.json)
+        ->JSON.stringifyAny
+        ->Option.getOrThrow
+      switch WebAPI.Blob.make(~blobParts=[String(json)]).size > maxOutputBytes {
+      | true => {ancestors, truncated: true}
+      | false => describe(index + 1, candidate.ancestors)
+      }
+    }
+  }
+  describe(0, [])
+}

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
@@ -29,7 +29,7 @@ let make = (
       let visibleToAgent = true
       let executionMode = Tool.Synchronous
       let description =
-        description ++ "\n\nResults also include Astro current-page client routing opt-in (enabled or disabled). Routing opt-in does not indicate completed navigation. An unavailable preview returns a tool error, not disabled routing.\n\nAstro persistence keys appear as data-astro-transition-persist attributes on inspected elements. astro_persistence describes marked DOM ancestors outside the selected element, nearest first, in both modes. It follows parentElement only and does not cross shadow roots. Attribute values may be shortened with '...'. Ancestor context is capped at 50 parent steps, 10 boundaries, and 4 KB with explicit truncation. These are markers, not proof that nodes, component state, or props survived navigation; exercise navigation to verify behavior."
+        description ++ "\n\nAstro results include current-page client-routing opt-in, persistence keys on inspected elements, and marked ancestors in astro_persistence in both modes. Ancestor lookup does not cross shadow roots. Routing opt-in and persistence markers are not proof of completed navigation or preserved state. Exercise navigation to verify behavior."
       type input = GetDom.input
       let inputSchema = GetDom.inputSchema
       let outputJsonSchema = Some(outputSchema->S.toJSONSchema)

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
@@ -1,18 +1,25 @@
 module GetDom = FrontmanAiFrontmanProtocol.FrontmanProtocol__GetDom
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module ClientRouting = FrontmanAstroBrowser__ClientRouting
+module Persistence = FrontmanAstroBrowser__Persistence
 
 @schema
 type output = {
   ...GetDom.output,
   @s.describe("Astro current-page routing opt-in, not navigation completion.") @live
   astro_client_routing: ClientRouting.t,
+  @s.describe("Current DOM persistence markers, not observed survival across navigation.") @live
+  astro_persistence: Persistence.t,
 }
 
 @live
 let make = (
   ~getPreviewDoc: unit => option<Tool.previewContext>,
-  ~inspect: (GetDom.input, Tool.previewContext) => result<GetDom.output, string>,
+  ~inspect: (
+    GetDom.input,
+    Tool.previewContext,
+  ) => result<(GetDom.output, WebAPI.DomTypes.element), string>,
+  ~describeAncestor: (WebAPI.DomTypes.element, Tool.previewContext) => string,
   ~description: string,
 ): module(Tool.BrowserTool) => {
   module(
@@ -22,7 +29,7 @@ let make = (
       let visibleToAgent = true
       let executionMode = Tool.Synchronous
       let description =
-        description ++ "\n\nResults also include Astro current-page client routing opt-in (enabled or disabled). Routing opt-in does not indicate completed navigation. An unavailable preview returns a tool error, not disabled routing."
+        description ++ "\n\nResults also include Astro current-page client routing opt-in (enabled or disabled). Routing opt-in does not indicate completed navigation. An unavailable preview returns a tool error, not disabled routing.\n\nAstro persistence keys appear as data-astro-transition-persist attributes on inspected elements. astro_persistence describes marked DOM ancestors outside the selected element, nearest first, in both modes. It follows parentElement only and does not cross shadow roots. Attribute values may be shortened with '...'. Ancestor context is capped at 50 parent steps, 10 boundaries, and 4 KB with explicit truncation. These are markers, not proof that nodes, component state, or props survived navigation; exercise navigation to verify behavior."
       type input = GetDom.input
       let inputSchema = GetDom.inputSchema
       let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
@@ -32,7 +39,7 @@ let make = (
         | Some(preview) =>
           switch inspect(input, preview) {
           | Error(message) => Tool.MCP.CallToolResult.makeError(message)
-          | Ok(result) =>
+          | Ok((result, element)) =>
             Tool.structuredResult(
               {
                 url: result.url,
@@ -41,6 +48,9 @@ let make = (
                 byteSize: result.byteSize,
                 hint: result.hint,
                 astro_client_routing: ClientRouting.read(Some(preview.doc)),
+                astro_persistence: Persistence.read(element, ~describeAncestor=element =>
+                  describeAncestor(element, preview)
+                ),
               },
               outputSchema,
             )

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Persistence.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Persistence.test.res
@@ -25,35 +25,6 @@ let nested = (count, ~marked) => {
   "</div>"->String.repeat(count)
 }
 
-test(
-  "finds marked DOM ancestors nearest first, including empty markers, not the selected node",
-  t => {
-    let element = selectedFromHtml(
-      "<main data-astro-transition-persist=\"outer\"><section data-astro-transition-persist=\"\"><div><button id=\"selected\" data-astro-transition-persist=\"self\"></button></div></section></main>",
-    )
-    let result = Persistence.read(element, ~describeAncestor=describeKey)
-    t->expect(result.ancestors)->Expect.toEqual(["", "outer"])
-    t->expect(result.truncated)->Expect.toBe(false)
-  },
-)
-
-test("ignores source directives and reads current markers without caching", t => {
-  let element = selectedFromHtml(
-    "<main transition:persist=\"audio\"><button id=\"selected\"></button></main>",
-  )
-  let parent = element.parentElement->Null.toOption->Option.getOrThrow->WebAPI.HTMLElement.asElement
-  t->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)->Expect.toEqual([])
-  parent->WebAPI.Element.setAttribute(
-    ~qualifiedName=Persistence.markerAttribute,
-    ~value="runtime-key",
-  )
-  t
-  ->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)
-  ->Expect.toEqual(["runtime-key"])
-  parent->WebAPI.Element.removeAttribute(Persistence.markerAttribute)
-  t->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)->Expect.toEqual([])
-})
-
 test("bounds parent traversal and distinguishes truncated empty results", t => {
   let element = selectedFromHtml(
     "<main data-astro-transition-persist=\"outside-limit\">" ++
@@ -90,14 +61,4 @@ test("caps serialized UTF-8 context including JSON escaping without partial desc
   let oversized = Persistence.read(element, ~describeAncestor=_ => "x"->String.repeat(4096))
   t->expect(oversized.ancestors)->Expect.toEqual([])
   t->expect(oversized.truncated)->Expect.toBe(true)
-})
-
-test("does not mistake a shadow host for a DOM parent", t => {
-  let host = selectedFromHtml("<div id=\"selected\" data-astro-transition-persist=\"host\"></div>")
-  let shadow = host->WebAPI.Element.attachShadow({mode: Open})
-  shadow.innerHTML = "<section data-astro-transition-persist=\"inside-shadow\"><button></button></section>"
-  let element = shadow->WebAPI.ShadowRoot.querySelector("button")->Null.toOption->Option.getOrThrow
-  let result = Persistence.read(element, ~describeAncestor=describeKey)
-  t->expect(result.ancestors)->Expect.toEqual(["inside-shadow"])
-  t->expect(result.truncated)->Expect.toBe(false)
 })

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Persistence.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Persistence.test.res
@@ -1,0 +1,103 @@
+open Vitest
+
+module Persistence = FrontmanAstroBrowser__Persistence
+
+let selectedFromHtml = html => {
+  let document =
+    WebAPI.DomGlobal.document.implementation->WebAPI.DOMImplementation.createHTMLDocument(~title="")
+  document.body.innerHTML = html
+  document->WebAPI.Document.querySelector("#selected")->Null.toOption->Option.getOrThrow
+}
+
+let describeKey = element =>
+  element
+  ->WebAPI.Element.getAttribute(Persistence.markerAttribute)
+  ->Null.toOption
+  ->Option.getOrThrow
+
+let nested = (count, ~marked) => {
+  let opening = switch marked {
+  | true => "<div data-astro-transition-persist=\"boundary\">"
+  | false => "<div>"
+  }
+  opening->String.repeat(count) ++
+  "<button id=\"selected\"></button>" ++
+  "</div>"->String.repeat(count)
+}
+
+test(
+  "finds marked DOM ancestors nearest first, including empty markers, not the selected node",
+  t => {
+    let element = selectedFromHtml(
+      "<main data-astro-transition-persist=\"outer\"><section data-astro-transition-persist=\"\"><div><button id=\"selected\" data-astro-transition-persist=\"self\"></button></div></section></main>",
+    )
+    let result = Persistence.read(element, ~describeAncestor=describeKey)
+    t->expect(result.ancestors)->Expect.toEqual(["", "outer"])
+    t->expect(result.truncated)->Expect.toBe(false)
+  },
+)
+
+test("ignores source directives and reads current markers without caching", t => {
+  let element = selectedFromHtml(
+    "<main transition:persist=\"audio\"><button id=\"selected\"></button></main>",
+  )
+  let parent = element.parentElement->Null.toOption->Option.getOrThrow->WebAPI.HTMLElement.asElement
+  t->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)->Expect.toEqual([])
+  parent->WebAPI.Element.setAttribute(
+    ~qualifiedName=Persistence.markerAttribute,
+    ~value="runtime-key",
+  )
+  t
+  ->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)
+  ->Expect.toEqual(["runtime-key"])
+  parent->WebAPI.Element.removeAttribute(Persistence.markerAttribute)
+  t->expect(Persistence.read(element, ~describeAncestor=describeKey).ancestors)->Expect.toEqual([])
+})
+
+test("bounds parent traversal and distinguishes truncated empty results", t => {
+  let element = selectedFromHtml(
+    "<main data-astro-transition-persist=\"outside-limit\">" ++
+    nested(50, ~marked=false) ++ "</main>",
+  )
+  let result = Persistence.read(element, ~describeAncestor=describeKey)
+  t->expect(result.ancestors)->Expect.toEqual([])
+  t->expect(result.truncated)->Expect.toBe(true)
+})
+
+test("caps marked ancestors at ten", t => {
+  let result = Persistence.read(
+    selectedFromHtml(nested(11, ~marked=true)),
+    ~describeAncestor=describeKey,
+  )
+  t->expect(result.ancestors->Array.length)->Expect.toBe(10)
+  t->expect(result.truncated)->Expect.toBe(true)
+})
+
+test("caps serialized UTF-8 context including JSON escaping without partial descriptors", t => {
+  let element = selectedFromHtml(nested(3, ~marked=true))
+  let description = "é\""->String.repeat(600)
+  let result = Persistence.read(element, ~describeAncestor=_ => description)
+  t->expect(result.ancestors)->Expect.toEqual([description])
+  t->expect(result.truncated)->Expect.toBe(true)
+  let json =
+    result
+    ->S.decodeOrThrow(~from=Persistence.schema, ~to=S.json)
+    ->JSON.stringifyAny
+    ->Option.getOrThrow
+  t
+  ->expect(WebAPI.Blob.make(~blobParts=[String(json)]).size <= Persistence.maxOutputBytes)
+  ->Expect.toBe(true)
+  let oversized = Persistence.read(element, ~describeAncestor=_ => "x"->String.repeat(4096))
+  t->expect(oversized.ancestors)->Expect.toEqual([])
+  t->expect(oversized.truncated)->Expect.toBe(true)
+})
+
+test("does not mistake a shadow host for a DOM parent", t => {
+  let host = selectedFromHtml("<div id=\"selected\" data-astro-transition-persist=\"host\"></div>")
+  let shadow = host->WebAPI.Element.attachShadow({mode: Open})
+  shadow.innerHTML = "<section data-astro-transition-persist=\"inside-shadow\"><button></button></section>"
+  let element = shadow->WebAPI.ShadowRoot.querySelector("button")->Null.toOption->Option.getOrThrow
+  let result = Persistence.read(element, ~describeAncestor=describeKey)
+  t->expect(result.ancestors)->Expect.toEqual(["inside-shadow"])
+  t->expect(result.truncated)->Expect.toBe(false)
+})


### PR DESCRIPTION
## Summary
- Show runtime persistence keys in Astro DOM inspection and element annotations.
- Include marked DOM ancestors in both `get_dom` modes. Reuse the shared descriptions and resolve the selected element once.
- Keep the shared inspector framework-neutral through caller-supplied attributes. Astro owns marker detection and response fields.
- Limit ancestor context to 50 parent steps, 10 boundaries, and 4 KB, with explicit truncation. Lookup does not cross shadow roots.

## Review adjustments
- Trim persistence unit coverage to three limit checks. Existing `get_dom` integration tests cover marker semantics, fresh results, and shadow boundaries.
- Shorten the tool description to essential interpretation and limitations. Keep detailed limits and formatting rules in the output schema.

## Validation
- Client suite: 447 tests passed.
- Astro browser suite: 12 tests passed.
- ReScript build and formatting passed; static analysis reported zero issues.
- Source-comment checks, `git diff --check`, and commit/push hooks passed.
- Checked the runtime marker in Astro 5.0.0, 6.0.0, and 7.0.0 source.

## Scope
- Includes a changeset.
- Markers do not prove completed navigation or preserved state.
- Navigation recording and the real two-page survival test remain in #1673–#1675.

Closes #1672
Parent: #1611