### PR TITLE
chore(server): move protocols under FrontmanServer.Protocols

### DIFF
--- a/.changeset/namespace-server-protocols.md
+++ b/.changeset/namespace-server-protocols.md
@@ -1,0 +1,4 @@
+---
+---
+
+Move server ACP, MCP, and JSON-RPC modules under `FrontmanServer.Protocols` without changing protocol behavior.

--- a/apps/frontman_server/lib/frontman_server.ex
+++ b/apps/frontman_server/lib/frontman_server.ex
@@ -45,5 +45,5 @@ defmodule FrontmanServer do
               _ -> @base_exports
             end)
 
-  use Boundary, deps: [ModelContextProtocol], exports: @exports
+  use Boundary, deps: [FrontmanServer.Protocols.MCP], exports: @exports
 end

--- a/apps/frontman_server/lib/frontman_server/protocols/acp.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/acp.ex
@@ -4,7 +4,7 @@
 # Licensed under the AGPL-3.0 — see LICENSE for details.
 # Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule AgentClientProtocol do
+defmodule FrontmanServer.Protocols.ACP do
   @moduledoc """
   ACP (Agent Client Protocol) translation layer.
 
@@ -17,10 +17,12 @@ defmodule AgentClientProtocol do
   """
 
   use Boundary,
-    deps: [JsonRpc, FrontmanServer],
+    top_level?: true,
+    deps: [FrontmanServer.Protocols.JsonRpc, FrontmanServer],
     exports: :all
 
   alias FrontmanServer.Agents.Agent
+  alias FrontmanServer.Protocols.JsonRpc
 
   @protocol_version 1
   @agent_attribution_version 1

--- a/apps/frontman_server/lib/frontman_server/protocols/acp/content.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/acp/content.ex
@@ -4,7 +4,7 @@
 # Licensed under the AGPL-3.0 — see LICENSE for details.
 # Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule AgentClientProtocol.Content do
+defmodule FrontmanServer.Protocols.ACP.Content do
   @moduledoc "Builders for ACP content blocks."
 
   alias FrontmanServer.CurrentPageContext

--- a/apps/frontman_server/lib/frontman_server/protocols/acp/history.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/acp/history.ex
@@ -4,11 +4,11 @@
 # Licensed under the AGPL-3.0 - see LICENSE for details.
 # Additional terms apply - see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule AgentClientProtocol.History do
+defmodule FrontmanServer.Protocols.ACP.History do
   @moduledoc "Encodes projected task row contexts as ACP notifications."
 
-  alias AgentClientProtocol, as: ACP
   alias FrontmanServer.Agents
+  alias FrontmanServer.Protocols.ACP
   alias FrontmanServer.Tasks.History, as: TaskHistory
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tasks.InteractionSchema

--- a/apps/frontman_server/lib/frontman_server/protocols/json_rpc.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/json_rpc.ex
@@ -4,7 +4,7 @@
 # Licensed under the AGPL-3.0 — see LICENSE for details.
 # Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule JsonRpc do
+defmodule FrontmanServer.Protocols.JsonRpc do
   @moduledoc """
   JSON-RPC 2.0 message parsing and construction.
 
@@ -28,7 +28,7 @@ defmodule JsonRpc do
   Domain logic should not depend on this module directly.
   """
 
-  use Boundary
+  use Boundary, top_level?: true
 
   @jsonrpc_version "2.0"
 
@@ -57,10 +57,10 @@ defmodule JsonRpc do
 
   ## Examples
 
-      iex> JsonRpc.parse(%{"jsonrpc" => "2.0", "id" => 1, "method" => "test", "params" => %{}})
+      iex> FrontmanServer.Protocols.JsonRpc.parse(%{"jsonrpc" => "2.0", "id" => 1, "method" => "test", "params" => %{}})
       {:ok, {:request, 1, "test", %{}}}
 
-      iex> JsonRpc.parse(%{"jsonrpc" => "2.0", "method" => "notify", "params" => %{}})
+      iex> FrontmanServer.Protocols.JsonRpc.parse(%{"jsonrpc" => "2.0", "method" => "notify", "params" => %{}})
       {:ok, {:notification, "notify", %{}}}
   """
   def parse(message) when is_map(message) do
@@ -87,10 +87,10 @@ defmodule JsonRpc do
 
   ## Examples
 
-      iex> JsonRpc.parse_response(%{"jsonrpc" => "2.0", "id" => 1, "result" => %{"data" => "value"}})
+      iex> FrontmanServer.Protocols.JsonRpc.parse_response(%{"jsonrpc" => "2.0", "id" => 1, "result" => %{"data" => "value"}})
       {:ok, {:success, 1, %{"data" => "value"}}}
 
-      iex> JsonRpc.parse_response(%{"jsonrpc" => "2.0", "id" => 1, "error" => %{"code" => -32601, "message" => "Not found"}})
+      iex> FrontmanServer.Protocols.JsonRpc.parse_response(%{"jsonrpc" => "2.0", "id" => 1, "error" => %{"code" => -32601, "message" => "Not found"}})
       {:ok, {:error, 1, %{"code" => -32601, "message" => "Not found"}}}
   """
   def parse_response(message) when is_map(message) do

--- a/apps/frontman_server/lib/frontman_server/protocols/mcp.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/mcp.ex
@@ -4,7 +4,7 @@
 # Licensed under the AGPL-3.0 — see LICENSE for details.
 # Additional terms apply — see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule ModelContextProtocol do
+defmodule FrontmanServer.Protocols.MCP do
   @moduledoc """
   MCP (Model Context Protocol) message builders and parsers.
 
@@ -20,8 +20,9 @@ defmodule ModelContextProtocol do
   Use with JsonRpc for complete message handling.
   """
 
-  use Boundary, deps: [JsonRpc], exports: :all
+  use Boundary, top_level?: true, deps: [FrontmanServer.Protocols.JsonRpc], exports: :all
 
+  alias FrontmanServer.Protocols.JsonRpc
   require Logger
 
   @protocol_version "2026-07-28"

--- a/apps/frontman_server/lib/frontman_server/protocols/mcp/schema.ex
+++ b/apps/frontman_server/lib/frontman_server/protocols/mcp/schema.ex
@@ -4,10 +4,10 @@
 # Licensed under the AGPL-3.0 - see LICENSE for details.
 # Additional terms apply - see AI-SUPPLEMENTARY-TERMS.md
 
-defmodule ModelContextProtocol.Schema do
+defmodule FrontmanServer.Protocols.MCP.Schema do
   @moduledoc false
 
-  @schema_dir Path.expand("../../../../libs/frontman-protocol/schemas/mcp", __DIR__)
+  @schema_dir Path.expand("../../../../../../libs/frontman-protocol/schemas/mcp", __DIR__)
   @discover_result_path Path.join(@schema_dir, "discoverResult.json")
   @tools_list_result_path Path.join(@schema_dir, "toolsListResult.json")
   @call_tool_result_path Path.join(@schema_dir, "callToolResult.json")

--- a/apps/frontman_server/lib/frontman_server/tasks.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks.ex
@@ -37,7 +37,7 @@ defmodule FrontmanServer.Tasks do
       FrontmanServer.Accounts,
       FrontmanServer.Providers,
       FrontmanServer.Skills,
-      ModelContextProtocol
+      FrontmanServer.Protocols.MCP
     ],
     exports: @exports
 
@@ -45,6 +45,7 @@ defmodule FrontmanServer.Tasks do
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Agents
   alias FrontmanServer.Observability.SentryContext
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Repo
   alias FrontmanServer.Skills
 
@@ -429,7 +430,7 @@ defmodule FrontmanServer.Tasks do
                 task,
                 turn_number,
                 call,
-                ModelContextProtocol.tool_result_error(reason)
+                MCP.tool_result_error(reason)
               )
 
             row

--- a/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
+++ b/apps/frontman_server/lib/frontman_server/tasks/execution/tool_executor.ex
@@ -11,10 +11,10 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutor do
 
   alias FrontmanServer.Accounts.Scope
   alias FrontmanServer.Observability.SentryContext
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tools
   alias FrontmanServer.Tools.Backend
-  alias ModelContextProtocol, as: MCP
   alias SwarmAi.Message.ContentPart
   alias SwarmAi.ToolExecution
 

--- a/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/agent_feedback.ex
@@ -11,9 +11,9 @@ defmodule FrontmanServer.Tools.AgentFeedback do
 
   @behaviour FrontmanServer.Tools.Backend
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tools.Backend.Context
   alias FrontmanServer.Workers.SendAgentFeedbackToDiscord
-  alias ModelContextProtocol, as: MCP
 
   @outcomes ~w(completed stuck failed feature_request)
 

--- a/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/get_tool_result.ex
@@ -11,10 +11,10 @@ defmodule FrontmanServer.Tools.GetToolResult do
 
   @behaviour FrontmanServer.Tools.Backend
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks.Interaction.ToolResult
   alias FrontmanServer.Tasks.InteractionSchema
   alias FrontmanServer.Tools.Backend.Context
-  alias ModelContextProtocol, as: MCP
 
   @impl true
   def name, do: "get_tool_result"

--- a/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/todo_write.ex
@@ -15,8 +15,8 @@ defmodule FrontmanServer.Tools.TodoWrite do
 
   @behaviour FrontmanServer.Tools.Backend
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks.Todos.Todo
-  alias ModelContextProtocol, as: MCP
 
   @impl true
   def name, do: "todo_write"

--- a/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
+++ b/apps/frontman_server/lib/frontman_server/tools/web_fetch.ex
@@ -14,8 +14,8 @@ defmodule FrontmanServer.Tools.WebFetch do
 
   @behaviour FrontmanServer.Tools.Backend
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.PublicURL
-  alias ModelContextProtocol, as: MCP
 
   @chrome_ua "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " <>
                "AppleWebKit/537.36 (KHTML, like Gecko) " <>

--- a/apps/frontman_server/lib/frontman_server_web.ex
+++ b/apps/frontman_server/lib/frontman_server_web.ex
@@ -26,9 +26,7 @@ defmodule FrontmanServerWeb do
   use Boundary,
     deps: [
       FrontmanServer,
-      AgentClientProtocol,
-      JsonRpc,
-      ModelContextProtocol
+      FrontmanServer.Protocols.{ACP, JsonRpc, MCP}
     ],
     exports: [Endpoint, Telemetry]
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel.ex
@@ -15,11 +15,11 @@ defmodule FrontmanServerWeb.TaskChannel do
   use FrontmanServerWeb, :channel
   require Logger
 
-  alias AgentClientProtocol, as: ACP
-  alias AgentClientProtocol.History, as: ACPHistory
   alias FrontmanServer.Agents
   alias FrontmanServer.Frameworks
   alias FrontmanServer.Observability.SentryContext
+  alias FrontmanServer.Protocols.{ACP, JsonRpc, MCP}
+  alias FrontmanServer.Protocols.ACP.History, as: ACPHistory
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.History, as: TaskHistory
@@ -27,8 +27,7 @@ defmodule FrontmanServerWeb.TaskChannel do
   alias FrontmanServer.Tasks.Todos.Todo
   alias FrontmanServer.Tools
   alias FrontmanServerWeb.TaskChannel.MCPInitializer
-  alias ModelContextProtocol, as: MCP
-  alias ModelContextProtocol.Schema, as: MCPSchema
+  alias MCP.Schema, as: MCPSchema
 
   @acp_message ACP.event_acp_message()
   @acp_title_updated ACP.event_title_updated()
@@ -582,7 +581,7 @@ defmodule FrontmanServerWeb.TaskChannel do
 
     Logger.error("MCP tool execution failed", metadata)
 
-    result = ModelContextProtocol.tool_result_error(error_message)
+    result = MCP.tool_result_error(error_message)
     {:noreply, persist_tool_call_result(tool_call, result, socket)}
   end
 

--- a/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/task_channel/mcp_initializer.ex
@@ -9,11 +9,10 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializer do
   require Logger
 
   alias FrontmanServer.Frameworks
+  alias FrontmanServer.Protocols.{JsonRpc, MCP}
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tools.MCP, as: MCPTools
-  alias JsonRpc
-  alias ModelContextProtocol, as: MCP
-  alias ModelContextProtocol.Schema, as: MCPSchema
+  alias MCP.Schema, as: MCPSchema
 
   @execution_context_extension "ai.frontman/execution-context"
   @tool_metadata_extension "ai.frontman/tool-metadata"

--- a/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
+++ b/apps/frontman_server/lib/frontman_server_web/channels/tasks_channel.ex
@@ -16,9 +16,9 @@ defmodule FrontmanServerWeb.TasksChannel do
   use FrontmanServerWeb, :verified_routes
   require Logger
 
-  alias AgentClientProtocol, as: ACP
   alias FrontmanServer.Agents
   alias FrontmanServer.Observability.SentryContext
+  alias FrontmanServer.Protocols.{ACP, JsonRpc}
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/mcp_tool_routing_test.exs
@@ -9,13 +9,13 @@ defmodule FrontmanServer.Tasks.Execution.McpToolRoutingTest do
 
   import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Protocols.JsonRpc
   alias FrontmanServer.Providers
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tools.MCP
   alias FrontmanServerWeb.UserSocket
-  alias JsonRpc
 
   describe "ToolExecutor MCP tool routing" do
     setup %{scope: scope} do

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_error_sentry_test.exs
@@ -8,6 +8,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
   import FrontmanServer.Test.Fixtures.Tasks
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
@@ -199,7 +200,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolErrorSentryTest do
 
       assert tool_result != nil
       assert tool_result.is_error == true
-      assert ModelContextProtocol.extract_content_text(tool_result.result) =~ "timed out"
+      assert MCP.extract_content_text(tool_result.result) =~ "timed out"
 
       reports = Sentry.Test.pop_sentry_reports()
       timeout_reports = Enum.filter(reports, &(&1.tags[:error_type] == "tool_timeout"))

--- a/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution/tool_executor_test.exs
@@ -4,6 +4,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Protocols
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
@@ -20,7 +21,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
     def parameter_schema, do: %{"type" => "object", "properties" => %{}}
     def timeout_ms, do: 30_000
     def execute(%{"invalid" => true}, _context), do: %{"unexpected" => "shape"}
-    def execute(_args, _context), do: ModelContextProtocol.tool_result_text("done")
+    def execute(_args, _context), do: Protocols.MCP.tool_result_text("done")
   end
 
   setup do
@@ -62,7 +63,8 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         {:ok, task} = Tasks.get_task_with_history(scope, task_id)
         assert [stored] = tool_results(task, tc.id)
         assert stored.is_error == winner.is_error
-        assert ModelContextProtocol.extract_content_text(stored.result) == hd(winner.content).text
+
+        assert Protocols.MCP.extract_content_text(stored.result) == hd(winner.content).text
       end
     end
   end
@@ -123,7 +125,7 @@ defmodule FrontmanServer.Tasks.Execution.ToolExecutorTest do
         scope,
         task_id,
         call,
-        ModelContextProtocol.tool_result_text("committed"),
+        Protocols.MCP.tool_result_text("committed"),
         turn_number: turn_number
       )
 

--- a/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_image_history_test.exs
@@ -12,6 +12,7 @@ defmodule FrontmanServer.Tasks.ExecutionImageHistoryTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Image
+  alias FrontmanServer.Protocols
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
   alias FrontmanServer.Tasks
@@ -269,7 +270,7 @@ defmodule FrontmanServer.Tasks.ExecutionImageHistoryTest do
   end
 
   defp mcp_image_result(binary, mime \\ "image/png"),
-    do: ModelContextProtocol.tool_result_image(Base.encode64(binary), mime)
+    do: Protocols.MCP.tool_result_image(Base.encode64(binary), mime)
 
   defp client_mcp_image_result(binary, mime \\ "image/png") do
     %{

--- a/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/execution_test.exs
@@ -32,6 +32,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Protocols
   alias FrontmanServer.Providers
   alias FrontmanServer.Repo
   alias FrontmanServer.Skills
@@ -44,7 +45,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
   alias ReqLLM.Error.API.Request
 
   @endpoint FrontmanServerWeb.Endpoint
-  @acp_message AgentClientProtocol.event_acp_message()
+  @acp_message Protocols.ACP.event_acp_message()
 
   defp error_timeout_mcp_tool_defs do
     [
@@ -972,7 +973,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
           scope,
           task_id,
           %{id: question_tc_id, name: "question"},
-          ModelContextProtocol.tool_result_json(%{"answers" => [%{"answer" => "A"}]})
+          Protocols.MCP.tool_result_json(%{"answers" => [%{"answer" => "A"}]})
         )
 
       assert_receive_interaction(%Interaction.AgentCompleted{}, _turn_number)
@@ -1140,7 +1141,7 @@ defmodule FrontmanServer.Tasks.ExecutionIntegrationTest do
                  scope,
                  task_id,
                  approval,
-                 ModelContextProtocol.tool_result_text("yes")
+                 Protocols.MCP.tool_result_text("yes")
                )
 
       assert :ok =

--- a/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/interaction_test.exs
@@ -11,7 +11,7 @@ defmodule FrontmanServer.Tasks.InteractionTest do
     UserMessage
   }
 
-  alias ModelContextProtocol, as: MCP
+  alias FrontmanServer.Protocols.MCP
 
   describe "SkillUsed.build/2" do
     test "snapshots skill content" do

--- a/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/todos_test.exs
@@ -4,9 +4,9 @@ defmodule FrontmanServer.Tasks.TodosTest do
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Todos
-  alias ModelContextProtocol, as: MCP
 
   setup do
     scope = user_scope_fixture()

--- a/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks/tool_result_concurrency_test.exs
@@ -6,12 +6,12 @@ defmodule FrontmanServer.Tasks.ToolResultConcurrencyTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Repo
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Execution.ToolExecutor
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tools.MCP, as: MCPTool
-  alias ModelContextProtocol, as: MCP
 
   test "two tasks with the same tool call id receive only their own result" do
     Sandbox.unboxed_run(Repo, fn ->

--- a/apps/frontman_server/test/frontman_server/tasks_test.exs
+++ b/apps/frontman_server/test/frontman_server/tasks_test.exs
@@ -15,12 +15,12 @@ defmodule FrontmanServer.TasksTest do
     ScrubToolResultMetadata
   }
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Interaction
   alias FrontmanServer.Tasks.InteractionSchema
   alias FrontmanServer.Tasks.TaskSchema
   alias FrontmanServer.Workers.GenerateTitle
-  alias ModelContextProtocol, as: MCP
 
   setup do
     scope = user_scope_fixture()

--- a/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/agent_feedback_test.exs
@@ -5,11 +5,11 @@ defmodule FrontmanServer.Tools.AgentFeedbackTest do
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tools.AgentFeedback
   alias FrontmanServer.Tools.Backend.Context
   alias FrontmanServer.Workers.SendAgentFeedbackToDiscord
-  alias ModelContextProtocol, as: MCP
 
   test "enqueues feedback for Discord" do
     scope = user_scope_fixture()

--- a/apps/frontman_server/test/frontman_server/tools/backend_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/backend_test.exs
@@ -1,6 +1,7 @@
 defmodule FrontmanServer.Tools.BackendTest do
   use ExUnit.Case, async: true
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tools.Backend
 
   setup_all do
@@ -15,7 +16,7 @@ defmodule FrontmanServer.Tools.BackendTest do
     def access, do: :read
     def parameter_schema, do: %{}
     def timeout_ms, do: 45_000
-    def execute(_args, _ctx), do: ModelContextProtocol.tool_result_text("done")
+    def execute(_args, _ctx), do: MCP.tool_result_text("done")
   end
 
   describe "to_swarm_tool/1" do

--- a/apps/frontman_server/test/frontman_server/tools/get_tool_result_paging_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/get_tool_result_paging_test.exs
@@ -1,12 +1,12 @@
 defmodule FrontmanServer.Tools.GetToolResultPagingTest do
   use ExUnit.Case, async: true
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks.Execution.LLMRequestPreflight
   alias FrontmanServer.Tasks.Interaction.ToolResult
   alias FrontmanServer.Tasks.InteractionSchema
   alias FrontmanServer.Tools.Backend.Context
   alias FrontmanServer.Tools.GetToolResult
-  alias ModelContextProtocol, as: MCP
   alias SwarmAi.Message
   alias SwarmAi.Message.ContentPart
 

--- a/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools/web_fetch_test.exs
@@ -1,8 +1,8 @@
 defmodule FrontmanServer.Tools.WebFetchTest do
   use FrontmanServer.DataCase, async: false
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tools.WebFetch
-  alias ModelContextProtocol, as: MCP
 
   setup do
     context = %FrontmanServer.Tools.Backend.Context{

--- a/apps/frontman_server/test/frontman_server/tools_test.exs
+++ b/apps/frontman_server/test/frontman_server/tools_test.exs
@@ -4,6 +4,7 @@ defmodule FrontmanServer.ToolsTest do
   import FrontmanServer.Test.Fixtures.Accounts
   import FrontmanServer.Test.Fixtures.Tasks
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServer.Tasks
   alias FrontmanServer.Tasks.Interaction.ToolResult
   alias FrontmanServer.Tasks.InteractionSchema
@@ -13,7 +14,6 @@ defmodule FrontmanServer.ToolsTest do
   alias FrontmanServer.Tools.GetToolResult
   alias FrontmanServer.Tools.TodoWrite
   alias FrontmanServer.Tools.WebFetch
-  alias ModelContextProtocol, as: MCP
 
   setup do
     scope = user_scope_fixture()

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel/mcp_initializer_test.exs
@@ -3,9 +3,9 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializerTest do
 
   import ExUnit.CaptureLog
 
+  alias FrontmanServer.Protocols.MCP
   alias FrontmanServerWeb.ChannelCase
   alias FrontmanServerWeb.TaskChannel.MCPInitializer
-  alias ModelContextProtocol, as: MCP
 
   setup do
     Sentry.Test.setup_sentry(dedup_events: false)
@@ -59,7 +59,7 @@ defmodule FrontmanServerWeb.TaskChannel.MCPInitializerTest do
       MCPInitializer.handle_response(state, state.discovery_request_id, result)
 
     assert tools_request["method"] == "tools/list"
-    assert tools_request["params"] == ModelContextProtocol.tools_list_params()
+    assert tools_request["params"] == MCP.tools_list_params()
   end
 
   describe "handle_timeout/1" do

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_sentry_test.exs
@@ -14,7 +14,7 @@ defmodule FrontmanServerWeb.TaskChannelSentryTest do
 
   import FrontmanServer.Test.Fixtures.Tasks
 
-  alias ModelContextProtocol, as: MCP
+  alias FrontmanServer.Protocols.{JsonRpc, MCP}
 
   setup %{scope: scope} do
     Sentry.Test.setup_sentry(dedup_events: false)

--- a/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/task_channel_test.exs
@@ -23,8 +23,8 @@ defmodule FrontmanServerWeb.TaskChannelTest do
   alias FrontmanServer.Workers.GenerateTitle
   alias FrontmanServerWeb.UserSocket
 
+  alias FrontmanServer.Protocols.{JsonRpc, MCP}
   alias FrontmanServer.Tasks.Interaction
-  alias ModelContextProtocol, as: MCP
 
   @persisted_restart_model "openrouter:openai/gpt-5.5"
   @logged_output_schema %{
@@ -1033,7 +1033,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       }
 
       assert :ok =
-               ModelContextProtocol.Schema.validate_call_tool_result(
+               MCP.Schema.validate_call_tool_result(
                  result,
                  @logged_output_schema
                )
@@ -1041,7 +1041,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
       assert :error =
                result
                |> Map.put("structuredContent", %{})
-               |> ModelContextProtocol.Schema.validate_call_tool_result(@logged_output_schema)
+               |> MCP.Schema.validate_call_tool_result(@logged_output_schema)
     end
   end
 
@@ -1109,7 +1109,7 @@ defmodule FrontmanServerWeb.TaskChannelTest do
     test "sends MCP discovery request on join", %{scope: scope} do
       {_socket, _task_id} = join_task_channel(scope)
 
-      expected_version = ModelContextProtocol.protocol_version()
+      expected_version = MCP.protocol_version()
 
       assert_push("mcp:message", %{
         "jsonrpc" => "2.0",

--- a/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
+++ b/apps/frontman_server/test/frontman_server_web/channels/tasks_channel_test.exs
@@ -5,7 +5,7 @@ defmodule FrontmanServerWeb.TasksChannelTest do
   import FrontmanServer.Test.Fixtures.Tasks
   import ExUnit.CaptureLog
 
-  alias AgentClientProtocol, as: ACP
+  alias FrontmanServer.Protocols.ACP
   alias FrontmanServer.Repo
   alias FrontmanServer.Tasks.TaskSchema
   alias FrontmanServerWeb.UserSocket

--- a/apps/frontman_server/test/protocols/acp_content_test.exs
+++ b/apps/frontman_server/test/protocols/acp_content_test.exs
@@ -1,7 +1,7 @@
-defmodule AgentClientProtocol.ContentTest do
+defmodule FrontmanServer.Protocols.ACP.ContentTest do
   use ExUnit.Case, async: true
 
-  alias AgentClientProtocol.Content
+  alias FrontmanServer.Protocols.{ACP, ACP.Content}
   alias FrontmanServer.ProtocolSchema
   alias FrontmanServer.Tasks.Interaction
 
@@ -60,7 +60,7 @@ defmodule AgentClientProtocol.ContentTest do
       blocks
       |> Enum.with_index()
       |> Enum.each(fn {content, index} ->
-        AgentClientProtocol.build_user_message_chunk_notification(
+        ACP.build_user_message_chunk_notification(
           "session-1",
           "resource-#{index}",
           content,

--- a/apps/frontman_server/test/protocols/acp_contract_test.exs
+++ b/apps/frontman_server/test/protocols/acp_contract_test.exs
@@ -2,16 +2,16 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
   use ExUnit.Case, async: true
 
   alias FrontmanServer.Agents.Agent
-  alias FrontmanServer.ProtocolSchema
+  alias FrontmanServer.{Protocols.ACP, ProtocolSchema}
 
-  describe "AgentClientProtocol.build_initialize_result/0" do
+  describe "ACP.build_initialize_result/0" do
     test "validates against acp/initializeResult schema" do
-      payload = AgentClientProtocol.build_initialize_result(agents(), "planner-id")
+      payload = ACP.build_initialize_result(agents(), "planner-id")
       ProtocolSchema.validate!(payload, "acp/initializeResult")
     end
 
     test "advertises Frontman agent attribution v1 under capability metadata" do
-      result = AgentClientProtocol.build_initialize_result(agents(), "planner-id")
+      result = ACP.build_initialize_result(agents(), "planner-id")
 
       assert %{
                "agentCapabilities" => %{
@@ -32,7 +32,7 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.negotiate_agent_attribution_version/1" do
+  describe "ACP.negotiate_agent_attribution_version/1" do
     test "negotiates v1 from a matching client advertisement" do
       capabilities = %{
         "_meta" => %{
@@ -40,16 +40,15 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
         }
       }
 
-      assert {:ok, 1} =
-               AgentClientProtocol.negotiate_agent_attribution_version(capabilities)
+      assert {:ok, 1} = ACP.negotiate_agent_attribution_version(capabilities)
     end
 
     test "disables attribution when advertisement is absent or unsupported" do
-      assert {:ok, nil} = AgentClientProtocol.negotiate_agent_attribution_version(nil)
-      assert {:ok, nil} = AgentClientProtocol.negotiate_agent_attribution_version(%{})
+      assert {:ok, nil} = ACP.negotiate_agent_attribution_version(nil)
+      assert {:ok, nil} = ACP.negotiate_agent_attribution_version(%{})
 
       assert {:ok, nil} =
-               AgentClientProtocol.negotiate_agent_attribution_version(%{
+               ACP.negotiate_agent_attribution_version(%{
                  "_meta" => %{
                    "frontman.dev" => %{"agentAttribution" => %{"version" => 2}}
                  }
@@ -58,12 +57,12 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
 
     test "rejects malformed known metadata" do
       assert {:error, _message} =
-               AgentClientProtocol.negotiate_agent_attribution_version(%{
+               ACP.negotiate_agent_attribution_version(%{
                  "_meta" => %{"frontman.dev" => "invalid"}
                })
 
       assert {:error, _message} =
-               AgentClientProtocol.negotiate_agent_attribution_version(%{
+               ACP.negotiate_agent_attribution_version(%{
                  "_meta" => %{
                    "frontman.dev" => %{"agentAttribution" => %{"version" => 0}}
                  }
@@ -71,18 +70,18 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.build_prompt_accepted_result/0" do
+  describe "ACP.build_prompt_accepted_result/0" do
     test "validates against acp/promptResult schema" do
-      payload = AgentClientProtocol.build_prompt_accepted_result()
+      payload = ACP.build_prompt_accepted_result()
 
       ProtocolSchema.validate!(payload, "acp/promptResult")
     end
   end
 
-  describe "AgentClientProtocol.tool_call_create/6" do
+  describe "ACP.tool_call_create/6" do
     test "validates against acp/sessionUpdateNotification schema" do
       payload =
-        AgentClientProtocol.tool_call_create(
+        ACP.tool_call_create(
           "session-123",
           "tc-1",
           "read_file",
@@ -95,12 +94,11 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.tool_call_update/4" do
+  describe "ACP.tool_call_update/4" do
     test "with raw input validates against acp/sessionUpdateNotification schema" do
       raw_input = %{"path" => "file.res"}
 
-      payload =
-        AgentClientProtocol.tool_call_update("session-123", "tc-1", "pending", nil, raw_input)
+      payload = ACP.tool_call_update("session-123", "tc-1", "pending", nil, raw_input)
 
       assert get_in(payload, ["params", "update", "rawInput"]) == raw_input
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
@@ -109,13 +107,13 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     test "with content validates against acp/sessionUpdateNotification schema" do
       content = [%{"type" => "content", "content" => %{"type" => "text", "text" => "result"}}]
 
-      payload = AgentClientProtocol.tool_call_update("session-123", "tc-1", "completed", content)
+      payload = ACP.tool_call_update("session-123", "tc-1", "completed", content)
 
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
     end
   end
 
-  describe "AgentClientProtocol.plan_update/2" do
+  describe "ACP.plan_update/2" do
     test "validates against acp/sessionUpdateNotification schema" do
       entries = [
         %{
@@ -130,15 +128,15 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
         }
       ]
 
-      payload = AgentClientProtocol.plan_update("session-123", entries)
+      payload = ACP.plan_update("session-123", entries)
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
     end
   end
 
-  describe "AgentClientProtocol.build_error_notification/4" do
+  describe "ACP.build_error_notification/4" do
     test "validates against acp/sessionUpdateNotification schema" do
       payload =
-        AgentClientProtocol.build_error_notification(
+        ACP.build_error_notification(
           "session-123",
           "Rate limit exceeded",
           DateTime.utc_now(),
@@ -156,9 +154,9 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.build_state_update_notification/3" do
+  describe "ACP.build_state_update_notification/3" do
     test "validates running state against acp/sessionUpdateNotification schema" do
-      payload = AgentClientProtocol.build_state_update_notification("session-123", "running")
+      payload = ACP.build_state_update_notification("session-123", "running")
 
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
 
@@ -174,11 +172,7 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
 
     test "validates idle state with stop reason" do
       payload =
-        AgentClientProtocol.build_state_update_notification(
-          "session-123",
-          "idle",
-          AgentClientProtocol.stop_reason_end_turn()
-        )
+        ACP.build_state_update_notification("session-123", "idle", ACP.stop_reason_end_turn())
 
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
 
@@ -194,18 +188,17 @@ defmodule FrontmanServer.Protocols.AcpContractTest do
     end
   end
 
-  describe "AgentClientProtocol.build_message_unqueued_notification/2" do
+  describe "ACP.build_message_unqueued_notification/2" do
     test "validates against acp/sessionUpdateNotification schema" do
-      payload =
-        AgentClientProtocol.build_message_unqueued_notification("session-123", "message-123")
+      payload = ACP.build_message_unqueued_notification("session-123", "message-123")
 
       ProtocolSchema.validate!(payload, "acp/sessionUpdateNotification")
     end
   end
 
-  describe "AgentClientProtocol.agent_info/0" do
+  describe "ACP.agent_info/0" do
     test "validates against acp/implementation schema" do
-      payload = AgentClientProtocol.agent_info()
+      payload = ACP.agent_info()
       ProtocolSchema.validate!(payload, "acp/implementation")
     end
   end

--- a/apps/frontman_server/test/protocols/acp_history_test.exs
+++ b/apps/frontman_server/test/protocols/acp_history_test.exs
@@ -1,4 +1,4 @@
-defmodule AgentClientProtocol.HistoryTest do
+defmodule FrontmanServer.Protocols.ACP.HistoryTest do
   use ExUnit.Case, async: true
 
   import FrontmanServer.InteractionCase.Helpers,
@@ -15,8 +15,8 @@ defmodule AgentClientProtocol.HistoryTest do
       user_msg: 1
     ]
 
-  alias AgentClientProtocol.History
   alias FrontmanServer.Agents.Agent
+  alias FrontmanServer.Protocols.ACP.History
   alias FrontmanServer.Tasks.History, as: TaskHistory
 
   @session_id "test-session-123"

--- a/apps/frontman_server/test/protocols/acp_test.exs
+++ b/apps/frontman_server/test/protocols/acp_test.exs
@@ -1,7 +1,7 @@
-defmodule AgentClientProtocolTest do
+defmodule FrontmanServer.Protocols.ACPTest do
   use ExUnit.Case, async: true
 
-  alias AgentClientProtocol, as: ACP
+  alias FrontmanServer.Protocols.ACP
 
   describe "plan_update/2" do
     test "builds valid plan update notification" do

--- a/apps/frontman_server/test/protocols/acp_upstream_compliance_test.exs
+++ b/apps/frontman_server/test/protocols/acp_upstream_compliance_test.exs
@@ -2,24 +2,24 @@ defmodule FrontmanServer.Protocols.AcpUpstreamComplianceTest do
   use ExUnit.Case, async: true
 
   alias FrontmanServer.Agents.Agent
-  alias FrontmanServer.ProtocolSchema
+  alias FrontmanServer.{Protocols.ACP, ProtocolSchema}
 
   @timestamp ~U[2026-07-15 10:00:00.000000Z]
 
   test "Frontman and generic ACP envelopes validate against pinned upstream v1 schema" do
     fixtures = [
       initialize_request(%{"frontman.dev" => %{"agentAttribution" => %{"version" => 1}}}),
-      response(2, AgentClientProtocol.build_initialize_result([agent()], "executor-id")),
-      response(3, AgentClientProtocol.build_session_new_result("session-1", [])),
-      response(4, AgentClientProtocol.build_session_load_result([])),
-      AgentClientProtocol.build_user_message_chunk_notification(
+      response(2, ACP.build_initialize_result([agent()], "executor-id")),
+      response(3, ACP.build_session_new_result("session-1", [])),
+      response(4, ACP.build_session_load_result([])),
+      ACP.build_user_message_chunk_notification(
         "session-1",
         "user-1",
         %{"type" => "text", "text" => "Hello"},
         "executor-id",
         @timestamp
       ),
-      AgentClientProtocol.build_agent_message_chunk_notification(
+      ACP.build_agent_message_chunk_notification(
         "session-1",
         "Hello back",
         @timestamp,

--- a/apps/frontman_server/test/protocols/json_rpc_test.exs
+++ b/apps/frontman_server/test/protocols/json_rpc_test.exs
@@ -1,6 +1,7 @@
-defmodule JsonRpcTest do
+defmodule FrontmanServer.Protocols.JsonRpcTest do
   use ExUnit.Case, async: true
 
+  alias FrontmanServer.Protocols.JsonRpc
   import FrontmanServer.Test.Fixtures.JsonRpc
 
   describe "parse/1" do

--- a/apps/frontman_server/test/protocols/jsonrpc_contract_test.exs
+++ b/apps/frontman_server/test/protocols/jsonrpc_contract_test.exs
@@ -1,7 +1,7 @@
 defmodule FrontmanServer.Protocols.JsonRpcContractTest do
   use ExUnit.Case, async: true
 
-  alias FrontmanServer.ProtocolSchema
+  alias FrontmanServer.{Protocols.JsonRpc, ProtocolSchema}
 
   describe "JsonRpc.request/3" do
     test "validates against jsonrpc/request schema" do

--- a/apps/frontman_server/test/protocols/mcp_contract_test.exs
+++ b/apps/frontman_server/test/protocols/mcp_contract_test.exs
@@ -1,8 +1,7 @@
 defmodule FrontmanServer.Protocols.McpContractTest do
   use ExUnit.Case, async: true
 
-  alias FrontmanServer.ProtocolSchema
-  alias ModelContextProtocol, as: MCP
+  alias FrontmanServer.{Protocols.MCP, ProtocolSchema}
 
   test "discovery and tools/list params satisfy the shared contract" do
     ProtocolSchema.validate!(MCP.request_params(), "mcp/discoverParams")

--- a/apps/frontman_server/test/protocols/mcp_test.exs
+++ b/apps/frontman_server/test/protocols/mcp_test.exs
@@ -1,9 +1,9 @@
-defmodule ModelContextProtocolTest do
+defmodule FrontmanServer.Protocols.MCPTest do
   use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
 
-  alias ModelContextProtocol, as: MCP
+  alias FrontmanServer.Protocols.MCP
 
   test "builds required MCP 2026 request metadata" do
     meta = MCP.request_params()["_meta"]

--- a/apps/frontman_server/test/support/channel_case.ex
+++ b/apps/frontman_server/test/support/channel_case.ex
@@ -20,6 +20,7 @@ defmodule FrontmanServerWeb.ChannelCase do
   alias Ecto.Adapters.SQL.Sandbox
   alias FrontmanServer.Accounts
   alias FrontmanServer.Accounts.Scope
+  alias FrontmanServer.Protocols.{ACP, JsonRpc, MCP}
   alias FrontmanServer.Providers
   alias FrontmanServer.Test.Fixtures.LLMProvider
 
@@ -30,7 +31,7 @@ defmodule FrontmanServerWeb.ChannelCase do
 
       @endpoint FrontmanServerWeb.Endpoint
 
-      @acp_message AgentClientProtocol.event_acp_message()
+      @acp_message ACP.event_acp_message()
     end
   end
 
@@ -38,7 +39,7 @@ defmodule FrontmanServerWeb.ChannelCase do
     Map.merge(
       %{
         "resultType" => "complete",
-        "supportedVersions" => [ModelContextProtocol.protocol_version()],
+        "supportedVersions" => [MCP.protocol_version()],
         "capabilities" => %{
           "tools" => %{"listChanged" => false},
           "extensions" => %{


### PR DESCRIPTION
## Summary
- Move ACP, MCP, JSON-RPC, and their child modules under `FrontmanServer.Protocols`.
- Update callers, tests, boundary dependencies, and the MCP schema path. Preserve existing boundary enforcement with `top_level?: true`.
- Keep implementation and tests line-neutral: 118 additions / 118 deletions. Add a four-line changeset.

## Verification
- `make -C apps/frontman_server strict-compile precommit` — passed, including strict compilation, formatting, Credo, and 904 tests.
- `git diff --check` — passed.

Closes #611