### PR TITLE
feat(astro): expose navigation completion in get_dom

### DIFF
--- a/.changeset/chilly-webs-add.md
+++ b/.changeset/chilly-webs-add.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/astro": minor
+---
+
+Include the latest observed Astro navigation in both modes of `get_dom`. Report its source URL, destination URL, and lifecycle phase. Distinguish missing instrumentation from an installed recorder with no navigation observed. Clarify that routing opt-in, DOM swaps, and hash changes do not prove page lifecycle completion or preserved state.

--- a/libs/client/test/Client__Tool__GetDom.test.res
+++ b/libs/client/test/Client__Tool__GetDom.test.res
@@ -3,6 +3,11 @@ open Vitest
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module GetDom = Client__Tool__GetDom
 module Persistence = FrontmanAiAstroBrowser.FrontmanAstroBrowser__Persistence
+module Navigation = FrontmanAiAstroBrowser.FrontmanAstroBrowser__Navigation
+
+@set
+external setNavigation: (WebAPI.DomTypes.window, option<Navigation.state>) => unit =
+  "__frontman_astro_navigation__"
 
 type previewModule
 type spy
@@ -22,6 +27,7 @@ type page = {
   html: string,
   astro_client_routing: option<string>,
   astro_persistence: option<Persistence.t>,
+  astro_navigation: option<Navigation.t>,
 }
 @schema
 type textContent = {text: string}
@@ -36,6 +42,7 @@ let get = spyOn(previewModule)
 afterEach(() => {
   WebAPI.DomGlobal.document.body.innerHTML = ""
   resetAllMocks()
+  setNavigation(WebAPI.DomGlobal.window, None)
 })
 
 let showPage = (enabled, ~text="Content", ~html=?) => {
@@ -99,6 +106,60 @@ let input: GetDom.input = {
       t->expect(page.html->String.includes("Content"))->Expect.toBe(true)
       t->expect(page.astro_client_routing)->Expect.toEqual(Some(routing))
     }
+  })
+})
+
+[#simplified, #full]->Array.forEach(mode => {
+  testAsync("reads fresh navigation evidence only from the preview window", async t => {
+    showPage(true)
+    let {win} = Client__Tool__PreviewContext.get()->Option.getOrThrow
+    let from = "https://preview.test/start"
+    let to = "https://preview.test/destination"
+    setNavigation(
+      WebAPI.DomGlobal.window,
+      Some({lastNavigation: Some({from, to, phase: PageLoad})}),
+    )
+    let absent = await execute(Astro, {...input, mode: Some(mode)})
+    let page = absent.structuredContent->Option.getOrThrow
+    t->expect(page.astro_client_routing)->Expect.toEqual(Some("enabled"))
+    t->expect(page.astro_navigation)->Expect.toEqual(Some(Navigation.Unavailable))
+
+    setNavigation(win, Some({lastNavigation: None}))
+    let empty = await execute(Astro, {...input, mode: Some(mode)})
+    t
+    ->expect((empty.structuredContent->Option.getOrThrow).astro_navigation)
+    ->Expect.toEqual(Some(Navigation.NotObserved))
+
+    let phases = [
+      Navigation.BeforePreparation,
+      AfterPreparation,
+      BeforeSwap,
+      AfterSwap,
+      PageLoad,
+      HashChange,
+    ]
+    for index in 0 to phases->Array.length - 1 {
+      let phase = phases->Array.get(index)->Option.getOrThrow
+      let destination = switch phase {
+      | HashChange => to ++ "#section"
+      | BeforePreparation | AfterPreparation | BeforeSwap | AfterSwap | PageLoad => to
+      }
+      setNavigation(win, Some({lastNavigation: Some({from, to: destination, phase})}))
+      let response = await execute(Astro, {...input, mode: Some(mode)})
+      let page = response.structuredContent->Option.getOrThrow
+      t
+      ->expect(page.astro_navigation)
+      ->Expect.toEqual(Some(Navigation.Observed({from, to: destination, phase})))
+      let text = (response.content->Array.get(0)->Option.getOrThrow).text
+      let textPage = S.decodeOrThrow(text, ~from=S.jsonString, ~to=pageSchema)
+      t->expect(textPage.astro_navigation)->Expect.toEqual(page.astro_navigation)
+    }
+
+    showPage(false)
+    let reloaded = await execute(Astro, {...input, mode: Some(mode)})
+    let page = reloaded.structuredContent->Option.getOrThrow
+    t->expect(page.astro_client_routing)->Expect.toEqual(Some("disabled"))
+    t->expect(page.astro_navigation)->Expect.toEqual(Some(Navigation.Unavailable))
   })
 })
 
@@ -202,6 +263,7 @@ testAsync(
     let page = response.structuredContent->Option.getOrThrow
     t->expect(page.html->String.includes("data-astro-transition-persist"))->Expect.toBe(false)
     t->expect(page.astro_persistence)->Expect.toEqual(None)
+    t->expect(page.astro_navigation)->Expect.toEqual(None)
   })
 })
 

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Navigation.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Navigation.res
@@ -17,7 +17,7 @@ type state = {lastNavigation: option<navigation>}
 type t =
   | @as("unavailable") Unavailable
   | @as("not_observed") NotObserved
-  | @as("observed") Observed({from: string, to: string, phase: phase})
+  | @as("observed") Observed({@live from: string, @live to: string, @live phase: phase})
 
 @get external readState: WebAPI.DomTypes.window => option<JSON.t> = "__frontman_astro_navigation__"
 

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Navigation.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Navigation.res
@@ -1,0 +1,32 @@
+@schema
+type phase =
+  | @as("astro:before-preparation") BeforePreparation
+  | @as("astro:after-preparation") AfterPreparation
+  | @as("astro:before-swap") BeforeSwap
+  | @as("astro:after-swap") AfterSwap
+  | @as("astro:page-load") PageLoad
+  | @as("hash-change") HashChange
+
+@schema
+type navigation = {from: string, to: string, phase: phase}
+
+@schema
+type state = {lastNavigation: option<navigation>}
+
+@schema @tag("status")
+type t =
+  | @as("unavailable") Unavailable
+  | @as("not_observed") NotObserved
+  | @as("observed") Observed({from: string, to: string, phase: phase})
+
+@get external readState: WebAPI.DomTypes.window => option<JSON.t> = "__frontman_astro_navigation__"
+
+let read = (window: WebAPI.DomTypes.window): t =>
+  switch readState(window) {
+  | None => Unavailable
+  | Some(value) =>
+    switch S.parseOrThrow(value, ~to=stateSchema).lastNavigation {
+    | None => NotObserved
+    | Some({from, to, phase}) => Observed({from, to, phase})
+    }
+  }

--- a/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
+++ b/libs/frontman-astro-browser/src/FrontmanAstroBrowser__Tool__GetDom.res
@@ -2,12 +2,18 @@ module GetDom = FrontmanAiFrontmanProtocol.FrontmanProtocol__GetDom
 module Tool = FrontmanAiFrontmanProtocol.FrontmanProtocol__Tool
 module ClientRouting = FrontmanAstroBrowser__ClientRouting
 module Persistence = FrontmanAstroBrowser__Persistence
+module Navigation = FrontmanAstroBrowser__Navigation
 
 @schema
 type output = {
   ...GetDom.output,
   @s.describe("Astro current-page routing opt-in, not navigation completion.") @live
   astro_client_routing: ClientRouting.t,
+  @s.describe(
+    "Latest observed navigation from the preview's dev recorder. Unavailable means no recorder; not_observed means no navigation recorded. astro:page-load is observed page lifecycle completion; astro:after-swap is not completion. hash-change is a same-document URL change, not an Astro page transition. This does not prove animation completion or preserved state."
+  )
+  @live
+  astro_navigation: Navigation.t,
   @s.describe("Current DOM persistence markers, not observed survival across navigation.") @live
   astro_persistence: Persistence.t,
 }
@@ -29,7 +35,7 @@ let make = (
       let visibleToAgent = true
       let executionMode = Tool.Synchronous
       let description =
-        description ++ "\n\nAstro results include current-page client-routing opt-in, persistence keys on inspected elements, and marked ancestors in astro_persistence in both modes. Ancestor lookup does not cross shadow roots. Routing opt-in and persistence markers are not proof of completed navigation or preserved state. Exercise navigation to verify behavior."
+        description ++ "\n\nAstro results include current-page client-routing opt-in, persistence keys on inspected elements, and marked ancestors in astro_persistence in both modes. Ancestor lookup does not cross shadow roots. astro_navigation reports the latest observed source URL, destination URL, and lifecycle phase, or unavailable/not_observed status. Only astro:page-load records page lifecycle completion; astro:after-swap is not completion, and hash-change is only a same-document URL change. Routing opt-in and persistence markers are not proof of completed navigation or preserved state. Exercise navigation and inspect again to verify behavior; lifecycle completion does not prove animation completion or preserved state."
       type input = GetDom.input
       let inputSchema = GetDom.inputSchema
       let outputJsonSchema = Some(outputSchema->S.toJSONSchema)
@@ -48,6 +54,7 @@ let make = (
                 byteSize: result.byteSize,
                 hint: result.hint,
                 astro_client_routing: ClientRouting.read(Some(preview.doc)),
+                astro_navigation: Navigation.read(preview.win),
                 astro_persistence: Persistence.read(element, ~describeAncestor=element =>
                   describeAncestor(element, preview)
                 ),

--- a/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Navigation.test.res
+++ b/libs/frontman-astro-browser/test/FrontmanAstroBrowser__Navigation.test.res
@@ -1,0 +1,45 @@
+open Vitest
+
+module Navigation = FrontmanAstroBrowser__Navigation
+
+@set
+external setState: (WebAPI.DomTypes.window, option<JSON.t>) => unit =
+  "__frontman_astro_navigation__"
+
+let host = WebAPI.DomGlobal.window
+afterEach(() => setState(host, None))
+
+describe("Astro navigation inspection", () => {
+  test("serializes unavailable, empty, and observed recorder states", t => {
+    let cases = [
+      (None, `"unavailable"`),
+      (Some(`{}`), `"not_observed"`),
+      (
+        Some(`{"lastNavigation":{"from":"https://preview.test/a","to":"https://preview.test/b","phase":"astro:page-load"}}`),
+        `{"status":"observed","from":"https://preview.test/a","to":"https://preview.test/b","phase":"astro:page-load"}`,
+      ),
+    ]
+    cases->Array.forEach(
+      ((state, expected)) => {
+        setState(
+          host,
+          state->Option.map(value => S.decodeOrThrow(value, ~from=S.jsonString, ~to=S.json)),
+        )
+        let actual = Navigation.read(host)->S.decodeOrThrow(~from=Navigation.schema, ~to=S.json)
+        t->expect(actual)->Expect.toEqual(S.decodeOrThrow(expected, ~from=S.jsonString, ~to=S.json))
+      },
+    )
+  })
+
+  test("rejects malformed records instead of reporting no navigation", t => {
+    [
+      `{"lastNavigation":{"from":"/a","to":"/b","phase":"completed"}}`,
+      `{"lastNavigation":{"from":"/a","phase":"astro:page-load"}}`,
+    ]->Array.forEach(
+      value => {
+        setState(host, Some(S.decodeOrThrow(value, ~from=S.jsonString, ~to=S.json)))
+        t->expect(() => Navigation.read(host)->ignore)->Expect.toThrow
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add fresh `astro_navigation` evidence from the preview window to both `get_dom` modes.
- Distinguish missing instrumentation, no observed navigation, and recorded lifecycle phases; clarify page-load completion versus swaps and hash changes.
- Validate recorder data with Sury; leave instrumentation and non-Astro outputs unchanged.
- Include a changeset.

## Validation
- `make -C libs/frontman-astro-browser test` — 14 tests passed.
- `make -C libs/client test` — 449 tests passed.
- Commit checks and pre-push reanalyze passed.

The real two-page navigation test remains scoped to #1675.

Closes #1674