### PR TITLE
refactor(client): type ACP request methods

### DIFF
--- a/.changeset/typed-acp-request-methods.md
+++ b/.changeset/typed-acp-request-methods.md
@@ -1,0 +1,5 @@
+---
+"@frontman-ai/frontman-client": patch
+---
+
+Reject invalid ACP request method names at compile time without changing wire messages.

--- a/libs/frontman-client/src/FrontmanClient__ACP.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP.res
@@ -501,7 +501,7 @@ let loadSession = async (
     let loadResult = await Protocol.sendRequest(
       ~channel=session.channel,
       ~state=conn.state,
-      ~method="session/load",
+      ~method=#"session/load",
       ~params=Some(
         params->S.decodeOrThrow(
           ~from=Types.sessionLoadParamsSchema,

--- a/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
+++ b/libs/frontman-client/src/FrontmanClient__ACP__Protocol.res
@@ -8,6 +8,8 @@ module Log = FrontmanLogs.Logs.Make({
   let component = #ACP
 })
 
+type requestMethod = [#initialize | #"session/new" | #"session/load" | #"session/prompt"]
+
 let requestTimeoutMs = 120000
 
 let pushReplyMessageSchema: S.t<JSON.t> = S.object(s => s.field("acp:message", S.json))
@@ -21,11 +23,12 @@ let parsePushReply = payload => {
 let sendRequest = (
   ~channel: Channel.t,
   ~state: ref<Client.state>,
-  ~method: string,
+  ~method: requestMethod,
   ~params: option<JSON.t>,
   ~timeoutMs: int=requestTimeoutMs,
   ~parseResult: JSON.t => result<'a, string>,
 ): promise<result<'a, string>> => {
+  let method = (method :> string)
   Promise.make((resolve, _) => {
     let id = state.contents.currentId + 1
     let idStr = Int.toString(id)
@@ -37,12 +40,7 @@ let sendRequest = (
     }
 
     let pending: Client.pendingRequest = {
-      resolve: json => {
-        switch parseResult(json) {
-        | Ok(result) => finish(Ok(result))
-        | Error(e) => finish(Error(e))
-        }
-      },
+      resolve: json => finish(parseResult(json)),
       reject: e => finish(Error(e)),
     }
 
@@ -78,7 +76,7 @@ let sendInitialize = (
   sendRequest(
     ~channel,
     ~state,
-    ~method="initialize",
+    ~method=#initialize,
     ~params=Some(params),
     ~parseResult=Client.parseInitializeResult,
   )
@@ -92,7 +90,7 @@ let sendSessionNew = (~channel: Channel.t, ~state: ref<Client.state>, ~sessionId
   sendRequest(
     ~channel,
     ~state,
-    ~method="session/new",
+    ~method=#"session/new",
     ~params=Some(JSON.Encode.object(params)),
     ~parseResult=Client.parseSessionNewResult,
   )
@@ -117,7 +115,7 @@ let sendPrompt = (
   sendRequest(
     ~channel,
     ~state,
-    ~method="session/prompt",
+    ~method=#"session/prompt",
     ~params=Some(promptParams),
     ~parseResult=Client.parsePromptResult,
   )

--- a/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
+++ b/libs/frontman-client/test/FrontmanClient__ACP__Client.test.res
@@ -7,6 +7,7 @@ afterEach(() => {
 module Client = FrontmanClient__ACP__Client
 module ACP = FrontmanClient__ACP
 module Protocol = FrontmanClient__ACP__Protocol
+module Decoders = FrontmanClient__Decoders
 module Types = FrontmanAiFrontmanProtocol.FrontmanProtocol__ACP
 module JsonRpc = FrontmanAiFrontmanProtocol.FrontmanProtocol__JsonRpc
 module Channel = FrontmanClient__Phoenix__Channel
@@ -373,33 +374,43 @@ describe("ACP Client parseInitializeResult", _t => {
 })
 
 describe("ACP Protocol sendRequest", _t => {
-  testAsync("resolves Phoenix push reply envelopes", async t => {
-    Vi.useFakeTimers()->ignore
-    let channel = %raw(`{
-      push(_event, payload) {
-        return {
-          receive(status, callback) {
-            if (status === "ok") {
-              callback({"acp:message": {jsonrpc: "2.0", id: payload.id, result: "accepted"}});
+  [
+    (#initialize, "initialize"),
+    (#"session/new", "session/new"),
+    (#"session/load", "session/load"),
+    (#"session/prompt", "session/prompt"),
+  ]->Array.forEach(((method, wireMethod)) => {
+    testAsync(
+      `sends ${wireMethod} and resolves Phoenix push reply envelopes`,
+      async t => {
+        Vi.useFakeTimers()->ignore
+        let channel = %raw(`{
+        push(_event, payload) {
+          return {
+            receive(status, callback) {
+              if (status === "ok") {
+                callback({"acp:message": {jsonrpc: "2.0", id: payload.id, result: payload.method}});
+              }
+              return this;
             }
-            return this;
-          }
-        };
-      }
-    }`)
-    let state = ref(Client.initialState)
-    let result = await Protocol.sendRequest(
-      ~channel,
-      ~state,
-      ~method="session/prompt",
-      ~params=None,
-      ~timeoutMs=10,
-      ~parseResult=json =>
-        json->JSON.Decode.string->Option.mapOr(Error("Expected string"), value => Ok(value)),
-    )
+          };
+        }
+      }`)
+        let state = ref(Client.initialState)
+        let result = await Protocol.sendRequest(
+          ~channel,
+          ~state,
+          ~method,
+          ~params=None,
+          ~timeoutMs=10,
+          ~parseResult=json => Decoders.parseSchema(json, S.string),
+        )
 
-    t->expect(result)->Expect.toEqual(Ok("accepted"))
-    t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+        t->expect(result)->Expect.toEqual(Ok(wireMethod))
+        t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
+        t->expect(Vi.getTimerCount())->Expect.toBe(0)
+      },
+    )
   })
 
   testAsync("rejects malformed Phoenix push reply envelopes immediately", async t => {
@@ -420,7 +431,7 @@ describe("ACP Protocol sendRequest", _t => {
     let result = await Protocol.sendRequest(
       ~channel,
       ~state,
-      ~method="session/prompt",
+      ~method=#"session/prompt",
       ~params=None,
       ~timeoutMs=10,
       ~parseResult=_ => Ok("unused"),
@@ -437,14 +448,10 @@ describe("ACP Protocol sendRequest", _t => {
     let promise = Protocol.sendRequest(
       ~channel=transport.channel,
       ~state,
-      ~method="test/method",
+      ~method=#"session/prompt",
       ~params=None,
       ~timeoutMs=10,
-      ~parseResult=json =>
-        switch json->JSON.Decode.string {
-        | Some(value) => Ok(value)
-        | None => Error("Expected string")
-        },
+      ~parseResult=json => Decoders.parseSchema(json, S.string),
     )
 
     t->expect(state.contents.pendingRequests->Dict.get("1")->Option.isSome)->Expect.toBe(true)
@@ -453,7 +460,7 @@ describe("ACP Protocol sendRequest", _t => {
 
     t
     ->expect(result)
-    ->Expect.toEqual(Error("Request test/method timed out after 10ms"))
+    ->Expect.toEqual(Error("Request session/prompt timed out after 10ms"))
     t->expect(state.contents.pendingRequests->Dict.get("1"))->Expect.toEqual(None)
   })
 })

--- a/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
+++ b/libs/frontman-core/src/tools/FrontmanCore__Tool__ListTree.res
@@ -398,7 +398,7 @@ let executeOutput = async (ctx: Tool.serverExecutionContext, input: input): resu
       | exn =>
         switch exn->JsExn.fromException->Option.flatMap(e => e->Fs.errorCode->Nullable.toOption) {
         | Some("ENOENT") => result.resolvedPath
-        | _ => raise(exn)
+        | _ => throw(exn)
         }
       }
 

--- a/libs/frontman-core/test/FrontmanCore__Tool__ListFiles.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__ListFiles.test.res
@@ -205,7 +205,7 @@ describe("ListFiles Tool - execute (integration)", _t => {
     | exn =>
       Process.env->Dict.set("PATH", path)
       (await ChildProcess.spawnResult("rm", ["-rf", dir]))->Result.getOrThrow->ignore
-      raise(exn)
+      throw(exn)
     }
     Process.env->Dict.set("PATH", path)
     await Fs.Promises.writeFile(dir ++ "/.git", "invalid git metadata\n")

--- a/libs/frontman-core/test/FrontmanCore__Tool__ListTree.test.res
+++ b/libs/frontman-core/test/FrontmanCore__Tool__ListTree.test.res
@@ -176,7 +176,7 @@ describe("ListTree Tool - execute (integration)", _t => {
     | exn =>
       Process.env->Dict.set("PATH", path)
       await cleanup(dir)
-      raise(exn)
+      throw(exn)
     }
     await cleanup(dir)
   })


### PR DESCRIPTION
## Summary
- Replace plain ACP request method strings with a closed polymorphic variant; coerce to string only at the generic JSON-RPC boundary.
- Migrate all request callers, remove a redundant Result match, and reuse Sury decoding in touched tests.
- Cover all four outgoing wire method names and timer cleanup. Notifications and generic JSON-RPC remain unchanged.
- Replace three deprecated raise calls with throw in core file-discovery code and tests.

Closes #185

## Verification
- Root ReScript build passed without warnings after the deprecation cleanup.
- Client formatting/build checks and 91 tests passed.
- Protocol build and 12 tests passed.
- Core formatting/build checks and 331 tests passed.
- Temporary invalid string and invalid variant probes both failed compilation as expected; restored valid source afterward.
- Pre-commit checks and pre-push reanalyze passed.
- Patch changeset included for the ACP type change.